### PR TITLE
Add new contextual menu variant with indicator and documented

### DIFF
--- a/docs/examples/patterns/contextual-menu/contextual-menu-indicator.html
+++ b/docs/examples/patterns/contextual-menu/contextual-menu-indicator.html
@@ -1,0 +1,72 @@
+---
+layout: examples
+title: Contextual menu / Indicator
+category: _patterns
+---
+
+<span class="p-contextual-menu--left">
+  <button href="#" class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="#menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--contextual-menu is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
+  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
+    <span class="p-contextual-menu__group">
+      <a href="#" class="p-contextual-menu__link">Commission</a>
+      <a href="#" class="p-contextual-menu__link">Aquire</a>
+      <a href="#" class="p-contextual-menu__link">Deploy</a>
+    </span>
+    <span class="p-contextual-menu__group">
+      <a href="#" class="p-contextual-menu__link">Test harware</a>
+      <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+      <a href="#" class="p-contextual-menu__link">Mark broken</a>
+    </span>
+  </span>
+</span>
+
+
+
+<script>
+
+function toggleMenu(element, show) {
+  element.setAttribute('aria-expanded', show);
+  document
+    .querySelector(element.getAttribute('aria-controls'))
+    .setAttribute('aria-hidden', !show);
+}
+
+function setupContextualMenuListeners(contextualMenuToggleSelector) {
+  const toggles = document.querySelectorAll(contextualMenuToggleSelector);
+
+  toggles.forEach(toggle => {
+    toggle.addEventListener('click', e => {
+      e.preventDefault();
+
+      const target = e.target;
+      const menuAlreadyOpen = toggle.getAttribute('aria-expanded') === 'true';
+
+      toggleMenu(toggle, !menuAlreadyOpen)
+    });
+  });
+
+  document.addEventListener('click', e => {
+    toggles.forEach(toggle => {
+      const contextualMenu = document.querySelector(toggle.getAttribute('aria-controls'));
+      const clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
+
+      if (clickOutside) {
+        toggleMenu(toggle, false);
+      }
+    })
+  });
+
+  document.onkeydown = e => {
+    e = e || window.event;
+
+    if (e.keyCode === 27) {
+      toggles.forEach(toggle => {
+        toggleMenu(toggle, false);
+      });
+    }
+  };
+}
+
+setupContextualMenuListeners('.p-contextual-menu__toggle');
+
+</script>

--- a/docs/examples/patterns/contextual-menu/contextual-menu.html
+++ b/docs/examples/patterns/contextual-menu/contextual-menu.html
@@ -1,6 +1,6 @@
 ---
 layout: examples
-title: Contextual menu
+title: Contextual menu / base
 category: _patterns
 ---
 

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -31,7 +31,22 @@ Using direction modifiers will change the placement of the drop-down menu. By de
   </p>
 </div>
 
-<a href="/examples/patterns/contextual-menu/"
+<a href="/examples/patterns/contextual-menu/contextual-menu"
+  class="js-example">
+View example of the contextual menu pattern
+</a>
+
+### Indicator
+
+If you require a drop-down button with a state indicator then the `p-contextual-menu__toggle` class can be used alongside the `p-icon` and `p-button` components.
+
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Information:</span>This example makes use of additional components
+  </p>
+</div>
+
+<a href="/examples/patterns/contextual-menu/contextual-menu-indicator"
   class="js-example">
 View example of the contextual menu pattern
 </a>

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -59,7 +59,6 @@
     padding: 0;
     position: absolute;
     right: 0;
-    top: calc(100% + #{$sp-x-small});
     z-index: 1;
 
     &::before,
@@ -95,16 +94,19 @@
 
   .p-contextual-menu__group {
     display: block;
-    padding: $sp-xx-small 0;
 
     + .p-contextual-menu__group {
       border-top: 1px solid $color-mid-light;
-      margin: 0;
+      margin: -1px 0 0 0;
     }
   }
 
   .p-contextual-menu__toggle {
     margin-bottom: $spv-inner--small + ($spv-nudge-compensation * 2);
+  }
+
+  .p-contextual-menu__dropdown {
+    margin-top: -#{$input-margin-bottom};
   }
 
   .p-contextual-menu__link {
@@ -115,7 +117,7 @@
     line-height: 1.5rem;
     margin: 0;
     overflow: hidden;
-    padding: $sp-xx-small $sp-small;
+    padding: $spv-inner--x-small $sp-small;
     text-align: left;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -125,5 +127,9 @@
       background-color: $color-light;
       text-decoration: none;
     }
+  }
+
+  .p-contextual-menu__toggle[aria-expanded='true'] .p-contextual-menu__indicator {
+    transform: rotate(180deg);
   }
 }


### PR DESCRIPTION
## Done

Added a dropdown button implementation by extending contextual menu

## QA

- Pull code
- Run `./run `
- Open http://0.0.0.0:8101/examples/patterns/contextual-menu/contextual-menu-indicator/
- Click the button and see the menu functionality
- Check the documentation at http://0.0.0.0:8101/patterns/contextual-menu/

## Screenshots

Fixes #2336 