### PR TITLE
tfoot border, remove leftover strong link references

### DIFF
--- a/docs/examples/base/table.html
+++ b/docs/examples/base/table.html
@@ -13,11 +13,6 @@ category: _base
   </thead>
   <tbody>
     <tr>
-      <th>One-time price</th>
-      <td>$75,000</td>
-      <td>$150,000</td>
-    </tr>
-    <tr>
       <th>Expert delivery of an Ubuntu OpenStack cloud</th>
       <td>Reference architecture</td>
       <td>Custom architecture</td>
@@ -28,4 +23,11 @@ category: _base
       <td>4-days</td>
     </tr>
   </tbody>
+  <tfoot>
+    <tr>
+      <th>One-time price</th>
+      <td>$75,000</td>
+      <td>$150,000</td>
+    </tr>
+  </tfoot>
 </table>

--- a/docs/examples/patterns/list-tree.html
+++ b/docs/examples/patterns/list-tree.html
@@ -12,10 +12,10 @@ category: _patterns
     </ul>
   </li>
   <li class="p-list-tree__item">
-    <a href="#" class="p-link--strong">charm-helpers-sync.yaml</a>
+    <a href="#">charm-helpers-sync.yaml</a>
   </li>
   <li class="p-list-tree__item">
-    <a href="#" class="p-link--strong">config.yaml</a>
+    <a href="#">config.yaml</a>
   </li>
   <li class="p-list-tree__item p-list-tree__item--group">
     <button class="p-list-tree__toggle" id="sub-2-btn" role="tab" aria-controls="sub-2" aria-expanded="false">/files</button>

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -44,15 +44,19 @@
   tbody {
     tr {
       &:not(:first-child) {
-        border-top: 1px solid $color-mid-light;
+        @extend %table-row-border;
       }
     }
   }
 
   tfoot {
     tr {
-      border-top: 1px solid $color-mid-light;
+      @extend %table-row-border;
     }
+  }
+
+  %table-row-border {
+    border-top: 1px solid $color-mid-light;
   }
 
   //accordion, table

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -19,6 +19,7 @@
     padding-left: 0;
     text-align: left;
     text-overflow: ellipsis;
+    vertical-align: top;
 
     @media screen and (min-width: $breakpoint-medium) {
       &:not(:last-child) {
@@ -48,9 +49,15 @@
     }
   }
 
+  tfoot {
+    tr {
+      border-top: 1px solid $color-mid-light;
+    }
+  }
+
   //accordion, table
   %single-border-text-vpadding--scaling {
-    padding-bottom: calc(#{$spv-inner--x-small--scaleable} - 1px);
-    padding-top: $spv-inner--x-small--scaleable;
+    padding-bottom: $spv-inner--x-small--scaleable;
+    padding-top: calc(#{$spv-inner--x-small--scaleable} - 1px);
   }
 }


### PR DESCRIPTION
## Done

• We're missing row border styling on tfoot trs. I've updated the css and markup to fix that.
• add vertical-align:top to td and th
• Drive by: remove leftover p-link--strong references

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/base/table/
- Verify vertical align and tfoot styling work as expected