### PR TITLE
Update docs icon examples

### DIFF
--- a/docs/patterns/icons.md
+++ b/docs/patterns/icons.md
@@ -34,7 +34,7 @@ Our icons have two predefined color styles: light and dark. The light variant is
         <p><i class="p-icon--spinner" style="margin-right: 1rem;"></i>p-icon--spinner</p>
       </div>
       <div class="p-card col-4 u-vertically-center">
-        <p><i class="p-icon--chevron" style="margin-right: 1rem;"></i>p-icon--chevron</p>
+        <p><i class="p-icon--drag" style="margin-right: 1rem;"></i>p-icon--drag</p>
       </div>
     </div>
 
@@ -102,6 +102,9 @@ Our icons have two predefined color styles: light and dark. The light variant is
       <div class="p-card col-4 u-vertically-center">
         <p><i class="p-icon--warning" style="margin-right: 1rem;"></i>p-icon--warning</p>
       </div>
+      <div class="p-card col-4 u-vertically-center">
+        <p><i class="p-icon--anchor" style="margin-right: 1rem;"></i>p-icon--anchor</p>
+      </div>
     </div>
 
   </div>
@@ -133,7 +136,7 @@ Our dark style of icons available when placed within `.p-strip--dark`, icon colo
         <p style="color: #fff;"><i class="p-icon--spinner" style="margin-right: 1rem;"></i>p-icon--spinner</p>
       </div>
       <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--chevron" style="margin-right: 1rem;"></i>p-icon--chevron</p>
+        <p style="color: #fff;"><i class="p-icon--drag" style="margin-right: 1rem;"></i>p-icon--drag</p>
       </div>
     </div>
 
@@ -200,6 +203,9 @@ Our dark style of icons available when placed within `.p-strip--dark`, icon colo
     <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
         <p style="color: #fff;"><i class="p-icon--warning" style="margin-right: 1rem;"></i>p-icon--warning</p>
+      </div>
+      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+        <p style="color: #fff;"><i class="p-icon--anchor" style="margin-right: 1rem;"></i>p-icon--anchor</p>
       </div>
     </div>
 


### PR DESCRIPTION
## Done

- Fixed `p-icon--contextual-menu` as it was missing
- Updated to `p-icon--drag` in the table
- Added `p-icon--anchor` to the list

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Scroll to Icons and check `p-icon--drag` and `p-icon--anchor` now feature in the list, check standard and standard dark table list.

## Details

- Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2385 and https://github.com/canonical-web-and-design/vanilla-framework/issues/2386

## Screenshots

<img width="1439" alt="Screenshot 2019-06-24 at 16 45 21" src="https://user-images.githubusercontent.com/17748020/60033443-7eee7000-96a0-11e9-963b-68ed3030e2ce.png">

