### PR TITLE
replace calculations with already existing var that does same thing.…

### DIFF
--- a/docs/examples/templates/tick-element-comparison.html
+++ b/docs/examples/templates/tick-element-comparison.html
@@ -5,12 +5,36 @@ category: _templates
 ---
 <div class="p-strip is-shallow u-no-padding--top">
   <div class="row">
-    <p>By default, checkbox and radio labels align with paragraphs.</p>
   </div>
   <div class="row">
     <div class="col-3">
-      <input type="checkbox" id="checkExample1" checked>
-      <label for="checkExample1">Checkbox option 1</label>
+      <form action="">
+        <input type="checkbox" id="checkExample2">
+        <label for="checkExample2">Checkbox option 2</label>
+        <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+        <label for="Radio1">Radio option 1</label>
+      </form>
+    </div>
+    <div class="col-3">
+      <form action="">
+        <input type="text">
+        <button>Button</button>
+      </form>
+    </div>
+    <div class="col-3">
+      <form action="">
+        <input type="text">
+        <input type="checkbox" id="checkExample1" checked>
+        <label for="checkExample1">Checkbox option 1</label>
+      </form>
+    </div>
+    <div class="col-3">
+      <form action="">
+        <input type="text">
+        <select name="" id=""></select>
+      </form>
+    </div>
+    <div class="col-3">
       <input type="checkbox" id="checkExample2">
       <label for="checkExample2">Checkbox option 2</label>
       <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -18,7 +18,7 @@
     font-size: 1rem;
     font-weight: 300;
     line-height: map-get($line-heights, default-text);
-    margin: 0 0 $spv-outer--scaleable - (2 * $spv-nudge) 0;
+    margin: 0 0 $input-margin-bottom 0;
     padding: calc(#{$spv-nudge} - 1px) $sph-inner--small * 1.5;
     text-align: center;
     text-decoration: none;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -164,7 +164,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     @include p-max-width;
     cursor: pointer;
     display: block;
-    margin-bottom: $spv-outer--small + $spv-nudge-compensation;
+    margin-bottom: $input-margin-bottom;
     margin-top: 0;
     padding-top: map-get($nudges, nudge--p);
     width: fit-content;
@@ -343,7 +343,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
   // Textarea styles
   textarea {
     @extend %vf-input-elements;
-    margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
+    margin-bottom: $input-margin-bottom;
     overflow: auto;
     vertical-align: top;
   }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -164,7 +164,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     @include p-max-width;
     cursor: pointer;
     display: block;
-    margin-bottom: $input-margin-bottom;
+    margin-bottom: $spv-outer--small-scaleable - $spv-nudge;
     margin-top: 0;
     padding-top: map-get($nudges, nudge--p);
     width: fit-content;


### PR DESCRIPTION
… Expand tick element template

## Done

We do the same calculation in a number of places, some use a variable some not. This conforms all instances to use the variable.
In doing the refactor, I noticed checkboxes are not using a scaleable margin-bottom, this fixes that (Will generate percy diffs).

## QA

- Pull code
- Run `./run serve --watch`
- QA percy
- QA code

