### PR TITLE
Documentation entry on max-width; u-no-max-width utility

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -66,3 +66,4 @@ patterns_article-pagination
 patterns_breadcrumbs
 CTA
 patterns_buttons
+unsetting

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -86,7 +86,7 @@ View example of the mixed headings pattern
 
 ### Line length
 
-Line length, measured in number of characters per line (cpl), has been shown to affect reading speed and comprehension. While there is little consensus on what the cpl optimal value is, most studies test with values between 45 and 95 characters per line. <a href="https://en.wikipedia.org/wiki/Line_length">Wikipedia</a> has a good historical overview and a list of studies on the subject.
+Line length, measured in number of characters per line (CPL), has been shown to affect reading speed and comprehension. While there is little consensus on what the optimal CPL value is, most studies test with values between 45 and 95 characters per line. <a href="https://en.wikipedia.org/wiki/Line_length">Wikipedia</a> has a good historical overview and a list of studies on the subject.
 
 The max-width of text elements in Vanilla Framework is limited using the `$max-width--default` variable, currently set to 40em, or around 90 characters.
 

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -88,7 +88,7 @@ View example of the mixed headings pattern
 
 Line length, measured in number of characters per line (CPL), has been shown to affect reading speed and comprehension. While there is little consensus on what the optimal CPL value is, most studies test with values between 45 and 95 characters per line. <a href="https://en.wikipedia.org/wiki/Line_length">Wikipedia</a> has a good historical overview and a list of studies on the subject.
 
-The max-width of text elements in Vanilla Framework is limited using the `$max-width--default` variable, currently set to 40em, or around 90 characters.
+The max-width of text elements in Vanilla Framework is limited using the `$max-width--default` variable, currently set to `40em`, or around 90 characters.
 
 Vanilla also includes a utility to unset the max-width where necessary &ndash; `u-no-max-width`:
 <a href="/examples/utilities/max-width-unset/"

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -99,7 +99,7 @@ View example of how to unset max-width
 Overriding or unsetting the `max-width` is reasonable in certain cases:
 
 - to avoid an <a href="https://en.wikipedia.org/wiki/Widows_and_orphans">orphan</a> in some fixed, high-profile text, like a promotional banner or notification.
-- when content is wrapped in a text element unintentionally, and fixing the markup is not possible. For example, a cms or a documentation service might insert `<p>` after every line break, resulting in `<div>`'s or `<iframe>`'s wrapped in `<p>`'s.
+- when content is wrapped in a text element unintentionally, and fixing the markup is not possible. For example, a CMS or a documentation service might insert `<p>` after every line break, resulting in `<div>`'s or `<iframe>`'s wrapped in `<p>`'s.
 
 ### Ordered list
 

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -84,6 +84,23 @@ better suits your document style and tree.
 View example of the mixed headings pattern
 </a>
 
+### Line length
+
+Line length, measured in number of characters per line (cpl), has been shown to affect reading speed and comprehension. While there is little consensus on what the cpl optimal value is, most studies test with values between 45 and 95 characters per line. <a href="https://en.wikipedia.org/wiki/Line_length">Wikipedia</a> has a good historical overview and a list of studies on the subject.
+
+The max-width of text elements in Vanilla Framework is limited using the `$max-width--default` variable, currently set to 40em, or around 90 characters.
+
+Vanilla also includes a utility to unset the max-width where necessary &ndash; `u-no-max-width`:
+<a href="/examples/utilities/max-width-unset/"
+    class="js-example">
+View example of how to unset max-width
+</a>
+
+Overriding or unsetting the `max-width` is reasonable in certain cases:
+
+- to avoid an <a href="https://en.wikipedia.org/wiki/Widows_and_orphans">orphan</a> in some fixed, high-profile text, like a promotional banner or notification.
+- when content is wrapped in a text element unintentionally, and fixing the markup is not possible. For example, a cms or a documentation service might insert `<p>` after every line break, resulting in `<div>`'s or `<iframe>`'s wrapped in `<p>`'s.
+
 ### Ordered list
 
 Use an ordered list when the order of the items is important.

--- a/docs/examples/utilities/max-width-unset.html
+++ b/docs/examples/utilities/max-width-unset.html
@@ -1,0 +1,7 @@
+---
+layout: examples
+title: Max-width unset
+category: _utilities
+---
+
+<p class="u-no-max-width">Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.</p>

--- a/scss/_base_typography-max-widths.scss
+++ b/scss/_base_typography-max-widths.scss
@@ -11,23 +11,26 @@
   }
 }
 
-// Optimal max-width for body copy
 @mixin p-max-width {
-  max-width: map-get($max-widths, default);
+  @include deprecate('3.0.0', 'Max-widths should not be based on font-size. Use map-get($max-widths, default) instead.') {
+    max-width: map-get($max-widths, default);
+  }
 }
 
-// Optimal max-width for main headings (up to 2 lines of copy)
 @mixin heading-max-width--short {
-  max-width: map-get($max-widths, heading--short);
+  @include deprecate('3.0.0', 'Max-widths should not be based on font-size. Use map-get($max-widths, default) instead.') {
+    max-width: map-get($max-widths, default);
+  }
 }
 
-// Optimal max-width for headings (up to 3 lines of copy)
 @mixin heading-max-width--long {
-  max-width: map-get($max-widths, heading--long);
+  @include deprecate('3.0.0', 'Max-widths should not be based on font-size. Use map-get($max-widths, default) instead.') {
+    max-width: map-get($max-widths, default);
+  }
 }
 
-// Relaxed max-width for cases like notifications, where minimizing vertical height is
-// more important than maintaining the optimal value
 @mixin p-max-width--long {
-  max-width: map-get($max-widths, long);
+  @include deprecate('3.0.0', 'Max-widths should not be based on font-size. Use map-get($max-widths, default) instead.') {
+    max-width: map-get($max-widths, default);
+  }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -57,7 +57,7 @@
 
   .p-notification__response,
   .p-notification--floating {
-    @include u-no-max-width;
+    @include vf-u-max-width;
   }
 }
 

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -57,7 +57,7 @@
 
   .p-notification__response,
   .p-notification--floating {
-    @include p-max-width--long;
+    @include u-no-max-width;
   }
 }
 

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -57,7 +57,7 @@
 
   .p-notification__response,
   .p-notification--floating {
-    @include vf-u-max-width;
+    max-width: unset;
   }
 }
 

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -128,19 +128,24 @@ $spv-nudge: map-get($nudges, nudge--p) !default; // top: nudge; bottom: unit - n
 $spv-nudge-compensation: $sp-unit - $spv-nudge !default;
 $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
+$max-width--default: 40em !default;
+
+@include deprecate('3.0.0', 'The map $max-widths will be removed in version 3.0. Use variable $max-width--default instead') {
+}
+
 $max-widths: (
-  long: 60em,
-  default: 40em,
-  heading--long: 30em,
-  heading--short: 20em
+  long: $max-width--default,
+  default: $max-width--default,
+  heading--long: $max-width--default,
+  heading--short: $max-width--default
 ) !default;
 
 $icon-sizes: (
   accordion: $sp-unit * 1.5,
   default: $sp-unit * 2,
-  heading-icon--x-small: $sp-unit * 3,
+  heading-icon--x-small: $sp-unit * 4,
   heading-icon--small: $sp-unit * 4,
-  heading-icon: $sp-unit * 5,
+  4 heading-icon: $sp-unit * 5,
   thumb: $sp-unit * 6,
   thumb--large: $sp-unit * 12
 ) !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -140,9 +140,9 @@ $max-widths: (
 $icon-sizes: (
   accordion: $sp-unit * 1.5,
   default: $sp-unit * 2,
-  heading-icon--x-small: $sp-unit * 4,
+  heading-icon--x-small: $sp-unit * 3,
   heading-icon--small: $sp-unit * 4,
-  4 heading-icon: $sp-unit * 5,
+  heading-icon: $sp-unit * 5,
   thumb: $sp-unit * 6,
   thumb--large: $sp-unit * 12
 ) !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -130,9 +130,6 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
 
 $max-width--default: 40em !default;
 
-@include deprecate('3.0.0', 'The map $max-widths will be removed in version 3.0. Use variable $max-width--default instead') {
-}
-
 $max-widths: (
   long: $max-width--default,
   default: $max-width--default,

--- a/scss/_utilities_max-width.scss
+++ b/scss/_utilities_max-width.scss
@@ -1,0 +1,5 @@
+@mixin vf-u-max-width {
+  .u-no-max-width {
+    max-width: unset !important;
+  }
+}

--- a/scss/_utilities_max-width.scss
+++ b/scss/_utilities_max-width.scss
@@ -1,4 +1,4 @@
-@mixin vf-u-max-width {
+@mixin vf-u-no-max-width {
   .u-no-max-width {
     max-width: unset !important;
   }

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -121,7 +121,7 @@
   @include vf-u-image-position;
   @include vf-u-layout;
   @include vf-u-margin-collapse;
-  @include vf-u-max-width;
+  @include vf-u-no-max-width;
   @include vf-u-off-screen;
   @include vf-u-padding-collapse;
   @include vf-u-show;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -55,6 +55,7 @@
 @import 'utilities_image-position';
 @import 'utilities_layout';
 @import 'utilities_margin-collapse';
+@import 'utilities_max-width';
 @import 'utilities_off-screen';
 @import 'utilities_padding-collapse';
 @import 'utilities_show';
@@ -120,6 +121,7 @@
   @include vf-u-image-position;
   @include vf-u-layout;
   @include vf-u-margin-collapse;
+  @include vf-u-max-width;
   @include vf-u-off-screen;
   @include vf-u-padding-collapse;
   @include vf-u-show;


### PR DESCRIPTION
## Done

- Add documentation entry on max-width
- Add example
- Add unset utility

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/utilities/max-width-unset/
- Verify example max width is overriden
- Open typography.md
- Check copy makes sense

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2586
