### PR TITLE
Replace chevron icon with guillemette

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -304,17 +304,17 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
   // Select styles
   select {
+    @include vf-icon-chevron;
     -moz-appearance: none; // sass-lint:disable-line no-vendor-prefixes
     -webkit-appearance: none; // sass-lint:disable-line no-vendor-prefixes
     appearance: none;
-    background: $color-x-light
-      url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB4bWxuczpza2V0Y2g9Imh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaC9ucyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBoZWlnaHQ9IjRweCIgd2lkdGg9IjEwcHgiIHZlcnNpb249IjEuMSIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZpZXdCb3g9IjAgMCAxMCA0Ij4gPHRpdGxlPmFjY29yZGlvbi1vcGVuPC90aXRsZT4gPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+IDxnIGlkPSJmaWx0ZXItcGFuZWwiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSIgZmlsbD0ibm9uZSI+ICA8ZyBpZD0iYWNjb3JkaW9uLW9wZW4iIGZpbGw9IiM4ODgiIHNrZXRjaDp0eXBlPSJNU0FydGJvYXJkR3JvdXAiPiAgIDxwYXRoIGlkPSJjaGV2cm9uIiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIiBkPSJtNi4zNjEgMC44NjIzYzAuNTE4IDAuMzY1IDEuMDUyIDAuNzc4MSAxLjYwMSAxLjIzOCAwLjU0OSAwLjQ1ODUgMS4wODkgMC45NTE4IDEuNjIxIDEuNDc3MiAwLjE0MiAwLjE0MDQgMC4yODEgMC4yODIxIDAuNDE1IDAuNDIyNWgtMS41NDFjLTAuMzA0LTAuMjg4OC0wLjYyLTAuNTcwOS0wLjk0Ny0wLjg0NjMtMC4xMzc5LTAuMTE2MS0wLjI3NjgtMC4yMjk3LTAuNDE2OC0wLjM0MDgtMC4xNjM2LTAuMTI5Ny0wLjMyODYtMC4yNTU4LTAuNDk1NC0wLjM3ODMtMC4wODUyLTAuMDYyNS0wLjE3MDgtMC4xMjQxLTAuMjU2OC0wLjE4NDYtMC4zOTctMC4yODIxLTAuOTM1LTAuNjI1Ny0xLjMxNS0wLjg0NzZoLTAuMDU0Yy0wLjM4IDAuMjIxOS0wLjkxOCAwLjU2NTUtMS4zMTUgMC44NDc2LTAuMzk4IDAuMjgwNy0wLjc4OCAwLjU4MjktMS4xNjkgMC45MDM3LTAuMzI3IDAuMjc1NC0wLjY0MyAwLjU1NzUtMC45NDcgMC44NDYzaC0xLjU0MWMwLjEzNS0wLjE0MDQgMC4yNzMtMC4yODIxIDAuNDE1LTAuNDIyNSAwLjUzMi0wLjUyNTQgMS4wNzItMS4wMTg3IDEuNjIxLTEuNDc3MiAwLjU1LTAuNDU5OSAxLjA4My0wLjg3MyAxLjYwMS0xLjIzOCAwLjUxOS0wLjM2NDk3IDAuOTczLTAuNjUyNDEgMS4zNjItMC44NjIzIDAuMzkgMC4yMDk4OSAwLjg0NCAwLjQ5NzMzIDEuMzYyIDAuODYyM3oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQuOTk5IDIpIHJvdGF0ZSgxODApIHRyYW5zbGF0ZSgtNC45OTkgLTIpIi8+ICA8L2c+IDwvZz48L3N2Zz4=')
-      no-repeat;
+    background-color: $color-x-light;
+    background-repeat: no-repeat;
     background-position: right $sph-inner--small center;
-    background-size: map-get($icon-sizes, accordion);
+    background-size: map-get($icon-sizes, default);
     box-shadow: none;
     color: $color-dark;
-    min-height: 24px;
+    min-height: map-get($line-heights, default-text);
     padding-right: $sph-inner--large;
     text-indent: 0.01px;
     text-overflow: '';

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -67,6 +67,10 @@ $social-icon-size: map-get($icon-sizes, social);
   display: inline-block;
 }
 
+@mixin vf-icon-chevron($color: $color-mid-dark) {
+  background-image: url("data:image/svg+xml, %3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg'%3E%3Cg id='chevron_down' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cpolygon id='chevron' fill='#{vf-url-friendly-color($color)}' transform='translate(8.000000, 8.193853) rotate(90.000000) translate(-8.000000, -8.193853) ' points='4.80614657 14.3333333 8.64539007 8.17730496 4.80614657 2.05437352 6.16312057 1.19385343 11.1938534 8.17730496 6.16312057 15.1938534'%3E%3C/polygon%3E%3C/g%3E%3C/svg%3E");
+}
+
 @mixin vf-icon-anchor($color) {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath d='M9.002 13.974a11.19 11.19 0 0 0 2.801-.574 12.166 12.166 0 0 0 3.273-1.702l.926 1.405a12.636 12.636 0 0 1-3.653 2.116c-1.356.518-2.805.777-4.347.777-1.543 0-2.998-.26-4.364-.777a12.695 12.695 0 0 1-3.636-2.116l.925-1.405c.98.727 2.066 1.295 3.256 1.702.893.306 1.833.498 2.819.574V5.996h-3v-1h3V3.733a1.999 1.999 0 1 1 2-.004v1.267h2.997v1H9.002v7.978z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
 }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -5,13 +5,15 @@
     position: relative;
 
     &::after {
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='4' width='10'%3E%3Cpath d='M3.637 3.138A26.335 26.335 0 0 1 0 0h1.541a21.242 21.242 0 0 0 1.364 1.187 16.899 16.899 0 0 0 .752.563c.397.282.935.626 1.315.848h.054c.38-.222.918-.566 1.315-.848.398-.28.788-.583 1.169-.904.327-.275.643-.557.947-.846h1.541a26.335 26.335 0 0 1-3.637 3.138c-.519.365-.973.652-1.362.862-.39-.21-.844-.497-1.362-.862z' fill='%23666' fill-rule='evenodd'/%3E%3C/svg%3E");
+      @include vf-icon-chevron;
+
       background-position: center;
       background-repeat: no-repeat;
       background-size: contain;
       content: '';
       display: block;
       height: $spv-inner--large;
+      pointer-events: none;
       position: absolute;
       right: $sph-inner;
       text-indent: calc(100% + 10rem);


### PR DESCRIPTION
## Done

- Replace old icon with guillemette.
- Change select icon color from legacy platform grey (#888) to currently used #666.
- Fix size to match chevrons in subnav.

Add pointer-events: none on icon so the pointer doesn't change to regular mouse pointer when you hover on it.

## QA

- Pull code
- Run `./run serve --watch`
- QA subnav and select

## Details

Fixes: https://github.com/canonical-web-and-design/vanilla-framework/issues/2189
