### PR TITLE
fix strip selector so class order doesn't matter

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -92,19 +92,19 @@
 }
 
 @mixin vf-p-strip-bordered {
-  [class^='p-strip'].is-bordered {
+  [class*='p-strip'].is-bordered {
     @extend %vf-pseudo-border--bottom;
   }
 }
 
 @mixin vf-p-strip-shallow {
-  [class^='p-strip'].is-shallow {
+  [class*='p-strip'].is-shallow {
     @extend %section-padding--shallow;
   }
 }
 
 @mixin vf-p-strip-deep {
-  [class^='p-strip'].is-deep {
+  [class*='p-strip'].is-deep {
     @extend %section-padding--deep;
   }
 }


### PR DESCRIPTION
## Done

Fix selector so "someclass  p-strip is-shallow" works. Currently, p-strip needs to be the first class for this rule to apply:
[class^='p-strip'].is-shallow 
changed to [class*='p-strip'].is-shallow 

## QA

- Pull code
- Run `./run serve --watch`
- Verify that preceding p-strip in the markup by another rule doesn't cancel the effect of e.g. "is-shallow"

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
