### PR TITLE
Fixed width class

### DIFF
--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -46,6 +46,8 @@
   }
 
   %row {
+    @extend %fixed-width-container;
+
     display: grid;
     grid-template-rows: auto;
     margin-left: auto;
@@ -64,8 +66,6 @@
     @media (max-width: $threshold-4-6-col) {
       grid-gap: 0 map-get($grid-gutter-widths, small);
       grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
-      padding-left: map-get($grid-margin-widths, small);
-      padding-right: map-get($grid-margin-widths, small);
 
       * {
         grid-column-end: span $grid-columns-small;
@@ -75,8 +75,6 @@
     @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
       grid-gap: 0 map-get($grid-gutter-widths, medium);
       grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
-      padding-left: map-get($grid-margin-widths, medium);
-      padding-right: map-get($grid-margin-widths, medium);
 
       * {
         grid-column-end: span $grid-columns-medium;
@@ -86,8 +84,6 @@
     @media (min-width: $threshold-6-12-col) {
       grid-gap: 0 map-get($grid-gutter-widths, large);
       grid-template-columns: repeat($grid-columns, minmax(0, 1fr));
-      padding-left: map-get($grid-margin-widths, large);
-      padding-right: map-get($grid-margin-widths, large);
 
       * {
         grid-column-end: span $grid-columns;

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -214,9 +214,7 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
     // $bullet-offset:
     @extend %numbered-step-container;
 
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-left: 0;
-    }
+    margin-left: auto;
 
     .p-stepped-list__content {
       @media (min-width: $threshold-6-12-col) {
@@ -233,9 +231,6 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
 
     .p-stepped-list__item {
       @extend %row;
-      @include row-reset-padding;
-      margin-left: auto;
-      width: 100%;
 
       .row & {
         @include row-reset;

--- a/scss/_utilities_layout.scss
+++ b/scss/_utilities_layout.scss
@@ -1,0 +1,26 @@
+@mixin vf-u-layout {
+  %fixed-width-container {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: $grid-max-width;
+    // set static gutter width per breakpoint
+    @media (max-width: $threshold-4-6-col) {
+      padding-left: map-get($grid-margin-widths, small);
+      padding-right: map-get($grid-margin-widths, small);
+    }
+
+    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+      padding-left: map-get($grid-margin-widths, medium);
+      padding-right: map-get($grid-margin-widths, medium);
+    }
+
+    @media (min-width: $threshold-6-12-col) {
+      padding-left: map-get($grid-margin-widths, large);
+      padding-right: map-get($grid-margin-widths, large);
+    }
+  }
+
+  .u-fixed-width {
+    @extend %fixed-width-container;
+  }
+}

--- a/scss/_utilities_layout.scss
+++ b/scss/_utilities_layout.scss
@@ -3,6 +3,7 @@
     margin-left: auto;
     margin-right: auto;
     max-width: $grid-max-width;
+    width: 100%;
     // set static gutter width per breakpoint
     @media (max-width: $threshold-4-6-col) {
       padding-left: map-get($grid-margin-widths, small);

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -53,6 +53,7 @@
 @import 'utilities_floats';
 @import 'utilities_hide';
 @import 'utilities_image-position';
+@import 'utilities_layout';
 @import 'utilities_margin-collapse';
 @import 'utilities_off-screen';
 @import 'utilities_padding-collapse';
@@ -116,6 +117,7 @@
   @include vf-u-floats;
   @include vf-u-hide;
   @include vf-u-image-position;
+  @include vf-u-layout;
   @include vf-u-margin-collapse;
   @include vf-u-off-screen;
   @include vf-u-padding-collapse;


### PR DESCRIPTION
## Done

Often content doesn't need to align to grid columns, but needs to be restrained by the fixed-width used by the grid. To provide that functionality separately, I've extracted fixed-width behaviour from .row into a placeholder, then .row and a new .u-fixed-width class extend that. 

## QA

- Pull code
- Run `./run serve --watch`
- Change row to u-fixed-width in any example. Observe how content within stays aligned to the fixed-width of the site.
## Details
