### PR TITLE
Theming correction

### DIFF
--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -18,10 +18,10 @@ displayed horizontally on larger screens.
   </p>
 </div>
 
-The navigation pattern is on of the firsts to implement the new theming architecture in vanilla. By default, the nav is light. t`o switch to a dark nav, you can either:
+The navigation pattern is one of the first patterns to implement the new theming architecture in Vanilla. The default is light. But, to switch to a dark navigation, you can either:
 
 - Change the value of the `nav` key in the `$theme-default--dark` map (located in `_settings_themes.scss`) to `true`
-- Add the class `is-dark` when the default nav is light, or `is-light` when the default has been changed to dark
+- Add a state class to the `p-navigation` class: `is-dark` when the default nav is light, or `is-light` when the default has been changed to dark
 
 You can also manually override the background color of the nav using the variable `$color-navigation-background`. If the lightness of the background is above 70%, the text colour will switch to dark to improve readibility.
 

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -14,16 +14,16 @@ displayed horizontally on larger screens.
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-    <span class="p-notification__status">Note:</span>By default, the width of the navigation is constrained to <code>$grid-max-width</code>. To make the nav full width, replace <code>.p-navigation__row</code> with <code>.p-navigation__row--full-width</code>.
+    <span class="p-notification__status">Note:</span>By default, the width of the navigation is constrained to <code>$grid-max-width</code>. To make the navigation full width, replace <code>.p-navigation__row</code> with <code>.p-navigation__row--full-width</code>.
   </p>
 </div>
 
 The navigation pattern is one of the first patterns to implement the new theming architecture in Vanilla. The default is light. But, to switch to a dark navigation, you can either:
 
 - Change the value of the `nav` key in the `$theme-default--dark` map (located in `_settings_themes.scss`) to `true`
-- Add a state class to the `p-navigation` class: `is-dark` when the default nav is light, or `is-light` when the default has been changed to dark
+- Add a state class to the `p-navigation` class: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark
 
-You can also manually override the background color of the nav using the variable `$color-navigation-background`. If the lightness of the background is above 70%, the text colour will switch to dark to improve readibility.
+You can also manually override the background color of the navigation using the variable `$color-navigation-background`. If the lightness of the background is above 70%, the text colour will switch to dark to improve readability.
 
 You can change the breakpoint at which the menu changes to a small screen menu
 by adjusting the `$breakpoint-navigation-threshold` in `_settings_breakpoints.scss`.

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -20,7 +20,7 @@ displayed horizontally on larger screens.
 
 The navigation pattern is one of the first patterns to implement the new theming architecture in Vanilla. The default is light. But, to switch to a dark navigation, you can either:
 
-- Change the value of the `nav` key in the `$theme-default--dark` map (located in `_settings_themes.scss`) to `true`
+- Override the value of the `nav` key in the `$theme-default--dark` map (initially set in `_settings_themes.scss`) to `true`: `$theme-default--dark: map-merge($theme-default--dark, ("nav": true));`
 - Add a state class to the `p-navigation` class: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark
 
 You can also manually override the background color of the navigation using the variable `$color-navigation-background`. If the lightness of the background is above 70%, the text colour will switch to dark to improve readability.

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -18,8 +18,12 @@ displayed horizontally on larger screens.
   </p>
 </div>
 
-The background color of a navigation pattern can be set via the
-`$color-navigation-background` variable.
+The navigation pattern is on of the firsts to implement the new theming architecture in vanilla. By default, the nav is light. t`o switch to a dark nav, you can either:
+
+- Change the value of the `nav` key in the `$theme-default--dark` map (located in `_settings_themes.scss`) to `true`
+- Add the class `is-dark` when the default nav is light, or `is-light` when the default has been changed to dark
+
+You can also manually override the background color of the nav using the variable `$color-navigation-background`. If the lightness of the background is above 70%, the text colour will switch to dark to improve readibility.
 
 You can change the breakpoint at which the menu changes to a small screen menu
 by adjusting the `$breakpoint-navigation-threshold` in `_settings_breakpoints.scss`.

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -406,22 +406,22 @@ $box-offsets-top: (
   // common properties
   %vf-tick-elements--light-theme {
     & + label {
-      color: map-get($colors--light-theme, text-default);
+      color: $colors--light-theme__text-default;
 
       &::before {
-        background: map-get($colors--light-theme, background);
-        border: 1px solid map-get($colors--light-theme, border-high-contrast);
+        background: $colors--light-theme__background;
+        border: 1px solid $colors--light-theme__border-high-contrast;
       }
     }
   }
 
   %vf-tick-elements--dark-theme {
     & + label {
-      color: map-get($colors--dark-theme, text-default);
+      color: $colors--dark-theme__text-default;
 
       &::before {
-        background: map-get($colors--dark-theme, background);
-        border: 1px solid map-get($colors--dark-theme, border-high-contrast);
+        background: $colors--dark-theme__background;
+        border: 1px solid $colors--dark-theme__border-high-contrast;
       }
     }
   }
@@ -430,7 +430,7 @@ $box-offsets-top: (
   %vf-checkbox--light-theme {
     & + label {
       &::after {
-        color: map-get($colors--light-theme, background);
+        color: $colors--light-theme__background;
       }
     }
   }
@@ -438,7 +438,7 @@ $box-offsets-top: (
   %vf-checkbox--dark-theme {
     & + label {
       &::after {
-        color: map-get($colors--dark-theme, text-default);
+        color: $colors--dark-theme__text-default;
       }
     }
   }
@@ -447,7 +447,7 @@ $box-offsets-top: (
   %vf-radio--light-theme {
     & + label {
       &::after {
-        background-color: map-get($colors--light-theme, background);
+        background-color: $colors--light-theme__background;
       }
     }
   }

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -406,22 +406,22 @@ $box-offsets-top: (
   // common properties
   %vf-tick-elements--light-theme {
     & + label {
-      color: $colors--light-theme__text-default;
+      color: $colors--light-theme--text-default;
 
       &::before {
-        background: $colors--light-theme__background;
-        border: 1px solid $colors--light-theme__border-high-contrast;
+        background: $colors--light-theme--background;
+        border: 1px solid $colors--light-theme--border-high-contrast;
       }
     }
   }
 
   %vf-tick-elements--dark-theme {
     & + label {
-      color: $colors--dark-theme__text-default;
+      color: $colors--dark-theme--text-default;
 
       &::before {
-        background: $colors--dark-theme__background;
-        border: 1px solid $colors--dark-theme__border-high-contrast;
+        background: $colors--dark-theme--background;
+        border: 1px solid $colors--dark-theme--border-high-contrast;
       }
     }
   }
@@ -430,7 +430,7 @@ $box-offsets-top: (
   %vf-checkbox--light-theme {
     & + label {
       &::after {
-        color: $colors--light-theme__background;
+        color: $colors--light-theme--background;
       }
     }
   }
@@ -438,7 +438,7 @@ $box-offsets-top: (
   %vf-checkbox--dark-theme {
     & + label {
       &::after {
-        color: $colors--dark-theme__text-default;
+        color: $colors--dark-theme--text-default;
       }
     }
   }
@@ -447,7 +447,7 @@ $box-offsets-top: (
   %vf-radio--light-theme {
     & + label {
       &::after {
-        background-color: $colors--light-theme__background;
+        background-color: $colors--light-theme--background;
       }
     }
   }

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -37,11 +37,11 @@
   }
 
   %hr--dark-theme {
-    background: $colors--dark-theme__border-default;
+    background: $colors--dark-theme--border-default;
   }
 
   %hr--light-theme {
-    background: $colors--light-theme__border-default;
+    background: $colors--light-theme--border-default;
   }
 
   .row.is-bordered {

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -37,11 +37,11 @@
   }
 
   %hr--dark-theme {
-    background: map-get($colors--dark-theme, border-default);
+    background: $colors--dark-theme__border-default;
   }
 
   %hr--light-theme {
-    background: map-get($colors--light-theme, border-default);
+    background: $colors--light-theme__border-default;
   }
 
   .row.is-bordered {

--- a/scss/_base_typography-max-widths.scss
+++ b/scss/_base_typography-max-widths.scss
@@ -1,9 +1,9 @@
 @mixin vf-b-typography-max-widths {
-  %max-width--p {
-    max-width: map-get($max-widths, default);
-  }
+  @include deprecate('3.0.0', 'Use the `p-max-width` mixin instead') {
+    %max-width--p {
+      max-width: map-get($max-widths, default);
+    }
 
-  @include deprecate('3.0.0', 'Use `%max-width--p` instead') {
     %measure--p,
     .measure--p {
       @extend %max-width--p;

--- a/scss/_base_typography-max-widths.scss
+++ b/scss/_base_typography-max-widths.scss
@@ -1,3 +1,15 @@
+@mixin vf-b-typography-max-widths {
+  %max-width--p {
+    max-width: map-get($max-widths, default);
+  }
+
+  //expose measure as a class
+  %measure--p,
+  .measure--p {
+    @extend %max-width--p;
+  }
+}
+
 // Optimal max-width for body copy
 @mixin p-max-width {
   max-width: map-get($max-widths, default);

--- a/scss/_base_typography-max-widths.scss
+++ b/scss/_base_typography-max-widths.scss
@@ -3,10 +3,11 @@
     max-width: map-get($max-widths, default);
   }
 
-  //expose measure as a class
-  %measure--p,
-  .measure--p {
-    @extend %max-width--p;
+  @include deprecate('3.0.0', 'Use `%max-width--p` instead') {
+    %measure--p,
+    .measure--p {
+      @extend %max-width--p;
+    }
   }
 }
 

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -6,6 +6,7 @@
 // Typographic element styles
 @mixin vf-b-typography {
   @include vf-b-typography-fontfaces;
+  @include vf-b-typography-max-widths;
 
   html {
     // sass-lint:disable no-vendor-prefixes

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -6,7 +6,10 @@
 // Typographic element styles
 @mixin vf-b-typography {
   @include vf-b-typography-fontfaces;
-  @include vf-b-typography-max-widths;
+
+  @include deprecate('3.0.0', 'The unused `vf-b-typography-max-widths` mixin will be removed') {
+    @include vf-b-typography-max-widths;
+  }
 
   html {
     // sass-lint:disable no-vendor-prefixes

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -2,6 +2,9 @@
 
 $nav-border-bottom-thickness: 1px;
 
+@mixin vf-navigation-default {
+} //only here to prevent a breaking change;
+
 // Default header styling
 @mixin vf-p-navigation {
   // no colours
@@ -209,8 +212,17 @@ $nav-border-bottom-thickness: 1px;
     }
   }
 
+  // Manually overriding the theming:
+  $color-navigation-background: null;
+  $color-navigation-text: null;
+  $color-navigation-text-hover: null;
+
   // Theming
   @if (map-get($theme-default--dark, nav) == true) {
+    // dark theme
+    $color-navigation-background: $colors--dark-theme__background-highlighted !default;
+    $color-navigation-text: if(lightness($color-navigation-background) < 70, blue, green) !default;
+
     .p-navigation {
       @extend %p-navigation--dark-theme;
     }
@@ -219,6 +231,11 @@ $nav-border-bottom-thickness: 1px;
       @extend %p-navigation--light-theme;
     }
   } @else {
+    // light theme
+    $color-navigation-background: rgb(92, 245, 72) !default;
+    // $color-navigation-text: if(lightness($color-navigation-background) > 70, map-get($colors--light-theme, text), $color-light) !default;
+    $color-navigation-text: blue !default;
+
     .p-navigation {
       @extend %p-navigation--light-theme;
     }
@@ -229,7 +246,7 @@ $nav-border-bottom-thickness: 1px;
   }
 
   %p-navigation--dark-theme {
-    background-color: map-get($colors--dark-theme, background-highlighted);
+    background-color: $color-navigation-background;
 
     .p-navigation__link > a,
     .p-navigation__toggle--close,
@@ -237,30 +254,31 @@ $nav-border-bottom-thickness: 1px;
       &,
       &:visited,
       &:focus {
-        color: map-get($colors--dark-theme, text-default);
+        color: $color-navigation-text;
       }
 
       &:hover {
-        color: map-get($colors--dark-theme, text-hover);
+        opacity: 0.5;
+        // color: $color-navigation-text-hover;
       }
     }
 
     @include deprecate('3.0.0', 'Selectors should use classes.') {
       .p-navigation__link.is-selected > a {
-        color: map-get($colors--dark-theme, text-hover);
+        color: $color-navigation-text;
       }
     }
 
     // separator color on small screens
     .p-navigation__link > a::before {
       @media (max-width: $breakpoint-navigation-threshold) {
-        background: map-get($colors--dark-theme, border-default);
+        background: $colors--dark-theme__border-default;
       }
     }
   }
 
   %p-navigation--light-theme {
-    background-color: map-get($colors--light-theme, background);
+    background-color: $color-navigation-background;
 
     .p-navigation__link > a,
     .p-navigation__toggle--close,
@@ -268,22 +286,25 @@ $nav-border-bottom-thickness: 1px;
       &,
       &:visited,
       &:focus {
-        color: map-get($colors--light-theme, text-default);
+        color: $color-navigation-text;
       }
 
       &:hover {
-        color: map-get($colors--light-theme, text-hover);
+        opacity: 0.5;
+        // color: $color-navigation-text-hover;
       }
     }
 
-    .p-navigation__link.is-selected > a {
-      color: map-get($colors--light-theme, text-hover);
+    @include deprecate('3.0.0', 'Selectors should use classes.') {
+      .p-navigation__link.is-selected > a {
+        color: $color-navigation-text;
+      }
     }
 
     .p-navigation__link > a::before {
       @media (max-width: $breakpoint-navigation-threshold) {
         // separator color on small screens
-        background: map-get($colors--light-theme, border-default);
+        background: $colors--light-theme__border-default;
       }
     }
   }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -2,10 +2,6 @@
 
 $nav-border-bottom-thickness: 1px;
 
-@mixin vf-navigation-default {
-} //only here to prevent a breaking change;
-
-// Default header styling
 @mixin vf-p-navigation {
   // no colours
   .p-navigation {
@@ -155,7 +151,7 @@ $nav-border-bottom-thickness: 1px;
       }
     }
 
-    @include deprecate('2.0.0', 'Use .p-navigation__row / .p-navigation__row--full-width instead') {
+    @include deprecate('3.0.0', 'Use .p-navigation__row / .p-navigation__row--full-width instead') {
       &.row {
         @extend %navigation-row;
       }
@@ -213,7 +209,6 @@ $nav-border-bottom-thickness: 1px;
   }
 
   // Theming
-  // Manually overriding the theming:
   $color-navigation-background: null !default;
   $color-navigation-text: null !default;
   $lightness-threshold: 70;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -295,7 +295,7 @@ $hover-opacity: 0.58;
     }
 
     &:hover {
-      opacity: $faded-opacity;
+      opacity: $hover-opacity;
     }
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -247,6 +247,7 @@ $nav-border-bottom-thickness: 1px;
   }
 
   background-color: $color-navigation-background;
+  $faded-opacity: 0.6;
 
   .p-navigation__link > a,
   .p-navigation__toggle--close,
@@ -258,13 +259,13 @@ $nav-border-bottom-thickness: 1px;
     }
 
     &:hover {
-      opacity: 0.6;
+      opacity: $faded-opacity;
     }
   }
 
   @include deprecate('3.0.0', 'Selectors should use classes.') {
     .p-navigation__link.is-selected > a {
-      color: $color-navigation-text;
+      opacity: $faded-opacity;
     }
   }
 
@@ -294,13 +295,13 @@ $nav-border-bottom-thickness: 1px;
     }
 
     &:hover {
-      opacity: 0.6;
+      opacity: $faded-opacity;
     }
   }
 
   @include deprecate('3.0.0', 'Selectors should use classes.') {
     .p-navigation__link.is-selected > a {
-      color: $color-navigation-text;
+      opacity: $faded-opacity;
     }
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -238,8 +238,6 @@ $nav-border-bottom-thickness: 1px;
       @include p-navigation--dark-theme($color-navigation-background, $color-navigation-text, true);
     }
   }
-
-  @debug lightness($color-navigation-background);
 }
 
 @mixin p-navigation--light-theme($color-navigation-background, $color-navigation-text, $override-default: false) {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,7 +1,6 @@
 @import 'settings';
 
-$nav-border-bottom-thickness: 1px;
-$hover-opacity: 0.58;
+$navigation-hover-opacity: 0.58;
 
 @mixin vf-p-navigation {
   // no colours
@@ -61,7 +60,7 @@ $hover-opacity: 0.58;
 
         &::before {
           content: '';
-          height: $nav-border-bottom-thickness;
+          height: 1px;
           left: 0;
           position: absolute;
           right: 0;
@@ -259,13 +258,13 @@ $hover-opacity: 0.58;
     }
 
     &:hover {
-      opacity: $hover-opacity;
+      opacity: $navigation-hover-opacity;
     }
   }
 
   @include deprecate('3.0.0', 'Selectors should use classes.') {
     .p-navigation__link.is-selected > a {
-      opacity: $hover-opacity;
+      opacity: $navigation-hover-opacity;
     }
   }
 
@@ -295,13 +294,13 @@ $hover-opacity: 0.58;
     }
 
     &:hover {
-      opacity: $hover-opacity;
+      opacity: $navigation-hover-opacity;
     }
   }
 
   @include deprecate('3.0.0', 'Selectors should use classes.') {
     .p-navigation__link.is-selected > a {
-      opacity: $hover-opacity;
+      opacity: $navigation-hover-opacity;
     }
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -212,100 +212,109 @@ $nav-border-bottom-thickness: 1px;
     }
   }
 
-  // Manually overriding the theming:
-  $color-navigation-background: null;
-  $color-navigation-text: null;
-  $color-navigation-text-hover: null;
-
   // Theming
+  // Manually overriding the theming:
+  $color-navigation-background: null !default;
+  $color-navigation-text: null !default;
+  $lightness-threshold: 70;
+
   @if (map-get($theme-default--dark, nav) == true) {
     // dark theme
     $color-navigation-background: $colors--dark-theme__background-highlighted !default;
-    $color-navigation-text: if(lightness($color-navigation-background) < 70, blue, green) !default;
+    $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme__text-default, $colors--dark-theme__text-default) !default;
 
     .p-navigation {
-      @extend %p-navigation--dark-theme;
+      @include p-navigation--dark-theme($color-navigation-background, $color-navigation-text, false);
     }
 
     .p-navigation.is-light {
-      @extend %p-navigation--light-theme;
+      @include p-navigation--light-theme($color-navigation-background, $color-navigation-text, true);
     }
   } @else {
     // light theme
-    $color-navigation-background: rgb(92, 245, 72) !default;
-    // $color-navigation-text: if(lightness($color-navigation-background) > 70, map-get($colors--light-theme, text), $color-light) !default;
-    $color-navigation-text: blue !default;
+    $color-navigation-background: $colors--light-theme__background !default;
+    $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme__text-default, $colors--dark-theme__text-default) !default;
 
     .p-navigation {
-      @extend %p-navigation--light-theme;
+      @include p-navigation--light-theme($color-navigation-background, $color-navigation-text, false);
     }
 
     .p-navigation.is-dark {
-      @extend %p-navigation--dark-theme;
+      @include p-navigation--dark-theme($color-navigation-background, $color-navigation-text, true);
     }
   }
 
-  %p-navigation--dark-theme {
-    background-color: $color-navigation-background;
+  @debug lightness($color-navigation-background);
+}
 
-    .p-navigation__link > a,
-    .p-navigation__toggle--close,
-    .p-navigation__toggle--open {
-      &,
-      &:visited,
-      &:focus {
-        color: $color-navigation-text;
-      }
+@mixin p-navigation--light-theme($color-navigation-background, $color-navigation-text, $override-default: false) {
+  @if ($override-default) {
+    $color-navigation-background: $colors--light-theme__background;
+    $color-navigation-text: $colors--light-theme__text-default;
+  }
 
-      &:hover {
-        opacity: 0.5;
-        // color: $color-navigation-text-hover;
-      }
+  background-color: $color-navigation-background;
+
+  .p-navigation__link > a,
+  .p-navigation__toggle--close,
+  .p-navigation__toggle--open {
+    &,
+    &:visited,
+    &:focus {
+      color: $color-navigation-text;
     }
 
-    @include deprecate('3.0.0', 'Selectors should use classes.') {
-      .p-navigation__link.is-selected > a {
-        color: $color-navigation-text;
-      }
-    }
-
-    // separator color on small screens
-    .p-navigation__link > a::before {
-      @media (max-width: $breakpoint-navigation-threshold) {
-        background: $colors--dark-theme__border-default;
-      }
+    &:hover {
+      opacity: 0.6;
     }
   }
 
-  %p-navigation--light-theme {
-    background-color: $color-navigation-background;
+  @include deprecate('3.0.0', 'Selectors should use classes.') {
+    .p-navigation__link.is-selected > a {
+      color: $color-navigation-text;
+    }
+  }
 
-    .p-navigation__link > a,
-    .p-navigation__toggle--close,
-    .p-navigation__toggle--open {
-      &,
-      &:visited,
-      &:focus {
-        color: $color-navigation-text;
-      }
+  .p-navigation__link > a::before {
+    @media (max-width: $breakpoint-navigation-threshold) {
+      // separator color on small screens
+      background: $colors--light-theme__border-default;
+    }
+  }
+}
 
-      &:hover {
-        opacity: 0.5;
-        // color: $color-navigation-text-hover;
-      }
+@mixin p-navigation--dark-theme($color-navigation-background, $color-navigation-text, $override-default: false) {
+  @if ($override-default) {
+    $color-navigation-background: $colors--dark-theme__background-highlighted;
+    $color-navigation-text: $colors--dark-theme__text-default;
+  }
+
+  background-color: $color-navigation-background;
+
+  .p-navigation__link > a,
+  .p-navigation__toggle--close,
+  .p-navigation__toggle--open {
+    &,
+    &:visited,
+    &:focus {
+      color: $color-navigation-text;
     }
 
-    @include deprecate('3.0.0', 'Selectors should use classes.') {
-      .p-navigation__link.is-selected > a {
-        color: $color-navigation-text;
-      }
+    &:hover {
+      opacity: 0.6;
     }
+  }
 
-    .p-navigation__link > a::before {
-      @media (max-width: $breakpoint-navigation-threshold) {
-        // separator color on small screens
-        background: $colors--light-theme__border-default;
-      }
+  @include deprecate('3.0.0', 'Selectors should use classes.') {
+    .p-navigation__link.is-selected > a {
+      color: $color-navigation-text;
+    }
+  }
+
+  // separator color on small screens
+  .p-navigation__link > a::before {
+    @media (max-width: $breakpoint-navigation-threshold) {
+      background: $colors--dark-theme__border-default;
     }
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -215,8 +215,8 @@ $nav-border-bottom-thickness: 1px;
 
   @if (map-get($theme-default--dark, nav) == true) {
     // dark theme
-    $color-navigation-background: $colors--dark-theme__background-highlighted !default;
-    $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme__text-default, $colors--dark-theme__text-default) !default;
+    $color-navigation-background: $colors--dark-theme--background-highlighted !default;
+    $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme--text-default, $colors--dark-theme--text-default) !default;
 
     .p-navigation {
       @include p-navigation--dark-theme($color-navigation-background, $color-navigation-text, false);
@@ -227,8 +227,8 @@ $nav-border-bottom-thickness: 1px;
     }
   } @else {
     // light theme
-    $color-navigation-background: $colors--light-theme__background !default;
-    $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme__text-default, $colors--dark-theme__text-default) !default;
+    $color-navigation-background: $colors--light-theme--background !default;
+    $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme--text-default, $colors--dark-theme--text-default) !default;
 
     .p-navigation {
       @include p-navigation--light-theme($color-navigation-background, $color-navigation-text, false);
@@ -242,8 +242,8 @@ $nav-border-bottom-thickness: 1px;
 
 @mixin p-navigation--light-theme($color-navigation-background, $color-navigation-text, $override-default: false) {
   @if ($override-default) {
-    $color-navigation-background: $colors--light-theme__background;
-    $color-navigation-text: $colors--light-theme__text-default;
+    $color-navigation-background: $colors--light-theme--background;
+    $color-navigation-text: $colors--light-theme--text-default;
   }
 
   background-color: $color-navigation-background;
@@ -271,15 +271,15 @@ $nav-border-bottom-thickness: 1px;
   .p-navigation__link > a::before {
     @media (max-width: $breakpoint-navigation-threshold) {
       // separator color on small screens
-      background: $colors--light-theme__border-default;
+      background: $colors--light-theme--border-default;
     }
   }
 }
 
 @mixin p-navigation--dark-theme($color-navigation-background, $color-navigation-text, $override-default: false) {
   @if ($override-default) {
-    $color-navigation-background: $colors--dark-theme__background-highlighted;
-    $color-navigation-text: $colors--dark-theme__text-default;
+    $color-navigation-background: $colors--dark-theme--background-highlighted;
+    $color-navigation-text: $colors--dark-theme--text-default;
   }
 
   background-color: $color-navigation-background;
@@ -307,7 +307,7 @@ $nav-border-bottom-thickness: 1px;
   // separator color on small screens
   .p-navigation__link > a::before {
     @media (max-width: $breakpoint-navigation-threshold) {
-      background: $colors--dark-theme__border-default;
+      background: $colors--dark-theme--border-default;
     }
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,6 +1,7 @@
 @import 'settings';
 
 $nav-border-bottom-thickness: 1px;
+$hover-opacity: 0.58;
 
 @mixin vf-p-navigation {
   // no colours
@@ -247,7 +248,6 @@ $nav-border-bottom-thickness: 1px;
   }
 
   background-color: $color-navigation-background;
-  $faded-opacity: 0.6;
 
   .p-navigation__link > a,
   .p-navigation__toggle--close,
@@ -259,13 +259,13 @@ $nav-border-bottom-thickness: 1px;
     }
 
     &:hover {
-      opacity: $faded-opacity;
+      opacity: $hover-opacity;
     }
   }
 
   @include deprecate('3.0.0', 'Selectors should use classes.') {
     .p-navigation__link.is-selected > a {
-      opacity: $faded-opacity;
+      opacity: $hover-opacity;
     }
   }
 
@@ -301,7 +301,7 @@ $nav-border-bottom-thickness: 1px;
 
   @include deprecate('3.0.0', 'Selectors should use classes.') {
     .p-navigation__link.is-selected > a {
-      opacity: $faded-opacity;
+      opacity: $hover-opacity;
     }
   }
 

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -78,9 +78,9 @@
 
   %search-box-input--light {
     //XXX: This should inherit from input color theming. Once that becomes available, delete this.
-    background-color: map-get($colors--light-theme, background);
-    border-color: map-get($colors--light-theme, border-high-contrast);
-    color: map-get($colors--light-theme, text-default);
+    background-color: $colors--light-theme__background;
+    border-color: $colors--light-theme__border-high-contrast;
+    color: $colors--light-theme__text-default;
 
     &:active,
     &:focus,
@@ -90,16 +90,16 @@
     &:-webkit-autofill:focus,
     &:-internal-autofill-selected {
       // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
-      background-color: map-get($colors--light-theme, background) !important;
-      border-color: map-get($colors--light-theme, border-high-contrast) !important;
+      background-color: $colors--light-theme__background !important;
+      border-color: $colors--light-theme__border-high-contrast !important;
     }
   }
 
   %search-box-input--dark {
     //XXX: This should inherit from input color theming. Once that becomes available, delete this.
-    background-color: map-get($colors--dark-theme, background);
-    border-color: map-get($colors--dark-theme, border-high-contrast);
-    color: map-get($colors--dark-theme, text-default);
+    background-color: $colors--dark-theme__background;
+    border-color: $colors--dark-theme__border-high-contrast;
+    color: $colors--dark-theme__text-default;
 
     &:active,
     &:focus,
@@ -109,8 +109,8 @@
     &:-webkit-autofill:focus,
     &:-internal-autofill-selected {
       // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
-      background-color: map-get($colors--dark-theme, background) !important;
-      border-color: map-get($colors--dark-theme, border-high-contrast) !important;
+      background-color: $colors--dark-theme__background !important;
+      border-color: $colors--dark-theme__border-high-contrast !important;
     }
   }
 

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -78,9 +78,9 @@
 
   %search-box-input--light {
     //XXX: This should inherit from input color theming. Once that becomes available, delete this.
-    background-color: $colors--light-theme__background;
-    border-color: $colors--light-theme__border-high-contrast;
-    color: $colors--light-theme__text-default;
+    background-color: $colors--light-theme--background;
+    border-color: $colors--light-theme--border-high-contrast;
+    color: $colors--light-theme--text-default;
 
     &:active,
     &:focus,
@@ -90,16 +90,16 @@
     &:-webkit-autofill:focus,
     &:-internal-autofill-selected {
       // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
-      background-color: $colors--light-theme__background !important;
-      border-color: $colors--light-theme__border-high-contrast !important;
+      background-color: $colors--light-theme--background !important;
+      border-color: $colors--light-theme--border-high-contrast !important;
     }
   }
 
   %search-box-input--dark {
     //XXX: This should inherit from input color theming. Once that becomes available, delete this.
-    background-color: $colors--dark-theme__background;
-    border-color: $colors--dark-theme__border-high-contrast;
-    color: $colors--dark-theme__text-default;
+    background-color: $colors--dark-theme--background;
+    border-color: $colors--dark-theme--border-high-contrast;
+    color: $colors--dark-theme--text-default;
 
     &:active,
     &:focus,
@@ -109,8 +109,8 @@
     &:-webkit-autofill:focus,
     &:-internal-autofill-selected {
       // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
-      background-color: $colors--dark-theme__background !important;
-      border-color: $colors--dark-theme__border-high-contrast !important;
+      background-color: $colors--dark-theme--background !important;
+      border-color: $colors--dark-theme--border-high-contrast !important;
     }
   }
 

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -132,43 +132,43 @@
   }
 
   %subnav-item--light-theme {
-    background-color: map-get($colors--light-theme, background);
+    background-color: $colors--light-theme__background;
 
     &,
     &:active,
     &:focus &:visited {
-      color: map-get($colors--light-theme, text-default);
+      color: $colors--light-theme__text-default;
     }
 
     &:hover {
-      color: map-get($colors--light-theme, text-hover);
+      color: $colors--light-theme__text-default;
     }
 
     &::before {
       @media (max-width: $breakpoint-navigation-threshold) {
         // separator color on small screens
-        background: map-get($colors--light-theme, border-default);
+        background: $colors--light-theme__border-default;
       }
     }
   }
 
   %subnav-item--dark-theme {
-    background-color: map-get($colors--dark-theme, background);
+    background-color: $colors--dark-theme__background;
 
     &,
     &:active,
     &:focus &:visited {
-      color: map-get($colors--dark-theme, text-default);
+      color: $colors--dark-theme__text-default;
     }
 
     &:hover {
-      color: map-get($colors--dark-theme, text-hover);
+      color: $colors--dark-theme__text-hover;
     }
 
     &::before {
       @media (max-width: $breakpoint-navigation-threshold) {
         // separator color on small screens
-        background: map-get($colors--dark-theme, border-default);
+        background: $colors--dark-theme__border-default;
       }
     }
   }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -132,43 +132,43 @@
   }
 
   %subnav-item--light-theme {
-    background-color: $colors--light-theme__background;
+    background-color: $colors--light-theme--background;
 
     &,
     &:active,
     &:focus &:visited {
-      color: $colors--light-theme__text-default;
+      color: $colors--light-theme--text-default;
     }
 
     &:hover {
-      color: $colors--light-theme__text-default;
+      color: $colors--light-theme--text-default;
     }
 
     &::before {
       @media (max-width: $breakpoint-navigation-threshold) {
         // separator color on small screens
-        background: $colors--light-theme__border-default;
+        background: $colors--light-theme--border-default;
       }
     }
   }
 
   %subnav-item--dark-theme {
-    background-color: $colors--dark-theme__background;
+    background-color: $colors--dark-theme--background;
 
     &,
     &:active,
     &:focus &:visited {
-      color: $colors--dark-theme__text-default;
+      color: $colors--dark-theme--text-default;
     }
 
     &:hover {
-      color: $colors--dark-theme__text-hover;
+      color: $colors--dark-theme--text-hover;
     }
 
     &::before {
       @media (max-width: $breakpoint-navigation-threshold) {
         // separator color on small screens
-        background: $colors--dark-theme__border-default;
+        background: $colors--dark-theme--border-default;
       }
     }
   }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -141,7 +141,7 @@
     }
 
     &:hover {
-      color: $colors--light-theme--text-default;
+      color: $colors--light-theme--text-hover;
     }
 
     &::before {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -39,7 +39,7 @@ $colors--light-theme__background: #fff !default;
 $colors--light-theme__background-highlighted: #f7f7f7 !default;
 $colors--light-theme__border-default: #cdcdcd !default;
 $colors--light-theme__border-high-contrast: #999 !default;
-$colors--light-theme__text-default: #757575 !default;
+$colors--light-theme__text-hover: #757575 !default;
 $colors--light-theme__text-disabled: #666 !default;
 $colors--light-theme__text-default: #111 !default;
 

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -35,18 +35,18 @@ $states: (
   information: $color-information
 );
 
-$colors--light-theme__background: #fff !default;
-$colors--light-theme__background-highlighted: #f7f7f7 !default;
-$colors--light-theme__border-default: #cdcdcd !default;
-$colors--light-theme__border-high-contrast: #999 !default;
-$colors--light-theme__text-hover: #757575 !default;
-$colors--light-theme__text-disabled: #666 !default;
-$colors--light-theme__text-default: #111 !default;
+$colors--light-theme--background: #fff !default;
+$colors--light-theme--background-highlighted: #f7f7f7 !default;
+$colors--light-theme--border-default: #cdcdcd !default;
+$colors--light-theme--border-high-contrast: #999 !default;
+$colors--light-theme--text-hover: #757575 !default;
+$colors--light-theme--text-disabled: #666 !default;
+$colors--light-theme--text-default: #111 !default;
 
 //text-hover: minimum contrast on primary that satisfies contrast checker AA
-$colors--dark-theme__background: hsl(0, 0%, 15%) !default;
-$colors--dark-theme__background-highlighted: hsl(0, 0%, 20%) !default;
-$colors--dark-theme__border-default: hsl(0, 0%, 27%) !default;
-$colors--dark-theme__border-high-contrast: hsl(0, 0%, 42%) !default;
-$colors--dark-theme__text-hover: hsl(0, 0%, 56%) !default;
-$colors--dark-theme__text-default: hsl(0, 0%, 100%) !default;
+$colors--dark-theme--background: hsl(0, 0%, 15%) !default;
+$colors--dark-theme--background-highlighted: hsl(0, 0%, 20%) !default;
+$colors--dark-theme--border-default: hsl(0, 0%, 27%) !default;
+$colors--dark-theme--border-high-contrast: hsl(0, 0%, 42%) !default;
+$colors--dark-theme--text-hover: hsl(0, 0%, 56%) !default;
+$colors--dark-theme--text-default: hsl(0, 0%, 100%) !default;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -35,22 +35,18 @@ $states: (
   information: $color-information
 );
 
-$colors--light-theme: (
-  background: #fff,
-  background-highlighted: #f7f7f7,
-  border-default: #cdcdcd,
-  border-high-contrast: #999,
-  text-hover: #757575,
-  text-disabled: #666,
-  text-default: #111
-) !default;
+$colors--light-theme__background: #fff !default;
+$colors--light-theme__background-highlighted: #f7f7f7 !default;
+$colors--light-theme__border-default: #cdcdcd !default;
+$colors--light-theme__border-high-contrast: #999 !default;
+$colors--light-theme__text-default: #757575 !default;
+$colors--light-theme__text-disabled: #666 !default;
+$colors--light-theme__text-default: #111 !default;
 
 //text-hover: minimum contrast on primary that satisfies contrast checker AA
-$colors--dark-theme: (
-  background: hsl(0, 0%, 15%),
-  background-highlighted: hsl(0, 0%, 20%),
-  border-default: hsl(0, 0%, 27%),
-  border-high-contrast: hsl(0, 0%, 42%),
-  text-hover: hsl(0, 0%, 56%),
-  text-default: hsl(0, 0%, 100%)
-) !default;
+$colors--dark-theme__background: hsl(0, 0%, 15%) !default;
+$colors--dark-theme__background-highlighted: hsl(0, 0%, 20%) !default;
+$colors--dark-theme__border-default: hsl(0, 0%, 27%) !default;
+$colors--dark-theme__border-high-contrast: hsl(0, 0%, 42%) !default;
+$colors--dark-theme__text-hover: hsl(0, 0%, 56%) !default;
+$colors--dark-theme__text-default: hsl(0, 0%, 100%) !default;

--- a/scss/_settings_themes.scss
+++ b/scss/_settings_themes.scss
@@ -3,4 +3,4 @@ $theme-default--dark: (
   nav: false,
   p-search-box: false,
   forms: false
-);
+) !default;


### PR DESCRIPTION
## Done

- Restore ability to override nav background colour with `$color-navigation-background`;
- Convert colours map to a variables for easier overriding

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/patterns/navigation/default/, verify it looks as expected
- Open examples/patterns/navigation/default-dark/, verify it looks as expected
- Run any other website like ubuntu.com with ./run --node-module {PATH_TO_VANILLA}
- In the other website, set `$color-navigation-background` to a value above and a value below the threshold (70) `hsl(350, 100%, {INSERT_VALUE_HERE});`
- Observe text colour switch between dark and light 
- Add is-dark/is-light classes, observe they also work
- inside vanilla's `_settings_themes.scss`, change the value of the key 'nav' from false to true; repeat above steps

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2566

## Screenshots
The lightness check switches colours at lightness > 70; shouldn't this be 50?
Screenshots of the color switching:
![image](https://user-images.githubusercontent.com/2741678/66396135-fd151f00-e9d0-11e9-8108-844638bd7769.png)
![image](https://user-images.githubusercontent.com/2741678/66396184-1918c080-e9d1-11e9-9589-b4be0aea1e2c.png)
