### PR TITLE
fix vr issue in nav and tabs

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -36,6 +36,7 @@ $nav-border-bottom-thickness: 1px;
       & > a {
         @include vf-animation;
         display: block;
+        line-height: map-get($line-heights, default-text);
         margin-bottom: 0;
         overflow: hidden;
         position: relative;

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -60,6 +60,7 @@
     &__link {
       color: $color-x-dark;
       display: inline-block;
+      line-height: map-get($line-heights, default-text);
       padding: $spv-inner--medium $sph-inner;
 
       &:visited,


### PR DESCRIPTION
## Done
Explicitly set line-height on nav and tabs, so they stay aligned to baseline grid after bump in fontsize at $breakpoint-x-large (>1680px).

## QA

In firefox, look at the following examples on a screen > 1680px:
- https://docs.vanillaframework.io/examples/patterns/tabs/
- https://docs.vanillaframework.io/examples/patterns/navigation/subnav/
Verify borders fall onto baseline grid 
Compare with https://docs.vanillaframework.io/examples/patterns/navigation/subnav/ to see the difference.

Before:
![image](https://user-images.githubusercontent.com/2741678/64947900-3a750980-d876-11e9-9e90-7acd223a26fe.png)

After:
![image](https://user-images.githubusercontent.com/2741678/64947990-67292100-d876-11e9-9a50-c89c1985851b.png)

## Details

Fixes #2543