### PR TITLE
Bump framework version to 2.1.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ See [Building with Vanilla](/building-vanilla) and [Customising Vanilla](/custom
   <div class="col-12">
     <h3>Hotlink</h3>
     <p>You can add Vanilla directly to your markup:</p>
-    <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-2.0.1.min.css" /&gt;</code></pre>
+    <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-2.1.0.min.css" /&gt;</code></pre>
   </div>
 </div>
 
@@ -48,7 +48,7 @@ See [Building with Vanilla](/building-vanilla) and [Customising Vanilla](/custom
   <div class="col-12">
     <h3>Download</h3>
     <p>Download the latest version of Vanilla from GitHub.</p>
-    <a href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v2.0.1.zip" class="p-button--positive">Download v2.0.1</a>
+    <a href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v2.1.0.zip" class="p-button--positive">Download v2.1.0</a>
   </div>
 </div>
 
@@ -59,19 +59,19 @@ See [Building with Vanilla](/building-vanilla) and [Customising Vanilla](/custom
     <h3>What's new</h3>
     <ul class="p-list">
       <li class="p-list__item--deep">
+        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.1.0">Release notes: v2.1.0</a>
+      </li>
+      <li class="p-list__item--deep">
         <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.1">Release notes: v2.0.1</a>
       </li>
       <li class="p-list__item--deep">
         <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v1.8.1">Release notes: v1.8.1</a>
       </li>
-      <li class="p-list__item--deep">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v1.7.1">Release notes: v1.7.1</a>
-      </li>
     </ul>
   </div>
 
   <hr class="is-deep u-hide--medium u-hide--large">
-  
+
   <div class="col-6">
     <h3>Getting help</h3>
     <ul class="p-list">

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch": "watch -p 'scss/*.scss' -p 'node_modules/vanilla-framework/scss/*.scss' -c 'yarn run build'",
     "clean": "rm -rf build docs/css docs/_site node_modules/ yarn-error.log .bundle"
   },
-  "version": "2.0.1",
+  "version": "2.1.0",
   "devDependenciesComments": {
     "vanilla-framework": "vanilla-framework is included in devDependencies for use in styling the docs site"
   },

--- a/scss/_settings_system.scss
+++ b/scss/_settings_system.scss
@@ -1,2 +1,2 @@
 // Global system settings
-$app-version: '2.0.1' !default;
+$app-version: '2.1.0' !default;


### PR DESCRIPTION
## Done

Bumped the version of the framework to 2.1.0

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/vanilla-framework/
- See that the links and references have been updated on the homepage