### PR TITLE
Fix nav feature removal and fix deprecations

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -152,9 +152,12 @@ $nav-border-bottom-thickness: 1px;
       }
     }
 
-    @include deprecate('2.0.0', 'Use .p-navigation__row / .p-navigation__row--full-width instead') {
+    @include deprecate('3.0.0', 'Use .p-navigation__row / .p-navigation__row--full-width instead') {
       &.row {
         @extend %navigation-row;
+        @media (min-width: $breakpoint-navigation-threshold) {
+          display: flex;
+        }
       }
     }
 

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -54,3 +54,23 @@ $colors--dark-theme: (
   text-hover: hsl(0, 0%, 56%),
   text-default: hsl(0, 0%, 100%)
 ) !default;
+
+@include deprecate('3.0.0', '$color-navigation-background will no longer be supported after the introduction of themes') {
+  /// XXX Fix for regression introduced in v2.4.0
+  /// Allows the variable $color-navigation-background to be used as explained in the docs
+  /// Note: This disables any theme-defined background colour
+  @if variable-exists(color-navigation-background) {
+    $colors--light-theme: map-merge(
+      $colors--light-theme,
+      (
+        background: $color-navigation-background
+      )
+    );
+    $colors--dark-theme: map-merge(
+      $colors--dark-theme,
+      (
+        background: $color-navigation-background
+      )
+    );
+  }
+}

--- a/scss/_settings_system.scss
+++ b/scss/_settings_system.scss
@@ -1,2 +1,5 @@
 // Global system settings
-$app-version: '2.4.0' !default;
+
+// Deprecate configuration
+$app-version: '2.4.0';
+$deprecate-mode: sensible !default; // Override to "verbose" to get full deprecation notices for sass that you are importing

--- a/scss/_settings_themes.scss
+++ b/scss/_settings_themes.scss
@@ -3,4 +3,4 @@ $theme-default--dark: (
   nav: false,
   p-search-box: false,
   forms: false
-);
+) !default;


### PR DESCRIPTION
## Done

- Clarify deprecate functionality.
- Add `!default` to theme map definiton. 
- Fix regressions that broke the API for navigation colour and rows.

## QA

- Pull code
- Run `./run` and `./run watch`
- Open http://0.0.0.0:8101/examples/patterns/navigation/default
- Add a definition of to some other colour. e.g.: `$color-navigation-background: #bb0000;`
- Refresh the page and see that the colour changes
- Inspect the page markup and change `p-navigation__row` to `row` and see that the nav works (despite some slight spacing differences)
- Edit _settings_system.scss to set `$deprecate-mode: verbose` and check that the new deprecations are visible in the terminal

## Details

Fixes #2566 