### PR TITLE
Make grid col names overrideable

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -61,7 +61,7 @@
 %vf-hide-text {
   overflow: hidden;
   // rem value necessary because text indent in % does not work with padding;
-  // 10rem is bigger than any padding value on an element you'd hide text in (buttons, icons)
+  // 10rem is larger than any padding value on an element you'd hide text in (buttons, icons)
   // but still smaller than 9999px so should have better performance
   text-indent: calc(100% + 10rem);
   white-space: nowrap;

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -31,7 +31,7 @@
       }
 
       @media screen and (min-width: $breakpoint-x-large) {
-        font-size: map-get($base-font-sizes, big);
+        font-size: map-get($base-font-sizes, large);
         //the rem value is not affected by the change in font-size; it needs to be multiplied by the ratio new font-size/default font-size
         line-height: map-get($line-heights, default-text) * $font-size-ratio--largescreen;
       }

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -137,7 +137,7 @@
   @media (min-width: $threshold-6-12-col) {
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
-      .#{$grid-big-col-prefix}#{$i} {
+      .#{$grid-large-col-prefix}#{$i} {
         grid-column-end: span #{$i};
 
         //nesting
@@ -168,7 +168,7 @@
   }
 
   @for $i from 1 through $grid-columns {
-    .#{$grid-big-col-prefix}#{$i} {
+    .#{$grid-large-col-prefix}#{$i} {
       @extend %span-full-grid-on-mobile;
       @extend %span-full-grid-on-tablet;
       @extend %display-block;

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -120,7 +120,7 @@
   // tablet grid
   @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
     @for $i from 1 through $grid-columns-medium {
-      .#{$grid-col-medium-prefix}#{$i} {
+      .#{$grid-medium-col-prefix}#{$i} {
         grid-column-end: span #{$i};
 
         //nesting
@@ -137,7 +137,7 @@
   @media (min-width: $threshold-6-12-col) {
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
-      .#{$grid-desktop-col-prefix}#{$i} {
+      .#{$grid-big-col-prefix}#{$i} {
         grid-column-end: span #{$i};
 
         //nesting
@@ -160,7 +160,7 @@
   }
 
   @for $i from 1 through $grid-columns-medium {
-    .#{$grid-col-medium-prefix}#{$i} {
+    .#{$grid-medium-col-prefix}#{$i} {
       @extend %span-full-grid-on-mobile;
       @extend %span-full-grid-on-desktop;
       @extend %display-block;
@@ -168,7 +168,7 @@
   }
 
   @for $i from 1 through $grid-columns {
-    .#{$grid-desktop-col-prefix}#{$i} {
+    .#{$grid-big-col-prefix}#{$i} {
       @extend %span-full-grid-on-mobile;
       @extend %span-full-grid-on-tablet;
       @extend %display-block;

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -9,6 +9,6 @@ $font-size-ratio--largescreen: 1.125 !default;
 $font-size-largescreen: #{$font-size-ratio--largescreen}rem;
 $base-font-sizes: (
   base: 1rem,
-  big: $font-size-largescreen
+  large: $font-size-largescreen
 ) !default;
 $font-weight-bold: 400 !default;

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -8,8 +8,8 @@ $threshold-6-12-col: $breakpoint-medium !default;
 $grid-gutter-column-ratio: 1.61803398875 !default; // golden ratio
 $grid-column-prefix: 'col-' !default;
 $grid-small-col-prefix: '#{$grid-column-prefix}small-' !default;
-$grid-col-medium-prefix: '#{$grid-column-prefix}medium-' !default;
-$grid-desktop-col-prefix: #{$grid-column-prefix} !default;
+$grid-medium-col-prefix: '#{$grid-column-prefix}medium-' !default;
+$grid-big-col-prefix: #{$grid-column-prefix} !default;
 
 $grid-gutter-widths: (
   small: $sp-unit * 3,

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -9,7 +9,7 @@ $grid-gutter-column-ratio: 1.61803398875 !default; // golden ratio
 $grid-column-prefix: 'col-' !default;
 $grid-small-col-prefix: '#{$grid-column-prefix}small-' !default;
 $grid-medium-col-prefix: '#{$grid-column-prefix}medium-' !default;
-$grid-big-col-prefix: #{$grid-column-prefix} !default;
+$grid-large-col-prefix: #{$grid-column-prefix} !default;
 
 $grid-gutter-widths: (
   small: $sp-unit * 3,

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -2,26 +2,26 @@
 $grid-columns: 12 !default;
 $grid-columns-small: 4 !default;
 $grid-columns-medium: 6 !default;
-$threshold-4-6-col: $breakpoint-small;
-$threshold-6-12-col: $breakpoint-medium;
+$threshold-4-6-col: $breakpoint-small !default;
+$threshold-6-12-col: $breakpoint-medium !default;
 
 $grid-gutter-column-ratio: 1.61803398875 !default; // golden ratio
-$grid-column-prefix: 'col-';
-$grid-small-col-prefix: '#{$grid-column-prefix}small-';
-$grid-col-medium-prefix: '#{$grid-column-prefix}medium-';
-$grid-desktop-col-prefix: #{$grid-column-prefix};
+$grid-column-prefix: 'col-' !default;
+$grid-small-col-prefix: '#{$grid-column-prefix}small-' !default;
+$grid-col-medium-prefix: '#{$grid-column-prefix}medium-' !default;
+$grid-desktop-col-prefix: #{$grid-column-prefix} !default;
 
 $grid-gutter-widths: (
   small: $sp-unit * 3,
   medium: $sp-unit * 4,
   large: $sp-unit * 5
-);
+) !default;
 
 $grid-margin-widths: (
   small: $sp-unit * 2,
   medium: $sp-unit * 3,
   large: $sp-unit * 3
-);
+) !default;
 
 $grid-margin-width: $sph-outer--large !default;
 $grid-max-width: 72rem !default;


### PR DESCRIPTION
## Done

Add !default at the end of grid col variables, so they can be overriden. Useful for something like the migration temp scss file, the goal of which is to produce a pr that is mergeable with the least amount of changes.