### PR TITLE
fix extra double-primes in expanding table code example

### DIFF
--- a/docs/examples/patterns/tables/table-expanding.html
+++ b/docs/examples/patterns/tables/table-expanding.html
@@ -9,9 +9,9 @@ category: _patterns
         <tr role="row">
             <th id="t-name" aria-sort="none">Name</th>
             <th id="t-users" aria-sort="none">Mac address</th>
-            <th id="t-units" aria-sort="none"">IP</th>
-            <th id="t-units" aria-sort="none"">Rack</th>
-            <th id="t-units" aria-sort="none"">Last seen</th>
+            <th id="t-units" aria-sort="none">IP</th>
+            <th id="t-units" aria-sort="none">Rack</th>
+            <th id="t-units" aria-sort="none">Last seen</th>
             <th id="t-revenue" aria-sort="none" class="u-align--right">Actions</th>
             <th class="u-hide">
                 <!-- empty cell required for validation -->
@@ -22,9 +22,9 @@ category: _patterns
         <tr role="row">
             <td role="rowheader" aria-label="Name">Unknown</td>
             <td role="gridcell" aria-label="Users">2c:44:fd:80:3f:25</td>
-            <td role="gridcell" aria-label="Units"">10.249.0.1</td>
-            <td role="gridcell" aria-label="Units"">karura</td>
-            <td role="gridcell" aria-label="Units"">Thu, 25 Oct. 2018 13:55:21</td>
+            <td role="gridcell" aria-label="Units">10.249.0.1</td>
+            <td role="gridcell" aria-label="Units">karura</td>
+            <td role="gridcell" aria-label="Units">Thu, 25 Oct. 2018 13:55:21</td>
             <td role="gridcell" class="u-align--right">
                 <button class="u-toggle" aria-controls="#expanded-row" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
@@ -43,9 +43,9 @@ category: _patterns
         <tr role="row">
             <td role="rowheader" aria-label="Name">Unknown</td>
             <td role="gridcell" aria-label="Users">52:54:00:3a:fe:e9</td>
-            <td role="gridcell" aria-label="Units"">172.16.99.191</td>
-            <td role="gridcell" aria-label="Units"">karura</td>
-            <td role="gridcell" aria-label="Units"">Wed, 3 Oct. 2018 23:08:06</td>
+            <td role="gridcell" aria-label="Units">172.16.99.191</td>
+            <td role="gridcell" aria-label="Units">karura</td>
+            <td role="gridcell" aria-label="Units">Wed, 3 Oct. 2018 23:08:06</td>
             <td role="gridcell" class="u-align--right">
                 <button class="u-toggle" aria-controls="#expanded-row-2" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
@@ -64,9 +64,9 @@ category: _patterns
         <tr role="row">
             <td role="rowheader" aria-label="Name">Unknown</td>
             <td role="gridcell" aria-label="Users">52:54:00:74:c2:10</td>
-            <td role="gridcell" aria-label="Units"">172.16.99.192</td>
-            <td role="gridcell" aria-label="Units"">karura</td>
-            <td role="gridcell" aria-label="Units"">Wed, 17 Oct. 2018 12:18:18</td>
+            <td role="gridcell" aria-label="Units">172.16.99.192</td>
+            <td role="gridcell" aria-label="Units">karura</td>
+            <td role="gridcell" aria-label="Units">Wed, 17 Oct. 2018 12:18:18</td>
             <td role="gridcell" class="u-align--right">
                 <button class="u-toggle" aria-controls="#expanded-row-3" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>


### PR DESCRIPTION
## Done

Fixed extra double-primes in expanding table code example

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Look at the expanding table docs section
- See that there are no extra symbols 

## Details

If you go to https://docs.vanillaframework.io/base/tables/#expanding and look at the code example for expanding table you should see instances of `"=""` on the `th` and `td` elements

## Screenshots

![Screenshot from 2019-07-23 11-08-39](https://user-images.githubusercontent.com/501889/61703788-4216a700-ad3a-11e9-8539-775b40832f02.png)

