### PR TITLE
Vanilla examples page zhoosh

### DIFF
--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -12,7 +12,7 @@
         {% endif %}
     </head>
 
-    <body style="margin: 1rem;">
+    <body>
 
 {{ content }}
     </body>

--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -12,7 +12,7 @@
         {% endif %}
     </head>
 
-    <body>
+    <body {% if page.url != '/' %}style="margin: 1rem;"{% endif %}>
 
 {{ content }}
     </body>

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@ title: Home
 
 <div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/b54d869a-vanilla-grad-background-min.png'); background-position: 75% 50%;">
   <div class="row">
-    <h1>Vanilla framework - Examples</h1>
-  </div>
+  <h1>Vanilla framework | Examples</h1>
+</div>
 </div>
 <div class="p-strip">
   <div class="row">

--- a/index.html
+++ b/index.html
@@ -4,29 +4,28 @@ title: Home
 ---
 
 {% capture pages %}
-  {% for page in site.pages %}
-    |{{ page.title }}#{{ page.url }}
-  {% endfor %}
+{% for page in site.pages %}
+|{{ page.title }}#{{ page.url }}
+{% endfor %}
 {% endcapture %}
 {% assign sortedpages = pages | split: '|' | sort %}
 
-<div class="p-strip is-shallow">
+<div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/b54d869a-vanilla-grad-background-min.png'); background-position: 75% 50%;">
   <div class="row">
-    <h1>{{ site.name }}</h1>
-    <hr />
+    <h1>Vanilla framework - Examples</h1>
   </div>
 </div>
-<div class="p-strip is-shallow">
+<div class="p-strip">
   <div class="row">
     <div class="col-3">
-      <h3>Base</h3>
+      <h3>Base elements</h3>
       <nav>
         <ul class="p-list">
           {% for page in sortedpages %}
           {% assign pageitems = page | split: '#' %}
           {% if pageitems[1] contains '/base/' %}
           <li class="p-list__item">
-            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link--soft">
+            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link">
               {{ pageitems[0] }}
             </a>
           </li>
@@ -36,14 +35,14 @@ title: Home
       </nav>
     </div>
     <div class="col-3">
-      <h3>Patterns</h3>
+      <h3>Components</h3>
       <nav>
         <ul class="p-list">
           {% for page in sortedpages %}
           {% assign pageitems = page | split: '#' %}
           {% if pageitems[1] contains '/patterns/' %}
           <li class="p-list__item">
-            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link--soft">
+            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link">
               {{ pageitems[0] }}
             </a>
           </li>
@@ -60,7 +59,7 @@ title: Home
           {% assign pageitems = page | split: '#' %}
           {% if pageitems[1] contains '/utilities/' %}
           <li class="p-list__item">
-            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link--soft">
+            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link">
               {{ pageitems[0] }}
             </a>
           </li>
@@ -77,7 +76,7 @@ title: Home
           {% assign pageitems = page | split: '#' %}
           {% if pageitems[1] contains '/templates/' %}
           <li class="p-list__item">
-            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link--soft">
+            <a href="{{ pageitems[1] | prepend:site.baseurl }}" class="p-link">
               {{ pageitems[0] }}
             </a>
           </li>
@@ -85,6 +84,9 @@ title: Home
           {% endfor %}
         </ul>
       </nav>
+    </div>
+    <div class="p-top">
+      <a href="#" class="p-top__link">Back to top</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done
- Little zhoosh of our examples page
- Update hero banner, heading titles and type hierarchy
- Link styling

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Look at the new shiny layout

## Details
- Downtime

## Screenshot
<img width="1439" alt="Screenshot 2019-04-17 at 12 19 09" src="https://user-images.githubusercontent.com/17748020/56283962-0fda2580-610b-11e9-9c80-71bbf020b3da.png">
