### PR TITLE
Add stacked variant for form input groups

### DIFF
--- a/docs/en/base/forms.md
+++ b/docs/en/base/forms.md
@@ -99,6 +99,21 @@ By applying the class `.p-form--stacked` and wrapping any form control in `.p-fo
 View examples of form stacked patterns
 </a>
 
+### Stacked with stacked inputs
+
+A variant use of the `.p-form--stacked` is to add `.is-stacked` to the `.p-form__group` elements. This stacks the labels above the form elements, which is required for some more compact designs.
+
+<a href="https://canonical-web-and-design.github.io/vanilla-framework/examples/patterns/forms/form-stacked-stacked-inputs/"
+    class="js-example">
+View examples of form stacked patterns with stacked inputs
+</a>
+
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Note:</span> Do not mix stacked and unstacked form groups within one form.
+  </p>
+</div>
+
 ### Disabled
 
 Adding the `disabled` attribute to an input will prevent user interaction.

--- a/examples/patterns/forms/form-stacked-stacked-inputs.html
+++ b/examples/patterns/forms/form-stacked-stacked-inputs.html
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Forms / Stacked (w/ stacked inputs)
+category: _patterns
+---
+
+<form class="p-form p-form--stacked">
+  <div class="p-form__group is-stacked">
+    <label for="full-name-stacked" class="p-form__label">Full name</label>
+    <div class="p-form__control">
+      <input type="text" id="full-name-stacked" required>
+    </div>
+  </div>
+  <div class="p-form__group is-stacked">
+    <label for="username-stacked" class="p-form__label">Username</label>
+    <div class="p-form__control">
+        <input type="text" id="username-stacked">
+        <p class="p-form-help-text">
+            30 characters or fewer.
+        </p>
+    </div>
+  </div>
+  <div class="p-form__group p-form-validation is-error is-stacked">
+      <label for="username-stacked-error" class="p-form__label">Email address</label>
+      <div class="p-form__control">
+          <input type="text" id="username-stacked-error" class="p-form-validation__input" aria-invalid="true" aria-describedby="username-error-message-stacked">
+          <p class="p-form-validation__message" id="username-error-message-stacked" role="alert">
+            <strong>Error:</strong> This field is required.
+          </p>
+      </div>
+    </div>
+    <div class="p-form__group is-stacked">
+      <label for="address-optional-stacked" class="p-form__label">Address line 1</label>
+      <div class="p-form__control">
+        <input type="text" id="address-optional-stacked">
+      </div>
+    </div>
+  <div class="p-form__group is-stacked">
+    <label for="address-optional-stacked" class="p-form__label">Address line 2</label>
+    <div class="p-form__control">
+      <input type="text" id="address-optional-stacked">
+    </div>
+  </div>
+  <button class="p-button--positive u-float-right">Add details</button>
+</form>

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -48,6 +48,14 @@
       }
     }
   }
+
+  .p-form--stacked .p-form__group.is-stacked {
+    display: block;
+
+    .p-form__label {
+      @extend %default-text;
+    }
+  }
 }
 
 @mixin vf-p-forms-inline {


### PR DESCRIPTION
## Done

Added am `is-stacked` option to form groups.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/forms/form-stacked-stacked-inputs/
- See the stacked labels and inputs

## Details

Fixes #1935 