### PR TITLE
Fix 404 broken link

### DIFF
--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -36,7 +36,7 @@ or more `p-subnav` components.
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-    <span class="p-notification__status">Note:</span> This component's functionality requires JavaScript. The <a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/develop/examples/patterns/navigation/subnav.html">sub-navigation example</a> provides an example implementation.
+    <span class="p-notification__status">Note:</span> This component's functionality requires JavaScript. The <a href="https://docs.vanillaframework.io/examples/patterns/navigation/subnav/">sub-navigation example</a> provides an example implementation.
   </p>
 </div>
 


### PR DESCRIPTION
## Done

- Fix broken link filed by @lilyvidenova on Usabilla 👍 

![Screenshot 2019-08-13 at 14 53 29](https://user-images.githubusercontent.com/17748020/62947268-22731b80-bdda-11e9-85c0-868702e908c5.png)

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/patterns/navigation/#sub-navigation-new
- Click _sub-navigation example_ link inside the note notification
- Make sure it points to here: https://docs.vanillaframework.io/examples/patterns/navigation/subnav/