### PR TITLE
Fix misleading text in checkbox docs

### DIFF
--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -39,7 +39,7 @@ Note: The attribute `readonly` disables the input but it still retains a default
 
 ### Checkbox
 
-Use checkboxes to select one or more options, default checkboxes can appear in four states: both selected, unselected and disabled.
+Use checkboxes to select one or more options, default checkboxes can appear in three states: selected, unselected and disabled.
 
 <a href="/examples/base/forms/checkboxes/"
     class="js-example">


### PR DESCRIPTION
## Done

Update text in the checkboxes section of the documentation

## QA
- Go to https://docs.vanillaframework.io/base/forms/#checkbox
- See that the first paragraph states that checkboxes can appear in four states, but only lists three
- Also see that the text refers to the listed states as both
- Pull code
- Go into docs directory (`cd docs`)
- Run `./run serve`
- Open http://0.0.0.0:8104/en/base/forms#checkbox
- See that the first paragraph makes sense
