### PR TITLE
Replace old chevron with new; Add missing role to markup

### DIFF
--- a/docs/examples/patterns/tables/table-sortable.html
+++ b/docs/examples/patterns/tables/table-sortable.html
@@ -7,10 +7,10 @@ category: _patterns
 <table class="p-table--sortable" role="grid">
   <thead>
     <tr>
-      <th id="t-name" aria-sort="none">Status</th>
-      <th id="t-users" aria-sort="none" class="u-align--right">Cores</th>
-      <th id="t-units" aria-sort="none" class="u-align--right">RAM</th>
-      <th id="t-revenue" aria-sort="none" class="u-align--right">Disks</th>
+      <th id="t-name" aria-sort="none" role="columnheader">Status</th>
+      <th id="t-users" aria-sort="none" role="columnheader" class="u-align--right">Cores</th>
+      <th id="t-units" aria-sort="none" role="columnheader" class="u-align--right">RAM</th>
+      <th id="t-revenue" aria-sort="none" role="columnheader" class="u-align--right">Disks</th>
     </tr>
   </thead>
   <tbody>

--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -2,19 +2,19 @@
 
 @mixin vf-p-table-sortable {
   %heading-icon {
+    @include vf-icon-chevron;
+    @include vf-icon-size(map-get($icon-sizes, default));
+    $vertical-offset: 0.5px;
+
     background: {
-      image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='4' width='10' viewBox='0 0 10 4'%3E%3Cpath d='M3.637 3.138c-.518-.365-1.052-.778-1.6-1.238C1.486 1.44.946.948.414.423.273.283.135.14 0 0h1.54c.305.29.62.57.948.846.138.116.277.23.417.34.163.13.328.257.495.38.085.062.17.123.257.184.397.282.935.626 1.315.848h.054c.38-.222.918-.566 1.315-.848.4-.28.79-.583 1.17-.904C7.837.57 8.153.29 8.457 0h1.54c-.134.14-.272.282-.414.422C9.05.948 8.51 1.442 7.963 1.9c-.55.46-1.084.873-1.602 1.238S5.39 3.79 5 4c-.39-.21-.845-.497-1.363-.862z' fill='%23888' fill-rule='evenodd'/%3E%3C/svg%3E");
-      position: center;
       repeat: no-repeat;
       size: 100%;
     }
 
     content: '';
     display: inline-block;
-    height: 0.4rem;
     margin-left: $sp-x-small;
-    vertical-align: middle;
-    width: $sp-medium;
+    vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $default-icon-size});
   }
 
   .p-table--sortable {
@@ -31,7 +31,7 @@
         @extend %heading-icon;
       }
 
-      &[aria-sort="descending"]::after {
+      &[aria-sort='descending']::after {
         // sass-lint:disable no-vendor-prefixes property-sort-order
         @extend %heading-icon;
         -webkit-transform: rotate(180deg);


### PR DESCRIPTION
## Done

Sortable table: replace chevron icon with new one
Add role attribute to `<th>`s; 

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/patterns/tables/table-sortable/
- Click on a column header, verify sorting icon that appears is the new chevron

## Details

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2634

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/68689994-33fac980-0569-11ea-8076-1201f3979789.png)
