### PR TITLE
fix table spacing

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -6,9 +6,14 @@
     border: 0;
     border-collapse: collapse;
     line-height: map-get($line-heights, default-text);
+    margin-bottom: $spv-outer--scaleable;
     overflow-x: auto;
-    padding-bottom: $spv-outer--scaleable;
     width: 100%;
+
+    &::after {
+      content: '';
+      margin-bottom: $spv-outer--scaleable;
+    }
 
     @if ($table-layout-fixed) {
       table-layout: fixed;

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -10,11 +10,6 @@
     overflow-x: auto;
     width: 100%;
 
-    &::after {
-      content: '';
-      margin-bottom: $spv-outer--scaleable;
-    }
-
     @if ($table-layout-fixed) {
       table-layout: fixed;
     } @else {

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -3,10 +3,11 @@
 // Tables
 @mixin vf-b-tables {
   table {
-    border: 0;
+    border: 0 0 $spv-outer--scaleable 0;
+    border-bottom-color: transparent;
+    border-bottom-style: solid;
     border-collapse: collapse;
     line-height: map-get($line-heights, default-text);
-    margin-bottom: $spv-outer--scaleable;
     overflow-x: auto;
     width: 100%;
 


### PR DESCRIPTION
## Done
Changes padding-bottom to transparent border-bottom, as padding doesn't work with border-collapse and margin-bottom triggers a strange bug in older ff (the one used by percy).

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/base/table/
- Add h2 under table
- Observe h2 being correctly pushed down by margin-bottom on the table

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2420

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/61881008-d70dd180-aeed-11e9-9e27-05fd84b954e6.png)

