### PR TITLE
Fix map name conflict

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -27,16 +27,16 @@
 
     @if ($increase-font-size-on-larger-screens) {
       @media screen and (max-width: $breakpoint-x-large) {
-        font-size: map-get($font-sizes, base);
+        font-size: map-get($base-font-sizes, base);
       }
 
       @media screen and (min-width: $breakpoint-x-large) {
-        font-size: map-get($font-sizes, big);
+        font-size: map-get($base-font-sizes, big);
         //the rem value is not affected by the change in font-size; it needs to be multiplied by the ratio new font-size/default font-size
         line-height: map-get($line-heights, default-text) * $font-size-ratio--largescreen;
       }
     } @else {
-      font-size: map-get($font-sizes, base);
+      font-size: map-get($base-font-sizes, base);
     }
   }
 

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -7,7 +7,7 @@ $font-allow-cyrillic-greek-latin: false !default;
 $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;
 $font-size-largescreen: #{$font-size-ratio--largescreen}rem;
-$font-sizes: (
+$base-font-sizes: (
   base: 1rem,
   big: $font-size-largescreen
 ) !default;


### PR DESCRIPTION
## Done

we have two sass maps called font-sizes, one dealing with the font-size increas on bigger screens, the other contianing font-sizes for headings. I've renamed the latter to base-font-size as it only changes the computed value of 1rem.

Currently the font-size increase doesn't happen, because apparently the headings one overwrites the previously defined one,  and the rules silently fail.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Verify on screens >1681px the font-size increase happens.
