### PR TITLE
Update nav in dark theme to use #333

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -229,7 +229,7 @@ $nav-border-bottom-thickness: 1px;
   }
 
   %p-navigation--dark-theme {
-    background-color: map-get($colors--dark-theme, background);
+    background-color: map-get($colors--dark-theme, background-highlighted);
 
     .p-navigation__link > a,
     .p-navigation__toggle--close,

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -43,15 +43,14 @@ $colors--light-theme: (
   text-hover: #757575,
   text-disabled: #666,
   text-default: #111
-);
+) !default;
 
 //text-hover: minimum contrast on primary that satisfies contrast checker AA
 $colors--dark-theme: (
   background: hsl(0, 0%, 15%),
-  background-dark: hsl(0, 0%, 12%),
   background-highlighted: hsl(0, 0%, 17%),
   border-default: hsl(0, 0%, 27%),
   border-high-contrast: hsl(0, 0%, 42%),
   text-hover: hsl(0, 0%, 56%),
   text-default: hsl(0, 0%, 100%)
-);
+) !default;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -48,7 +48,7 @@ $colors--light-theme: (
 //text-hover: minimum contrast on primary that satisfies contrast checker AA
 $colors--dark-theme: (
   background: hsl(0, 0%, 15%),
-  background-highlighted: hsl(0, 0%, 17%),
+  background-highlighted: hsl(0, 0%, 20%),
   border-default: hsl(0, 0%, 27%),
   border-high-contrast: hsl(0, 0%, 42%),
   text-hover: hsl(0, 0%, 56%),


### PR DESCRIPTION
## Done

Fix https://github.com/canonical-web-and-design/vanilla-framework/issues/2554
## QA

- Pull code
- Run `./run serve --watch`
- Open dark nav example
- Verify background color is #333
