### PR TITLE
Add usage to code-copyable

### DIFF
--- a/docs/base/code.md
+++ b/docs/base/code.md
@@ -25,18 +25,33 @@ View example of the base code block
 
 ### Copyable
 
-Code copyable should be used when presenting the user with a small snippet of code that they will likely want to copy and paste.
+This component should be used when displaying a single line of code, accompanied by a copy icon, which allows users to copy the provided code to their clipboard.
 
-<div class="p-notification--caution">
-  <p class="p-notification__response">
-    <span class="p-notification__status">Warning:</span>This pattern requires JS to be functional.
-  </p>
+<div class="p-strip is-shallow">
+  <div class="row">
+     <div class="col-6">
+       <div class="p-notification--positive">
+        <p class="p-notification__response"><span class="p-notification__status">Do:</span>Use for single line terminal commands, functions or instructions.</p>
+       </div>
+     </div>
+    <div class="col-6">
+      <div class="p-notification--negative">
+        <p class="p-notification__response"><span class="p-notification__status">Don't:</span>Use more than two lines of code, if required, it's recommended you use code <a href="#block" class="p-notification__action">block</a>.</p>
+      </div>
+    </div>
+  </div>
 </div>
 
 <a href="/examples/patterns/code-copyable/"
     class="js-example">
 View example of the code copyable pattern
 </a>
+
+<div class="p-notification--caution">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Warning:</span>This pattern requires JS to be functional.
+  </p>
+</div>
 
 ### Functionality
 


### PR DESCRIPTION
## Done

- Edited intro to component
- Add 'Do' and 'Don't' basic usage guidelines
- Plan to update component next cycle, so this is an initial drive-by before we make future updates

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/base/code/#copyable
- Check the copy for 'Do' and 'Don't' and that links work

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2568

## Screenshots

<img width="930" alt="Screenshot 2019-11-01 at 12 00 14" src="https://user-images.githubusercontent.com/17748020/68023581-771e8800-fc9f-11e9-9792-06928ade79ec.png">

