### PR TITLE
Make p-card's spacing rules less greedy

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -79,9 +79,9 @@
   }
 
   [class*='p-card'] {
-    p:not([class^='p-heading--']),
-    h5,
-    h6 {
+    > p:not([class^='p-heading--']),
+    > h5,
+    > h6 {
       &:last-child {
         margin-bottom: $spv-nudge-compensation;
       }


### PR DESCRIPTION
## Done

Fix the p-card rules for margins to be less greedy

## QA

- Pull code
- Run `./run`
- Open a random example: e.g. http://0.0.0.0:8101/examples/base/abbr/
- Inspect the page and replace the markup with the example from [bartaz's codepen](https://jsfiddle.net/bartaz/8zcbj56k/)
- See that the spacing is better

*note*: The last element in a p-card in this sort of useage may have too much margin. u-no-margin--bottom can be applied if needed.

## Details

Fixes #2447 