### PR TITLE
doc page for theming

### DIFF
--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -20,7 +20,7 @@ displayed horizontally on larger screens.
 
 The navigation pattern is one of the first patterns to implement the new theming architecture in Vanilla. The default is light. But, to switch to a dark navigation, you can either:
 
-- Override the value of the `nav` key in the `$theme-default--dark` map (initially set in `_settings_themes.scss`) to `true`: `$theme-default--dark: map-merge($theme-default--dark, ("nav": true));`
+- Override the value of the `$theme-default-nav` in `_settings_themes.scss` to `dark`
 - Add a state class to the `p-navigation` class: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark
 
 You can also manually override the background color of the navigation using the variable `$color-navigation-background`. If the lightness of the background is above 70%, the text colour will switch to dark to improve readability.

--- a/docs/settings/color-settings.md
+++ b/docs/settings/color-settings.md
@@ -142,7 +142,7 @@ It’s important for us to meet all web accessibility standards. Vanilla encoura
   </div>
 </div>
 
-### Color theming <span class="p-label--in-progress" style="margin-left: 0.5rem;">In progress</span>
+### Color theming
 
 Starting with the 2.3 release, Vanilla framework introduces a theming mechanism. The current default for all patterns is referred to as the light theme. A subset of elements and patterns now offer a dark theme:
 

--- a/docs/settings/color-settings.md
+++ b/docs/settings/color-settings.md
@@ -142,6 +142,33 @@ It’s important for us to meet all web accessibility standards. Vanilla encoura
   </div>
 </div>
 
+### Color theming <span class="p-label--in-progress" style="margin-left: 0.5rem;">In progress</span>
+
+Starting with the 2.3 release, Vanilla framework introduces a theming mechanism. The current default for all patterns is referred to as the light theme. A subset of elements and patterns now offer a dark theme:
+
+- `checkbox`
+- `hr`
+- `radio`
+- navigation pattern
+- search box pattern
+
+| Element / Pattern | Variable                      | Default value |
+| ----------------- | ----------------------------- | ------------- |
+| checkbox          | `$theme-default-forms`        | 'light'       |
+| radio             | `$theme-default-forms`        | 'light'       |
+| hr                | `$theme-default-hr`           | 'light'       |
+| Navigation        | `$theme-default-nav`          | 'light'       |
+| Search box        | `$theme-default-p-search-box` | 'light'       |
+
+Future releases will expand this list to include all elements and patterns.
+
+#### Setting the default color theme per element / pattern
+
+To set the default theme to dark on any of the elements / patterns listed above:
+
+- Go to `_settings_themes.scss`
+- Set the value of the respective variable in the table above to 'dark'
+
 ### Design
 
 For more information [view the color design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Color), which includes the specification in markdown format and a PNG image.

--- a/docs/settings/color-settings.md
+++ b/docs/settings/color-settings.md
@@ -171,7 +171,7 @@ To set the default theme to dark on any of the elements / patterns listed above:
 
 #### Invoking a theme that is not currently a default
 
-Bersides setting the default, you can invoke the non-default theme by adding a class to your markup. For the list of themed elements above, add `is-dark` (if the default for the respective element or pattern is `light`, or `is-light` if the default is dark.
+Besides setting the default, you can invoke the non-default theme by adding a class to your markup. For the list of themed elements above, add `is-dark` (if the default for the respective element or pattern is `light`, or `is-light` if the default is dark.
 
 ### Design
 

--- a/docs/settings/color-settings.md
+++ b/docs/settings/color-settings.md
@@ -169,6 +169,10 @@ To set the default theme to dark on any of the elements / patterns listed above:
 - Go to `_settings_themes.scss`
 - Set the value of the respective variable in the table above to 'dark'
 
+#### Invoking a theme that is not currently a default
+
+Bersides setting the default, you can invoke the non-default theme by adding a class to your markup. For the list of themed elements above, add `is-dark` (if the default for the respective element or pattern is `light`, or `is-light` if the default is dark.
+
 ### Design
 
 For more information [view the color design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Color), which includes the specification in markdown format and a PNG image.

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -460,7 +460,7 @@ $box-offsets-top: (
     }
   }
 
-  @if (map-get($theme-default--dark, forms) == true) {
+  @if ($theme-default-forms == 'dark') {
     [type='checkbox'] {
       @extend %vf-tick-elements--dark-theme;
       @extend %vf-checkbox--dark-theme;

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -16,7 +16,7 @@
   }
 
   // Theming
-  @if (map-get($theme-default--dark, hr) == true) {
+  @if ($theme-default-hr == 'dark') {
     hr {
       @extend %hr--dark-theme;
     }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -213,7 +213,7 @@ $navigation-hover-opacity: 0.58;
   $color-navigation-text: null !default;
   $lightness-threshold: 70;
 
-  @if (map-get($theme-default--dark, nav) == true) {
+  @if ($theme-default-nav == 'dark') {
     // dark theme
     $color-navigation-background: $colors--dark-theme--background-highlighted !default;
     $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme--text-default, $colors--dark-theme--text-default) !default;

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -115,7 +115,7 @@
     }
   }
 
-  @if (map-get($theme-default--dark, p-search-box) == true) {
+  @if ($theme-default-p-search-box == 'dark') {
     .p-search-box__input {
       @extend %search-box-input--dark;
     }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -41,7 +41,7 @@
   }
 
   // Theming
-  @if (map-get($theme-default--dark, nav) == true) {
+  @if ($theme-default-nav == 'dark') {
     .p-subnav::after {
       @include vf-icon-chevron($color-light);
     }

--- a/scss/_settings_themes.scss
+++ b/scss/_settings_themes.scss
@@ -1,6 +1,4 @@
-$theme-default--dark: (
-  hr: false,
-  nav: false,
-  p-search-box: false,
-  forms: false
-) !default;
+$theme-default-forms: 'light' !default;
+$theme-default-hr: 'light' !default;
+$theme-default-nav: 'dark' !default;
+$theme-default-p-search-box: 'dark' !default;

--- a/scss/_settings_themes.scss
+++ b/scss/_settings_themes.scss
@@ -1,4 +1,4 @@
 $theme-default-forms: 'light' !default;
 $theme-default-hr: 'light' !default;
-$theme-default-nav: 'dark' !default;
-$theme-default-p-search-box: 'dark' !default;
+$theme-default-nav: 'light' !default;
+$theme-default-p-search-box: 'light' !default;


### PR DESCRIPTION
## Done

- Expand the color page to include information about the newly introduced theming mechanism
- Replace color theming map with variables for easier override

## QA

- Pull code
- In color-settings.md, check that the copy makes sense
- In color-settings.md, check that the described way of altering a theme works
- In color-settings.md, check that the described way of applying is-dark / is-light classes works
- If the above seem agreeable, build the documentation and check if it looks ok

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2331
