### PR TITLE
Refactor tooltips so that they no longer require class duplication

### DIFF
--- a/docs/examples/patterns/tooltips.html
+++ b/docs/examples/patterns/tooltips.html
@@ -7,33 +7,33 @@ category: _patterns
   Bottom left
   <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Product name to be displayed on the storefront.</span>
 </button>
-<button class="p-tooltip p-tooltip--btm-center" aria-describedby="btm-cntr">
+<button class="p-tooltip--btm-center" aria-describedby="btm-cntr">
   Bottom center
   <span class="p-tooltip__message" role="tooltip" id="btm-cntr">Product name to be displayed on the storefront.</span>
 </button>
-<button class="p-tooltip p-tooltip--btm-right" aria-describedby="btm-rgt">
+<button class="p-tooltip--btm-right" aria-describedby="btm-rgt">
   Bottom right
   <span class="p-tooltip__message" role="tooltip" id="btm-rgt">Product name to be displayed on the storefront.</span>
 </button>
-<button class="p-tooltip p-tooltip--left" aria-describedby="left">
+<button class="p-tooltip--left" aria-describedby="left">
   Left
   <span class="p-tooltip__message" role="tooltip" id="left">Product name to be displayed on the storefront.</span>
 </button>
 <br />
 <br />
-<button class="p-tooltip p-tooltip--right" aria-describedby="rght">
+<button class="p-tooltip--right" aria-describedby="rght">
   Right
   <span class="p-tooltip__message" role="tooltip" id="rght">Product name to be displayed on the storefront.</span>
 </button>
-<button class="p-tooltip p-tooltip--top-left" aria-describedby="tp-lft">
+<button class="p-tooltip--top-left" aria-describedby="tp-lft">
   Top left
   <span class="p-tooltip__message" role="tooltip" id="tp-lft">Product name to be displayed on the storefront.</span>
 </button>
-<button class="p-tooltip p-tooltip--top-center" aria-describedby="tp-cntr">
+<button class="p-tooltip--top-center" aria-describedby="tp-cntr">
   Top center
   <span class="p-tooltip__message" role="tooltip" id="tp-cntr">Product name to be displayed on the storefront.</span>
 </button>
-<button class="p-tooltip p-tooltip--top-right" aria-describedby="tp-rght">
+<button class="p-tooltip--top-right" aria-describedby="tp-rght">
   Top right
   <span class="p-tooltip__message" role="tooltip" id="tp-rght">Product name to be displayed on the storefront.</span>
 </button>

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -2,7 +2,7 @@
 $triangle-height: $sp-unit;
 
 @mixin vf-p-tooltips {
-  .p-tooltip {
+  %tooltip {
     position: relative;
 
     &:focus,
@@ -12,6 +12,10 @@ $triangle-height: $sp-unit;
         text-decoration: initial;
       }
     }
+  }
+
+  .p-tooltip {
+    @extend %tooltip;
   }
 
   .p-tooltip__message {
@@ -53,6 +57,8 @@ $triangle-height: $sp-unit;
 
   // Bottom center tooltip
   .p-tooltip--btm-center {
+    @extend %tooltip;
+
     .p-tooltip__message {
       // sass-lint:disable no-vendor-prefixes property-sort-order
       bottom: inherit;
@@ -74,6 +80,8 @@ $triangle-height: $sp-unit;
 
   // Bottom right tooltip
   .p-tooltip--btm-right {
+    @extend %tooltip;
+
     .p-tooltip__message {
       // sass-lint:disable no-vendor-prefixes property-sort-order
       bottom: inherit;
@@ -93,6 +101,8 @@ $triangle-height: $sp-unit;
 
   // Top left tooltip
   .p-tooltip--top-left {
+    @extend %tooltip;
+
     .p-tooltip__message {
       // sass-lint:disable no-vendor-prefixes property-sort-order
       bottom: 100%;
@@ -117,6 +127,8 @@ $triangle-height: $sp-unit;
 
   // Top center tooltip
   .p-tooltip--top-center {
+    @extend %tooltip;
+
     .p-tooltip__message {
       // sass-lint:disable no-vendor-prefixes property-sort-order
       bottom: 100%;
@@ -143,6 +155,8 @@ $triangle-height: $sp-unit;
 
   // Top right tooltip
   .p-tooltip--top-right {
+    @extend %tooltip;
+
     .p-tooltip__message {
       // sass-lint:disable no-vendor-prefixes property-sort-order
       bottom: 100%;
@@ -169,6 +183,8 @@ $triangle-height: $sp-unit;
 
   // Right tooltip
   .p-tooltip--right {
+    @extend %tooltip;
+
     .p-tooltip__message {
       bottom: inherit;
       left: 100%;
@@ -198,6 +214,8 @@ $triangle-height: $sp-unit;
 
   // Left tooltip
   .p-tooltip--left {
+    @extend %tooltip;
+
     .p-tooltip__message {
       // sass-lint:disable no-vendor-prefixes property-sort-order
       bottom: inherit;


### PR DESCRIPTION
## Done

Fixed tooltips so that they only need one class.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/examples/patterns/tooltips/
- See that they look the same

## Details

Fixes #2324 