### PR TITLE
Consistent footers

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -250,18 +250,18 @@
         </div>
 
         <hr>
-
+        
         <footer class="p-strip is-shallow" role="contentinfo">
           <div class="p-content__row">
             <div class="col-12">
-              <p>&copy; 2019 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+              &copy; {{ "now" | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
               <nav>
                 <ul class="p-inline-list--middot">
                   <li class="p-inline-list__item">
                     <a href="https://www.ubuntu.com/legal">Legal info</a>
                   </li>
                   <li class="p-inline-list__item">
-                    <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new">Report a bug</a>
+                    <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose">Report a bug with this site</a>
                   </li>
                 </ul>
                 <span class="u-off-screen">


### PR DESCRIPTION
## Done

- Match /docs footer with marketing site footer
- Link style and layout
- Date updates automatically

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework
- Check the footer styling matches what is seen on https://vanillaframework.io/

## Details

- #consitency

## Screenshots

<img width="1440" alt="Screenshot 2019-08-19 at 10 13 51" src="https://user-images.githubusercontent.com/17748020/63253599-110e9100-c26a-11e9-8458-27a2f0898785.png">

