### PR TITLE
Reorder and add sections to icons page

### DIFF
--- a/docs/patterns/icons.md
+++ b/docs/patterns/icons.md
@@ -13,7 +13,7 @@ Icons provide visual context and enhance usability, they can be added via an `<i
 Our icons have two predefined color styles: light and dark. The light variant is the default style.
 
 <section>
-  <div class="p-strip is-shallow">
+  <div class="p-strip is-shallow u-no-padding--top">
     <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center">
         <p><i class="p-icon--plus" style="margin-right: 1rem;"></i>p-icon--plus</p>
@@ -87,135 +87,66 @@ Our icons have two predefined color styles: light and dark. The light variant is
     </div>
 
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
-        <p><i class="p-icon--question" style="margin-right: 1rem;"></i>p-icon--question</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center">
-        <p><i class="p-icon--error" style="margin-right: 1rem;"></i>p-icon--error</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center">
-        <p><i class="p-icon--success" style="margin-right: 1rem;"></i>p-icon--success</p>
-      </div>
-    </div>
-
-    <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
-        <p><i class="p-icon--warning" style="margin-right: 1rem;"></i>p-icon--warning</p>
+      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <i class="p-icon--share" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--share
       </div>
       <div class="p-card col-4 u-vertically-center">
         <p><i class="p-icon--anchor" style="margin-right: 1rem;"></i>p-icon--anchor</p>
+      </div>
+      <div class="p-card col-4 u-vertically-center">
+        <p><i class="p-icon--question" style="margin-right: 1rem;"></i>p-icon--question</p>
       </div>
     </div>
 
   </div>
 </section>
 
-### Standard dark
+### Dark theme
 
-Our dark style of icons available when placed within `.p-strip--dark`, icon colors are reverted to ensure legibility.
+Our dark-themed icons are available when placed within `.p-strip--dark`, icon colors are reverted to ensure legibility as shown in our example.
 
 <section>
-<div class="p-strip--dark is-shallow" style="background-color: transparent;">
+<div class="p-strip--dark is-shallow u-no-padding--top" style="background-color: transparent;">
     <div class="row u-equal-height">
       <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
         <p style="color: #fff;"><i class="p-icon--plus" style="margin-right: 1rem;"></i>p-icon--plus</p>
       </div>
       <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--minus" style="margin-right: 1rem;"></i>p-icon--minus</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--expand" style="margin-right: 1rem;"></i>p-icon--expand</p>
-      </div>
-    </div>
-
-    <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--collapse" style="margin-right: 1rem;"></i>p-icon--collapse</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--spinner" style="margin-right: 1rem;"></i>p-icon--spinner</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--drag" style="margin-right: 1rem;"></i>p-icon--drag</p>
-      </div>
-    </div>
-
-    <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--close" style="margin-right: 1rem;"></i>p-icon--close</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--help" style="margin-right: 1rem;"></i>p-icon--help</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--information" style="margin-right: 1rem;"></i>p-icon--information</p>
-      </div>
-      </div>
-
-    <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--delete" style="margin-right: 1rem;"></i>p-icon--delete</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
         <p style="color: #fff;"><i class="p-icon--external-link" style="margin-right: 1rem;"></i>p-icon--external-link</p>
       </div>
       <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--contextual-menu" style="margin-right: 1rem;"></i>p-icon--contextual-menu</p>
-      </div>
-    </div>
-
-    <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--menu" style="margin-right: 1rem;"></i>p-icon--menu</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--code" style="margin-right: 1rem;"></i>p-icon--code</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--copy" style="margin-right: 1rem;"></i>p-icon--copy</p>
-      </div>
-    </div>
-
-    <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
         <p style="color: #fff;"><i class="p-icon--search" style="margin-right: 1rem;"></i>p-icon--search</p>
       </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--share" style="margin-right: 1rem;"></i>p-icon--share</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--user" style="margin-right: 1rem;"></i>p-icon--user</p>
-      </div>
     </div>
+</div>
+</section>
 
+### Alert
+
+Our alert icons are used to indicate the status of a message in a notification.
+
+<section>
+  <div class="p-strip is-shallow u-no-padding--top">
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--question" style="margin-right: 1rem;"></i>p-icon--question</p>
+      <div class="p-card col-4 u-vertically-center">
+        <p><i class="p-icon--error" style="margin-right: 1rem;"></i>p-icon--error</p>
       </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--error" style="margin-right: 1rem;"></i>p-icon--error</p>
+      <div class="p-card col-4 u-vertically-center">
+        <p><i class="p-icon--warning" style="margin-right: 1rem;"></i>p-icon--warning</p>
       </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--success" style="margin-right: 1rem;"></i>p-icon--success</p>
-      </div>
-    </div>
-
-    <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--warning" style="margin-right: 1rem;"></i>p-icon--warning</p>
-      </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
-        <p style="color: #fff;"><i class="p-icon--anchor" style="margin-right: 1rem;"></i>p-icon--anchor</p>
+      <div class="p-card col-4 u-vertically-center">
+        <p><i class="p-icon--success" style="margin-right: 1rem;"></i>p-icon--success</p>
       </div>
     </div>
-
   </div>
 </section>
 
 ### Social
 
+Our social icons are used to drive users to social content.
+
 <section>
-  <div class="p-strip is-shallow">
+  <div class="p-strip is-shallow u-no-padding--top">
     <div class="row">
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--facebook" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--facebook
@@ -225,7 +156,6 @@ Our dark style of icons available when placed within `.p-strip--dark`, icon colo
       </div>
       <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--twitter" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--twitter
-      </div>
     </div>
 
     <div class="row">
@@ -245,17 +175,30 @@ Our dark style of icons available when placed within `.p-strip--dark`, icon colo
         <i class="p-icon--ubuntu" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--ubuntu
       </div>
       </div>
+    </div>
 
   </div>
 </section>
 
 ### Share
 
-If you wish to add share icons for Twitter, Facebook, Google+ or LinkedIn, we recommend using the networks' official buttons:
+If you wish to add share icons for Twitter, Facebook or LinkedIn, we recommend using the networks' official buttons:
 
-- [**Twitter**](https://dev.twitter.com/web/tweet-button)
-- [**Facebook**](https://developers.facebook.com/docs/plugins/share-button/)
-- [**LinkedIn**](https://developer.linkedin.com/plugins/share)
+<div class="p-strip is-shallow u-no-padding--top">
+  <div class="row">
+    <ul class="p-inline-list--middot">
+      <li class="p-inline-list__item">
+        <a href="https://dev.twitter.com/web/tweet-button/">Twitter</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a href="https://developers.facebook.com/docs/plugins/share-button/">Facebook</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a href="https://developer.linkedin.com/plugins/share">LinkedIn</a>
+      </li>
+    </ul>
+  </div>
+</div>
 
 ### Design
 


### PR DESCRIPTION
## Done

- Updated dark style icon examples
- Move status icons into its own section 
- Fixed paddings between sections
- Updated layout of share icons into an inline list 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/patterns/icons/
- Scroll down the page and notice http://0.0.0.0:8101/patterns/icons/#dark-theme has been updated to just show a few examples rather than duplicating our standard icon set
- New section http://0.0.0.0:8101/patterns/icons/#alert 
- Updated to inline rather than stacked links http://0.0.0.0:8101/patterns/icons/#share

## Details

Fixes https://github.com/canonical-web-and-design/design-vanilla-framework/issues/417

## Screenshots

![AwesomeScreenshot-0-0-0-0-patterns-icons--2019-08-16_2_28](https://user-images.githubusercontent.com/17748020/63171078-b50df780-c032-11e9-87f2-f4adcd61bdca.png)

