### PR TITLE
correct name of grid bordered row example

### DIFF
--- a/docs/examples/patterns/grid/bordered.html
+++ b/docs/examples/patterns/grid/bordered.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Grid / Default
+title: Grid / Bordered row
 category: _patterns
 ---
 <div class="grid-demo">


### PR DESCRIPTION
## Done

Before:
![image](https://user-images.githubusercontent.com/2741678/58620701-ab8cb300-82bf-11e9-96e9-c2e054c0358b.png)

After:
![image](https://user-images.githubusercontent.com/2741678/58620725-b5aeb180-82bf-11e9-8ce9-989854be852c.png)

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples
- Verify grid example name is correct
