### PR TITLE
Remove coding standards page from docs nav

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -47,7 +47,6 @@
                 <li class="p-navigation__link"><a href="/examples">Examples</a></li>
                 <li class="p-navigation__link"><a href="https://vanillaframework.io/accessibility">Accessibility</a></li>
               <li class="p-navigation__link"><a href="https://vanillaframework.io/browser-support">Browser support</a></li>
-              <li class="p-navigation__link"><a href="https://vanillaframework.io/coding-standards">Coding standards</a></li>
               <li class="p-navigation__link"><a href="https://vanillaframework.io/contribute">Contribute</a></li>
             </ul>
           </nav>


### PR DESCRIPTION
## Done

- Removed 'Coding standards' page from documentation site as this page is no longer live

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/
- Notice that 'Coding standards' has been removed from the navigation to match navigation structure on https://vanillaframework.io/

## Screenshots

<img width="760" alt="Screenshot 2019-11-07 at 11 28 01" src="https://user-images.githubusercontent.com/17748020/68385476-c22e1480-0151-11ea-82a8-a1e4fb65e3ed.png">

