### PR TITLE
Add support for right-aligned subnavs

### DIFF
--- a/docs/examples/patterns/navigation/subnav.html
+++ b/docs/examples/patterns/navigation/subnav.html
@@ -76,7 +76,7 @@ category: _patterns
           <a class="p-subnav__toggle" aria-controls="account-menu" aria-expanded="false">
             My account
           </a>
-          <ul class="p-subnav__items" id="account-menu" aria-hidden="true">
+          <ul class="p-subnav__items--right" id="account-menu" aria-hidden="true">
             <li>
               <a href="/logout" class="p-subnav__item">Sign out</a>
             </li>
@@ -88,7 +88,7 @@ category: _patterns
 </header>
 
 <script>
-var subnavContainers = document.querySelectorAll('.p-subnav__items');
+var subnavContainers = document.querySelectorAll('[class^="p-subnav__items"]');
 var subnavs = document.querySelectorAll('.p-subnav');
 var subnavToggles = document.querySelectorAll('.p-subnav__toggle');
 
@@ -105,7 +105,7 @@ subnavs.forEach(function(currentSubnav) {
     var clickedDropdown = this;
 
     subnavs.forEach(function(subnav) {
-      var subnavContent = subnav.querySelector('.p-subnav__items');
+      var subnavContent = subnav.querySelector('[class^="p-subnav__items"]');
       if (subnav === clickedDropdown) {
         if (subnav.classList.contains('is-active')) {
           closeSubnav(subnav, subnavContent);

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -36,15 +36,11 @@ or more `p-subnav` components.
 
 To open the subnav-menu you need to set the `is-active` class on `p-subnav` element, but also set `aria-hidden` to `false` on `p-subnav__items`.
 
-<div class="p-notification--information">
-  <p class="p-notification__response">
-    <span class="p-notification__status">Note:</span> This component's functionality requires JavaScript. The <a href="https://docs.vanillaframework.io/examples/patterns/navigation/subnav/">sub-navigation example</a> provides an example implementation.
-  </p>
-</div>
+By default the sub-navigation menus are left-aligned with their parent, if you'd prefer the menu to be positioned from the right, use the `p-subnav__items--right` modifier. This can be seen in the "My account" menu in the example.
 
 <div class="p-notification--caution">
   <p class="p-notification__response">
-    <span class="p-notification__status">Warning:</span>This pattern requires JS to be functional.
+    <span class="p-notification__status">Warning:</span> This component's functionality requires JavaScript. The <a href="https://docs.vanillaframework.io/examples/patterns/navigation/subnav/">sub-navigation example</a> provides an example implementation.
   </p>
 </div>
 

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -28,7 +28,8 @@
         transform: rotate(180deg);
       }
 
-      .p-subnav__items {
+      .p-subnav__items,
+      .p-subnav__items--right {
         display: block;
       }
     }
@@ -41,7 +42,8 @@
     }
   }
 
-  .p-subnav__items {
+  .p-subnav__items,
+  .p-subnav__items--right {
     @extend %vf-is-bordered;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
@@ -61,6 +63,10 @@
       border: 0;
       box-shadow: none;
     }
+  }
+
+  .p-subnav__items--right {
+    right: 0;
   }
 
   .p-subnav__item {


### PR DESCRIPTION
## Done

Added a variant for right-aligned nav dropdowns

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/examples/patterns/navigation/subnav/
- Look at the right-hand dropdown (add more text if you want the effect to be clearer)

## Details
Fixes #2479 