### PR TITLE
Add icons accessibility callout

### DIFF
--- a/docs/patterns/icons.md
+++ b/docs/patterns/icons.md
@@ -10,7 +10,7 @@ Icons provide visual context and enhance usability, they can be added via an `<i
 
 ### Accessibility
 
-For accessibility purposes, you can add text within the `alt` attribute inside an icon which will not be displayed. Like so in our example:
+For accessibility purposes, you can add text inside the icon element which will not be displayed to the user. E.g.
 
 `<i class"p-icon--contextual-menu">This text will not be displayed</i>`
 

--- a/docs/patterns/icons.md
+++ b/docs/patterns/icons.md
@@ -8,6 +8,12 @@ layout: default
 
 Icons provide visual context and enhance usability, they can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`
 
+### Accessibility
+
+For accessibility purposes, you can add text within the `alt` attribute inside an icon which will not be displayed. Like so in our example:
+
+`<i class"p-icon--contextual-menu">This text will not be displayed</i>`
+
 ### Standard
 
 Our icons have two predefined color styles: light and dark. The light variant is the default style.


### PR DESCRIPTION
## Done

- Added "Accessibility Callout" to the icons documentation page
- Originally discovered by @barrymcgee 🔍  

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/patterns/icons/#accessibility
- Read through content and example to check callout makes sense 😉 

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2573

## Screenshots

<img width="1440" alt="Screenshot 2019-10-28 at 13 47 47" src="https://user-images.githubusercontent.com/17748020/67683593-8c3aa480-f989-11e9-9f72-c917550319a6.png">

