### PR TITLE
#2475 - Rearrange select validation priorities.

### DIFF
--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -59,17 +59,6 @@
     }
   }
 
-  .is-error {
-    .p-form-validation__input {
-      border-color: $color-negative;
-    }
-
-    :not(select).p-form-validation__input,
-    .p-form-validation__select-wrapper::after {
-      background-image: url('#{$assets-path}4b0cd7fc-icon-error.svg');
-    }
-  }
-
   .is-success {
     .p-form-validation__input {
       border-color: $color-positive;
@@ -89,6 +78,17 @@
     :not(select).p-form-validation__input,
     .p-form-validation__select-wrapper::after {
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h16v16H0z'/%3E%3Cpath stroke-linejoin='round' fill='#{vf-url-friendly-color($color-caution)}' transform='matrix%282.28 0 0 2.437 -2180.8 -490.52%29' stroke='#{vf-url-friendly-color($color-caution)}' stroke-width='.848' d='M963.07 207.03h-6.15l3.08-5.33z'/%3E%3Cpath d='M7 5v5h2V5H7zm0 6v2h2v-2H7z' fill='%23111'/%3E%3C/g%3E%3C/svg%3E");
+    }
+  }
+
+  .is-error {
+    .p-form-validation__input {
+      border-color: $color-negative;
+    }
+
+    :not(select).p-form-validation__input,
+    .p-form-validation__select-wrapper::after {
+      background-image: url('#{$assets-path}4b0cd7fc-icon-error.svg');
     }
   }
 }


### PR DESCRIPTION
## Done

- Rearranged select validation so that error > caution > success in the cases where it has multiple validation classes. This can happen in MAAS where a caution is shown when a certain option is selected, but a server error could occur when trying to save.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/examples/patterns/forms/form-validation/
- Change the class of any validaion divs to `p-form-validation is-error is-caution is-success`
- Check that the error state is shown
- Change the class to `p-form-validation is-caution is-success`
- Check that the caution state is shown
- Change the class to `p-form-validation is-success`
- Check that the success state is shown

## Details

Fixes #2475 