### PR TITLE
Consistent page titles

### DIFF
--- a/docs/examples/base/font-weights.html
+++ b/docs/examples/base/font-weights.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Ubuntu font weights
+title: Font weights
 category: _base
 ---
 

--- a/docs/examples/base/forms/select-multiple.html
+++ b/docs/examples/base/forms/select-multiple.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Forms / Multiple select
+title: Forms / Select multiple
 category: _base
 ---
 <form>

--- a/docs/examples/base/forms/textarea.html
+++ b/docs/examples/base/forms/textarea.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Forms / Textarea input
+title: Forms / Textarea
 category: _base
 ---
 <form>

--- a/docs/examples/patterns/article-pagination.html
+++ b/docs/examples/patterns/article-pagination.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Article Pagination
+title: Article pagination
 category: _patterns
 ---
 

--- a/docs/examples/patterns/code-copyable.html
+++ b/docs/examples/patterns/code-copyable.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Code copyable
+title: Code / Copyable
 category: _patterns
 redirect_from: "/examples/patterns/code-snippet/"
 ---

--- a/docs/examples/patterns/code-numbered.html
+++ b/docs/examples/patterns/code-numbered.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Code numbered
+title: Code / Numbered
 category: _patterns
 ---
 

--- a/docs/examples/patterns/grid/bordered.html
+++ b/docs/examples/patterns/grid/bordered.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Grid / Bordered row
+title: Grid / Bordered
 category: _patterns
 ---
 <div class="grid-demo">

--- a/docs/examples/patterns/grid/nested-medium.html
+++ b/docs/examples/patterns/grid/nested-medium.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Grid / Nesting - medium
+title: Grid / Nesting - Medium screens
 category: _patterns
 ---
 

--- a/docs/examples/patterns/grid/nested-small.html
+++ b/docs/examples/patterns/grid/nested-small.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Grid / Nesting - small
+title: Grid / Nesting - Small screens
 category: _patterns
 ---
 

--- a/docs/examples/patterns/grid/nested.html
+++ b/docs/examples/patterns/grid/nested.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Grid / Nesting - all screens
+title: Grid / Nesting - All screens
 category: _patterns
 ---
 

--- a/docs/examples/patterns/icons/icons-dark.html
+++ b/docs/examples/patterns/icons/icons-dark.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Icons (dark)
+title: Icons / Dark
 category: _patterns
 ---
 

--- a/docs/examples/patterns/icons/icons-light.html
+++ b/docs/examples/patterns/icons/icons-light.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Icons (light)
+title: Icons / Light
 category: _patterns
 ---
 

--- a/docs/examples/patterns/icons/icons-social.html
+++ b/docs/examples/patterns/icons/icons-social.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Icons (social)
+title: Icons / Social
 category: _patterns
 ---
 

--- a/docs/examples/patterns/image/bordered.html
+++ b/docs/examples/patterns/image/bordered.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Image / with border
+title: Image / Border
 category: _patterns
 ---
 

--- a/docs/examples/patterns/image/shadowed.html
+++ b/docs/examples/patterns/image/shadowed.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Image / with shadow
+title: Image / Shadow
 category: _patterns
 ---
 

--- a/docs/examples/patterns/lists/lists-stepped-detailed.html
+++ b/docs/examples/patterns/lists/lists-stepped-detailed.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Lists / Horizontal stepped
+title: Lists / Stepped detailed
 category: _patterns
 ---
 

--- a/docs/examples/patterns/lists/lists-stepped.html
+++ b/docs/examples/patterns/lists/lists-stepped.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Lists / Vertical stepped
+title: Lists / Stepped
 category: _patterns
 ---
 

--- a/docs/examples/patterns/media-object/media-object-circ-img.html
+++ b/docs/examples/patterns/media-object/media-object-circ-img.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Media object (w/ circular image)
+title: Media object / Circle
 category: _patterns
 ---
 

--- a/docs/examples/patterns/media-object/media-object-large.html
+++ b/docs/examples/patterns/media-object/media-object-large.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Media object - large
+title: Media object / Large
 category: _patterns
 ---
 

--- a/docs/examples/patterns/media-object/media-object.html
+++ b/docs/examples/patterns/media-object/media-object.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Media object
+title: Media object / Default
 category: _patterns
 ---
 

--- a/docs/examples/patterns/navigation/default-dark.html
+++ b/docs/examples/patterns/navigation/default-dark.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Navigation / Default - dark
+title: Navigation / Default dark
 category: _patterns
 ---
 <header id="navigation" class="p-navigation is-dark">

--- a/docs/examples/patterns/navigation/subnav.html
+++ b/docs/examples/patterns/navigation/subnav.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Navigation / Sub Navigation
+title: Navigation / Sub navigation
 category: _patterns
 ---
 

--- a/docs/examples/patterns/pagination/pagination-disabled.html
+++ b/docs/examples/patterns/pagination/pagination-disabled.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Pagination / Disabled control
+title: Pagination / Disabled
 category: _patterns
 ---
 <ol class="p-pagination">

--- a/docs/examples/patterns/strips/deep.html
+++ b/docs/examples/patterns/strips/deep.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Strip / is-deep
+title: Strip / Deep
 category: _patterns
 ---
 <section class="p-strip--light is-deep">

--- a/docs/examples/patterns/strips/is-bordered.html
+++ b/docs/examples/patterns/strips/is-bordered.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Strip / is-bordered
+title: Strip / Bordered
 category: _patterns
 ---
 <section class="p-strip is-bordered">

--- a/docs/examples/patterns/strips/shallow.html
+++ b/docs/examples/patterns/strips/shallow.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Strip / is-shallow
+title: Strip / Shallow
 category: _patterns
 ---
 <section class="p-strip--light is-shallow">

--- a/docs/examples/patterns/tables/table-expanding.html
+++ b/docs/examples/patterns/tables/table-expanding.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Table expanding
+title: Table / Expanding
 category: _patterns
 ---
 

--- a/docs/examples/patterns/tables/table-mobile-card.html
+++ b/docs/examples/patterns/tables/table-mobile-card.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Table mobile card
+title: Table / Mobile card
 category: _patterns
 ---
 <table class="p-table--mobile-card" role="grid">

--- a/docs/examples/patterns/tables/table-sortable.html
+++ b/docs/examples/patterns/tables/table-sortable.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Table sortable
+title: Table / Sortable
 category: _patterns
 ---
 


### PR DESCRIPTION
## Done

- Drive-by to review and update page titles based on the raised issue
- Hopefully, when we push out a new release next iteration it will fix the regression so that the page titles are displayed and don't repeat as seen currently
  - [Vanilla documentation](https://docs.vanillaframework.io/base/typography/)

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/examples/
- See that page titles are more consistent
  - Amended grouping in places
  - Fixed spelling

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2585