### PR TITLE
Remove dividing lines and restyled related links

### DIFF
--- a/docs/building-vanilla.md
+++ b/docs/building-vanilla.md
@@ -65,8 +65,6 @@ Now if you open an extra terminal and run `yarn watch-css`, the CSS will be rebu
 
 For more options on configuring `node-sass`, for example minification and autoprefixing, refer to [the README.md](https://github.com/sass/node-sass).
 
----
-
 ### Webpack
 
 [Webpack](https://webpack.js.org/) is used to compile JavaScript modules, and can be used to inject Vanilla styles to the DOM. To get set up using Vanilla with Webpack, add the `webpack` and `vanilla-framework` packages to your project dependencies:
@@ -208,8 +206,6 @@ Your project's folder structure should now look something like this:
 
 For more options on configuring Webpack, for example minification and autoprefixing, refer to [the docs](https://webpack.js.org/concepts/).
 
----
-
 ### Gulp
 
 To get started with [gulp-sass](https://github.com/dlmanning/gulp-sass), add the following packages to your project:
@@ -272,8 +268,6 @@ Now run `gulp build-css`, which will convert any Sass files in the `src/` folder
 If you open an extra terminal and run `gulp watch-css`, the CSS will be rebuilt every time your Sass files are edited and saved.
 
 For more options on configuring `gulp-sass`, for example minification and autoprefixing, refer to [the README.md](https://github.com/dlmanning/gulp-sass).
-
----
 
 ### Git submodules
 

--- a/docs/customising-vanilla.md
+++ b/docs/customising-vanilla.md
@@ -29,8 +29,6 @@ $grid-max-width: 1440px;
 @include vanilla;
 ```
 
----
-
 ### Importing individual components
 
 Your project may not warrant including all of Vanilla, in which case you can include components modularly. You must at least include `vf-base` as many components depend on the base styling. Below is an example of how to include Vanilla components on an as-needed basis:
@@ -48,15 +46,27 @@ Your project may not warrant including all of Vanilla, in which case you can inc
 @include vf-p-links;
 ```
 
----
+### Related settings
 
-### Related
-
-- [Animation settings](/settings/animation-settings)
-- [Assets settings](/settings/assets-settings)
-- [Breakpoint settings](/settings/breakpoint-settings)
-- [Color settings](/settings/color-settings)
-- [Font settings](/settings/font-settings)
-- [Layout settings](/settings/layout-settings)
-- [Placeholder settings](/settings/placeholder-settings)
-- [Spacing settings](/settings/spacing-settings)
+<div class="row">
+  <div class="col-4">
+  <ul class="p-list--divided">
+  <li class="p-list__item"><a href="/settings/animation-settings">Animation</a></li>
+  <li class="p-list__item"><a href="/settings/assets-settings">Assets</a></li>
+  <li class="p-list__item"><a href="/settings/breakpoint-settings">Breakpoint</a></li>
+  </ul>
+  </div>
+  <div class="col-4">
+  <ul class="p-list--divided">
+  <li class="p-list__item"><a href="/settings/color-settings">Color</a></li>
+  <li class="p-list__item"><a href="/settings/font-settings">Font</a></li>
+  <li class="p-list__item"><a href="/settings/layout-settings">Layout</a></li>
+  </ul>
+  </div>
+  <div class="col-4">
+  <ul class="p-list--divided">
+  <li class="p-list__item"><a href="/settings/placeholder-settings">Placeholder</a></li>
+  <li class="p-list__item"><a href="/settings/spacing-settings">Spacing</a></li>
+  </ul>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Removed `hr` dividing lines from sections on /building-vanilla/ and /customising-vanilla/ pages
- Updated related list on /customising-vanilla/ page

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/building-vanilla/
  - Check all `hr` dividing lines have been removed from sections
- Open http://0.0.0.0:8101/customising-vanilla/
  - Check all `hr` dividing lines have been removed from sections
  - Updated 'Related' to 'Related settings'
  - Updated vertical list to a 3x3-col divider list 💯 

## Details

Fixes consistent page styling across documentation site

## Screenshots

<img width="1440" alt="Screenshot 2019-08-12 at 16 50 17" src="https://user-images.githubusercontent.com/17748020/62878909-f1cfab00-bd21-11e9-8f0f-5d16e8acaabd.png">

