### PR TITLE
Update README to match docs/index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Then reference it from your own Sass files, with optional settings:
 $color-brand: #ffffff;
 
 // Import the theme
-@import 'vanilla-framework/scss/build';
+@import 'vanilla-framework/scss/vanilla';
+@include vanilla;
 
 // Add theme if applicable
 ```


### PR DESCRIPTION
The instructions should recommend `@include vanilla` over `build` (as they already do in `docs/index.md`)