### PR TITLE
Add baseline grid background

### DIFF
--- a/docs/_layouts/examples.html
+++ b/docs/_layouts/examples.html
@@ -39,5 +39,25 @@
         });
       }
     </script>
+    <style>
+      html::after {
+        background: linear-gradient(to top, rgba(255,0,0,0.15), rgba(255,0,0,0.15) 1px, rgba(255,0,0,0.05) 1px, rgba(255,0,0,0.05));
+        background-size: 100% .5em;
+        bottom: 0;
+        content: '';
+        display: block;
+        left: 0;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+        z-index: -1;
+      }
+
+      body {
+        background-color: #fff;
+      }
+    </style>
+
   </body>
 </html>

--- a/docs/_layouts/examples.html
+++ b/docs/_layouts/examples.html
@@ -6,6 +6,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %} {{ page.title }} | {% endif %} {{ site.name }}</title>
     <link rel="stylesheet" type="text/css" href="/build/css/build.css" />
+    <style>
+      html::after {
+        background: linear-gradient(to top, rgba(255,0,0,0.15), rgba(255,0,0,0.15) 1px, rgba(255,0,0,0.05) 1px, rgba(255,0,0,0.05));
+        background-size: 100% .5em;
+        bottom: 0;
+        content: '';
+        display: block;
+        left: 0;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+        z-index: -1;
+      }
+
+      body {
+        background-color: #fff;
+      }
+    </style>
   </head>
 
   <body {% if page.url != '/' %}style="margin: 1rem;"{% endif %}>
@@ -39,25 +58,5 @@
         });
       }
     </script>
-    <style>
-      html::after {
-        background: linear-gradient(to top, rgba(255,0,0,0.15), rgba(255,0,0,0.15) 1px, rgba(255,0,0,0.05) 1px, rgba(255,0,0,0.05));
-        background-size: 100% .5em;
-        bottom: 0;
-        content: '';
-        display: block;
-        left: 0;
-        pointer-events: none;
-        position: absolute;
-        right: 0;
-        top: 0;
-        z-index: -1;
-      }
-
-      body {
-        background-color: #fff;
-      }
-    </style>
-
   </body>
 </html>


### PR DESCRIPTION
## Done

Add a light pink baseline-grid background as a visual aid.
- helps see where a pattern begins, and where it ends
- helps see if it is on the baseline grid or not
- helps distinguish between 1rem example padding and actual example, useful for components that are flush with the page - like the nav, strips, etc.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Open any of the examples

## Details


## Screenshots

![image](https://user-images.githubusercontent.com/2741678/63507753-5fbd6480-c4d0-11e9-871b-da38969ba005.png)

