### PR TITLE
Fix spacing in navigation and subnav patterns

### DIFF
--- a/docs/examples/patterns/navigation/default.html
+++ b/docs/examples/patterns/navigation/default.html
@@ -4,37 +4,39 @@ title: Navigation / Default
 category: _patterns
 ---
 <header id="navigation" class="p-navigation">
-  <div class="p-navigation__banner">
-    <div class="p-navigation__logo">
-      <a class="p-navigation__link" href="#">
-        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
-      </a>
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-    <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    <nav class="p-navigation__nav">
+      <form class="p-search-box" action="/search">
+        <input type="search" class="p-search-box__input" name="q" placeholder="Search" required="">
+        <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
+        <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+      </form>
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link is-selected" role="menuitem">
+          <a href="#">Products</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a href="#">Services</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a href="#">Partners</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a href="#">About</a>
+        </li>
+      </ul>
+    </nav>
   </div>
-  <nav class="p-navigation__nav">
-    <form class="p-search-box" action="/search">
-      <input type="search" class="p-search-box__input" name="q" placeholder="Search" required="">
-      <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
-      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
-    </form>
-    <span class="u-off-screen">
-      <a href="#main-content">Jump to main content</a>
-    </span>
-    <ul class="p-navigation__links" role="menu">
-      <li class="p-navigation__link is-selected" role="menuitem">
-        <a href="#">Products</a>
-      </li>
-      <li class="p-navigation__link" role="menuitem">
-        <a href="#">Services</a>
-      </li>
-      <li class="p-navigation__link" role="menuitem">
-        <a href="#">Partners</a>
-      </li>
-      <li class="p-navigation__link" role="menuitem">
-        <a href="#">About</a>
-      </li>
-    </ul>
-  </nav>
 </header>

--- a/docs/examples/patterns/navigation/full-width.html
+++ b/docs/examples/patterns/navigation/full-width.html
@@ -1,0 +1,42 @@
+---
+layout: examples
+title: Navigation / Full-width
+category: _patterns
+---
+<header id="navigation" class="p-navigation">
+  <div class="p-navigation__row--full-width">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav">
+      <form class="p-search-box" action="/search">
+        <input type="search" class="p-search-box__input" name="q" placeholder="Search" required="">
+        <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
+        <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+      </form>
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link is-selected" role="menuitem">
+          <a href="#">Products</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a href="#">Services</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a href="#">Partners</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a href="#">About</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/docs/examples/patterns/navigation/subnav.html
+++ b/docs/examples/patterns/navigation/subnav.html
@@ -86,7 +86,6 @@ category: _patterns
     </nav>
   </div>
 </header>
-<div class="u-fixed-width"><div class="u-align-right"><select name="" id=""></select></div></div>
 
 <script>
 var subnavContainers = document.querySelectorAll('.p-subnav__items');

--- a/docs/examples/patterns/navigation/subnav.html
+++ b/docs/examples/patterns/navigation/subnav.html
@@ -3,79 +3,90 @@ layout: examples
 title: Navigation / Sub Navigation
 category: _patterns
 ---
+
 <header id="navigation" class="p-navigation">
-  <div class="p-navigation__banner">
-    <div class="p-navigation__logo">
-      <a class="p-navigation__link" href="#">
-        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="" width="95" />
-      </a>
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="" width="95" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-    <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    <nav class="p-navigation__nav">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
+          <a href="#link-1-menu" class="p-subnav__toggle">LXC</i>
+          </a>
+          <ul class="p-subnav__items" id="link-1-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-subnav__item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started</a>
+            </li>
+          </ul>
+        </li>
+        <li class="p-navigation__link p-subnav" role="menuitem" id="link-2">
+          <a href="#link-2-menu" class="p-subnav__toggle">LXD</i>
+          </a>
+          <ul class="p-subnav__items" id="link-2-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-subnav__item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started - Command line</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started - OpenStack</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started - OpenNebula</a>
+            </li>
+          </ul>
+        </li>
+        <li class="p-navigation__link p-subnav" role="menuitem" id="link-3">
+          <a href="#link-3-menu" class="p-subnav__toggle">LXCFS</a>
+          <ul class="p-subnav__items" id="link-3-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-subnav__item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
+          <a class="p-subnav__toggle" aria-controls="account-menu" aria-expanded="false">
+            My account
+          </a>
+          <ul class="p-subnav__items" id="account-menu" aria-hidden="true">
+            <li>
+              <a href="/logout" class="p-subnav__item">Sign out</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
   </div>
-  <nav class="p-navigation__nav">
-    <form class="p-search-box" action="/search">
-      <input type="search" class="p-search-box__input" name="q" placeholder="Search" required="">
-      <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
-      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
-    </form>
-    <span class="u-off-screen">
-      <a href="#main-content">Jump to main content</a>
-    </span>
-    <ul class="p-navigation__links" role="menu">
-      <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
-        <a href="#link-1-menu" class="p-subnav__toggle">LXC</i>
-        </a>
-        <ul class="p-subnav__items" id="link-1-menu" aria-hidden="true">
-          <li>
-            <a href="#" class="p-subnav__item">Introduction</a>
-          </li>
-          <li>
-            <a href="#" class="p-subnav__item">News</a>
-          </li>
-          <li>
-            <a href="#" class="p-subnav__item">Getting started</a>
-          </li>
-        </ul>
-      </li>
-      <li class="p-navigation__link p-subnav" role="menuitem" id="link-2">
-        <a href="#link-2-menu" class="p-subnav__toggle">LXD</i>
-        </a>
-        <ul class="p-subnav__items" id="link-2-menu" aria-hidden="true">
-          <li>
-            <a href="#" class="p-subnav__item">Introduction</a>
-          </li>
-          <li>
-            <a href="#" class="p-subnav__item">News</a>
-          </li>
-          <li>
-            <a href="#" class="p-subnav__item">Getting started - Command line</a>
-          </li>
-          <li>
-            <a href="#" class="p-subnav__item">Getting started - OpenStack</a>
-          </li>
-          <li>
-            <a href="#" class="p-subnav__item">Getting started - OpenNebula</a>
-          </li>
-        </ul>
-      </li>
-      <li class="p-navigation__link p-subnav" role="menuitem" id="link-3">
-        <a href="#link-3-menu" class="p-subnav__toggle">LXCFS</a>
-        <ul class="p-subnav__items" id="link-3-menu" aria-hidden="true">
-          <li>
-            <a href="#" class="p-subnav__item">Introduction</a>
-          </li>
-          <li>
-            <a href="#" class="p-subnav__item">News</a>
-          </li>
-          <li>
-            <a href="#" class="p-subnav__item">Getting started</a>
-          </li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
 </header>
+<div class="u-fixed-width"><div class="u-align-right"><select name="" id=""></select></div></div>
 
 <script>
 var subnavContainers = document.querySelectorAll('.p-subnav__items');

--- a/docs/examples/patterns/search-box/navigation.html
+++ b/docs/examples/patterns/search-box/navigation.html
@@ -4,30 +4,32 @@ title: Search box / Navigation
 category: _patterns
 ---
 <header id="navigation" class="p-navigation">
-  <div class="p-navigation__banner">
-    <div class="p-navigation__logo">
-      <a class="p-navigation__link" href="#">
-        <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
-      </a>
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-    <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    <nav class="p-navigation__nav">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link" role="menuitem"><a href="#">Products</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="#">Services</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="#">Partners</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="#">About</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="#">Partners</a></li>
+      </ul>
+      <form class="p-search-box">
+        <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
+        <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
+        <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+      </form>
+    </nav>
   </div>
-  <nav class="p-navigation__nav">
-    <span class="u-off-screen">
-      <a href="#main-content">Jump to main content</a>
-    </span>
-    <ul class="p-navigation__links" role="menu">
-      <li class="p-navigation__link" role="menuitem"><a href="#">Products</a></li>
-      <li class="p-navigation__link" role="menuitem"><a href="#">Services</a></li>
-      <li class="p-navigation__link" role="menuitem"><a href="#">Partners</a></li>
-      <li class="p-navigation__link" role="menuitem"><a href="#">About</a></li>
-      <li class="p-navigation__link" role="menuitem"><a href="#">Partners</a></li>
-    </ul>
-    <form class="p-search-box">
-      <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
-      <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
-      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
-    </form>
-  </nav>
 </header>

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -14,7 +14,7 @@ displayed horizontally on larger screens.
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-    <span class="p-notification__status">Note:</span>You can constrain the width of the navigation to match the <code>$grid-max-width</code> by placing everything inside the header element within a <code>.row</code> wrapper.
+    <span class="p-notification__status">Note:</span>By default, the width of the navigation is constrained to <code>$grid-max-width</code>. To make the nav full width, replace <code>.p-navigation__row</code> with <code>.p-navigation__row--full-width</code>.
   </p>
 </div>
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -318,7 +318,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     box-shadow: none;
     color: $color-dark;
     min-height: map-get($line-heights, default-text);
-    padding-right: $sph-inner--large;
+    padding-right: $default-icon-size + 2 * $sph-inner--small;
     text-indent: 0.01px;
     text-overflow: '';
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -78,10 +78,10 @@ $nav-border-bottom-thickness: 1px;
       white-space: nowrap;
 
       @media (max-width: $breakpoint-navigation-threshold) {
-        padding: $spv-inner--medium $grid-margin-width;
+        padding: $spv-inner--medium 0;
 
         &::before {
-          background: $color-light;
+          background: $color-mid-light;
           content: '';
           height: $nav-border-bottom-thickness;
           left: 0;
@@ -91,18 +91,8 @@ $nav-border-bottom-thickness: 1px;
         }
       }
 
-      @media (min-width: $breakpoint-navigation-threshold + 1) {
+      @media (min-width: $breakpoint-navigation-threshold) {
         padding: $spv-inner--medium $sph-inner;
-
-        &::before {
-          background: $border-color;
-          bottom: 0;
-          content: '';
-          height: $nav-border-bottom-thickness;
-          left: 0;
-          position: absolute;
-          right: 0;
-        }
       }
 
       &:hover {
@@ -128,7 +118,8 @@ $nav-border-bottom-thickness: 1px;
     @media (max-width: $breakpoint-navigation-threshold) {
       margin-top: -1px; // prevents bottom border of nav from moving 1px
     }
-    @media (min-width: $breakpoint-navigation-threshold + 1) {
+
+    @media (min-width: $breakpoint-navigation-threshold) {
       display: flex;
       flex-wrap: wrap;
     }
@@ -138,7 +129,7 @@ $nav-border-bottom-thickness: 1px;
     display: flex;
     flex: 0 0 auto;
     height: 3rem;
-    margin: 0 $sph-inner 0 $grid-margin-width;
+    margin: 0;
 
     .p-navigation__link {
       display: flex;
@@ -179,12 +170,9 @@ $nav-border-bottom-thickness: 1px;
     }
   }
 
-  &__row,
-  & .row {
+  &__row {
     display: flex;
-    padding-left: 0;
-    padding-right: 0;
-    width: 100%;
+    @extend %fixed-width-container;
 
     @media (max-width: $breakpoint-navigation-threshold) {
       flex-direction: column;
@@ -215,7 +203,7 @@ $nav-border-bottom-thickness: 1px;
     &--open,
     &--close {
       display: none;
-      margin: 0 $grid-margin-width auto $sph-inner;
+      margin: 0 0 auto $sph-inner;
       padding: $spv-inner--medium 0;
     }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -129,7 +129,7 @@ $nav-border-bottom-thickness: 1px;
     display: flex;
     flex: 0 0 auto;
     height: 3rem;
-    margin: 0;
+    margin: 0 $sph-inner 0 0;
 
     .p-navigation__link {
       display: flex;
@@ -155,7 +155,7 @@ $nav-border-bottom-thickness: 1px;
 
     @media (max-width: $breakpoint-navigation-threshold) {
       flex: 1 0 auto;
-      margin: -1px $grid-margin-width $spv-inner--small $grid-margin-width;
+      margin: -1px 0 $spv-inner--small 0;
       order: -1;
     }
 
@@ -164,7 +164,7 @@ $nav-border-bottom-thickness: 1px;
       $input-gap-top: $spv-inner--medium - $spv-nudge;
       display: flex;
       flex: 1 1 auto;
-      margin: $input-gap-top $sph-inner auto auto;
+      margin: $input-gap-top 0 auto auto;
       max-width: 20rem;
       order: 1;
     }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -171,8 +171,8 @@ $nav-border-bottom-thickness: 1px;
   }
 
   %navigation-row {
-    display: flex;
     @extend %fixed-width-container;
+    display: flex;
 
     @media (max-width: $breakpoint-navigation-threshold) {
       flex-direction: column;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -170,12 +170,27 @@ $nav-border-bottom-thickness: 1px;
     }
   }
 
-  &__row {
+  %navigation-row {
     display: flex;
     @extend %fixed-width-container;
 
     @media (max-width: $breakpoint-navigation-threshold) {
       flex-direction: column;
+    }
+  }
+
+  &__row {
+    @extend %navigation-row;
+
+    &--full-width {
+      @extend %navigation-row;
+      max-width: 100%;
+    }
+  }
+
+  @include deprecate('2.0.0', 'Use .p-navigation__row / .p-navigation__row--full-width instead') {
+    &.row {
+      @extend %navigation-row;
     }
   }
 

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -47,6 +47,7 @@
     @extend %vf-has-round-corners;
     display: none;
     margin: 0;
+    min-width: 100%;
     padding: 0;
     z-index: 5;
 
@@ -65,7 +66,14 @@
   .p-subnav__item {
     background-color: $color-navigation-background;
     display: block;
-    padding: $spv-inner--medium $grid-margin-width;
     white-space: nowrap;
+
+    @media (max-width: $breakpoint-navigation-threshold) {
+      padding: $spv-inner--small $grid-margin-width;
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      padding: $spv-inner--medium $sph-inner;
+    }
   }
 }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -17,7 +17,7 @@
       height: $spv-inner--large;
       pointer-events: none;
       position: absolute;
-      right: $sph-inner;
+      right: calc(#{$sph-inner--small} + 1px); // 1px for the border on selects. this aligns itr with any selects underneath
       text-indent: calc(100% + 10rem);
       top: $spv-inner--large;
       width: $sph-inner;
@@ -37,7 +37,7 @@
     // Can be updated with resolution of:
     // https://github.com/canonical-web-and-design/vanilla-framework/issues/2168
     > a {
-      padding-right: $sph-inner--x-large;
+      padding-right: 2 * $sph-inner--small + map-get($icon-sizes, default); // icon padded with the default padding-right of selects, inputs etc.
     }
   }
 

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -103,7 +103,6 @@ $spv-outer--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 $sph-inner--small: $sp-unit !default; // input-elements,
 $sph-inner: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
 $sph-inner--large: $sp-unit * 3 !default;
-$sph-inner--x-large: $sp-unit * 5 !default;
 // 2.2 Horizontal spacing outside components
 $sph-outer: $sph-inner !default;
 $sph-outer--large: $sp-unit * 3 !default; // checboxes, radios, list bullets


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/patterns/navigation/subnav/
- Add this under the nav and verify chevrons align:
```<div class="u-fixed-width"><div class="u-float-right"><select name="" id=""></select></div></div>```


## Details

- Currently, we remove the padding on the row wrapping nav contents, and apply that padding on the first / last element. This is prone to breaking, and needs to be applied to a variety of elements - search, right aligned dropdowns, etc. Note that it means all fixed width navs need the class p-navigation__row.

This pr reinstates the regular margins of a row, but uses .p-navigation__row for clarity - as a row comes with grid-gaps which get in the way as reported in #2483.

It also partially fixes #2480, by ensuring the chevron position aligns with select elements placed underneath it: 
![image](https://user-images.githubusercontent.com/2741678/63784965-68a2a180-c8e7-11e9-9562-d34041d02998.png)
