### PR TITLE
Fix nav styling at smaller viewports so that it's full-width

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -64,8 +64,10 @@ $nav-border-bottom-thickness: 1px;
   }
 
   &__link {
-    $nav-link-max-width: 20em !default;
-    max-width: $nav-link-max-width;
+    @media (min-width: $breakpoint-navigation-threshold) {
+      $nav-link-max-width: 20em !default;
+      max-width: $nav-link-max-width;
+    }
 
     & > a {
       display: block;


### PR DESCRIPTION
## Done

Made the navigation elements full width at smaller screens

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/examples/patterns/navigation/default/
- Resize the browser to the smallest viewport
- Interact with the nav and see that it's full-width
