### PR TITLE
Add new variable - with default values - for navigation border and text colours

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -8,6 +8,10 @@ $nav-border-bottom-thickness: 1px;
 }
 
 @mixin vf-navigation-default {
+  $color-navigation-background: $color-x-light !default;
+  $color-navigation-border: if(lightness($color-navigation-background) > 50, $color-mid-light, transparent) !default;
+  $color-navigation-text: if(lightness($color-navigation-background) > 70, $color-dark, $color-light) !default;
+
   .p-navigation {
     @include vf-navigation-pattern($background-color: $color-navigation-background, $border-color: $color-navigation-border, $text-color: $color-navigation-text);
   }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -9,11 +9,7 @@ $nav-border-bottom-thickness: 1px;
 
 @mixin vf-navigation-default {
   .p-navigation {
-    @include vf-navigation-pattern(
-      $background-color: $color-navigation-background,
-      $border-color: if(lightness($color-navigation-background) > 50, $color-mid-light, transparent),
-      $text-color: if(lightness($color-navigation-background) > 70, $color-dark, $color-light)
-    );
+    @include vf-navigation-pattern($background-color: $color-navigation-background, $border-color: $color-navigation-border, $text-color: $color-navigation-text);
   }
 }
 

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -1,6 +1,8 @@
 @import 'settings';
 
 @mixin vf-p-subnav {
+  $color-navigation-background: $color-x-light !default;
+
   .p-subnav {
     position: relative;
 

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -1,6 +1,9 @@
 @import 'settings';
 
 @mixin vf-p-tabs {
+  // for _patterns_tabs.scss
+  $color-tabs-active-bar: $color-mid-dark !default;
+
   .p-tabs {
     border-radius: 0;
     overflow: hidden;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -9,6 +9,7 @@ $color-light: #f7f7f7 !default;
 $color-mid-x-light: #e5e5e5 !default;
 $color-mid-light: #cdcdcd !default;
 $color-mid: #999 !default;
+$color-navigation-selected: #757575 !default;
 $color-mid-dark: #666 !default;
 $color-dark: #111 !default;
 $color-x-dark: #000 !default;
@@ -25,19 +26,6 @@ $color-accent-background: $color-accent !default;
 
 // for visual outline on :active / :focus elements
 $color-focus: #19b6ee !default;
-
-// for _patterns_grid-list.scss
-$grid-border-style: 1px dotted $color-mid-light !default;
-
-// for _patterns_navigation.scss
-$color-navigation-background: $color-x-light !default;
-$color-navigation-border: if(lightness($color-navigation-background) > 50, $color-mid-light, transparent) !default;
-$color-navigation-text: if(lightness($color-navigation-background) > 70, $color-dark, $color-light) !default;
-
-$color-navigation-selected: #757575 !default;
-
-// for _patterns_tabs.scss
-$color-tabs-active-bar: $color-mid-dark !default;
 
 $states: (
   error: $color-negative,

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -31,6 +31,9 @@ $grid-border-style: 1px dotted $color-mid-light !default;
 
 // for _patterns_navigation.scss
 $color-navigation-background: $color-x-light !default;
+$color-navigation-border: if(lightness($color-navigation-background) > 50, $color-mid-light, transparent) !default;
+$color-navigation-text: if(lightness($color-navigation-background) > 70, $color-dark, $color-light) !default;
+
 $color-navigation-selected: #757575 !default;
 
 // for _patterns_tabs.scss


### PR DESCRIPTION
## Done

There should be no visual changes to the navigation, the code is just restructured

## QA

- Pull code
- Run `./run serve --watch`
- http://0.0.0.0:8101/examples/patterns/navigation/default/
- See that the navigation looks good
- Change $color-navigation-background in `_settings_colors.scss` to #000
- http://0.0.0.0:8101/examples/patterns/navigation/default/
- See that the colours still work together

## Details

Fixes #2046 