### PR TITLE
Update sidebar active link

### DIFF
--- a/docs/sass/styles.scss
+++ b/docs/sass/styles.scss
@@ -53,7 +53,7 @@ hr {
       position: relative;
 
       &::before {
-        background-color: $color-mid-light;
+        background-color: $color-accent;
         bottom: -$spv-inner--x-small;
         content: '';
         left: -$sph-inner;


### PR DESCRIPTION
## Done

- Updated `.p-sidebar-nav__item .is-active::before` color to `$color-accent`

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/vanilla-framework/
- See that the active link in the sidebar has a newly selected color

## Details

- Fixes #2216 

## Screenshots

<img width="1440" alt="Screenshot 2019-08-05 at 10 02 45" src="https://user-images.githubusercontent.com/17748020/62452651-8bb6b700-b768-11e9-82af-2a287c4ec159.png">

