### PR TITLE
remove var that is no longer used

### DIFF
--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -5,7 +5,6 @@ $grid-columns-medium: 6 !default;
 $threshold-4-6-col: $breakpoint-small !default;
 $threshold-6-12-col: $breakpoint-medium !default;
 
-$grid-gutter-column-ratio: 1.61803398875 !default; // golden ratio
 $grid-column-prefix: 'col-' !default;
 $grid-small-col-prefix: '#{$grid-column-prefix}small-' !default;
 $grid-medium-col-prefix: '#{$grid-column-prefix}medium-' !default;


### PR DESCRIPTION
## Done

$grid-gutter-column-ratio is no longer used. Grid gutters are now defined in https://github.com/canonical-web-and-design/vanilla-framework/blob/588530e9ecf7090acbb9a9953e527c905ada8917/scss/_settings_grid.scss#L14, so this var can be removed

## QA

- Pull code
- verify var has been deleted and there are no remaining references to it