### PR TITLE
Add subset latin fonts

### DIFF
--- a/docs/_layouts/examples.html
+++ b/docs/_layouts/examples.html
@@ -5,6 +5,12 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %} {{ page.title }} | {% endif %} {{ site.name }}</title>
+
+    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/46ed6870-Ubuntu-L-subset.woff2" crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/3baab91b-Ubuntu-Th-subset.woff2" crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/6113b69a-Ubuntu-LI-subset.woff2" crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/0c7b8dc0-Ubuntu-R-subset.woff2" crossorigin>
+
     <link rel="stylesheet" type="text/css" href="/build/css/build.css" />
     <style>
       html::after {

--- a/docs/_layouts/examples.html
+++ b/docs/_layouts/examples.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %} {{ page.title }} | {% endif %} {{ site.name }}</title>
 
-    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/46ed6870-Ubuntu-L-subset.woff2" crossorigin>
-    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/3baab91b-Ubuntu-Th-subset.woff2" crossorigin>
-    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/6113b69a-Ubuntu-LI-subset.woff2" crossorigin>
-    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/0c7b8dc0-Ubuntu-R-subset.woff2" crossorigin>
-
     <link rel="stylesheet" type="text/css" href="/build/css/build.css" />
     <style>
       html::after {

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -180,7 +180,7 @@ $font-allow-cyrillic-greek-latin: true;
 
 ### `font-display` options
 
-The css [font-display](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) option allows you to set a strategy for what backup font is shown while an external font is loading. This is a very subjective decision; however, if you set the following variable to the option you want, it will add it to the typography for you.
+The CSS [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) option allows you to set a strategy for what backup font is shown while an external font is loading. This is a very subjective decision; however, if you set the following variable to the option you want, it will add it to the typography for you.
 
 ```sass
 $font-display-option: <auto | block | swap | fallback | optional>;

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -186,7 +186,7 @@ The CSS [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-
 $font-display-option: <auto | block | swap | fallback | optional>;
 ```
 
-The default is not to add a `font-display` descriptor.
+The `font-display` descriptor's default setting is `auto`.
 
 ### Design
 

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -160,6 +160,14 @@ If you are using the Ubuntu font, it comes in five weights; thin, light, regular
 View example of the Ubuntu font weights.
 </a>
 
+### Using a smaller set of Latin font faces
+
+The default Ubuntu fonts are fairly large as they contain glyphs for many languages. If you are building sites in; Afrikaans, Albanian, Catalan, Danish, Dutch, English, German, Icelandic, Italian, Norwegian, Portuguese, Spanish, Swedish or Zulu, you could use the subset of Latin fonts by setting the following variable to true:
+
+```sass
+$font-use-subset-latin: true;
+```
+
 ### Enabling Cyrillic, Greek and Latin fonts
 
 Due to the extra weight of loading these fonts they are not imported by
@@ -169,6 +177,16 @@ following font setting to true.
 ```sass
 $font-allow-cyrillic-greek-latin: true;
 ```
+
+### `font-display` options
+
+The css [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) option allows you to set a strategy for what backup font is shown while an external font is loading. This is a very subjective decision; however, if you set the following variable to the option you want, it will add it to the typography for you.
+
+```sass
+$font-display-option: <auto | block | swap | fallback | optional>;
+```
+
+The default is not to add a `font-display` descriptor.
 
 ### Design
 

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -180,7 +180,7 @@ $font-allow-cyrillic-greek-latin: true;
 
 ### `font-display` options
 
-The css [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) option allows you to set a strategy for what backup font is shown while an external font is loading. This is a very subjective decision; however, if you set the following variable to the option you want, it will add it to the typography for you.
+The css [font-display](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) option allows you to set a strategy for what backup font is shown while an external font is loading. This is a very subjective decision; however, if you set the following variable to the option you want, it will add it to the typography for you.
 
 ```sass
 $font-display-option: <auto | block | swap | fallback | optional>;

--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -2,6 +2,9 @@
   @if str-index($font-base-family, 'Ubuntu') {
     @if $font-use-subset-latin {
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -10,6 +13,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 400;
@@ -18,6 +24,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: italic;
         font-weight: 300;
@@ -26,6 +35,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: italic;
         font-weight: 400;
@@ -34,6 +46,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 100;
@@ -42,6 +57,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 300;
@@ -50,6 +68,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 400;
@@ -58,6 +79,9 @@
       }
     } @else {
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -65,6 +89,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 400;
@@ -72,6 +99,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: italic;
         font-weight: 300;
@@ -79,6 +109,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: italic;
         font-weight: 400;
@@ -86,6 +119,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 100;
@@ -93,6 +129,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 300;
@@ -100,6 +139,9 @@
       }
 
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 400;
@@ -110,6 +152,9 @@
     @if $font-allow-cyrillic-greek-latin {
       // cyrillic-ext
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -119,6 +164,9 @@
 
       // cyrillic
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -128,6 +176,9 @@
 
       // greek-ext
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -137,6 +188,9 @@
 
       // greek
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -146,6 +200,9 @@
 
       // latin-ext
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -155,6 +212,9 @@
 
       // latin
       @font-face {
+        @if $font-display-option {
+          font-display: $font-display-option;
+        }
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;

--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -2,9 +2,7 @@
   @if str-index($font-base-family, 'Ubuntu') {
     @if $font-use-subset-latin {
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -13,9 +11,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 400;
@@ -24,9 +20,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: italic;
         font-weight: 300;
@@ -35,9 +29,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: italic;
         font-weight: 400;
@@ -46,9 +38,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 100;
@@ -57,9 +47,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 300;
@@ -68,9 +56,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 400;
@@ -79,9 +65,7 @@
       }
     } @else {
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -89,9 +73,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 400;
@@ -99,9 +81,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: italic;
         font-weight: 300;
@@ -109,9 +89,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: italic;
         font-weight: 400;
@@ -119,9 +97,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 100;
@@ -129,9 +105,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 300;
@@ -139,9 +113,7 @@
       }
 
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 400;
@@ -152,9 +124,7 @@
     @if $font-allow-cyrillic-greek-latin {
       // cyrillic-ext
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -164,9 +134,7 @@
 
       // cyrillic
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -176,9 +144,7 @@
 
       // greek-ext
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -188,9 +154,7 @@
 
       // greek
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -200,9 +164,7 @@
 
       // latin-ext
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
@@ -212,9 +174,7 @@
 
       // latin
       @font-face {
-        @if $font-display-option {
-          font-display: $font-display-option;
-        }
+        font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;

--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -1,52 +1,110 @@
 @mixin vf-b-typography-fontfaces {
   @if str-index($font-base-family, 'Ubuntu') {
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: normal;
-      font-weight: 300;
-      src: url('#{$assets-path}e8c07df6-Ubuntu-L_W.woff2') format('woff2'), url('#{$assets-path}8619add2-Ubuntu-L_W.woff') format('woff');
-    }
+    @if $font-use-subset-latin {
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 300;
+        src: url('#{$assets-path}46ed6870-Ubuntu-L-subset.woff2') format('woff2'), url('#{$assets-path}4070835e-Ubuntu-L-subset.woff') format('woff');
+        unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
 
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: normal;
-      font-weight: 400;
-      src: url('#{$assets-path}fff37993-Ubuntu-R_W.woff2') format('woff2'), url('#{$assets-path}7af50859-Ubuntu-R_W.woff') format('woff');
-    }
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 400;
+        src: url('#{$assets-path}0c7b8dc0-Ubuntu-R-subset.woff2') format('woff2'), url('#{$assets-path}ef4d35ed-Ubuntu-R-subset.woff') format('woff');
+        unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
 
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: italic;
-      font-weight: 300;
-      src: url('#{$assets-path}f8097dea-Ubuntu-LI_W.woff2') format('woff2'), url('#{$assets-path}8be89d02-Ubuntu-LI_W.woff') format('woff');
-    }
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: italic;
+        font-weight: 300;
+        src: url('#{$assets-path}6113b69a-Ubuntu-LI-subset.woff2') format('woff2'), url('#{$assets-path}56a10e22-Ubuntu-LI-subset.woff') format('woff');
+        unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
 
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: italic;
-      font-weight: 400;
-      src: url('#{$assets-path}fca66073-ubuntu-ri-webfont.woff2') format('woff2'), url('#{$assets-path}f0898c72-ubuntu-ri-webfont.woff') format('woff');
-    }
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: italic;
+        font-weight: 400;
+        src: url('#{$assets-path}fd4ec0c7-Ubuntu-RI-subset.woff2') format('woff2'), url('#{$assets-path}89be6515-Ubuntu-RI-subset.woff') format('woff');
+        unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
 
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: normal;
-      font-weight: 100;
-      src: url('#{$assets-path}7f100985-Ubuntu-Th_W.woff2') format('woff2'), url('#{$assets-path}502cc3a1-Ubuntu-Th_W.woff') format('woff');
-    }
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 100;
+        src: url('#{$assets-path}3baab91b-Ubuntu-Th-subset.woff2') format('woff2'), url('#{$assets-path}cb89e3ac-Ubuntu-Th-subset.woff') format('woff');
+        unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
 
-    @font-face {
-      font-family: 'Ubuntu Mono';
-      font-style: normal;
-      font-weight: 300;
-      src: url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
-    }
+      @font-face {
+        font-family: 'Ubuntu Mono';
+        font-style: normal;
+        font-weight: 300;
+        src: url('#{$assets-path}a6c34b5d-UbuntuMono-R-subset.woff2') format('woff2'), url('#{$assets-path}e6daa284-UbuntuMono-R-subset.woff') format('woff');
+        unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
 
-    @font-face {
-      font-family: 'Ubuntu Mono';
-      font-style: normal;
-      font-weight: 400;
-      src: url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
+      @font-face {
+        font-family: 'Ubuntu Mono';
+        font-style: normal;
+        font-weight: 400;
+        src: url('#{$assets-path}a662364d-UbuntuMono-B-subset.woff2') format('woff2'), url('#{$assets-path}22f97dd9-UbuntuMono-B-subset.woff') format('woff');
+        unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+    } @else {
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 300;
+        src: url('#{$assets-path}e8c07df6-Ubuntu-L_W.woff2') format('woff2'), url('#{$assets-path}8619add2-Ubuntu-L_W.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 400;
+        src: url('#{$assets-path}fff37993-Ubuntu-R_W.woff2') format('woff2'), url('#{$assets-path}7af50859-Ubuntu-R_W.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: italic;
+        font-weight: 300;
+        src: url('#{$assets-path}f8097dea-Ubuntu-LI_W.woff2') format('woff2'), url('#{$assets-path}8be89d02-Ubuntu-LI_W.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: italic;
+        font-weight: 400;
+        src: url('#{$assets-path}fca66073-ubuntu-ri-webfont.woff2') format('woff2'), url('#{$assets-path}f0898c72-ubuntu-ri-webfont.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Ubuntu';
+        font-style: normal;
+        font-weight: 100;
+        src: url('#{$assets-path}7f100985-Ubuntu-Th_W.woff2') format('woff2'), url('#{$assets-path}502cc3a1-Ubuntu-Th_W.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Ubuntu Mono';
+        font-style: normal;
+        font-weight: 300;
+        src: url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Ubuntu Mono';
+        font-style: normal;
+        font-weight: 400;
+        src: url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
+      }
     }
 
     @if $font-allow-cyrillic-greek-latin {
@@ -55,7 +113,7 @@
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
-        src: local('Ubuntu'), url('#{$font-import}ODszJI8YqNw8V2xPulzjO_esZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        src: url('#{$assets-path}8aba5b6f-Ubuntu-L-cyrillic-ext-subset.woff2') format('woff2'), url('#{$assets-path}55e29aa9-Ubuntu-L-cyrillic-ext-subset.woff') format('woff');
         unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
       }
 
@@ -64,7 +122,7 @@
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
-        src: local('Ubuntu'), url('#{$font-import}iQ9VJx1UMASKNiGywyyCXvesZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        src: url('#{$assets-path}5bea8279-Ubuntu-L-cyrillic-subset.woff2') format('woff2'), url('#{$assets-path}b8058442-Ubuntu-L-cyrillic-subset.woff') format('woff');
         unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
       }
 
@@ -73,7 +131,7 @@
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
-        src: local('Ubuntu'), url('#{$font-import}WkvQmvwsfw_KKeau9SlQ2_esZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        src: url('#{$assets-path}a6dcff6e-Ubuntu-L-greek-ext-subset.woff2') format('woff2'), url('#{$assets-path}496f3bda-Ubuntu-L-greek-ext-subset.woff') format('woff');
         unicode-range: U+1F00-1FFF;
       }
 
@@ -82,7 +140,7 @@
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
-        src: local('Ubuntu'), url('#{$font-import}gYAtqXUikkQjyJA1SnpDLvesZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        src: url('#{$assets-path}b7ba71af-Ubuntu-L-greek-subset.woff2') format('woff2'), url('#{$assets-path}b864c12e-Ubuntu-L-greek-subset.woff') format('woff');
         unicode-range: U+0370-03FF;
       }
 
@@ -91,7 +149,7 @@
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
-        src: local('Ubuntu'), url('#{$font-import}Wu5Iuha-XnKDBvqRwQzAG_esZW2xOQ-xsNqO47m55DA.woff2') format('woff2');
+        src: url('#{$assets-path}98e516d3-Ubuntu-L-latin-ext-subset.woff2') format('woff2'), url('#{$assets-path}11a74839-Ubuntu-L-latin-ext-subset.woff') format('woff');
         unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
       }
 
@@ -100,7 +158,7 @@
         font-family: 'Ubuntu';
         font-style: normal;
         font-weight: 300;
-        src: local('Ubuntu'), url('#{$font-import}sDGTilo5QRsfWu6Yc11AXg.woff2') format('woff2');
+        src: url('#{$assets-path}317bd676-Ubuntu-L-latin-subset.woff2') format('woff2'), url('#{$assets-path}c09862e1-Ubuntu-L-latin-subset.woff') format('woff');
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
       }
     }

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -14,6 +14,9 @@
     -webkit-font-smoothing: antialiased;
     // sass-lint:enable no-vendor-prefixes
     color: $color-dark;
+    @if $font-display-option {
+      font-display: $font-display-option;
+    }
     font-family: unquote($font-base-family);
     // sass-lint:disable no-misspelled-properties
     font-smoothing: subpixel-antialiased;

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -14,9 +14,6 @@
     -webkit-font-smoothing: antialiased;
     // sass-lint:enable no-vendor-prefixes
     color: $color-dark;
-    @if $font-display-option {
-      font-display: $font-display-option;
-    }
     font-family: unquote($font-base-family);
     // sass-lint:disable no-misspelled-properties
     font-smoothing: subpixel-antialiased;

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -3,7 +3,7 @@ $font-base-family: '"Ubuntu", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ca
 $font-monospace: '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
 $font-heading-family: $font-base-family !default;
 $font-use-subset-latin: false !default;
-$font-display-option: false !default; // options - auto | block | swap | fallback | optional
+$font-display-option: auto !default; // options - auto | block | swap | fallback | optional
 $font-allow-cyrillic-greek-latin: false !default;
 $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -2,7 +2,8 @@
 $font-base-family: '"Ubuntu", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
 $font-monospace: '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
 $font-heading-family: $font-base-family !default;
-$font-import: 'http://fonts.gstatic.com/s/ubuntu/v9/' !default;
+$font-use-subset-latin: false !default;
+$font-display-option: false !default; // options - auto | block | swap | fallback | optional
 $font-allow-cyrillic-greek-latin: false !default;
 $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;


### PR DESCRIPTION
## Done

- created a set of subset fonts for the Ubuntu typeface
    - they can be optionally added via a `$font-use-subset-latin: true;` setting. but will give users a ~66% font size savings to download.
    - the default is exactly want it is today
    - I also created non-google hosted subset fonts for cyrillic, greek, and latin (not sure why we need latin)
    - Removed the `$font-import: 'http://fonts.gstatic.com/s/ubuntu/v9/' !default;` setting as it is no longer used
- added a `$font-display-option: false !default;` setting and added the logic to allow users to easily add that option in `_base_typography.scss`
- Updated the `typography.md` documentation to reflect these changes
- preloading the subset fonts in `examples.md`, but this can be removed or extended

## QA

- Pull code
- Set combinations of the above variables
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Look at the iframes in examples and their performance
- Read http://0.0.0.0:8101/base/typography/ to see if the new sections make sense

