### PR TITLE
Docs: correct the path for the heading-icon examples. 

### DIFF
--- a/docs/patterns/heading-icon.md
+++ b/docs/patterns/heading-icon.md
@@ -9,7 +9,7 @@ layout: default
 
 A header can be emphasised by adding an icon alongside the text.
 
-<a href="/examples/patterns/heading-icon/"
+<a href="/examples/patterns/heading-icon/heading-icon/"
   class="js-example">
 View example of the pattern heading icons
 </a>
@@ -18,7 +18,7 @@ View example of the pattern heading icons
 
 This variant positions the icon vertically with the text content for an alternate layout.
 
-<a href="/examples/patterns/heading-icon-stacked/"
+<a href="/examples/patterns/heading-icon/heading-icon-stacked/"
   class="js-example">
 View example of the pattern heading icon stacked
 </a>
@@ -27,7 +27,7 @@ View example of the pattern heading icon stacked
 
 The icon for this component is also available at a smaller size of 32 x 32 pixels rather than our default size of 60 x 60 pixels.
 
-<a href="/examples/patterns/heading-icon-small/"
+<a href="/examples/patterns/heading-icon/heading-icon-small/"
   class="js-example">
 View example of the pattern heading icon small
 </a>


### PR DESCRIPTION
## Done

Updated the heading-icon docs to include the examples and updated the examples to include a line break to give additional spacing at the top.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/patterns/heading-icon/
- See that the examples look good

## Details

Fixes #2349 