### PR TITLE
decrease scope of selector so only direct children of .row  span full width

### DIFF
--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -73,7 +73,7 @@
       grid-gap: 0 map-get($grid-gutter-widths, small);
       grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
 
-      * {
+      & > * {
         grid-column-end: span $grid-columns-small;
       }
     }
@@ -82,7 +82,7 @@
       grid-gap: 0 map-get($grid-gutter-widths, medium);
       grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
 
-      * {
+      & > * {
         grid-column-end: span $grid-columns-medium;
       }
     }
@@ -91,7 +91,7 @@
       grid-gap: 0 map-get($grid-gutter-widths, large);
       grid-template-columns: repeat($grid-columns, minmax(0, 1fr));
 
-      * {
+      & > * {
         grid-column-end: span $grid-columns;
       }
     }


### PR DESCRIPTION
Done

Decrease scope of .row * to .row > *, so that it only affects direct children of .row

## QA

- Pull code
- Run `./run serve --watch`
- Copy the markup and .grid-component style into an example
- Verify Left and right appear side by side instead of stacked.

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2444
