### PR TITLE
Docs sidebar refresh

### DIFF
--- a/docs/sass/styles.scss
+++ b/docs/sass/styles.scss
@@ -81,8 +81,7 @@ hr {
 }
 
 .p-sidebar {
-  background-color: $color-light;
-  border-right: $border;
+  background-color: $color-mid-x-light;
   flex: 0 0 18rem;
 
   @supports (position: sticky) {

--- a/docs/sass/styles.scss
+++ b/docs/sass/styles.scss
@@ -261,8 +261,8 @@ hr.is-deep {
 }
 
 .p-sidebar__toggle.is-active {
-  border-bottom: 1px solid $color-light;
-  background-color: $color-light;
+  border-bottom: 1px solid $color-mid-x-light;
+  background-color: $color-mid-x-light;
   z-index: 1;
 
   &:focus {


### PR DESCRIPTION
## Done

- Removed `border-right: 1px solid #cdcdcd` as it's not needed, the background color supplies a divide between the content
- Updated background color to `$color-mid-x-light`

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/
- See updated sidebar color 👀 

## Screenshots

<img width="1440" alt="Screenshot 2019-08-19 at 16 48 13" src="https://user-images.githubusercontent.com/17748020/63279633-3c60a280-c2a1-11e9-8b76-bf5422df013c.png">

