### PR TITLE
Fix base buttons class - .is--disabled to .is-disabled

### DIFF
--- a/docs/examples/patterns/buttons/base.html
+++ b/docs/examples/patterns/buttons/base.html
@@ -4,4 +4,4 @@ title: Buttons / Base
 category: _patterns
 ---
 <p><button class="p-button--base">Base</button><button class="p-button--base" disabled>Base disabled</button></p>
-<p><a href="#" class="p-button--base">Base link</a><a href="#" class="p-button--base is--disabled" aria-disabled="true">Base link button</a></p>
+<p><a href="#" class="p-button--base">Base link</a><a href="#" class="p-button--base is-disabled" aria-disabled="true">Base link button</a></p>

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -30,7 +30,7 @@
     }
 
     &:disabled,
-    &.is--disabled {
+    &.is-disabled {
       cursor: not-allowed;
       opacity: 0.5;
     }
@@ -106,7 +106,7 @@
   }
 
   &:disabled,
-  &.is--disabled {
+  &.is-disabled {
     &:active,
     &:hover {
       background-color: $button-disabled-background-color;


### PR DESCRIPTION
## Done

Rename incorrect ".is--disabled" class to ".is-disabled" to match class name rules elsewhere in the project

## QA

- Pull code
- Run `./run serve --watch`
- http://0.0.0.0:8101/examples/patterns/buttons/base/
- See that the disabled buttons both look similar

Fixes #2236 