### PR TITLE
Removes <span> elements from <blockquote> example

### DIFF
--- a/docs/examples/base/blockquotes.html
+++ b/docs/examples/base/blockquotes.html
@@ -4,6 +4,6 @@ title: Blockquote
 category: _base
 ---
 <blockquote>
-  <p><span>“</span> Ubuntu is an ancient African word meaning 'humanity to others'. Ubuntu is an ancient African word meaning 'humanity to others'. <span>”</span></p>
+  <p>“Ubuntu is an ancient African word meaning ‘humanity to others’. Ubuntu is an ancient African word meaning ‘humanity to others’.”</p>
   <p><cite>Canonical</cite></p>
 </blockquote>


### PR DESCRIPTION
Fixes #2597.

## Done

- Removes `<span>` elements from `<blockquote>` example, and trailing+leading spaces.
- Fixes nested quote marks.