### PR TITLE
Fix icons inside buttons; add font-metrics utility

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -45,6 +45,7 @@ sub-navigation
 spec
 _n_
 px
+.5rem
 1.5rem
 1.0rem
 2.0rem
@@ -65,4 +66,6 @@ patterns_accordion
 patterns_article-pagination
 patterns_breadcrumbs
 CTA
+css
+FontForge
 patterns_buttons

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -43,8 +43,9 @@
               <a href="#main-content">Jump to main content</a>
             </span>
             <ul class="p-navigation__links">
-              <li class="p-navigation__link is-selected"><a href="/">Docs</a></li>
-              <li class="p-navigation__link"><a href="https://vanillaframework.io/accessibility">Accessibility</a></li>
+                <li class="p-navigation__link is-selected"><a href="/">Docs</a></li>
+                <li class="p-navigation__link"><a href="/examples">Examples</a></li>
+                <li class="p-navigation__link"><a href="https://vanillaframework.io/accessibility">Accessibility</a></li>
               <li class="p-navigation__link"><a href="https://vanillaframework.io/browser-support">Browser support</a></li>
               <li class="p-navigation__link"><a href="https://vanillaframework.io/coding-standards">Coding standards</a></li>
               <li class="p-navigation__link"><a href="https://vanillaframework.io/contribute">Contribute</a></li>
@@ -128,6 +129,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/embedded-media/' %}is-active{% endif %}" href="/utilities/embedded-media/">Embedded media</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/equal-height/' %}is-active{% endif %}" href="/utilities/equal-height/">Equal height</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/floats/' %}is-active{% endif %}" href="/utilities/floats/">Floats</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/font-metrics/' %}is-active{% endif %}" href="/utilities/font-metrics/">Font metrics</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/functions/' %}is-active{% endif %}" href="/utilities/functions/">Functions</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/hide/' %}is-active{% endif %}" href="/utilities/hide/">Hide</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/image-position/' %}is-active{% endif %}" href="/utilities/image-position/">Image position</a></li>

--- a/docs/examples/patterns/buttons/icon.html
+++ b/docs/examples/patterns/buttons/icon.html
@@ -3,21 +3,6 @@ layout: examples
 title: Buttons / Icon
 category: _patterns
 ---
-
-<h1 style="display:inline-block">
-    <i class="p-icon--success"></i>
-    <span class="u-visualise-font-metrics">Xx</span>
-</h1>
 <button class="p-button--positive has-icon"><i class="p-icon--minus is-light"></i></button>
-<button class="p-button has-icon"><i class="p-icon--plus"></i> <span class="u-visualise-font-metrics">Button with icon</span></button>
-<button class="p-button has-icon"><i class="p-icon--plus"></i><span class="u-visualise-font-metrics">Icon before text</span></button>
-<button class="p-button has-icon"><span class="u-visualise-font-metrics">Icon after textX</span><i class="p-icon--contextual-menu"></i></button>
-<button class="p-button"><span class="u-visualise-font-metrics">Xx</span></button>
-<button class="p-button">Anonimous text</button>
-<button class="p-button"><span>Text in span</span></button>
-<button class="p-button has-icon"><i class="p-icon--minus"></i></button>
-<form class="p-search-box">
-    <input type="search" class="p-search-box__input" name="search" placeholder="Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search " required="">
-    <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i><span class=" u-visualise-cap-height">text</span></button>
-    <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
-</form>
+<button class="p-button has-icon"><i class="p-icon--plus"></i><span>Icon before text</span></button>
+<button class="p-button has-icon"><span>Icon after text</span><i class="p-icon--contextual-menu"></i></button>

--- a/docs/examples/patterns/buttons/icon.html
+++ b/docs/examples/patterns/buttons/icon.html
@@ -3,6 +3,21 @@ layout: examples
 title: Buttons / Icon
 category: _patterns
 ---
+
+<h1 style="display:inline-block">
+    <i class="p-icon--success"></i>
+    <span class="u-visualise-font-metrics">Xx</span>
+</h1>
 <button class="p-button--positive has-icon"><i class="p-icon--minus is-light"></i></button>
-<button class="p-button has-icon"><i class="p-icon--plus"></i> <span>Button with icon</span></button>
-<button class="p-button--neutral has-icon" disabled><i class="p-icon--spinner u-animation--spin"></i></button>
+<button class="p-button has-icon"><i class="p-icon--plus"></i> <span class="u-visualise-font-metrics">Button with icon</span></button>
+<button class="p-button has-icon"><i class="p-icon--plus"></i><span class="u-visualise-font-metrics">Icon before text</span></button>
+<button class="p-button has-icon"><span class="u-visualise-font-metrics">Icon after textX</span><i class="p-icon--contextual-menu"></i></button>
+<button class="p-button"><span class="u-visualise-font-metrics">Xx</span></button>
+<button class="p-button">Anonimous text</button>
+<button class="p-button"><span>Text in span</span></button>
+<button class="p-button has-icon"><i class="p-icon--minus"></i></button>
+<form class="p-search-box">
+    <input type="search" class="p-search-box__input" name="search" placeholder="Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search Search " required="">
+    <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i><span class=" u-visualise-cap-height">text</span></button>
+    <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+</form>

--- a/docs/examples/utilities/font-metrics.html
+++ b/docs/examples/utilities/font-metrics.html
@@ -5,34 +5,44 @@ category: _utilities
 ---
 
 <h1>
-    <span class="u-visualise-font-metrics">Xx</span>
-
+  <i class="p-icon--success"></i>
+  <span class="u-visualise-font-metrics">Xx</span>
 </h1>
 <h2>
-    <span class="u-visualise-font-metrics">Xx</span>
-
+  <i class="p-icon--success"></i>
+  <span class="u-visualise-font-metrics">Xx</span>
 </h2>
 <h3>
-    <span class="u-visualise-font-metrics">Xx</span>
-
+  <i class="p-icon--success"></i>
+  <span class="u-visualise-font-metrics">Xx</span>
 </h3>
 <h4>
-    <span class="u-visualise-font-metrics">Xx</span>
-
+  <i class="p-icon--success"></i>
+  <span class="u-visualise-font-metrics">Xx</span>
 </h4>
 <h5>
-    <span class="u-visualise-font-metrics">Xx</span>
-
+  <i class="p-icon--success"></i>
+  <span class="u-visualise-font-metrics">Xx</span>
 </h5>
 <h6>
-    <span class="u-visualise-font-metrics">Xx</span>
-
+  <i class="p-icon--success"></i>
+  <span class="u-visualise-font-metrics">Xx</span>
 </h6>
-<p><span class="u-visualise-font-metrics">Xx</span></p>
+<p>
+  <i class="p-icon--success"></i>
+  <span class="u-visualise-font-metrics">Xx</span>
+</p>
 <button class="p-button has-icon">
-    <span class="u-visualise-font-metrics">
-        Button with icon
-    </span>
-    <i class="p-icon--plus">
-    </i>
+  <span class="u-visualise-font-metrics">
+    Button with icon
+  </span>
+  <i class="p-icon--contextual-menu">
+  </i>
+</button>
+<button class="p-button has-icon">
+  <i class="p-icon--plus">
+  </i>
+  <span class="u-visualise-font-metrics">
+    Button with icon
+  </span>
 </button>

--- a/docs/examples/utilities/font-metrics.html
+++ b/docs/examples/utilities/font-metrics.html
@@ -1,0 +1,38 @@
+---
+layout: examples
+title: Font metrics
+category: _utilities
+---
+
+<h1>
+    <span class="u-visualise-font-metrics">Xx</span>
+
+</h1>
+<h2>
+    <span class="u-visualise-font-metrics">Xx</span>
+
+</h2>
+<h3>
+    <span class="u-visualise-font-metrics">Xx</span>
+
+</h3>
+<h4>
+    <span class="u-visualise-font-metrics">Xx</span>
+
+</h4>
+<h5>
+    <span class="u-visualise-font-metrics">Xx</span>
+
+</h5>
+<h6>
+    <span class="u-visualise-font-metrics">Xx</span>
+
+</h6>
+<p><span class="u-visualise-font-metrics">Xx</span></p>
+<button class="p-button has-icon">
+    <span class="u-visualise-font-metrics">
+        Button with icon
+    </span>
+    <i class="p-icon--plus">
+    </i>
+</button>

--- a/docs/utilities/baseline-grid.md
+++ b/docs/utilities/baseline-grid.md
@@ -2,11 +2,11 @@
 layout: default
 ---
 
-## Baseline grid
+## Font metrics
 
 <hr>
 
-You can apply this utility to an element (such as `<body>`) to give it a series of horizontal lines separated by one `$sp-unit`.
+You can apply this utility to an element (such as `<body>`) to visualise the .5rem baseline grid to which text elements adhere.
 
 <a href="/examples/utilities/baseline-grid/"
     class="js-example">

--- a/docs/utilities/baseline-grid.md
+++ b/docs/utilities/baseline-grid.md
@@ -6,7 +6,7 @@ layout: default
 
 <hr>
 
-You can apply this utility to an element (such as `<body>`) to visualise the .5rem baseline grid to which text elements adhere.
+You can apply this utility to an element (such as `<body>`) to visualise the `.5rem` baseline grid to which text elements adhere.
 
 <a href="/examples/utilities/baseline-grid/"
     class="js-example">

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -26,7 +26,7 @@ To import just this utility into your project, copy the snippet below and includ
 
 Then insert a `span` with class `u-visualise-font-metrics` in a heading, paragraph or button.
 
-The `$horisontal-bleed` variable (default value `2rem`) makes the lines protrude on either side of the element, in order to help align adjacent elements. To hide the bleed, use `@include vf-u-visualise-baseline(0)`.
+The `$horisontal-bleed` variable (default value `2rem`) makes the lines protrude on either side of the element, in order to help align adjacent elements. To remove the bleed, use `@include vf-u-visualise-baseline(0)`.
 
 For more information on font metrics, this <a class="p-link--external" href="http://iamvdo.me/en/blog/css-font-metrics-line-height-and-vertical-align">blog post</a> gives a good overview.
 

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -24,9 +24,7 @@ To import just this utility into your project, copy the snippet below and includ
 @include vf-u-visualise-baseline($horisontal-bleed: 2rem);
 ```
 
-```html
 Wrap an anonimous string of text in a span with class `u-visualise-font-metrics`.
-```
 
 The `$horisontal-bleed` variable (default value `2rem`) makes the lines protrude on either side of the element, in order to help align adjacent elements. To hide the bleed, use `@include vf-u-visualise-baseline(0)`.
 

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -24,7 +24,7 @@ To import just this utility into your project, copy the snippet below and includ
 @include vf-u-visualise-baseline($horisontal-bleed: 2rem);
 ```
 
-Wrap an anonimous string of text in a span with class `u-visualise-font-metrics`.
+Then insert a `span` with class `u-visualise-font-metrics` in a heading, paragraph or button.
 
 The `$horisontal-bleed` variable (default value `2rem`) makes the lines protrude on either side of the element, in order to help align adjacent elements. To hide the bleed, use `@include vf-u-visualise-baseline(0)`.
 

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -6,13 +6,13 @@ layout: default
 
 <hr>
 
-Being able to visualise the baseline position, cap-height and x-height of a typeface can help precisely align  inline-block elements (for example icons) to text. For an example of how to do this, you can inspect th
+Being able to visualise the baseline position, cap-height and x-height of a typeface can help precisely align inline-block elements (for example icons) to text.
 
 These properties are not directly accessible via css, but can be obtained from font-editing software like FontForge. The values (for the Ubuntu font family) are stored in `_settings_font.scss`. If you want to use this utility with another font, you will need to change the default values to match your font.
 
 <a href="/examples/utilities/font-metrics/"
     class="js-example">
-  View an example of the font metrics utility
+View an example of the font metrics utility
 </a>
 
 ### Import

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -10,7 +10,8 @@ Being able to visualise the baseline position, cap-height and x-height of a type
 
 These properties are not directly accessible via css, but can be obtained from font-editing software like FontForge. The values (for the Ubuntu font family) are stored in `_settings_font.scss`. If you want to use this utility with another font, you will need to change the default values to match your font.
 
-<a href="/examples/utilities/font-metrics/">
+<a href="/examples/utilities/font-metrics/"
+    class="js-example">
   View an example of the font metrics utility
 </a>
 
@@ -21,6 +22,10 @@ To import just this utility into your project, copy the snippet below and includ
 ```scss
 @import 'utilities_font-metrics';
 @include vf-u-visualise-baseline($horisontal-bleed: 2rem);
+```
+
+```html
+Wrap an anonimous string of text in a span with class `u-visualise-font-metrics`.
 ```
 
 The 2rem `$horisontal-bleed` variable makes the lines protrude on either side of the element, in order to help align adjacent elements. To hide the bleed, use `@include vf-u-visualise-baseline(0)`.

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -28,7 +28,7 @@ To import just this utility into your project, copy the snippet below and includ
 Wrap an anonimous string of text in a span with class `u-visualise-font-metrics`.
 ```
 
-The 2rem `$horisontal-bleed` variable makes the lines protrude on either side of the element, in order to help align adjacent elements. To hide the bleed, use `@include vf-u-visualise-baseline(0)`.
+The `$horisontal-bleed` variable (default value `2rem`) makes the lines protrude on either side of the element, in order to help align adjacent elements. To hide the bleed, use `@include vf-u-visualise-baseline(0)`.
 
 For more information on font metrics, this <a class="p-link--external" href="http://iamvdo.me/en/blog/css-font-metrics-line-height-and-vertical-align">blog post</a> gives a good overview.
 

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -6,9 +6,9 @@ layout: default
 
 <hr>
 
-Being able to visualise the baseline position, cap-height and x-height of a typeface can help precisely align inline-block elements (for example icons) to text.
+Being able to visualise the <a target="_blank" href="https://en.wikipedia.org/wiki/Baseline_(typography)">baseline</a> position, <a target="_blank" href="https://en.wikipedia.org/wiki/Cap_height">cap-height</a> and <a target="_blank" href="https://en.wikipedia.org/wiki/X-height">x-height</a> of a typeface can be helpful, for example when trying to precisely align inline-block elements (like icons) to text.
 
-These properties are not directly accessible via css, but can be obtained from font-editing software like FontForge. The values (for the Ubuntu font family) are stored in `_settings_font.scss`. If you want to use this utility with another font, you will need to change the default values to match your font.
+These properties are not directly accessible via css, but can be obtained from font-editing software like <a target="_blank" href="https://fontforge.github.io/">FontForge</a>. The values are stored in `_settings_font.scss` (the defaults apply to the Ubuntu font family). If you want to use this utility with another font, you will need to change the default values to match your font.
 
 <a href="/examples/utilities/font-metrics/"
     class="js-example">

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -1,0 +1,30 @@
+---
+layout: default
+---
+
+## Font metrics
+
+<hr>
+
+Being able to visualise the baseline position, cap-height and x-height of a typeface can help precisely align  inline-block elements (for example icons) to text. For an example of how to do this, you can inspect th
+
+These properties are not directly accessible via css, but can be obtained from font-editing software like FontForge. The values (for the Ubuntu font family) are stored in `_settings_font.scss`. If you want to use this utility with another font, you will need to change the default values to match your font.
+
+<a href="/examples/utilities/font-metrics/">
+  View an example of the font metrics utility
+</a>
+
+### Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'utilities_font-metrics';
+@include vf-u-visualise-baseline($horisontal-bleed: 2rem);
+```
+
+The 2rem `$horisontal-bleed` variable makes the lines protrude on either side of the element, in order to help align adjacent elements. To hide the bleed, use `@include vf-u-visualise-baseline(0)`.
+
+For more information on font metrics, this <a class="p-link--external" href="http://iamvdo.me/en/blog/css-font-metrics-line-height-and-vertical-align">blog post</a> gives a good overview.
+
+For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -14,7 +14,7 @@
     border-style: solid;
     border-width: 1px;
     cursor: pointer;
-    display: inline-flex;
+    display: inline-block;
     font-size: 1rem;
     font-weight: 300;
     justify-content: center;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -179,7 +179,7 @@ $input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
     box-shadow: none;
     color: $color-dark;
     min-height: map-get($line-heights, default-text);
-    padding-right: $default-icon-size + 2 * $sph-inner--small;
+    padding-right: calc(#{$default-icon-size} + #{2 * $sph-inner--small});
     text-indent: 0.01px;
     text-overflow: '';
 

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -148,17 +148,15 @@
     width: auto;
 
     & [class*='p-icon'] {
-      height: map-get($line-heights, default-text); // so height matches that of text inside buttons
-      margin-left: -#{$sph-inner--small};
-      top: 0;
+      margin-left: $sph-inner--small;
+      margin-right: $sph-inner--small;
 
-      // Apply negative margins to make textless button icon a square
-      &:only-child {
-        margin-right: -#{$sph-inner--small};
+      &:first-child {
+        margin-left: -#{$sph-inner--small};
       }
 
-      + * {
-        margin-left: $sph-inner--small;
+      &:last-child {
+        margin-right: -#{$sph-inner--small};
       }
     }
   }

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -1,6 +1,6 @@
 @import 'settings';
 
-$default-icon-size: map-get($icon-sizes, default);
+$default-icon-size: 1rem; // map-get($icon-sizes, default);
 $social-icon-size: map-get($icon-sizes, heading-icon--small);
 $color-social-icon-background: $color-mid-dark !default;
 $color-social-icon-foreground: $color-mid-x-light !default;
@@ -52,7 +52,8 @@ $color-social-icon-foreground: $color-mid-x-light !default;
     margin: 0;
     padding: 0;
     position: relative;
-    top: 2px;
+    top: 0;
+    vertical-align: calc(#{0.5 * $cap-height} - #{0.5 * $default-icon-size});
   }
 
   %social-icon {
@@ -567,8 +568,7 @@ $color-social-icon-foreground: $color-mid-x-light !default;
   // Style overides for icons within a button
   [class*='p-button-'] {
     [class*='p-icon-'] {
-      top: -1px;
-      vertical-align: middle;
+      top: 0;
     }
   }
 }

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -600,11 +600,13 @@ $color-social-icon-foreground: $color-mid-x-light !default;
   }
 }
 
-@mixin vf-p-icon-in-button {
-  // Style overides for icons within a button
-  [class*='p-button-'] {
-    [class*='p-icon-'] {
-      top: 0;
+@include deprecate('3.0.0', 'No longer necessary') {
+  @mixin vf-p-icon-in-button {
+    // Style overides for icons within a button
+    [class*='p-button-'] {
+      [class*='p-icon-'] {
+        top: 0;
+      }
     }
   }
 }

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -600,8 +600,8 @@ $color-social-icon-foreground: $color-mid-x-light !default;
   }
 }
 
-@include deprecate('3.0.0', 'No longer necessary') {
-  @mixin vf-p-icon-in-button {
+@mixin vf-p-icon-in-button {
+  @include deprecate('3.0.0', 'No longer necessary') {
     // Style overides for icons within a button
     [class*='p-button-'] {
       [class*='p-icon-'] {

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -1,6 +1,6 @@
 @import 'settings';
 
-$default-icon-size: 1rem;
+$default-icon-size: map-get($icon-sizes, default);
 $social-icon-size: map-get($icon-sizes, heading-icon--small);
 $color-social-icon-background: $color-mid-dark !default;
 $color-social-icon-foreground: $color-mid-x-light !default;
@@ -43,7 +43,7 @@ $color-social-icon-foreground: $color-mid-x-light !default;
   %icon {
     @extend %vf-hide-text;
     @include vf-icon-size($default-icon-size);
-    $vertical-offset: .5px;
+    $vertical-offset: 0.5px;
     background: {
       position: center;
       repeat: no-repeat;

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -92,12 +92,6 @@ $color-social-icon-foreground: $color-mid-x-light !default;
     }
   }
 
-  .match-h1 {
-    --icon-size: --cap-height;
-    --cap-height: $cap-height;
-    @include vf-icon-size(--icon-size);
-  }
-
   %social-icon {
     @extend %vf-hide-text;
     @include vf-icon-size($social-icon-size);

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -1,6 +1,6 @@
 @import 'settings';
 
-$default-icon-size: 1rem; // map-get($icon-sizes, default);
+$default-icon-size: 1rem;
 $social-icon-size: map-get($icon-sizes, heading-icon--small);
 $color-social-icon-background: $color-mid-dark !default;
 $color-social-icon-foreground: $color-mid-x-light !default;
@@ -43,17 +43,59 @@ $color-social-icon-foreground: $color-mid-x-light !default;
   %icon {
     @extend %vf-hide-text;
     @include vf-icon-size($default-icon-size);
+    $vertical-offset: .5px;
     background: {
       position: center;
       repeat: no-repeat;
       size: contain;
     }
     display: inline-block;
+    font-size: inherit; // allow icons to match size of parent text element, when set in em
     margin: 0;
     padding: 0;
     position: relative;
-    top: 0;
-    vertical-align: calc(#{0.5 * $cap-height} - #{0.5 * $default-icon-size});
+    vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $default-icon-size});
+  }
+
+  h1,
+  .p-heading--one,
+  .u-match-h1 {
+    [class*='p-icon'] {
+      @include vf-icon-size($x-height);
+      vertical-align: 0;
+    }
+  }
+
+  h2,
+  .p-heading--two,
+  .u-match-h2 {
+    [class*='p-icon'] {
+      @include vf-icon-size($x-height);
+      vertical-align: 0;
+    }
+  }
+
+  h3,
+  .p-heading--three,
+  .u-match-h3 {
+    [class*='p-icon'] {
+      @include vf-icon-size($default-icon-size);
+      vertical-align: 0;
+    }
+  }
+
+  h4,
+  .p-heading--four,
+  .u-match-h4 {
+    [class*='p-icon'] {
+      vertical-align: 0;
+    }
+  }
+
+  .match-h1 {
+    --icon-size: --cap-height;
+    --cap-height: $cap-height;
+    @include vf-icon-size(--icon-size);
   }
 
   %social-icon {

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -17,7 +17,7 @@
     }
 
     & [class*='p-icon'] {
-      top: 0;
+      vertical-align: 0; // reset vertical-align, as icon is aligned to the parent container, not the baseline of the text.
 
       &:only-child {
         margin-left: -#{$sph-inner--small};

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -13,3 +13,8 @@ $base-font-sizes: (
   large: $font-size-largescreen
 ) !default;
 $font-weight-bold: 400 !default;
+
+// Ubuntu Font metrics
+$baseline-position: 0.932em !default; // HHead Ascent from the font file's metrics. Viewable in Fontforge Font Information>OS/2
+$cap-height: 0.693em !default;
+$x-height: 0.517em !default;

--- a/scss/_utilities_font-metrics.scss
+++ b/scss/_utilities_font-metrics.scss
@@ -7,9 +7,9 @@
     &::before {
       content: '';
       border-bottom-color: transparentize($color-information, 0.5);
-      border-top-style: solid;
-      border-top-color: transparentize($color-positive, 0.5);
       border-bottom-style: solid;
+      border-top-color: transparentize($color-positive, 0.5);
+      border-top-style: solid;
       border-width: 1px;
       height: calc(#{$cap-height - $x-height});
       left: -#{$horisontal-bleed};

--- a/scss/_utilities_font-metrics.scss
+++ b/scss/_utilities_font-metrics.scss
@@ -1,8 +1,6 @@
 @import 'settings_font';
 
-@mixin vf-u-visualise-baseline {
-  $horisontal-bleed: 2rem;
-
+@mixin vf-u-visualise-baseline($horisontal-bleed: 2rem) {
   .u-visualise-font-metrics {
     position: relative;
 

--- a/scss/_utilities_font-metrics.scss
+++ b/scss/_utilities_font-metrics.scss
@@ -5,12 +5,12 @@
     position: relative;
 
     &::before {
-      content: '';
       border-bottom-color: transparentize($color-information, 0.5);
       border-bottom-style: solid;
       border-top-color: transparentize($color-positive, 0.5);
       border-top-style: solid;
       border-width: 1px;
+      content: '';
       height: calc(#{$cap-height - $x-height});
       left: -#{$horisontal-bleed};
       position: absolute;

--- a/scss/_utilities_font-metrics.scss
+++ b/scss/_utilities_font-metrics.scss
@@ -1,0 +1,33 @@
+@import 'settings_font';
+
+@mixin vf-u-visualise-baseline {
+  $horisontal-bleed: 2rem;
+
+  .u-visualise-font-metrics {
+    position: relative;
+
+    &::before {
+      content: '';
+      border-bottom-color: transparentize($color-information, 0.5);
+      border-top-style: solid;
+      border-top-color: transparentize($color-positive, 0.5);
+      border-bottom-style: solid;
+      border-width: 1px;
+      height: calc(#{$cap-height - $x-height});
+      left: -#{$horisontal-bleed};
+      position: absolute;
+      top: calc(#{$baseline-position - $cap-height} - 1px);
+      width: calc(#{$horisontal-bleed * 2} + 100%);
+    }
+
+    &::after {
+      background-color: transparentize($color-negative, 0.5);
+      content: '';
+      height: 1px;
+      left: -#{$horisontal-bleed};
+      position: absolute;
+      top: calc(#{$baseline-position} - 1px);
+      width: calc(#{$horisontal-bleed * 2} + 100%);
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -51,6 +51,7 @@
 @import 'utilities_embedded-media';
 @import 'utilities_equal-height';
 @import 'utilities_floats';
+@import 'utilities_font-metrics';
 @import 'utilities_hide';
 @import 'utilities_image-position';
 @import 'utilities_layout';
@@ -125,5 +126,6 @@
   @include vf-u-show;
   @include vf-u-vertical-spacing;
   @include vf-u-vertically-center;
+  @include vf-u-visualise-baseline;
   @include vf-u-no-print;
 }


### PR DESCRIPTION
## Done

- Fix horizontal position of icons within buttons
- Fix vertical-align of icons next to text
- Add font-metrics utility
- Document font-metrics utility
- Small improvement of the baseline-grid doc page
- Add Examples to the documentation home nav

## QA

- Pull code
- Run `./run serve --watch`
- Verify button position in examples/patterns/buttons/icon/ is correct
- View font-metrics examples/utilities/font-metrics/ page, verify it look ok
- View utilities/font-metrics/, proof copy

## Details

Fixes #2555