### PR TITLE
remove duplicate code. convert margin to padding so it pushes border down

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -130,7 +130,7 @@
 
   .p-card__header {
     border-bottom: 1px solid $color-mid-light;
-    margin-bottom: $spv-inner--large;
+    padding-bottom: $spv-inner--large;
 
     > .p-link--soft {
       display: inline-block;
@@ -140,15 +140,5 @@
 
   .p-card__thumbnail {
     max-height: map-get($icon-sizes, thumb--card);
-  }
-
-  .p-card__header {
-    border-bottom: 1px solid $color-mid-light;
-    margin-bottom: $spv-inner--large;
-
-    > .p-link--soft {
-      display: inline-block;
-      overflow: auto;
-    }
   }
 }


### PR DESCRIPTION
I noticed a few places on ubuntu.com (when run on 2.0 alpha) where this happens:

![image](https://user-images.githubusercontent.com/2741678/57924115-20adc080-789c-11e9-98d9-fa649da04a7c.png)


## Done
This pr fixes the border to appear after the white space.

## QA

- Pull code
- Run `./run serve --watch`
- Open card example, add header class, observe correct position of border