### PR TITLE
Spacing adjustment

### DIFF
--- a/docs/examples/templates/typographic-spacing.html
+++ b/docs/examples/templates/typographic-spacing.html
@@ -8,6 +8,10 @@ category: _templates
     display: flex;
     justify-content: space-between;
   }
+
+  .row {
+    max-width: 100vw;
+  }
 </style>
 
 <!-- h1+others -->
@@ -15,36 +19,42 @@ category: _templates
   <div class="flex-col">
     <h1>Canonical’s AI and ML solutions feature…</h1>
     <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
   </div>
   <div class="flex-col">
     <h1>Canonical’s AI and ML solutions feature…</h1>
     <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <a href="#" class="p-button">Get started</a>
   </div>
   <div class="flex-col">
     <h1>Canonical’s AI and ML solutions feature…</h1>
     <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h1>Canonical’s AI and ML solutions feature…</h1>
     <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h1>Canonical’s AI and ML solutions feature…</h1>
     <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h1>Canonical’s AI and ML solutions feature…</h1>
     <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
 </div>
@@ -54,36 +64,42 @@ category: _templates
   <div class="flex-col">
     <h2>Canonical’s AI and ML solutions feature…</h2>
     <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
   </div>
   <div class="flex-col">
     <h2>Canonical’s AI and ML solutions feature…</h2>
     <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <a href="#" class="p-button">Get started</a>
   </div>
   <div class="flex-col">
     <h2>Canonical’s AI and ML solutions feature…</h2>
     <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h2>Canonical’s AI and ML solutions feature…</h2>
     <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h2>Canonical’s AI and ML solutions feature…</h2>
     <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h2>Canonical’s AI and ML solutions feature…</h2>
     <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
 </div>
@@ -93,36 +109,42 @@ category: _templates
   <div class="flex-col">
     <h3>Canonical’s AI and ML solutions feature…</h3>
     <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
   </div>
   <div class="flex-col">
     <h3>Canonical’s AI and ML solutions feature…</h3>
     <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <a href="#" class="p-button">Get started</a>
   </div>
   <div class="flex-col">
     <h3>Canonical’s AI and ML solutions feature…</h3>
     <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h3>Canonical’s AI and ML solutions feature…</h3>
     <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h3>Canonical’s AI and ML solutions feature…</h3>
     <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h3>Canonical’s AI and ML solutions feature…</h3>
     <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
 </div>
@@ -132,36 +154,42 @@ category: _templates
   <div class="flex-col">
     <h4>Canonical’s AI and ML solutions feature…</h4>
     <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
   </div>
   <div class="flex-col">
     <h4>Canonical’s AI and ML solutions feature…</h4>
     <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <a href="#" class="p-button">Get started</a>
   </div>
   <div class="flex-col">
     <h4>Canonical’s AI and ML solutions feature…</h4>
     <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h4>Canonical’s AI and ML solutions feature…</h4>
     <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h4>Canonical’s AI and ML solutions feature…</h4>
     <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h4>Canonical’s AI and ML solutions feature…</h4>
     <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
 </div>
@@ -171,36 +199,42 @@ category: _templates
   <div class="flex-col">
     <h5>Canonical’s AI and ML solutions feature…</h5>
     <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
   </div>
   <div class="flex-col">
     <h5>Canonical’s AI and ML solutions feature…</h5>
     <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <a href="#" class="p-button">Get started</a>
   </div>
   <div class="flex-col">
     <h5>Canonical’s AI and ML solutions feature…</h5>
     <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h5>Canonical’s AI and ML solutions feature…</h5>
     <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h5>Canonical’s AI and ML solutions feature…</h5>
     <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h5>Canonical’s AI and ML solutions feature…</h5>
     <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
 </div>
@@ -210,36 +244,42 @@ category: _templates
   <div class="flex-col">
     <h6>Canonical’s AI and ML solutions feature…</h6>
     <h1>Architectural freedom. Fully automated operations.</h1>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
   </div>
   <div class="flex-col">
     <h6>Canonical’s AI and ML solutions feature…</h6>
     <h2>Architectural freedom. Fully automated operations.</h2>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <a href="#" class="p-button">Get started</a>
   </div>
   <div class="flex-col">
     <h6>Canonical’s AI and ML solutions feature…</h6>
     <h3>Architectural freedom. Fully automated operations.</h3>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h6>Canonical’s AI and ML solutions feature…</h6>
     <h4>Architectural freedom. Fully automated operations.</h4>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h6>Canonical’s AI and ML solutions feature…</h6>
     <h5>Architectural freedom. Fully automated operations.</h5>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
   <div class="flex-col">
     <h6>Canonical’s AI and ML solutions feature…</h6>
     <h6>Architectural freedom. Fully automated operations.</h6>
-    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
+    <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+      your AI, ML and DL services exactly where you want them while sharing operational code with a large community.</p>
     <button>Contact us</button>
   </div>
 </div>
@@ -1290,24 +1330,54 @@ category: _templates
     <hr>
   </div>
   <div class="row">
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
     <h1>Heading one</h1>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
     <h2>Heading two</h2>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
     <h3>Heading three</h3>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
     <h4>Heading four</h4>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
     <h5>Heading five</h5>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
     <h6>Heading six</h6>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
 
     <p class="p-muted-heading">Muted heading</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque. Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo. Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
+      Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
+      Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
+      erat et.</p>
   </div>
 </div>
 
@@ -1316,10 +1386,15 @@ category: _templates
     <div class="col-9">
       <h1>Canonical’s AI and ML solutions feature…</h1>
       <p class="p-heading--two">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+        your AI, ML and DL services exactly where you want them while sharing operational code with a large community.
+        From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest
+        tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for
+        startups.</p>
       <button>Contact us</button>
-      <p><a href="/ai/contact-us?product=ai-features">Contact us for machine learning, deep learning and AI consulting&nbsp;›</a></p>
+      <p><a href="/ai/contact-us?product=ai-features">Contact us for machine learning, deep learning and AI
+          consulting&nbsp;›</a></p>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
@@ -1331,8 +1406,12 @@ category: _templates
     <div class="col-9">
       <h1>Canonical’s AI and ML solutions feature…</h1>
       <p class="p-heading--three">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+        your AI, ML and DL services exactly where you want them while sharing operational code with a large community.
+        From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest
+        tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for
+        startups.</p>
       <button>Contact us</button>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
@@ -1346,8 +1425,12 @@ category: _templates
     <div class="col-9">
       <h1>Canonical’s AI and ML solutions feature…</h1>
       <p class="p-heading--four">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+        your AI, ML and DL services exactly where you want them while sharing operational code with a large community.
+        From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest
+        tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for
+        startups.</p>
       <button>Contact us</button>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
@@ -1361,8 +1444,12 @@ category: _templates
     <div class="col-9">
       <h2>Canonical’s AI and ML solutions feature…</h2>
       <p class="p-heading--three">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+        your AI, ML and DL services exactly where you want them while sharing operational code with a large community.
+        From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest
+        tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for
+        startups.</p>
       <button>Contact us</button>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
@@ -1376,8 +1463,12 @@ category: _templates
     <div class="col-9">
       <h2>Canonical’s AI and ML solutions feature…</h2>
       <p class="p-heading--four">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
-      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place your AI, ML and DL services exactly where you want them while sharing operational code with a large community. From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest tools, drivers and libraries.</p>
-      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for startups.</p>
+      <p>Canonical’s AI solutions such as <a href="/ai/install">Kubeflow</a> on Ubuntu give you the flexibility to place
+        your AI, ML and DL services exactly where you want them while sharing operational code with a large community.
+        From your developer workstation, to your racks, to the public cloud, AI on Ubuntu is accelerated with the latest
+        tools, drivers and libraries.</p>
+      <p>The standard for enterprise machine learning, from Silicon Valley to Wall Street, for the Fortune 50 and for
+        startups.</p>
       <button>Contact us</button>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
@@ -1385,3 +1476,206 @@ category: _templates
     </div>
   </div>
 </section>
+
+
+
+<div class="row">
+  <div class="col-2 col-medium-2 col-small-2">
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+    <input type="radio" name="" id="Radio1">
+    <label for="Radio1">radio</label>
+    <p>This is a paragraph</p>
+  </div>
+  <div class="col-2 col-medium-2 col-small-2">
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+    <p>This is a paragraph</p>
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected="">Select</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </div>
+  <div class="col-2 col-medium-2 col-small-2">
+    <label for="exampleInputEmail1">Email address</label>
+    <p>This is a paragraph</p>
+  </div>
+  <div class="col-2 col-medium-2 col-small-2">
+    <input type="text" id="exampleInputEmail1" placeholder="Email">
+    <p>This is a paragraph</p>
+  </div>
+  <div class="col-2 col-medium-2 col-small-2">
+    <button>Button</button>
+    <p>This is a paragraph</p>
+  </div>
+  <div class="col-2 col-medium-2 col-small-2">
+    <p>para</p>
+    <p>This is a paragraph</p>
+  </div>
+</div>
+<hr>
+<div class="row">
+  <div class="col-6 p-strip is-shallow">
+    <h1>
+      Headings and paragraphs are siblings, p + h* rules apply
+    </h1>
+    <p>
+      Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a
+      single build. They update automatically and roll back gracefully.
+    </p>
+    <h2>
+      Headings and paragraphs are siblings, p + h* rules apply
+    </h2>
+    <p>
+      Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a
+      single build. They update automatically and roll back gracefully.
+    </p>
+    <h3>
+      Headings and paragraphs are siblings, p + h* rules apply
+    </h3>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+    <h3>
+      Headings and paragraphs are siblings, p + h* rules apply
+    </h3>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+    <h4>
+      Headings and paragraphs are siblings, p + h* rules apply
+    </h4>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+    <p>
+      Headings and paragraphs are siblings, p + h* rules apply
+    </p>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+  </div>
+
+
+  <div class="col-6">
+    <div class="p-strip is-shallow u-no-padding--bottom">
+      <h1>
+        Headings wrapped in divs so p + h* no longer apply
+      </h1>
+    </div>
+    <p>
+      Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a
+      single build. They update automatically and roll back gracefully.
+    </p>
+    <div class="p-strip is-shallow u-no-padding--bottom">
+      <h2>
+        Headings wrapped in divs so p + h* no longer apply
+      </h2>
+    </div>
+    <p>
+      Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a
+      single build. They update automatically and roll back gracefully.
+    </p>
+    <div class="p-strip is-shallow u-no-padding--bottom">
+      <h3>
+        Headings wrapped in divs so p + h* no longer apply
+      </h3>
+    </div>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+    <h3>
+      Headings wrapped in divs so p + h* no longer apply
+    </h3>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+    <h4>
+      Headings wrapped in divs so p + h* no longer apply
+    </h4>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+    <p>
+      Headings wrapped in divs so p + h* no longer apply
+    </p>
+    <p>
+      Snap is available for CentOS 7.6+, and Red Hat Enterprise Linux 7.6+, from the Extra Packages for Enterprise Linux
+      (EPEL) repository. The EPEL repository can be added to your system with the following command:
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <a target="_blank" rel="noopener noreferrer"
+    href="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg"><img
+      src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg"
+      alt="image" style="max-width:100%;"></a>
+  <h3>This is a heading following an image</h3>
+</div>
+
+<div class="row">
+  <div class="col-2">
+    <h1>Heading</h1>
+    <div class="p-strip--dark">
+      <h1>This is an h1 heading inside a dark strip</h1>
+      <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
+    </div>
+  </div>
+  <div class="col-2">
+    <h2>Heading</h2>
+    <div class="p-strip--dark">
+      <h2>This is an h2 heading inside a dark strip</h2>
+      <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
+    </div>
+  </div>
+  <div class="col-2">
+    <h3>Heading</h3>
+    <div class="p-strip--dark">
+      <h3>This is an h3 heading inside a dark strip</h3>
+      <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
+    </div>
+  </div>
+  <div class="col-2">
+    <h4>Heading</h4>
+    <div class="p-strip--dark">
+      <h4>This is an h4 heading inside a dark strip</h4>
+      <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
+    </div>
+  </div>
+  <div class="col-2">
+    <h5>Heading</h5>
+    <div class="p-strip--dark">
+      <h5>This is an h5 heading inside a dark strip</h5>
+      <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
+    </div>
+  </div>
+  <div class="col-2">
+    <h6>Heading</h6>
+    <div class="p-strip--dark">
+      <h6>This is an h6 heading inside a dark strip</h6>
+      <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
+    </div>
+  </div>
+</div>

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -18,7 +18,7 @@
     font-size: 1rem;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
-    margin: 0 0 $spv-outer--scaleable + 2 * $spv-nudge-compensation 0;
+    margin: 0 0 $spv-outer--scaleable - (2 * $spv-nudge) 0;
     padding: calc(#{$spv-nudge} - 1px) $sph-inner--small * 1.5;
     text-align: center;
     text-decoration: none;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -9,7 +9,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
   // Used in buttons, inputs
   %bordered-text-vertical-padding {
-    margin-bottom: $input-margin-bottom;
     padding-bottom: calc(#{$spv-nudge} - 1px);
     padding-top: calc(#{$spv-nudge} - 1px);
   }
@@ -34,6 +33,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     font-size: 1rem;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
+    margin-bottom: $input-margin-bottom;
     min-width: 10em;
     padding-left: $sph-inner--small;
     padding-right: $sph-inner--small;
@@ -92,7 +92,8 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
       &::before,
       &::after {
-        @include vf-animation(all, brisk);
+        $properties: #{background-color, border-color};
+        @include vf-animation($properties);
         position: absolute;
       }
 
@@ -102,6 +103,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
         content: '';
         height: $box-size;
         left: 0;
+        outline-offset: 1px;
         top: $box-offset-top;
         width: $box-size;
       }
@@ -128,7 +130,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
       opacity: 1;
     }
 
-    &:focus + label {
+    &:focus + label::before {
       outline: 2px solid $color-focus;
     }
 
@@ -202,6 +204,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
   [type='file'] {
     @extend %bordered-text-vertical-padding;
     @include vf-focus;
+    margin-bottom: $input-margin-bottom;
     width: 100%;
   }
 

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -32,7 +32,7 @@
   }
 
   dd {
-    @extend %paragraph;
+    @extend %default-text;
     margin-left: $sph-inner;
   }
 
@@ -44,6 +44,10 @@
 
     &:first-of-type {
       border-top: 0;
+    }
+
+    dd + & {
+      margin-top: $spv-outer--scaleable - $spv-nudge-compensation;
     }
   }
 }

--- a/scss/_base_placeholders-margin-collapse.scss
+++ b/scss/_base_placeholders-margin-collapse.scss
@@ -1,5 +1,9 @@
 @import 'settings';
 
+// @function smallestPositivePnumber($value) {
+//   return min(max($sp-unit, $value - ));
+// }
+
 %u-no-margin--bottom {
   &:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(p):not(small):not([class*='p-heading']) {
     margin-bottom: 0 !important;
@@ -34,7 +38,7 @@
 
 %u-no-margin--bottom--h3 {
   @media (max-width: $breakpoint-heading-threshold) {
-    margin-bottom: -#{map-get($nudges, nudge--h3-mobile)} !important;
+    margin-bottom: #{$sp-unit - map-get($nudges, nudge--h3-mobile)} !important;
   }
 
   @media (min-width: $breakpoint-heading-threshold) {
@@ -44,7 +48,7 @@
 
 %u-no-margin--bottom--h4 {
   @media (max-width: $breakpoint-heading-threshold) {
-    margin-bottom: -#{map-get($nudges, nudge--h4-mobile)} !important;
+    margin-bottom: #{$sp-unit - map-get($nudges, nudge--h4-mobile)} !important;
   }
 
   @media (min-width: $breakpoint-heading-threshold) {
@@ -59,7 +63,7 @@
 }
 
 %u-no-margin--bottom--default-text {
-  margin-bottom: $sp-unit - map-get($nudges, nudge--p) !important;
+  margin-bottom: #{$sp-unit - map-get($nudges, nudge--p)} !important;
 }
 
 %u-no-margin--bottom--small {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -6,7 +6,7 @@
     @include heading-max-width--short;
     font-style: normal;
     font-weight: 100;
-    margin-top: -#{$sp-unit};
+    margin-top: 0;
 
     @media (max-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h1-mobile)}rem;
@@ -38,7 +38,7 @@
     @include heading-max-width--short;
     font-style: normal;
     font-weight: 100;
-    margin-top: -#{$sp-unit};
+    margin-top: 0;
 
     @media (max-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h2-mobile)}rem;
@@ -63,7 +63,7 @@
     @include heading-max-width--long;
     font-style: normal;
     font-weight: 300;
-    margin-top: -#{$sp-unit};
+    margin-top: 0;
 
     @media (max-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h3-mobile)}rem;
@@ -167,6 +167,10 @@
     @extend %common-default-text-properties;
     margin-bottom: map-get($sp-after, p) - map-get($nudges, nudge--p);
 
+    & + & {
+      margin-top: -#{$sp-unit};
+    }
+
     &.u-no-margin--bottom {
       @extend %u-no-margin--bottom--default-text;
     }
@@ -210,51 +214,46 @@
   // Placeholder naming: $sp + -- + {preceding element} + {following element}, e.g. for p + h1: $sp--ph1
 
   %sp--ph1 {
-    padding-top: map-get($nudges, nudge--h1) + map-get($sp-before, h1);
+    padding-top: map-get($nudges, nudge--h1) + $spv-outer--scaleable;
 
     @media (max-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h1-mobile) + map-get($sp-before, h1-mobile);
+      padding-top: map-get($nudges, nudge--h1-mobile) + $spv-outer--scaleable;
     }
   }
 
   %sp--ph2 {
-    padding-top: map-get($nudges, nudge--h2) + map-get($sp-before, h2);
+    padding-top: map-get($nudges, nudge--h2) + $spv-outer--scaleable;
 
     @media (max-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h2-mobile) + map-get($sp-before, h2-mobile);
+      padding-top: map-get($nudges, nudge--h2-mobile) + $spv-outer--scaleable;
     }
   }
 
   %sp--ph3 {
     @media (max-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h3-mobile) + map-get($sp-before, h3-mobile);
+      padding-top: map-get($nudges, nudge--h3-mobile) + $spv-outer--scaleable;
     }
 
     @media (min-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h3) + map-get($sp-before, h3);
+      padding-top: map-get($nudges, nudge--h3) + $spv-outer--scaleable;
     }
   }
 
   %sp--ph4 {
     @media (max-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h4-mobile) + map-get($sp-before, h4);
+      padding-top: map-get($nudges, nudge--h4-mobile) + $spv-outer--scaleable;
     }
 
     @media (min-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h4) + map-get($sp-before, h4);
+      padding-top: map-get($nudges, nudge--h4) + $spv-outer--scaleable;
     }
   }
 
   %sp--ph5 {
-    padding-top: map-get($nudges, nudge--p) + map-get($sp-before, p);
+    padding-top: map-get($nudges, nudge--p) + $spv-outer--scaleable;
   }
 
   %sp--pmuted {
-    padding-top: map-get($nudges, nudge--small) + map-get($sp-before, muted);
-  }
-
-  // any heading followed by a paragraph
-  %sp--hp {
-    margin-top: $spv-p-after-heading-adjustment;
+    padding-top: map-get($nudges, nudge--small) + $spv-outer--scaleable;
   }
 }

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -83,33 +83,6 @@
     }
   }
 
-  // All text elements have extra margin-bottom to keep following block level elements at a comfortable distance.
-  // When a text element is followed by another text element, this extra space needs to be compensated for.
-  // Notably, the selectors below do not include rules for p + any heading, which usually indicates beginning of next heading/paragraphs group, which requires an increase in white space. This is handled further down.
-  h1,
-  .p-heading--one,
-  h2,
-  .p-heading--two,
-  h3,
-  .p-heading--three,
-  h4,
-  .p-heading--four,
-  h5,
-  .p-heading--five,
-  h6,
-  .p-heading--six,
-  .p-muted-heading {
-    & + h1,
-    & + h2,
-    & + h3,
-    & + h4,
-    & + h5,
-    & + h6,
-    & + p:not([class*='p-muted-heading']) {
-      @extend %sp--hp;
-    }
-  }
-
   //@section Adjusted spacing for headings (or a p) following a paragraph
   p:not([class*='p-heading--']):not([class*='p-muted-heading']) {
     & + h1,
@@ -141,10 +114,6 @@
 
     & + .p-muted-heading {
       @extend %sp--pmuted;
-    }
-
-    & + & {
-      @extend %sp--hp;
     }
 
     // N.B.: selector order matters here - the epmty selector must come after all other rules affecting paragraphs

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -75,7 +75,7 @@
   }
 
   .p-card__thumbnail {
-    max-height: map-get($icon-sizes, thumb--card);
+    max-height: map-get($icon-sizes, heading-icon--small);
   }
 
   [class*='p-card'] {

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -10,6 +10,7 @@ $cc-button-size: 36px;
     @extend %vf-has-round-corners;
     @extend %vf-is-bordered;
     display: flex;
+    margin-bottom: $input-margin-bottom;
     overflow: hidden;
     position: relative;
 

--- a/scss/_patterns_form-help-text.scss
+++ b/scss/_patterns_form-help-text.scss
@@ -4,6 +4,6 @@
   .p-form-help-text {
     @extend %small-text;
     color: $color-mid-dark;
-    margin-top: -$sp-unit;
+    margin-top: $sp-unit * 2 - $spv-outer--scaleable; // negate the effect of scaling, as we don't want helper text position to change when the density multiplier changes
   }
 }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -19,7 +19,7 @@
 
   .p-form-validation__message {
     @extend %small-text;
-    margin-top: -$sp-unit;
+    margin-top: $sp-unit * 2 - $spv-outer--scaleable; // negate the effect of scaling, as we don't want helper text position to change when the density multiplier changes
   }
 
   .p-form-validation__icon {

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -62,20 +62,7 @@
         .p-form__control {
           display: inline-block;
         }
-
-        .p-form-validation__message,
-        .p-form-help-text {
-          clear: both;
-          min-width: 100%; // Sets the width to the minimum width of the parent
-          width: 0; // Removes any block level width
-        }
       }
-    }
-
-    [class*='p-button'] {
-      flex: initial;
-      flex-shrink: 0;
-      margin-top: 0;
     }
   }
 }

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -11,9 +11,6 @@
 
   .p-heading-icon__header {
     display: flex;
-    // Match adjustment of margin-top on paragraphs that are following a heading.
-    // Necessary because in this pattern the heading and paragraph are not in the same parent, so h3 + p rules do not apply
-    margin-bottom: $spv-p-after-heading-adjustment;
 
     &.is-stacked {
       display: inherit;
@@ -23,17 +20,17 @@
   .p-heading-icon__img {
     flex-shrink: 0;
     height: map-get($icon-sizes, heading-icon--small);
-    margin-bottom: $spv-inner--small;
+    margin-bottom: 0;
     margin-right: $sph-inner;
     width: map-get($icon-sizes, heading-icon--small);
 
     @media (max-width: $breakpoint-medium) {
-      margin-top: 0;
+      margin-top: map-get($nudges, nudge--h3-mobile);
     }
 
     @media (min-width: $breakpoint-medium) {
       height: map-get($icon-sizes, heading-icon);
-      margin-top: -#{$spv-inner--small};
+      margin-top: map-get($nudges, nudge--h3);
       width: map-get($icon-sizes, heading-icon);
     }
   }

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -1,7 +1,7 @@
 @import 'settings';
 
 $default-icon-size: map-get($icon-sizes, default);
-$social-icon-size: map-get($icon-sizes, social);
+$social-icon-size: map-get($icon-sizes, heading-icon--small);
 $color-social-icon-background: $color-mid-dark !default;
 $color-social-icon-foreground: $color-mid-x-light !default;
 

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -24,7 +24,7 @@
   }
 
   .p-inline-images__logo {
-    max-height: map-get($icon-sizes, thumb--small);
+    max-height: map-get($icon-sizes, thumb);
     max-width: 7rem;
     width: auto;
 

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -1,6 +1,11 @@
 @import 'settings';
 $tick-height: 0.875rem; // 14px value from svg as rem so it can be used in calculations
-$spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bottom for lists containing loose text.
+$spv-list-item--inner: null;
+@if ($pad-lists) {
+  $spv-list-item--inner: $spv-inner--x-small--scaleable * 0.5; // padding top and bottom for lists containing loose text.
+} @else {
+  $spv-list-item--inner: 0;
+}
 
 //Placeholders
 %numbered-step-container {
@@ -35,10 +40,8 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
 
   // Mixin for list items
   %vf-list-item {
-    @if ($pad-lists) {
-      padding-bottom: $spv-list-item--inner;
-      padding-top: $spv-list-item--inner;
-    }
+    padding-bottom: $spv-list-item--inner;
+    padding-top: $spv-list-item--inner;
 
     form & {
       padding-bottom: 0;
@@ -192,7 +195,7 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
     float: none;
     margin-left: 0;
     overflow: visible;
-    padding-bottom: map-get($sp-before, h3);
+    padding-bottom: $spv-outer--scaleable;
     position: relative;
     width: 100%;
   }

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -2,7 +2,7 @@
 
 // List Grid
 @mixin vf-p-matrix {
-  $matrix-img-width: map-get($icon-sizes, thumb--small);
+  $matrix-img-width: map-get($icon-sizes, heading-icon--small);
   $matrix-img-gutter: $sph-outer;
 
   .p-matrix {
@@ -88,11 +88,24 @@
 
   .p-matrix__img {
     align-self: flex-start;
-    margin-bottom: $spv-inner--scaleable;
+    height: auto;
+    margin-bottom: $spv-inner--small;
     margin-right: $matrix-img-gutter;
-    max-height: $matrix-img-width;
-    max-width: $matrix-img-width;
-    width: auto;
+    width: $matrix-img-width;
+
+    @media (max-width: $breakpoint-heading-threshold) {
+      margin-top: #{map-get($nudges, nudge--h4-mobile)};
+    }
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      margin-top: -#{map-get($nudges, nudge--h4)};
+    }
+
+    @if ($increase-font-size-on-larger-screens) {
+      @media (min-width: $breakpoint-x-large) {
+        margin-top: -#{map-get($nudges, nudge--h4-large)};
+      }
+    }
   }
 
   .p-matrix__content {
@@ -108,18 +121,10 @@
 
   .p-matrix__title {
     @extend %vf-heading-4;
+    @extend %u-no-margin--bottom--h4;
   }
 
   .p-matrix__desc {
-    &:last-child {
-      @extend %sp--hp;
-      margin-bottom: $spv-nudge-compensation;
-    }
-
-    > p:last-child {
-      margin-bottom: $spv-nudge-compensation;
-    }
-
     @media (max-width: $breakpoint-heading-threshold) {
       margin-top: -#{$sp-unit};
     }

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -47,6 +47,7 @@
 
   .p-media-object__title {
     @extend %vf-heading-4;
+    @extend %u-no-margin--bottom--h4;
   }
 
   .p-media-object__meta-list {
@@ -88,6 +89,7 @@
 
     .p-media-object__title {
       @extend %vf-heading-1;
+      @extend %u-no-margin--bottom--h1;
     }
   }
 }

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -89,7 +89,6 @@
 
     .p-media-object__title {
       @extend %vf-heading-1;
-      @extend %u-no-margin--bottom--h1;
     }
   }
 }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -36,7 +36,7 @@
       @extend %vf-pseudo-border--bottom;
       display: flex;
       font-size: 0;
-      margin: 0 auto $spv-inner--scaleable;
+      margin: 0 auto $spv-outer--scaleable;
       overflow-x: auto;
       padding: 0;
       position: relative;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -88,13 +88,13 @@ $spv-inner--large: $sp-unit * 2;
 $spv-inner--x-large: $sp-unit * 5.5;
 
 // 1.2 Vertical spacing between components
-$spv-outer--small: $sp-unit * 1 !default; //labels
+$spv-outer--small: $sp-unit !default; //labels
 $spv-outer--small-scaleable: $sp-unit * $multi !default;
 $spv-outer--medium: $sp-unit * 2 !default;
 $spv-outer--scaleable: $sp-unit * (1 + $multi) !default;
 
 // 1.3 Vertical spacing between a group of components and its wrapper - strips, views, entire page
-$spv-outer--shallow-scaleable: $sp-unit * 2 * $multi !default;
+$spv-outer--shallow-scaleable: $spv-outer--scaleable !default;
 $spv-outer--regular-scaleable: $sp-unit * 2 * (2 + $multi) !default;
 $spv-outer--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 
@@ -108,34 +108,19 @@ $sph-inner--x-large: $sp-unit * 5 !default;
 $sph-outer: $sph-inner !default;
 $sph-outer--large: $sp-unit * 3 !default; // checboxes, radios, list bullets
 
-$sp-before: (
-  h1: $sp-unit * 3,
-  h2: $sp-unit * 3,
-  h3: $sp-unit * 3,
-  h4: $sp-unit * 3,
-  p: $sp-unit * 3,
-  h1-mobile: $sp-unit * 3,
-  h2-mobile: $sp-unit * 3,
-  h3-mobile: $sp-unit * 3,
-  h4-mobile: $sp-unit * 3,
-  muted: $sp-unit * 3
-) !default;
-
-$spv-p-after-heading-adjustment: #{$sp-unit * -1};
-
-// space after element on desktop
+// Space after text elements
 $sp-after: (
-  h1: $sp-unit * 3,
-  h2: $sp-unit * 3,
-  h3: $sp-unit * 3,
-  h4: $sp-unit * 2,
-  p: $sp-unit * 3,
-  h1-mobile: $sp-unit * 2,
-  h2-mobile: $sp-unit * 2,
-  h3-mobile: $sp-unit * 2,
-  h4-mobile: $sp-unit * 2,
-  small: $sp-unit * 2,
-  small--dense: $sp-unit * 2,
+  h1: $spv-outer--small-scaleable,
+  h2: $spv-outer--small-scaleable,
+  h3: $spv-outer--small-scaleable,
+  h4: $spv-outer--small-scaleable,
+  p: $spv-outer--scaleable,
+  h1-mobile: $spv-outer--small-scaleable,
+  h2-mobile: $spv-outer--small-scaleable,
+  h3-mobile: $spv-outer--small-scaleable,
+  h4-mobile: $spv-outer--small-scaleable,
+  small: $spv-outer--small-scaleable,
+  small--dense: $spv-outer--small-scaleable,
   default-text: $sp-unit
 ) !default;
 
@@ -149,14 +134,11 @@ $max-widths: (
 $icon-sizes: (
   accordion: $sp-unit * 1.5,
   default: $sp-unit * 2,
-  heading-icon--small: $sp-unit * 4,
   heading-icon--x-small: $sp-unit * 3,
+  heading-icon--small: $sp-unit * 4,
   heading-icon: $sp-unit * 5,
-  social: $sp-unit * 4,
-  thumb--card: $sp-unit * 4,
-  thumb--large: $sp-unit * 12,
-  thumb--small: $sp-unit * 6,
-  thumb: $sp-unit * 6
+  thumb: $sp-unit * 6,
+  thumb--large: $sp-unit * 12
 ) !default;
 
 // generic units


### PR DESCRIPTION
## Done

This is a work in progress branch that aims to:
- make text spacing slightly simplified
- make shallow strip match the standard bottom spacing on the majority of elements. This means go from 2rem to 1.5rem; 
- make headings slightly more spaced from generic divs like images etc, which was requested in https://github.com/canonical-web-and-design/vanilla-framework/issues/2420
- makes spacing under button match that under inputs and many other elements

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/templates/typographic-spacing/ and scroll to the bottom
- Inspect the examples showing headings and paragraphs with different parents matching those in the same parents:
![image](https://user-images.githubusercontent.com/2741678/62557108-3ebd0880-b86e-11e9-8193-cd7f4f42e7eb.png)
- Verify the image sits further from the heading:
![image](https://user-images.githubusercontent.com/2741678/62557139-4c728e00-b86e-11e9-82f0-c112b2a5a30e.png)

- QA percy for visual changes