### PR TITLE
Fix label search result

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -197,6 +197,7 @@
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/image-position/' %}is-active{% endif %}" href="/utilities/image-position/">Image position</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/images/' %}is-active{% endif %}" href="/patterns/images/">Images</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/inline-images/' %}is-active{% endif %}" href="/patterns/inline-images/">Inline images</a></li>
+              <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/labels/' %}is-active{% endif %}" href="/patterns/labels/">Labels</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/links/' %}is-active{% endif %}" href="/patterns/links/">Links</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/list-tree/' %}is-active{% endif %}" href="/patterns/list-tree/">List tree</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/lists/' %}is-active{% endif %}" href="/patterns/lists/">Lists</a></li>


### PR DESCRIPTION
## Done

- Add 'Labels' to docs search list

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Type labels in the search bar and see that the result appears

## Details

Fixes #2471 

## Screenshots

<img width="450" alt="Screenshot 2019-08-12 at 09 49 50" src="https://user-images.githubusercontent.com/17748020/62854261-b82d7e80-bce6-11e9-8255-c7f62508157b.png">

