### PR TITLE
Rejig homepage layout

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,6 @@ You can use Vanilla in your projects in a few different ways. See [Building with
 </div>
 
 <div class="row">
-<div class="u-equal-height">
   <div class="col-12">
     <h3>Hotlink</h3>
     <p>You can add Vanilla directly to your markup:</p>
@@ -42,11 +41,11 @@ You can use Vanilla in your projects in a few different ways. See [Building with
 
 <br>
 
-<div class="row u-equal-height">
+<div class="row">
   <div class="col-12">
     <h3>Download</h3>
-    <span>Download the latest version of Vanilla from GitHub.</span>
-    <a href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v2.3.0.zip" class="p-button--positive">Download v2.3.0</a>
+    <p>Download the latest version of Vanilla from GitHub.</p>
+    <button class="p-button--positive"><a href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v2.3.0.zip">Download v2.3.0</a></button>
   </div>
 </div>
 
@@ -54,20 +53,16 @@ You can use Vanilla in your projects in a few different ways. See [Building with
 
 <div class="row">
 <h3>Release notes</h3>
-  <div class="col-6">
-    <ul class="p-list--divided">
+<div class="row">
+    <ul class="p-list--divided is-split">
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0">Release v2.3.0 - 9 August, 2019</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.2.0">Release v2.2.0 - 1 August, 2019</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.1.0">Release v2.1.0 - 9 July, 2019</a></li>
-    </ul>
-  </div>
-
-  <div class="col-6">
-    <ul class="p-list--divided">
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.1">Release v2.0.1 - 11 June, 2019</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.0">Release v2.0.0 - 10 June, 2019</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.1.0">Release v2.0.0-beta.1 - 30 May, 2019</a></li>
     </ul>
+  </div>
   </div>
 
   <br>

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,8 +31,6 @@ You can use Vanilla in your projects in a few different ways. See [Building with
   </div>
 </div>
 
-<br>
-
 <div class="row">
 <div class="u-equal-height">
   <div class="col-12">

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,11 +5,9 @@ homepage: true
 
 ## Get started
 
-You can use Vanilla in your projects in a few different ways.
+<hr>
 
-See [Building with Vanilla](/building-vanilla) and [Customising Vanilla](/customising-vanilla) for more in-depth setup instructions.
-
-<hr class="is-deep">
+You can use Vanilla in your projects in a few different ways. See [Building with Vanilla](/building-vanilla) and [Customising Vanilla](/customising-vanilla) for more in-depth setup instructions.
 
 <h3>Install</h3>
 <div class="row">
@@ -33,7 +31,9 @@ See [Building with Vanilla](/building-vanilla) and [Customising Vanilla](/custom
   </div>
 </div>
 
-<hr class="is-deep">
+<br>
+
+<div class="row">
 <div class="u-equal-height">
   <div class="col-12">
     <h3>Hotlink</h3>
@@ -42,53 +42,50 @@ See [Building with Vanilla](/building-vanilla) and [Customising Vanilla](/custom
   </div>
 </div>
 
-<hr class="is-deep">
+<br>
 
-<div class="u-equal-height">
+<div class="row u-equal-height">
   <div class="col-12">
     <h3>Download</h3>
-    <p>Download the latest version of Vanilla from GitHub.</p>
+    <span>Download the latest version of Vanilla from GitHub.</span>
     <a href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v2.3.0.zip" class="p-button--positive">Download v2.3.0</a>
   </div>
 </div>
 
-<hr class="is-deep">
+<br>
 
 <div class="row">
+<h3>Release notes</h3>
   <div class="col-6">
-    <h3>What's new</h3>
-    <ul class="p-list">
-      <li class="p-list__item--deep">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0">Release notes: v2.3.0</a>
-      </li>
-      <li class="p-list__item--deep">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.2.0">Release notes: v2.2.0</a>
-      </li>
-      <li class="p-list__item--deep">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.1.0">Release notes: v2.1.0</a>
-      </li>
+    <ul class="p-list--divided">
+      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0">Release v2.3.0 - 9 August, 2019</a></li>
+      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.2.0">Release v2.2.0 - 1 August, 2019</a></li>
+      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.1.0">Release v2.1.0 - 9 July, 2019</a></li>
     </ul>
   </div>
 
-  <hr class="is-deep u-hide--medium u-hide--large">
-
   <div class="col-6">
-    <h3>Getting help</h3>
-    <ul class="p-list">
-      <li class="p-list__item">
-        <i class="p-list__icon--github"></i><a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new">GitHub</a>
-      </li>
-      <li class="p-list__item">
-        <i class="p-list__icon--twitter"></i><a href="https://twitter.com/vanillaframewrk">Twitter</a>
-      </li>
-      <li class="p-list__item">
-        <i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Slack</a>
-      </li>
+    <ul class="p-list--divided">
+      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.1">Release v2.0.1 - 11 June, 2019</a></li>
+      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.0">Release v2.0.0 - 10 June, 2019</a></li>
+      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.1.0">Release v2.0.0-beta.1 - 30 May, 2019</a></li>
     </ul>
+  </div>
+
+  <br>
+
+  <div class="row">
+  <div class="col-12">
+  <h3>Local development</h3>
+  <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-framework" class="p-link--external">README.md</a>.</p>
+
+  <br>
+
+  <ul class="p-inline-list">
+    <li class="p-inline-list__item"><i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Join our channel</a></li>
+    <li class="p-inline-list__item"><i class="p-list__icon--twitter"></i><a href="https://twitter.com/vanillaframewrk">Tweet us</a></li>
+    <li class="p-inline-list__item"><i class="p-list__icon--github"></i><a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new">Fork us on GitHub</a></li>
+  </ul>
+  </div>
   </div>
 </div>
-
-<hr class="is-deep">
-
-<h3>Local development</h3>
-<p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-framework" class="p-link--external">README.md</a>.</p>


### PR DESCRIPTION
## Done

- Added `hr` under the page heading
- Removed dividing lines between sections so it's consistent with the rest of the documentation site
- Added `br` between sections as they were too tight 
- Updated download link to use `p-button is-inline`
- Update `What's new` to 'Release notes' in heading and renamed links, added another list and release date
- Moving social links to bottom od the page and reordered so it matches marketing site

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/
- Scroll down the homepage and check out its full glory 💯 

## Details

Fixes old styling

## Screenshots

![AwesomeScreenshot-0-0-0-0--2019-08-12_3_51](https://user-images.githubusercontent.com/17748020/62874514-43276c80-bd19-11e9-848f-10500d175c72.png)

