### PR TITLE
Fix positive buttons with icons

### DIFF
--- a/docs/examples/patterns/buttons/icon.html
+++ b/docs/examples/patterns/buttons/icon.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Icon
 category: _patterns
 ---
-<button class="p-button has-icon"><i class="p-icon--plus"></i></button>
+<button class="p-button--positive has-icon"><i class="p-icon--plus"></i></button>
 <button class="p-button has-icon"><i class="p-icon--plus"></i> <span>Button with icon</span></button>

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -144,7 +144,7 @@
 }
 
 @mixin vf-button-icon {
-  [class~='p-button'].has-icon {
+  [class^='p-button'].has-icon {
     width: auto;
 
     & [class*='p-icon'] {
@@ -158,5 +158,9 @@
         margin-left: $sph-inner--small / 2;
       }
     }
+  }
+
+  [class*='--positive'].has-icon [class*='p-icon'] {
+    @include vf-icon-plus($color-x-light);
   }
 }


### PR DESCRIPTION
## Done

- Fixes #2485.
- Changes icon color in positive buttons from grey to white

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/patterns/buttons/icon/
- Verify positive button does not go full-width on mobile