### PR TITLE
Add padding below tables

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -4,10 +4,10 @@
 @mixin vf-b-tables {
   table {
     border: 0;
+    border-bottom: $spv-outer--scaleable solid transparent;
     border-collapse: collapse;
     line-height: map-get($line-heights, default-text);
     overflow-x: auto;
-    padding-bottom: $spv-outer--scaleable;
     width: 100%;
 
     @if ($table-layout-fixed) {


### PR DESCRIPTION
## Done
Add a small amount of padding using a transparent bottom border to space elements below tables.

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Go to the tables example
- Duplicate the table with the inspector
- See that there is some padding between the tables

## Details
Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2491

## Screenshots
![Screenshot_2019-09-24 Table Vanilla framework documentation](https://user-images.githubusercontent.com/1413534/65530587-2e312200-def0-11e9-8cc4-2ac7648ef66b.png)

