### PR TITLE
Stop bullets from beforming when the title wraps

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -220,6 +220,7 @@ $spv-list-item--inner: 0.25 * $spv-outer--small-scaleable; // padding top and bo
   h#{$i}.p-stepped-list__title {
     // sass-lint:enable no-qualifying-elements
     &::before {
+      flex-shrink: 0;
       margin-right: $sph-inner;
 
       @media (max-width: $breakpoint-heading-threshold) {


### PR DESCRIPTION
## Done

Fixed the issue where the circular background of stepped list bullets went "rugby ball shaped" when the heading wrapped over two lines

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/examples/patterns/lists/lists-stepped-detailed/
- Resize browser until the headings wrap and see that the bullets stay circular

## Details

Fixes #2424 