### PR TITLE
update grid gutter to 2rem, as it is a closer match to vf 1.8

### DIFF
--- a/docs/patterns/grid.md
+++ b/docs/patterns/grid.md
@@ -12,7 +12,7 @@ Vanilla has a responsive grid with the following columns and gutters:
 | -------------------------------------- | ------- | ------------------ | ------------- |
 | 0 - $breakpoint-small                  | 4       | 1.5rem             | 1.0rem        |
 | $breakpoint-small - $breakpoint-medium | 6       | 2.0rem             | 1.5rem        |
-| above $breakpoint-medium               | 12      | 2.5rem             | 1.5rem        |
+| above $breakpoint-medium               | 12      | 2.0rem             | 1.5rem        |
 
 <br>
 

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -13,7 +13,7 @@ $grid-large-col-prefix: #{$grid-column-prefix} !default;
 $grid-gutter-widths: (
   small: $sp-unit * 3,
   medium: $sp-unit * 4,
-  large: $sp-unit * 5
+  large: $sp-unit * 4
 ) !default;
 
 $grid-margin-widths: (


### PR DESCRIPTION

## Done

Grid gutters in vf 2.0 are fixed, not percentage The values they are fixed to are adjusted per breakpoint. THe desktop breakpoint was set too high - 2.5rem, when in fact 2rem would match the older grid closer. I've changed it to 2 rem to reflect that.

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/patterns/grid/default/
- Verify grid gutters are 2rem

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
