### PR TITLE
fix tick position

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -100,7 +100,7 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
 @mixin vf-p-list-item-state {
   .is-ticked {
     background-image: svg-tick($color-accent);
-    background-position-y: 56%; // slightly off-center to align better with text.
+    background-position-y: $spv-list-item--inner + map-get($nudges, nudge--p);
     background-repeat: no-repeat;
     background-size: $tick-height;
     padding-left: 2rem;


### PR DESCRIPTION
## Done
Fix icon position when text wraps.
## QA

- Pull code
- Run `./run serve --watch`
- Open http://192.168.64.7:8101/examples/patterns/lists/lists-dividers-ticked/
- Resize to force wrap; observe icon is properly aligned with text.

## Details

Fixes #2313

## Screenshots

[if relevant, include a screenshot]
