### PR TITLE
Ensure nested rows get correct column count when not direct children of cols

### DIFF
--- a/docs/examples/patterns/grid/nested-medium.html
+++ b/docs/examples/patterns/grid/nested-medium.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Grid / Nesteding - medium
+title: Grid / Nesting - medium
 category: _patterns
 ---
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -103,13 +103,13 @@
 
   // mobile grid
   @media (max-width: $threshold-4-6-col) {
-    @for $i from 1 through $grid-columns-small {
+    @for $i from $grid-columns-small through 1 {
       .#{$grid-small-col-prefix}#{$i} {
         grid-column-end: span #{$i};
 
         //nesting
         @if $i > 1 {
-          & > .row {
+          & .row {
             grid-template-columns: repeat($i, minmax(0, 1fr));
           }
         }
@@ -119,13 +119,13 @@
 
   // tablet grid
   @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
-    @for $i from 1 through $grid-columns-medium {
+    @for $i from $grid-columns-medium through 1 {
       .#{$grid-medium-col-prefix}#{$i} {
         grid-column-end: span #{$i};
 
         //nesting
         @if $i > 1 {
-          & > .row {
+          & .row {
             grid-template-columns: repeat($i, minmax(0, 1fr));
           }
         }
@@ -142,7 +142,7 @@
 
         //nesting
         @if $i > 1 {
-          & > .row {
+          & .row {
             grid-template-columns: repeat($i, minmax(0, 1fr));
           }
         }


### PR DESCRIPTION
## Done

- The selector for rows inside col-* classes was too specific (.col-9>.row). So it wouldn't apply when we have .row>.col-9>.p-card>.row as there's a div in between. I've stripped the ">" from the selectors to remedy that.

- Drive by typo fix in nested columns example

- Drive by fix order of classes in generated css, to prevent this from happening: (.col-3 .row should be defined after .col-6 .row, as you can't have a col-6 inside a col-3b but you can have col-3 inside col-6)

![image](https://user-images.githubusercontent.com/2741678/61800879-c09c4300-ae25-11e9-9c60-16de9bf83b8c.png)

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/patterns/grid/nested/
- Ensure nesting works as expected when you resize
- Insert a div in between one of the parent .col-* divs and a child .row; ensure this also works as expected

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
