### PR TITLE
Table expanding panel: Prevent children with defined margins from stretching 

### DIFF
--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -26,6 +26,7 @@
 
     th,
     td {
+      align-items: flex-start;
       display: flex;
       flex: {
         basis: 0;


### PR DESCRIPTION
****
## Done
Before:
![image](https://user-images.githubusercontent.com/2741678/68211027-a51d0880-ffce-11e9-873a-5ff6cf1fd61d.png)
After:
![image](https://user-images.githubusercontent.com/2741678/68211043-ae0dda00-ffce-11e9-9816-4e9a78f3406c.png)

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/patterns/tables/table-expanding/
- Verify buttons look like the second image above
