### PR TITLE
Move focus outline inside element. Tint with validation colours if el…

### DIFF
--- a/scss/_base_details.scss
+++ b/scss/_base_details.scss
@@ -1,6 +1,7 @@
 @mixin vf-b-details {
   details {
     margin-bottom: $spv-outer--scaleable;
+    overflow: auto;
   }
 
   summary {

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -16,7 +16,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
   // Default form input element styles
   %vf-input-elements {
     @extend %bordered-text-vertical-padding;
-    @include vf-focus;
+    @include vf-focus($color-focus, $bar-thickness, true);
 
     // sass-lint:disable no-vendor-prefixes property-sort-order
     -webkit-appearance: textfield;

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -41,9 +41,23 @@
 }
 
 // Adds visiual focus to elements on :focus
-@mixin vf-focus($color: $color-focus, $width: 2px) {
+@mixin vf-focus($color: $color-focus, $width: $bar-thickness, $has-validation: false) {
   &:focus {
     outline: $width solid $color;
+    outline-offset: -#{$width};
+  }
+  @if ($has-validation) {
+    .is-error &:focus {
+      outline-color: $color-negative;
+    }
+
+    .is-caution &:focus {
+      outline-color: $color-caution;
+    }
+
+    .is-success &:focus {
+      outline-color: $color-positive;
+    }
   }
 }
 

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -3,6 +3,7 @@
 
 @mixin vf-p-pagination {
   %pagination-link {
+    @include vf-focus;
     border-color: $color-mid;
     border-radius: $border-radius;
     border-style: solid;

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -1,11 +1,10 @@
 @mixin vf-p-search-box {
-  $focus-border-thickness: 2px;
   $input-border-thicknes: 1px;
 
   %search-box-button {
     display: block;
-    height: calc(#{2 * $spv-nudge + map-get($line-heights, default-text)} - #{2 * $focus-border-thickness}); // side padding + icon width - focus outline width * 2
-    margin: $focus-border-thickness 0;
+    height: calc(#{2 * $spv-nudge + map-get($line-heights, default-text)} - #{2 * $bar-thickness}); // side padding + icon width - focus outline width * 2
+    margin: $bar-thickness 0;
     position: relative;
     width: auto;
 
@@ -52,7 +51,7 @@
     border-left-style: solid;
     border-left-width: 1px;
     border-radius: 0 $border-radius $border-radius 0;
-    margin-right: $focus-border-thickness;
+    margin-right: $bar-thickness;
   }
 
   .p-search-box__reset {
@@ -60,7 +59,7 @@
     @extend %transparent-button;
 
     &:not(:last-of-type):not(:only-of-type) {
-      margin-right: $focus-border-thickness;
+      margin-right: $bar-thickness;
     }
   }
 

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -17,6 +17,8 @@
     }
 
     & [class*='p-icon'] {
+      top: 0;
+
       &:only-child {
         margin-left: -#{$sph-inner--small};
         margin-right: -#{$sph-inner--small};

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -1,6 +1,6 @@
 // Global placeholder settings
 
-$bar-thickness: 0.1875rem !default; //3 px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
+$bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
 $border-radius: $sp-unit * 0.25 !default;
 $border: 1px solid $color-mid-light !default;
 $box-shadow: 0 1px 5px 1px transparentize($color-dark, 0.8) !default;

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -1,6 +1,6 @@
 // Global placeholder settings
 
-$bar-thickness: 3px !default;
+$bar-thickness: 0.1875rem !default; //3 px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
 $border-radius: $sp-unit * 0.25 !default;
 $border: 1px solid $color-mid-light !default;
 $box-shadow: 0 1px 5px 1px transparentize($color-dark, 0.8) !default;

--- a/scss/_utilities_layout.scss
+++ b/scss/_utilities_layout.scss
@@ -3,7 +3,7 @@
     @extend %fixed-width-container;
   }
 
-  @if ($table-layout-fixed == 'true') {
+  @if ($table-layout-fixed) {
     .u-table-layout--auto {
       table-layout: auto !important;
     }


### PR DESCRIPTION
…ement requires validation.

## Done

Use $bar-thickness to controll focus thickness for consistency (it raises thickness from 2 to 3px, which makes it easier to spot the change from non-focused to focused).

Move focus inward from the border of the element, instead of outward.

Tint with validation colours based on a variable passed to the mixin.


## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- [Add additional steps]

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/2741678/64951008-1b2daa80-d87d-11e9-8392-878f4d77b35f.png)
![image](https://user-images.githubusercontent.com/2741678/64951026-2385e580-d87d-11e9-98ba-e40d6e383e96.png)
