### PR TITLE
Block cols

### DIFF
--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -46,7 +46,7 @@
   }
 
   %display-block {
-    // make columns explicitly display:block; the use of a placeholder is to ensure the ruel appears only once in the compiled css
+    // make columns explicitly display:block; the use of a placeholder is to ensure the rule appears only once in the compiled css
     display: block;
   }
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -104,7 +104,6 @@
   @media (max-width: $threshold-4-6-col) {
     @for $i from 1 through $grid-columns-small {
       .#{$grid-small-col-prefix}#{$i} {
-        @extend %display-block;
         grid-column-end: span #{$i};
 
         //nesting
@@ -121,7 +120,6 @@
   @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
     @for $i from 1 through $grid-columns-medium {
       .#{$grid-col-medium-prefix}#{$i} {
-        @extend %display-block;
         grid-column-end: span #{$i};
 
         //nesting
@@ -139,7 +137,6 @@
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
       .#{$grid-desktop-col-prefix}#{$i} {
-        @extend %display-block;
         grid-column-end: span #{$i};
 
         //nesting
@@ -157,6 +154,7 @@
     .#{$grid-small-col-prefix}#{$i} {
       @extend %span-full-grid-on-tablet;
       @extend %span-full-grid-on-desktop;
+      @extend %display-block;
     }
   }
 
@@ -164,6 +162,7 @@
     .#{$grid-col-medium-prefix}#{$i} {
       @extend %span-full-grid-on-mobile;
       @extend %span-full-grid-on-desktop;
+      @extend %display-block;
     }
   }
 
@@ -171,6 +170,7 @@
     .#{$grid-desktop-col-prefix}#{$i} {
       @extend %span-full-grid-on-mobile;
       @extend %span-full-grid-on-tablet;
+      @extend %display-block;
     }
   }
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -45,6 +45,11 @@
     margin-bottom: $spv-outer--small;
   }
 
+  %display-block {
+    // make columns explicitly display:block; the use of a placeholder is to ensure the ruel appears only once in the compiled css
+    display: block;
+  }
+
   %row {
     @extend %fixed-width-container;
 
@@ -99,6 +104,7 @@
   @media (max-width: $threshold-4-6-col) {
     @for $i from 1 through $grid-columns-small {
       .#{$grid-small-col-prefix}#{$i} {
+        @extend %display-block;
         grid-column-end: span #{$i};
 
         //nesting
@@ -115,6 +121,7 @@
   @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
     @for $i from 1 through $grid-columns-medium {
       .#{$grid-col-medium-prefix}#{$i} {
+        @extend %display-block;
         grid-column-end: span #{$i};
 
         //nesting
@@ -132,6 +139,7 @@
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
       .#{$grid-desktop-col-prefix}#{$i} {
+        @extend %display-block;
         grid-column-end: span #{$i};
 
         //nesting

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -214,9 +214,7 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
     // $bullet-offset:
     @extend %numbered-step-container;
 
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-left: 0;
-    }
+    margin-left: auto;
 
     .p-stepped-list__content {
       @media (min-width: $threshold-6-12-col) {
@@ -233,9 +231,6 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
 
     .p-stepped-list__item {
       @extend %row;
-      @include row-reset-padding;
-      margin-left: auto;
-      width: 100%;
 
       .row & {
         @include row-reset;


### PR DESCRIPTION
## Done

col-* classes do not explicitly have display set to block; this leads to situations like this:
<img width="642" alt="Screenshot 2019-05-24 at 13 52 37" src="https://user-images.githubusercontent.com/2741678/58329000-700b6800-7e2b-11e9-93cd-a4da0d90c26e.png">

This pr corrects that.

## QA
QA percy screenshots 