### PR TITLE
Includes the referenced margin collapse utility into typography

### DIFF
--- a/scss/_base_placeholders-margin-collapse.scss
+++ b/scss/_base_placeholders-margin-collapse.scss
@@ -1,0 +1,69 @@
+@import 'settings';
+
+@mixin vf-b-placeholders-margin-collapse {
+  %u-no-margin--bottom {
+    &:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(p):not(small):not([class*='p-heading']) {
+      margin-bottom: 0 !important;
+    }
+  }
+
+  %u-no-margin--bottom--h1 {
+    @media (max-width: $breakpoint-heading-threshold) {
+      margin-bottom: -#{map-get($nudges, nudge--h1-mobile)} !important;
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      margin-bottom: -#{map-get($nudges, nudge--h1)} !important;
+    }
+
+    @if ($increase-font-size-on-larger-screens) {
+      @media (min-width: $breakpoint-x-large) {
+        margin-bottom: -#{map-get($nudges, nudge--h1-large)} !important;
+      }
+    }
+  }
+
+  %u-no-margin--bottom--h2 {
+    @media (max-width: $breakpoint-heading-threshold) {
+      margin-bottom: -#{map-get($nudges, nudge--h2-mobile)} !important;
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      margin-bottom: -#{map-get($nudges, nudge--h2)} !important;
+    }
+  }
+
+  %u-no-margin--bottom--h3 {
+    @media (max-width: $breakpoint-heading-threshold) {
+      margin-bottom: -#{map-get($nudges, nudge--h3-mobile)} !important;
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      margin-bottom: -#{map-get($nudges, nudge--h3)} !important;
+    }
+  }
+
+  %u-no-margin--bottom--h4 {
+    @media (max-width: $breakpoint-heading-threshold) {
+      margin-bottom: -#{map-get($nudges, nudge--h4-mobile)} !important;
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      margin-bottom: -#{map-get($nudges, nudge--h4)} !important;
+    }
+
+    @if ($increase-font-size-on-larger-screens) {
+      @media (min-width: $breakpoint-x-large) {
+        margin-bottom: -#{map-get($nudges, nudge--h4-large)} !important;
+      }
+    }
+  }
+
+  %u-no-margin--bottom--default-text {
+    margin-bottom: $sp-unit - map-get($nudges, nudge--p) !important;
+  }
+
+  %u-no-margin--bottom--small {
+    margin-bottom: -#{map-get($nudges, nudge--small)} !important;
+  }
+}

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -1,4 +1,7 @@
+@import 'utilities_margin-collapse';
+
 @mixin vf-b-typography-definitions {
+  @include vf-u-margin-collapse;
   //@section Heading styling in placeholders
 
   %vf-heading-1 {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -1,8 +1,8 @@
-@import 'utilities_margin-collapse';
+@import 'base_placeholders-margin-collapse';
 
 @mixin vf-b-typography-definitions {
-  @include vf-u-margin-collapse;
   //@section Heading styling in placeholders
+  @include vf-b-placeholders-margin-collapse;
 
   %vf-heading-1 {
     @include heading-max-width--short;

--- a/scss/_utilities_margin-collapse.scss
+++ b/scss/_utilities_margin-collapse.scss
@@ -1,73 +1,7 @@
 @import 'settings';
-
+@import 'base_placeholders-margin-collapse';
 // Collapse margins
 @mixin vf-u-margin-collapse {
-  %u-no-margin--bottom {
-    &:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(p):not(small):not([class*='p-heading']) {
-      margin-bottom: 0 !important;
-    }
-  }
-
-  %u-no-margin--bottom--h1 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h1-mobile)} !important;
-    }
-
-    @media (min-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h1)} !important;
-    }
-
-    @if ($increase-font-size-on-larger-screens) {
-      @media (min-width: $breakpoint-x-large) {
-        margin-bottom: -#{map-get($nudges, nudge--h1-large)} !important;
-      }
-    }
-  }
-
-  %u-no-margin--bottom--h2 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h2-mobile)} !important;
-    }
-
-    @media (min-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h2)} !important;
-    }
-  }
-
-  %u-no-margin--bottom--h3 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h3-mobile)} !important;
-    }
-
-    @media (min-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h3)} !important;
-    }
-  }
-
-  %u-no-margin--bottom--h4 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h4-mobile)} !important;
-    }
-
-    @media (min-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h4)} !important;
-    }
-
-    @if ($increase-font-size-on-larger-screens) {
-      @media (min-width: $breakpoint-x-large) {
-        margin-bottom: -#{map-get($nudges, nudge--h4-large)} !important;
-      }
-    }
-  }
-
-  %u-no-margin--bottom--default-text {
-    margin-bottom: $sp-unit - map-get($nudges, nudge--p) !important;
-  }
-
-  %u-no-margin--bottom--small {
-    margin-bottom: -#{map-get($nudges, nudge--small)} !important;
-  }
-
   .u-no-margin {
     margin: 0 !important;
 


### PR DESCRIPTION

## Done

- Includes the referenced margin collapse utility into the typography base definitions

## QA

- Create a new folder `mkdir test`
- init a new npm repo `cd test && npm init` and just press enter on all questions
- install node-sass `npm i node-sass`
- create a file styles.scss `mkdir syles.scss` and include the following content:
```
@import "node_modules/vanilla-framework/scss/base_typography";
@include vf-b-typography;
```
- run node-sass on the file and make sure it transpiles `npx node-sass styles.scss`

## Details

The base typography definitions are using a mixin that is defined in the margin collapse utility.
In order to make the typography includable in isolation it needs to include all referenced functionality.

## Screenshot

**This is the error without this fix**
![image](https://user-images.githubusercontent.com/2843450/58317030-e351b180-7e0c-11e9-8ebd-c8ed85243f56.png)

