### PR TITLE
Stacked form: replace hardcoded layout with grid classes

### DIFF
--- a/docs/examples/patterns/forms/form-stacked.html
+++ b/docs/examples/patterns/forms/form-stacked.html
@@ -5,41 +5,76 @@ category: _patterns
 ---
 
 <form class="p-form p-form--stacked">
-  <div class="p-form__group">
-    <label for="full-name-stacked" class="p-form__label">Full name</label>
-    <div class="p-form__control">
-      <input type="text" id="full-name-stacked" required>
+  <div class="p-form__group row">
+
+    <div class="col-4">
+      <label for="full-name-stacked" class="p-form__label">Full name</label>
     </div>
-  </div>
-  <div class="p-form__group">
-    <label for="username-stacked" class="p-form__label">Username</label>
-    <div class="p-form__control">
-        <input type="text" id="username-stacked">
-        <p class="p-form-help-text">
-            30 characters or fewer.
-        </p>
-    </div>
-  </div>
-  <div class="p-form__group p-form-validation is-error">
-      <label for="username-stacked-error" class="p-form__label">Email address</label>
+
+    <div class="col-8">
       <div class="p-form__control">
-          <input type="text" id="username-stacked-error" class="p-form-validation__input" aria-invalid="true" aria-describedby="username-error-message-stacked">
-          <p class="p-form-validation__message" id="username-error-message-stacked" role="alert">
-            <strong>Error:</strong> This field is required.
-          </p>
+        <input type="text" id="full-name-stacked" required>
       </div>
     </div>
-    <div class="p-form__group">
+  </div>
+  <div class="p-form__group row">
+
+    <div class="col-4">
+      <label for="username-stacked" class="p-form__label">Username</label>
+    </div>
+
+    <div class="col-8">
+      <div class="p-form__control">
+        <input type="text" id="username-stacked">
+        <p class="p-form-help-text">
+          30 characters or fewer.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="p-form__group row p-form-validation is-error">
+
+    <div class="col-4">
+      <label for="username-stacked-error" class="p-form__label">Email address</label>
+    </div>
+
+    <div class="col-8">
+      <div class="p-form__control">
+        <input type="text" id="username-stacked-error" class="p-form-validation__input" aria-invalid="true"
+          aria-describedby="username-error-message-stacked">
+        <p class="p-form-validation__message" id="username-error-message-stacked" role="alert">
+          <strong>Error:</strong> This field is required.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="p-form__group row">
+
+    <div class="col-4">
       <label for="address-optional-stacked" class="p-form__label">Address line 1</label>
+    </div>
+
+    <div class="col-8">
       <div class="p-form__control">
         <input type="text" id="address-optional-stacked">
       </div>
     </div>
-  <div class="p-form__group">
-    <label for="address-optional-stacked" class="p-form__label">Address line 2</label>
-    <div class="p-form__control">
-      <input type="text" id="address-optional-stacked">
+  </div>
+  <div class="p-form__group row">
+
+    <div class="col-4">
+      <label for="address-optional-stacked" class="p-form__label">Address line 2</label>
+    </div>
+
+    <div class="col-8">
+      <div class="p-form__control">
+        <input type="text" id="address-optional-stacked">
+      </div>
     </div>
   </div>
-  <button class="p-button--positive u-float-right">Add details</button>
+  <div class="row">
+  	<div class="col-12">
+      <button class="p-button--positive u-float-right">Add details</button>
+    </div>
+  </div>
 </form>

--- a/docs/examples/patterns/forms/form-stacked.html
+++ b/docs/examples/patterns/forms/form-stacked.html
@@ -73,7 +73,7 @@ category: _patterns
     </div>
   </div>
   <div class="row">
-  	<div class="col-12">
+    <div class="col-12">
       <button class="p-button--positive u-float-right">Add details</button>
     </div>
   </div>

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -39,6 +39,7 @@
 
     .p-form__group {
       @media screen and (min-width: $breakpoint-medium) {
+        display: flex;
         width: auto;
 
         + .p-form__group,

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -5,7 +5,7 @@
   @include vf-p-forms-inline;
 
   form + [class*='p-button'] {
-    margin-top: $sp-large;
+    margin-top: $spv-outer--scaleable;
   }
 }
 
@@ -16,35 +16,10 @@
     .p-form__group {
       @media screen and (min-width: $breakpoint-medium) {
         align-items: baseline;
-        display: flex;
-        flex-flow: wrap;
 
         + .p-form__group {
-          margin-top: $sp-small;
+          margin-top: $spv-inner--small;
         }
-      }
-    }
-
-    .p-form__label {
-      @media screen and (min-width: $breakpoint-medium) {
-        flex: {
-          basis: 25%;
-          grow: 1;
-        }
-        margin: 0;
-        max-width: 25%;
-        padding-right: $sp-small;
-      }
-    }
-
-    .p-form__control {
-      @media screen and (min-width: $breakpoint-medium) {
-        flex: {
-          basis: 75%;
-          grow: 1;
-        }
-        margin: 0;
-        max-width: 75%;
       }
     }
   }
@@ -64,12 +39,11 @@
 
     .p-form__group {
       @media screen and (min-width: $breakpoint-medium) {
-        display: inline-flex;
         width: auto;
 
         + .p-form__group,
         + [class*='p-button'] {
-          margin-left: $sp-large;
+          margin-left: $sph-inner--large;
         }
 
         .p-form__label,
@@ -81,7 +55,7 @@
 
         .p-form__label {
           flex-shrink: 0;
-          padding-right: $sp-medium;
+          padding-right: $sph-inner;
         }
 
         .p-form__control {


### PR DESCRIPTION
## Done

Remove hardcoded css widths; update example to use the grid

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- QA /examples/patterns/forms/form-stacked/

## Details

Fixes #1921

## Screenshots

[if relevant, include a screenshot]
