### PR TITLE
Remove 1600px viewport from Percy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 script:
   - yarn run test
   - yarn run build-docs
-  - percy snapshot --widths "375,1280" docs/_site/
+  - percy snapshot --widths "375,1280,1600" docs/_site/
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 script:
   - yarn run test
   - yarn run build-docs
-  - percy snapshot --widths "375,1280,1600" docs/_site/
+  - percy snapshot --widths "375,1280" docs/_site/
 notifications:
   irc:
     channels:


### PR DESCRIPTION
## Done

- Removed `1600px` viewport from Percy as it's eating up bandwidth and our Snapshots

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check viewport has been removed on a Percy diff

## Details

- Originally put in for testing larger screen breakpoints for v2.0.0
