### PR TITLE
Remove densification of inputs in tables and provide dense inputs/but…

### DIFF
--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -135,6 +135,15 @@ By applying the class `.is-required` the attribute specifies that an input field
 View example of an input required element
 </a>
 
+### Dense form elements
+
+In contexts where vertical space is limited, e.g. inside a table row, you might prefer form elements with reduced vertical padding. Add class `.is-dense` to achieve that:
+
+<a href="/examples/patterns/forms/dense/"
+    class="js-example">
+View example of the dense form elements
+</a>
+
 ### Design
 
 For more information [view the forms design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms), which includes the specification in markdown format and a PNG image.

--- a/docs/examples/patterns/buttons/dense.html
+++ b/docs/examples/patterns/buttons/dense.html
@@ -1,0 +1,7 @@
+---
+layout: examples
+title: Buttons / Dense
+category: _patterns
+---
+<span>Everything you need to get started with Vanilla.</span>
+<button class="p-button--neutral is-dense">Dense button</button>

--- a/docs/examples/patterns/forms/dense.html
+++ b/docs/examples/patterns/forms/dense.html
@@ -1,0 +1,18 @@
+---
+layout: examples
+title: Forms / Dense
+category: _patterns
+---
+<form class="">
+  <label for="username">Username</label>
+  <input type="text" id="username" class="is-dense" required>
+  <label for="address2">Email address</label>
+  <input type="text" id="address2" class="is-dense" required>
+  <label for="exampleSelect">Ubuntu releases</label>
+  <select name="exampleSelect" id="exampleSelect" class="is-dense">
+    <option value="" disabled="disabled" selected>Select an option</option>
+    <option value="1">Cosmic Cuttlefish</option>
+    <option value="2">Bionic Beaver</option>
+    <option value="3">Xenial Xerus</option>
+  </select>
+</form>

--- a/docs/examples/patterns/tables/table-expanding.html
+++ b/docs/examples/patterns/tables/table-expanding.html
@@ -26,7 +26,7 @@ category: _patterns
             <td role="gridcell" aria-label="Units">karura</td>
             <td role="gridcell" aria-label="Units">Thu, 25 Oct. 2018 13:55:21</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle" aria-controls="#expanded-row" aria-expanded="false" data-shown-text="Hide"
+                <button class="u-toggle is-dense" aria-controls="#expanded-row" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row" class="p-table-expanding__panel" aria-hidden="true">
@@ -47,7 +47,7 @@ category: _patterns
             <td role="gridcell" aria-label="Units">karura</td>
             <td role="gridcell" aria-label="Units">Wed, 3 Oct. 2018 23:08:06</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle" aria-controls="#expanded-row-2" aria-expanded="false" data-shown-text="Hide"
+                <button class="u-toggle is-dense" aria-controls="#expanded-row-2" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-2" class="p-table-expanding__panel" aria-hidden="true">
@@ -68,7 +68,7 @@ category: _patterns
             <td role="gridcell" aria-label="Units">karura</td>
             <td role="gridcell" aria-label="Units">Wed, 17 Oct. 2018 12:18:18</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle" aria-controls="#expanded-row-3" aria-expanded="false" data-shown-text="Hide"
+                <button class="u-toggle is-dense" aria-controls="#expanded-row-3" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-3" class="p-table-expanding__panel" aria-hidden="true">

--- a/docs/patterns/buttons.md
+++ b/docs/patterns/buttons.md
@@ -68,6 +68,15 @@ Should you wish to place a button after a line of inline text, as a CTA for exam
 View example of the inline button pattern
 </a>
 
+### Dense
+
+In contexts where vertical space is limited, you might want a button with reduced vertical padding. Add class `.is-dense` to achieve that:
+
+<a href="/examples/patterns/buttons/dense/"
+    class="js-example">
+View example of the dense button pattern
+</a>
+
 ### Icon
 
 Should you wish to place an icon in a button. You will not want to button to become full width on small screens. Therefore, you can add the state class `has-icon` to the button.

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -48,7 +48,7 @@
       }
     }
 
-    table & {
+    &.is-dense {
       margin-bottom: $spv-nudge-compensation;
       padding-bottom: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
       padding-top: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -39,7 +39,7 @@
     vertical-align: baseline;
     width: 100%;
 
-    table & {
+    &.is-dense {
       margin: 0 0 ($spv-inner--small - $spv-nudge) 0;
       padding-bottom: calc(#{$spv-nudge - $spv-inner--x-small} - 1px);
       padding-top: calc(#{$spv-nudge - $spv-inner--x-small} - 1px);


### PR DESCRIPTION
…tons via is-dense classes

## Done

- Fixes #2462
Removes the automatically applied reduced padding on input elementa and buttons, and provides it on request via is-dense classes

## QA

- Pull code
- Run `./run serve --watch`
- Open /base/forms/, scroll to bottom and qa example and doc copy
- Open patterns/buttons/, scroll to sedtion titled Dense and qa example and doc copy
