### PR TITLE
Delete mixin invocations that dump into the beginning of build.css

### DIFF
--- a/docs/examples/patterns/icons/icons-dark.html
+++ b/docs/examples/patterns/icons/icons-dark.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <div class="p-strip--dark is-shallow">
-  <div class="row">
+  <div class="u-fixed-width">
     <ul class="p-inline-list u-align--center u-no-margin--bottom">
       <li class="p-inline-list__item">
         <i class="p-icon--plus"></i>

--- a/docs/examples/patterns/icons/icons-light.html
+++ b/docs/examples/patterns/icons/icons-light.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <div class="p-strip--light is-shallow">
-  <div class="row">
+  <div class="u-fixed-width">
     <ul class="p-inline-list u-align--center u-no-margin--bottom">
       <li class="p-inline-list__item">
         <i class="p-icon--plus"></i>

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -1,7 +1,5 @@
 @import 'settings';
 @import 'patterns_icons';
-@include vf-p-icon-minus;
-@include vf-p-icon-plus;
 
 @mixin vf-p-accordion {
   $icon-size: map-get($icon-sizes, accordion);

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -82,7 +82,8 @@ $color-social-icon-foreground: $color-mid-x-light !default;
 }
 
 @mixin vf-icon-minus($color) {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M0 8.889V7.111h16v1.778z'/%3E%3C/svg%3E");
+  color: red;
+  //background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M0 8.889V7.111h16v1.778z'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-expand($color) {
@@ -223,7 +224,7 @@ $color-social-icon-foreground: $color-mid-x-light !default;
 
 @mixin vf-p-icon-minus {
   .p-icon--minus {
-    @extend %icon;
+    // @extend %icon;
     @include vf-icon-minus($color-mid-dark);
 
     [class*='--dark'] &,

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -82,8 +82,7 @@ $color-social-icon-foreground: $color-mid-x-light !default;
 }
 
 @mixin vf-icon-minus($color) {
-  color: red;
-  //background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M0 8.889V7.111h16v1.778z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M0 8.889V7.111h16v1.778z'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-expand($color) {

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -223,7 +223,7 @@ $color-social-icon-foreground: $color-mid-x-light !default;
 
 @mixin vf-p-icon-minus {
   .p-icon--minus {
-    // @extend %icon;
+    @extend %icon;
     @include vf-icon-minus($color-mid-dark);
 
     [class*='--dark'] &,

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -1,6 +1,5 @@
 @import 'settings';
 @import 'patterns_icons';
-@include vf-p-icon-contextual-menu;
 
 @mixin vf-p-pagination {
   %pagination-link {


### PR DESCRIPTION
## Done

A few mixins were invoked in the global scope, resulting in the css appearing above the reset rules. I've experimentally deleted them to see if this will result in any diffs.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [Add additional steps]

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
