### PR TITLE
Add import snippet to utilities documentation

### DIFF
--- a/docs/settings/layout-settings.md
+++ b/docs/settings/layout-settings.md
@@ -13,3 +13,13 @@ These settings are used specifically to configure the grid which will determine 
 | `$grid-gutter-width` | `20px`        |
 | `$grid-columns`      | `12`          |
 | `$grid-max-width`    | `1030px`      |
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_layout';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/settings/spacing-settings.md
+++ b/docs/settings/spacing-settings.md
@@ -95,3 +95,13 @@ There are also generic spacing units for backwards compatibility with components
 | `$sp-xxx-large`   | `$sp-unit * 6`    | `3rem`        |
 | `$sp-xxxx-large`  | `$sp-unit * 8`    | `4rem`        |
 | `$sp-xxxxx-large` | `$sp-unit * 12`   | `6rem`        |
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_vertical-spacing';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/align.md
+++ b/docs/utilities/align.md
@@ -12,3 +12,13 @@ You can use these utilities to force the content inside an element to align cent
     class="js-example">
 View example of the content align utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_content-align';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/baseline-grid.md
+++ b/docs/utilities/baseline-grid.md
@@ -18,3 +18,13 @@ View example of the baseline grid utility
     <span class="p-notification__status">Warning:</span>This pattern requires JS to be functional.
   </p>
 </div>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_baseline-grid';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/clearfix.md
+++ b/docs/utilities/clearfix.md
@@ -16,3 +16,13 @@ In the example below, the parent wrapping container does not collapse even thoug
     class="js-example">
 View example of the clearfix utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_clearfix';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/embedded-media.md
+++ b/docs/utilities/embedded-media.md
@@ -12,3 +12,13 @@ Embed media objects such as videos, maps and calendars.
     class="js-example">
 View example of the embedded media utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_embedded-media';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/equal-height.md
+++ b/docs/utilities/equal-height.md
@@ -12,3 +12,13 @@ To ensure two or more elements have an equal height regardless of their content,
     class="js-example">
 View example of the equal height utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_equal-height';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/floats.md
+++ b/docs/utilities/floats.md
@@ -44,3 +44,13 @@ You can limit floats to only small screen sizes using the following example.
     class="js-example">
 View example of the small screen floats utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_floats';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/hide.md
+++ b/docs/utilities/hide.md
@@ -16,3 +16,13 @@ To hide only at a specific viewport, add `--small`, `--medium` or `--large` modi
     class="js-example">
 View example of the Hide utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_hide';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/image-position.md
+++ b/docs/utilities/image-position.md
@@ -72,6 +72,16 @@ View example of the utilities image position bottom right
 View example of the utilities image position bottom left
 </a>
 
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_image-position';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+
 ### Design
 
 For more information view the [image position design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Image%20position) which includes the specification in markdown format and a PNG image.

--- a/docs/utilities/margin-collapse.md
+++ b/docs/utilities/margin-collapse.md
@@ -12,3 +12,13 @@ Remove one or more margins of an element.
     class="js-example">
 View example of the margin collapse utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_margin-collapse';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/no-print.md
+++ b/docs/utilities/no-print.md
@@ -15,3 +15,13 @@ Use your browser's print preview to see the following example working.
   class="js-example">
 View example of the no-print utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_no-print';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/off-screen.md
+++ b/docs/utilities/off-screen.md
@@ -12,3 +12,13 @@ The `.u-off-screen` class will position an element out of the page flow and off-
     class="js-example">
 View example of the off-screen utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_off-screen';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/padding-collapse.md
+++ b/docs/utilities/padding-collapse.md
@@ -12,3 +12,13 @@ Remove one or more paddings on an element.
     class="js-example">
 View example of the padding collapse utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_padding-collapse';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/show.md
+++ b/docs/utilities/show.md
@@ -12,3 +12,13 @@ Show an element within a certain breakpoint.
     class="js-example">
 View example of the Show utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_show';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/utilities/vertically-center.md
+++ b/docs/utilities/vertically-center.md
@@ -14,3 +14,13 @@ Note: only affects medium and large screens.
     class="js-example">
 View example of the vertically center utility
 </a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_vertically-center';
+```
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
## Done

- Added a section in the context menu called 'Import' to components
- Provides import snippet to paste into your project
- Links to Customising Vanilla page for further information

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/
- Check 'Import' section applied to specific utilities
  - http://0.0.0.0:8101/utilities/align/#import
  - http://0.0.0.0:8101/utilities/baseline-grid/#import
  - http://0.0.0.0:8101/utilities/clearfix/#import
  - http://0.0.0.0:8101/utilities/embedded-media/#import
  - http://0.0.0.0:8101/utilities/equal-height/#import
  - http://0.0.0.0:8101/utilities/floats/#import
  - http://0.0.0.0:8101/utilities/hide/#import
  - http://0.0.0.0:8101/utilities/image-position/#import
  - http://0.0.0.0:8101/utilities/margin-collapse/#import
  - http://0.0.0.0:8101/utilities/no-print/#import
  - http://0.0.0.0:8101/utilities/off-screen/#import
  - http://0.0.0.0:8101/utilities/padding-collapse/#import
  - http://0.0.0.0:8101/utilities/show/#import
  - http://0.0.0.0:8101/utilities/vertically-center/#import
  - http://0.0.0.0:8101/settings/layout-settings/#import
  - http://0.0.0.0:8101/settings/spacing-settings/#import

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2436

## Screenshots

<img width="928" alt="Screenshot 2019-11-01 at 13 59 05" src="https://user-images.githubusercontent.com/17748020/68030491-85759f80-fcb1-11e9-9712-d250dc7f23cf.png">
