### PR TITLE
Remove <p> nesting in button examples

### DIFF
--- a/docs/examples/patterns/buttons/base.html
+++ b/docs/examples/patterns/buttons/base.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Base
 category: _patterns
 ---
-<p><button class="p-button--base">Base</button><button class="p-button--base" disabled>Base disabled</button></p>
-<p><a href="#" class="p-button--base">Base link</a><a href="#" class="p-button--base is-disabled" aria-disabled="true">Base link button</a></p>
+<button class="p-button--base">Base</button>
+<button class="p-button--base" disabled>Base disabled</button>

--- a/docs/examples/patterns/buttons/brand.html
+++ b/docs/examples/patterns/buttons/brand.html
@@ -3,4 +3,5 @@ layout: examples
 title: Buttons / Brand
 category: _patterns
 ---
-<p><button class="p-button--brand">Brand button</button><button class="p-button--brand" disabled>Brand button disabled</button></p>
+<button class="p-button--brand">Brand button</button>
+<button class="p-button--brand" disabled>Brand button disabled</button>

--- a/docs/examples/patterns/buttons/icon.html
+++ b/docs/examples/patterns/buttons/icon.html
@@ -3,10 +3,5 @@ layout: examples
 title: Buttons / Icon
 category: _patterns
 ---
-<button class="p-button has-icon">
-  <i class="p-icon--plus"></i>
-</button>
-
-<button class="p-button has-icon">
-  <i class="p-icon--plus"></i> <span>Button with icon</span>
-</button>
+<button class="p-button has-icon"><i class="p-icon--plus"></i></button>
+<button class="p-button has-icon"><i class="p-icon--plus"></i> <span>Button with icon</span></button>

--- a/docs/examples/patterns/buttons/negative.html
+++ b/docs/examples/patterns/buttons/negative.html
@@ -3,4 +3,5 @@ layout: examples
 title: Buttons / Negative
 category: _patterns
 ---
-<p><button class="p-button--negative">Negative button</button><button class="p-button--negative" disabled>Negative button disabled</button></p>
+<button class="p-button--negative">Negative button</button>
+<button class="p-button--negative" disabled>Negative button disabled</button>

--- a/docs/examples/patterns/buttons/neutral.html
+++ b/docs/examples/patterns/buttons/neutral.html
@@ -3,4 +3,5 @@ layout: examples
 title: Buttons / Neutral
 category: _patterns
 ---
-<p><button class="p-button--neutral">Neutral button</button><button class="p-button--neutral" disabled>Neutral button disabled</button></p>
+<button class="p-button--neutral">Neutral button</button>
+<button class="p-button--neutral" disabled>Neutral button disabled</button>

--- a/docs/examples/patterns/buttons/positive.html
+++ b/docs/examples/patterns/buttons/positive.html
@@ -3,4 +3,5 @@ layout: examples
 title: Buttons / Positive
 category: _patterns
 ---
-<p><button class="p-button--positive">Positive button</button><button class="p-button--positive" disabled>Positive button disabled</button></p>
+<button class="p-button--positive">Positive button</button>
+<button class="p-button--positive" disabled>Positive button disabled</button>


### PR DESCRIPTION
## Done

- Remove `<p>` from all button examples
- No longer needed as 2.0 fixes buttons to sit inline 👍 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/patterns/buttons/
- Check that all examples are no longer nested inside a `<p>` tag
  - /buttons/#base
  - /buttons/#positive
  - /buttons/#negative
  - /buttons/#brand
  - /buttons/#icon

## Details

Fixes #2158 

## Screenshots

<img width="862" alt="Screenshot 2019-08-12 at 10 30 11" src="https://user-images.githubusercontent.com/17748020/62856203-2fb1dc80-bcec-11e9-91c3-5e9ab3894c4c.png">

