### PR TITLE
line-height fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 script:
   - yarn run test
   - yarn run build-docs
-  - percy snapshot --widths "375,1280" docs/_site/
+  - percy snapshot --widths "375,1280,1600" docs/_site/
 notifications:
   irc:
     channels:

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -40,6 +40,14 @@
     }
   }
 
+  @if ($increase-font-size-on-larger-screens) {
+    @media screen and (min-width: $breakpoint-x-large) {
+      *:not(html) {
+        line-height: map-get($line-heights, default-text);
+      }
+    }
+  }
+
   // headings
   h1 {
     @extend %vf-heading-1;


### PR DESCRIPTION
## Done
Some components (e.g. navigation) inherit the increased line-height from html, which shouldn't happen.
It is only needed on html because increasing the font-size doesn't affect the computed line-height (it is still calculated against the default rem size, 16px).

This pr explicitly sets the line-height of anything not html to 1.5rem. 