### PR TITLE
#2579 - Fix Details title in docs.

### DIFF
--- a/docs/base/details.md
+++ b/docs/base/details.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-## Code
+## Details
 
 <hr>
 


### PR DESCRIPTION
## Done

- Fixed the title of the Details page in docs.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/base/details/
- Admire a title that matches the component.

## Details

Fixes #2579 
