### PR TITLE
Add missing vf- prefix to animation example

### DIFF
--- a/docs/settings/animation-settings.md
+++ b/docs/settings/animation-settings.md
@@ -46,7 +46,7 @@ Animations are preset to components. Components can be modified or extended to
 include animation by including the animation mixin.
 
 ```scss
-@include animation(property: all, duration: brisk, easing: out);
+@include vf-animation(property: all, duration: brisk, easing: out);
 ```
 
 ### Reduced motion


### PR DESCRIPTION
## Done

Add missing vf- prefix to animation example

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Sanity check code


