### PR TITLE
Update docs vanilla dependency to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "vanilla-framework": "vanilla-framework is included in devDependencies for use in styling the docs site"
   },
   "devDependencies": {
-    "vanilla-framework": "2.4.0",
+    "vanilla-framework": "2.4.1",
     "autoprefixer": "9.5.0",
     "husky": "1.3.1",
     "markdown-spellcheck": "1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,10 +3765,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.0.tgz#95fd15738ce72cbb30bb667ba255cc7e9ae3f13d"
-  integrity sha512-NacSE5eKsugHnKlWlwsfKm24cDpsmcer2RC0+PCmFz4US4BLrEanQ0mZUkXg3toEwue867FFvDB+I7jiKP+zow==
+vanilla-framework@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.1.tgz#36ef374e90b8457a07e55cf33be1bcfd07092c84"
+  integrity sha512-St8LdmoMpWSFWvFRDBNjFcdfWo/nOMwrkRPJN+dR0vOHP/Jb1UqOSxw+wDxkiGrpeRb0VPFwCuz/2u0RWb0xuQ==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Updated the docs version of vanilla to 2.4.1

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Check that the styling looks good

## Details

Fixes #2562 
