### PR TITLE
#1960 - Add padding to search box so text doesn't go underneath.

### DIFF
--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -36,6 +36,7 @@
   .p-search-box__input {
     flex: 1 1 100%;
     margin-bottom: 0;
+    padding-right: calc(2 * #{2 * $spv-nudge + map-get($line-heights, default-text)});
     position: absolute;
 
     &::-webkit-search-cancel-button {


### PR DESCRIPTION
## Done

- Added padding to search box so text doesn't go underneath.

## QA

- Pull code
- Run `./run serve --watch`
- Open 0.0.0.0:8101/examples/patterns/search-box/default/
- Add enough text to the search box input so it reaches the reset button
- Check that the text doesn't go underneath

## Details

Fixes #1960 
