### PR TITLE
Ellipsise nav links longer than 20em

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -64,10 +64,16 @@ $nav-border-bottom-thickness: 1px;
   }
 
   &__link {
+    $nav-link-max-width: 20em !default;
+    max-width: $nav-link-max-width;
+
     & > a {
       display: block;
       margin-bottom: 0;
+      overflow: hidden;
       position: relative;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 
       @media (max-width: $breakpoint-navigation-threshold) {
         padding: $spv-inner--medium $grid-margin-width;


### PR DESCRIPTION
## Done

Fixes #1740.

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/patterns/navigation/subnav/
- Add enough text to make menu item longer than 20 em
- Observe ellipsis

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
