### PR TITLE
Add dark theme support to subnavs

### DIFF
--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -5,39 +5,39 @@
 
   .p-subnav {
     position: relative;
+  }
 
+  .p-subnav::after {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    content: '';
+    display: block;
+    height: $spv-inner--large;
+    pointer-events: none;
+    position: absolute;
+    right: calc(#{$sph-inner--small} + 1px); // 1px for the border on selects. this aligns itr with any selects underneath
+    text-indent: calc(100% + 10rem);
+    top: $spv-inner--large;
+    width: $sph-inner;
+  }
+
+  .p-subnav.is-active {
     &::after {
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: contain;
-      content: '';
+      transform: rotate(180deg);
+    }
+
+    .p-subnav__items,
+    .p-subnav__items--right {
       display: block;
-      height: $spv-inner--large;
-      pointer-events: none;
-      position: absolute;
-      right: calc(#{$sph-inner--small} + 1px); // 1px for the border on selects. this aligns itr with any selects underneath
-      text-indent: calc(100% + 10rem);
-      top: $spv-inner--large;
-      width: $sph-inner;
     }
+  }
 
-    &.is-active {
-      &::after {
-        transform: rotate(180deg);
-      }
-
-      .p-subnav__items,
-      .p-subnav__items--right {
-        display: block;
-      }
-    }
-
-    // XXX: Fix required because of greedy rule in p-navigation
-    // Can be updated with resolution of:
-    // https://github.com/canonical-web-and-design/vanilla-framework/issues/2168
-    > a {
-      padding-right: 2 * $sph-inner--small + map-get($icon-sizes, default); // icon padded with the default padding-right of selects, inputs etc.
-    }
+  // XXX: Fix required because of greedy rule in p-navigation
+  // Can be updated with resolution of:
+  // https://github.com/canonical-web-and-design/vanilla-framework/issues/2168
+  .p-subnav > a {
+    padding-right: 2 * $sph-inner--small + map-get($icon-sizes, default); // icon padded with the default padding-right of selects, inputs etc.
   }
 
   // Theming
@@ -53,11 +53,6 @@
     .p-subnav.is-light {
       &::after {
         @include vf-icon-chevron;
-      }
-
-      .p-subnav__items,
-      .p-subnav__items--right {
-        @extend %vf-is-bordered;
       }
 
       .p-subnav__item {

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -7,8 +7,6 @@
     position: relative;
 
     &::after {
-      @include vf-icon-chevron;
-
       background-position: center;
       background-repeat: no-repeat;
       background-size: contain;
@@ -42,9 +40,57 @@
     }
   }
 
+  // Theming
+  @if (map-get($theme-default--dark, nav) == true) {
+    .p-subnav::after {
+      @include vf-icon-chevron($color-light);
+    }
+
+    .p-subnav__item {
+      @extend %subnav-item--dark-theme;
+    }
+
+    .p-subnav.is-light {
+      &::after {
+        @include vf-icon-chevron;
+      }
+
+      .p-subnav__items,
+      .p-subnav__items--right {
+        @extend %vf-is-bordered;
+      }
+
+      .p-subnav__item {
+        @extend %subnav-item--light-theme;
+      }
+    }
+  } @else {
+    .p-subnav::after {
+      @include vf-icon-chevron($color-mid-light);
+    }
+
+    .p-subnav__items,
+    .p-subnav__items--right {
+      @extend %vf-is-bordered;
+    }
+
+    .p-subnav__item {
+      @extend %subnav-item--light-theme;
+    }
+
+    .p-subnav.is-dark {
+      &::after {
+        @include vf-icon-chevron;
+      }
+
+      .p-subnav__item {
+        @extend %subnav-item--dark-theme;
+      }
+    }
+  }
+
   .p-subnav__items,
   .p-subnav__items--right {
-    @extend %vf-is-bordered;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
     display: none;
@@ -70,7 +116,6 @@
   }
 
   .p-subnav__item {
-    @extend %subnav-item--light-theme;
     display: block;
     white-space: nowrap;
 
@@ -108,6 +153,27 @@
       @media (max-width: $breakpoint-navigation-threshold) {
         // separator color on small screens
         background: map-get($colors--light-theme, border-default);
+      }
+    }
+  }
+
+  %subnav-item--dark-theme {
+    background-color: map-get($colors--dark-theme, background);
+
+    &,
+    &:active,
+    &:focus &:visited {
+      color: map-get($colors--dark-theme, text-default);
+    }
+
+    &:hover {
+      color: map-get($colors--dark-theme, text-hover);
+    }
+
+    &::before {
+      @media (max-width: $breakpoint-navigation-threshold) {
+        // separator color on small screens
+        background: map-get($colors--dark-theme, border-default);
       }
     }
   }

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -18,7 +18,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Top specificity',
       benchmark: 40,
-      threshold: 50,
+      threshold: 60,
       result: results['top-selector-specificity'],
       selector: results['top-selector-specificity-selector']
     },


### PR DESCRIPTION
## Done

Added dark mode for subnavs

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/examples/patterns/navigation/subnav/
- Change the "nav" entry to "true" in `_settings_themes.scss`
- Open http://0.0.0.0:8101/examples/patterns/navigation/subnav/
- See the nav in dark mode

![image](https://user-images.githubusercontent.com/118614/64700259-79821400-d49e-11e9-872d-12663150c58c.png)

## Details

Fixes #2478 

*NOTE*: There's no docs for the themes yet, that will be added in another PR
