### PR TITLE
Update the tabs example to include nesting within a row and update docs

### DIFF
--- a/docs/en/patterns/tabs.md
+++ b/docs/en/patterns/tabs.md
@@ -11,7 +11,7 @@ Tabs organise and allow navigation between groups of content that are related an
 
 To select the active tab add the attribute `aria-selected="true"` and that list item will have the correct styling.
 
-To horizontally align the tablist with other content, the whole tabset can be contained within a `.row` element to provide correct gutters.
+To horizontally align the tab list with other content, the whole tab set can be contained within a `.row` element to provide correct gutters.
 
 <a href="https://canonical-web-and-design.github.io/vanilla-framework/examples/patterns/tabs/"
     class="js-example">

--- a/docs/en/patterns/tabs.md
+++ b/docs/en/patterns/tabs.md
@@ -11,6 +11,8 @@ Tabs organise and allow navigation between groups of content that are related an
 
 To select the active tab add the attribute `aria-selected="true"` and that list item will have the correct styling.
 
+To horizontally align the tablist with other content, the whole tabset can be contained within a `.row` element to provide correct gutters.
+
 <a href="https://canonical-web-and-design.github.io/vanilla-framework/examples/patterns/tabs/"
     class="js-example">
 View example of the tabs pattern

--- a/examples/patterns/tabs.html
+++ b/examples/patterns/tabs.html
@@ -3,65 +3,68 @@ layout: default
 title: Tabs
 category: _patterns
 ---
-
-<nav class="p-tabs">
-  <ul class="p-tabs__list" role="tablist">
-    <li class="p-tabs__item" role="presentation">
-      <a href="#section1"
-        class="p-tabs__link"
-        tabindex="0"
-        role="tab"
-        aria-controls="section1"
-        aria-selected="true">Machine summary</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a href="#section2"
-        class="p-tabs__link"
-        tabindex="-1"
-        role="tab"
-        aria-controls="section2">Interfaces</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a href="#section3"
-        class="p-tabs__link"
-        tabindex="-1"
-        role="tab"
-        aria-controls="section3">Storage</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a href="#section4"
-        class="p-tabs__link"
-        tabindex="-1"
-        role="tab"
-        aria-controls="section4">Commissioning</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a href="#section5"
-        class="p-tabs__link"
-        tabindex="-1"
-        role="tab"
-        aria-controls="section5">Hardware tests</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a href="#section6"
-        class="p-tabs__link"
-        tabindex="-1"
-        role="tab"
-        aria-controls="section6">Logs</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a href="#section7"
-        class="p-tabs__link"
-        tabindex="-1"
-        role="tab"
-        aria-controls="section7">Event</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a href="#section8"
-        class="p-tabs__link"
-        tabindex="-1"
-        role="tab"
-        aria-controls="section8">Configuration</a>
-    </li>
-  </ul>
-</nav>
+<div class="p-strip">
+  <div class="row">
+    <nav class="p-tabs">
+      <ul class="p-tabs__list" role="tablist">
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section1"
+            class="p-tabs__link"
+            tabindex="0"
+            role="tab"
+            aria-controls="section1"
+            aria-selected="true">Machine summary</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section2"
+            class="p-tabs__link"
+            tabindex="-1"
+            role="tab"
+            aria-controls="section2">Interfaces</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section3"
+            class="p-tabs__link"
+            tabindex="-1"
+            role="tab"
+            aria-controls="section3">Storage</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section4"
+            class="p-tabs__link"
+            tabindex="-1"
+            role="tab"
+            aria-controls="section4">Commissioning</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section5"
+            class="p-tabs__link"
+            tabindex="-1"
+            role="tab"
+            aria-controls="section5">Hardware tests</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section6"
+            class="p-tabs__link"
+            tabindex="-1"
+            role="tab"
+            aria-controls="section6">Logs</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section7"
+            class="p-tabs__link"
+            tabindex="-1"
+            role="tab"
+            aria-controls="section7">Event</a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
+          <a href="#section8"
+            class="p-tabs__link"
+            tabindex="-1"
+            role="tab"
+            aria-controls="section8">Configuration</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>


### PR DESCRIPTION
## Done

Updated the tabs example to put it in a row to show how to have it sit properly with other content.

I also updated the docs to mention it.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/examples/patterns/tabs/
- See that it now has gutters

## Details

Fixes #1894 