### PR TITLE
Fix icons in buttons. Document is-light/dark classes. Add more icon button examples

### DIFF
--- a/docs/examples/patterns/buttons/icon.html
+++ b/docs/examples/patterns/buttons/icon.html
@@ -3,5 +3,6 @@ layout: examples
 title: Buttons / Icon
 category: _patterns
 ---
-<button class="p-button--positive has-icon"><i class="p-icon--plus"></i></button>
+<button class="p-button--positive has-icon"><i class="p-icon--minus is-light"></i></button>
 <button class="p-button has-icon"><i class="p-icon--plus"></i> <span>Button with icon</span></button>
+<button class="p-button--neutral has-icon" disabled><i class="p-icon--spinner u-animation--spin"></i></button>

--- a/docs/patterns/buttons.md
+++ b/docs/patterns/buttons.md
@@ -79,7 +79,7 @@ View example of the dense button pattern
 
 ### Icon
 
-Should you wish to place an icon in a button. You will not want to button to become full width on small screens. Therefore, you can add the state class `has-icon` to the button.
+Should you wish to place an icon in a button. You will not want to button to become full width on small screens. Therefore, you can add the state class `has-icon` to the button. If the contrast between the icon chosen and the button background is not sufficient then the `is-dark` or `is-light` classes can be added to the icon where appropriate.
 
 <a href="/examples/patterns/buttons/icon/"
     class="js-example">

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -162,8 +162,4 @@
       }
     }
   }
-
-  [class*='--positive'].has-icon [class*='p-icon'] {
-    @include vf-icon-plus($color-x-light);
-  }
 }


### PR DESCRIPTION
## Done

Fix icons in buttons. 
Document is-light/dark classes. 
Add more icon button examples

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/examples/patterns/buttons/icon/
- Check that the buttons all render correctly

## Details

Fixes #2552 