### PR TITLE
Hide second navigation list in docs side nav on page

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -161,7 +161,7 @@
               </li>
             </ul>
 
-            <ul class="p-sidebar-nav__list" id="docs-list-sorted">
+            <ul class="p-sidebar-nav__list u-hide" id="docs-list-sorted">
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/accordion/' %}is-active{% endif %}" href="/patterns/accordion/">Accordion</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/align/' %}is-active{% endif %}" href="/utilities/align/">Alignment</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/examples/' %}is-active{% endif %}" href="/examples/">All component examples</a></li>


### PR DESCRIPTION
## Done

Fix the navigation bug in docs where the duplicate nav is visible on page load

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/
- See that the docs sidebar ends with the "resources" section
- Test the search box still works
