### PR TITLE
Add new status page and labels. Update doc vanilla dependency to 2.2.0

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -73,7 +73,7 @@
               <li class="p-sidebar-nav__item">
                 <strong>Base elements</strong>
                 <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/code/' %}is-active{% endif %}" href="/base/code/">Code</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/code/' %}is-active{% endif %}" href="/base/code/">Code</a><div class="p-label--updated u-float-right">Updated</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/forms/' %}is-active{% endif %}" href="/base/forms/">Forms</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/reset/' %}is-active{% endif %}" href="/base/reset/">Reset</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/tables/' %}is-active{% endif %}" href="/base/tables">Tables</a></li>
@@ -84,7 +84,7 @@
               <li class="p-sidebar-nav__item">
                 <strong>Components</strong>
                 <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/accordion/' %}is-active{% endif %}" href="/patterns/accordion/">Accordion</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/accordion/' %}is-active{% endif %}" href="/patterns/accordion/">Accordion</a><div class="p-label--updated u-float-right">Updated</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/article-pagination/' %}is-active{% endif %}" href="/patterns/article-pagination/">Article pagination</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/breadcrumbs/' %}is-active{% endif %}" href="/patterns/breadcrumbs/">Breadcrumbs</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/buttons/' %}is-active{% endif %}" href="/patterns/buttons/">Buttons</a></li>
@@ -95,16 +95,18 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/icons/' %}is-active{% endif %}" href="/patterns/icons/">Icons</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/images/' %}is-active{% endif %}" href="/patterns/images/">Images</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/inline-images/' %}is-active{% endif %}" href="/patterns/inline-images/">Inline images</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/labels/' %}is-active{% endif %}" href="/patterns/labels/">Labels</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/links/' %}is-active{% endif %}" href="/patterns/links/">Links</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/list-tree/' %}is-active{% endif %}" href="/patterns/list-tree/">List tree</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/lists/' %}is-active{% endif %}" href="/patterns/lists/">Lists</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/matrix/' %}is-active{% endif %}" href="/patterns/matrix/">Matrix</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/media-object/' %}is-active{% endif %}" href="/patterns/media-object/">Media object</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/menu-button/' %}is-active{% endif %}" href="/patterns/menu-button/">Menu button</a><div class="p-label--in-progress u-float-right">In progress</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/modal/' %}is-active{% endif %}" href="/patterns/modal/">Modal</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/muted-heading/' %}is-active{% endif %}" href="/patterns/muted-heading/">Muted heading</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/navigation/' %}is-active{% endif %}" href="/patterns/navigation/">Navigation</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/navigation/' %}is-active{% endif %}" href="/patterns/navigation/">Navigation</a><div class="p-label--new u-float-right">New</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/notification/' %}is-active{% endif %}" href="/patterns/notification/">Notifications</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/pagination/' %}is-active{% endif %}" href="/patterns/pagination/">Pagination</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/pagination/' %}is-active{% endif %}" href="/patterns/pagination/">Pagination</a><div class="p-label--new u-float-right">New</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/pull-quote/' %}is-active{% endif %}" href="/patterns/pull-quote/">Quotes</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/search-box/' %}is-active{% endif %}" href="/patterns/search-box/">Search box</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/slider/' %}is-active{% endif %}" href="/patterns/slider/">Slider</a></li>
@@ -155,7 +157,8 @@
               <li class="p-sidebar-nav__item">
                 <strong>Resources</strong>
                 <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/examples/' %}is-active{% endif %}" href="/examples/">All component examples</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/examples/' %}is-active{% endif %}" href="/examples/">Component examples</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/component-status/' %}is-active{% endif %}" href="/component-status/">Component status</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == 'https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch' %}is-active{% endif %}" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></li>
                 </ul>
               </li>

--- a/docs/base/code.md
+++ b/docs/base/code.md
@@ -8,7 +8,7 @@ layout: default
 
 Vanilla gives you multiple ways to display code using the standard HTML elements.
 
-### Inline
+### Inline <span class="p-label--updated" style="margin-left: 0.5rem;">Updated</span>
 
 When you refer to code inline with other text, use the <code>&lt;code&gt;</code> tag.
 

--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -1,0 +1,96 @@
+---
+layout: default
+permalink: /component-status.html
+---
+
+## Component status
+
+<hr>
+
+When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
+
+### Current status
+
+<table style="margin-bottom: 1rem;">
+  <thead>
+    <tr>
+      <th style="width: 25%">Component</th>
+      <th style="width: 25%">Status</th>
+      <th style="width: 50%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th><a href="/patterns/menu-button">Menu button</a></th>
+      <td><div class="p-label--in-progress">In progress</div></td>
+      <td><a href="https://github.com/canonical-web-and-design/design-vanilla-framework/tree/master/Menu%20button">Design spec</a> created and ready for build</td>
+    </tr>
+    <tr>
+      <th><a href="/patterns/navigation/#sub-navigation">Sub-navigation</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>This component's functionality requires JavaScript</td>
+    </tr>
+    <tr>
+      <th><a href="/patterns/pagination/">Pagination</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>Should be used to navigate between pages of content</td>
+    </tr>
+    <tr>
+      <th><a href="/patterns/accordion">Accordion</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>Icons now appear on the left rather than the right</td>
+    </tr>
+    <tr>
+      <th><a href="/base/code/#inline">Code</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>Inline code elements now have a grey highlight to help them stand out from other text</td>
+    </tr>
+    <tr>
+      <th>Footer</th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>Removed from release <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.0">v2.0.0</a></td>
+    </tr>
+    <tr>
+      <th>Sidebar navigation</th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>Removed from release <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.0">v2.0.0</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+  </tfoot>
+</table>
+
+### Status key
+
+<div class="row">
+  <div class="col-4 u-equal-height">
+    <div class="p-card--highlighted">
+      <div class="p-label--new">New</div>
+      <p class="p-card__content">Newly released components, utilities or settings that are safe to use in projects.</p>
+    </div>
+  </div>
+  <div class="col-4 u-equal-height">
+  <div class="p-card--highlighted">
+      <div class="p-label--deprecated">Deprecated</div>
+      <p class="p-card__content">These components, utilities or settings are in the process of being removed and should no longer be used in projects.</p>
+    </div>
+  </div>
+  <div class="col-4 u-equal-height">
+  <div class="p-card--highlighted">
+      <div class="p-label--in-progress">In progress</div>
+      <p class="p-card__content">Design spec and code implementation are not yet finished.</p>
+    </div>
+  </div>
+  <div class="col-4 u-equal-height">
+  <div class="p-card--highlighted">
+      <div class="p-label--updated">Updated</div>
+      <p class="p-card__content">These are existing components, utilities or settings that have been updated either through design or code.</p>
+    </div>
+  </div>
+  <div class="col-4 u-equal-height">
+  <div class="p-card--highlighted">
+      <div class="p-label--validated">Validated</div>
+      <p class="p-card__content">Proposal approved in our bi-weekly meeting . A design spec is created and development starts ready for code review.</p>
+    </div>
+  </div>
+</div>

--- a/docs/patterns/accordion.md
+++ b/docs/patterns/accordion.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-## Accordion
+## Accordion <span class="p-label--updated" style="margin-left: 0.5rem;">Updated</span>
 
 <hr>
 

--- a/docs/patterns/menu-button.md
+++ b/docs/patterns/menu-button.md
@@ -1,0 +1,19 @@
+---
+layout: default
+---
+
+## Menu button <span class="p-label--in-progress" style="margin-left: 0.5rem;">In progress</span>
+
+<hr>
+
+The menu button component can display a list of menu items when clicked or pressed, it can show and hide items inside a contextual menu.
+
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Note:</span>Code implementation of component not yet finished.
+  </p>
+</div>
+
+### Design
+
+For more information [view the menu button design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/master/Menu%20button), which includes the specification in markdown format and a PNG image.

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -29,7 +29,7 @@ by adjusting the `$breakpoint-navigation-threshold` in `_settings_breakpoints.sc
 View example of the navigation pattern
 </a>
 
-### Sub-navigation
+### Sub-navigation <span class="p-label--new" style="margin-left: 0.5rem;">New</span>
 
 Sub-navigation drop-down menus can be added to the navigation by including one
 or more `p-subnav` components.

--- a/docs/patterns/pagination.md
+++ b/docs/patterns/pagination.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-## Pagination
+## Pagination <span class="p-label--new" style="margin-left: 0.5rem;">New</span>
 
 <hr>
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vanilla-framework": "vanilla-framework is included in devDependencies for use in styling the docs site"
   },
   "devDependencies": {
-    "vanilla-framework": "2.0.1",
+    "vanilla-framework": "2.2.0",
     "autoprefixer": "9.5.0",
     "husky": "1.3.1",
     "markdown-spellcheck": "1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,10 +3765,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.0.1.tgz#028e5cc4a156973f21cbd38ab3758c9532f3c36b"
-  integrity sha512-vE4e4ck40lrcFmREy06yoXy/dHKF+ewA/lsC6ZeooirXB69/XmZv+jgkCUlftbn6ya+N8F6b9yWGHKfg7AiEkg==
+vanilla-framework@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.2.0.tgz#c098b030f261bd321b55f6473e3ce614cb701e1f"
+  integrity sha512-KmQkdJYF8zeBjZaNv+ZGap7mC5rSwq5oymYHkVuu9AqyuyWX1m8feEwlArN1/jFD9lRQdhP9nAh2w0zJToPO2w==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

*Note:* This is @kwm14's work that I've put together into a single branch.

- Added the new status page
- Added status labels to the docs nav
- Upped vanilla-framework dep used by the docs to 2.2.0 so that the label component was available

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/component-status/
- Review the page content
- See the labels in the left-hand nav

## Details

Fixes #2413 
Fixes #2414 