### PR TITLE
Fix notification icon position

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -15,7 +15,7 @@
       background-color: transparent;
       background-size: map-get($icon-sizes, default);
       border: 0;
-      margin: $sp-unit * 2 $sph-inner auto auto;
+      margin: #{$sp-unit * 2 - $bar-thickness} $sph-inner auto auto;
       padding: $spv-inner--small;
     }
   }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -1,4 +1,6 @@
 @import 'settings';
+$response-top-padding: $spv-inner--x-small--scaleable + $bar-thickness;
+$response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 
 // Notification style patterns
 @mixin vf-p-notification {
@@ -15,7 +17,7 @@
       background-color: transparent;
       background-size: map-get($icon-sizes, default);
       border: 0;
-      margin: #{$sp-unit * 2 - $bar-thickness} $sph-inner auto auto;
+      margin: $response-top-padding + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default)) $sph-inner auto auto;
       padding: $spv-inner--small;
     }
   }
@@ -40,10 +42,10 @@
 
   .p-notification__response {
     @extend %u-no-margin--bottom--default-text;
-    background-position: $sph-inner $spv-inner--x-small--scaleable + $spv-nudge + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
+    background-position: $sph-inner $response-top-padding + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
-    padding: $spv-inner--x-small--scaleable + $spv-nudge $sph-inner $spv-inner--x-small--scaleable;
+    padding: $response-top-padding $sph-inner $spv-inner--x-small--scaleable;
   }
 
   .p-notification__status {
@@ -70,7 +72,7 @@
     .p-notification__response {
       // prettier-ignore
       background-image: url("data:image/svg+xml,%3Csvg width='17px' height='17px' viewBox='0 0 17 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='notification-success' transform='translate(1.000000, 1.000000)'%3E%3Cg id='Page-3---colours'%3E%3Cg id='Notifications---single'%3E%3Cg id='Group'%3E%3Cg id='ICON'%3E%3Ccircle id='circle6710' stroke='" + vf-url-friendly-color($color-positive) + "' stroke-width='1.5' fill='" + vf-url-friendly-color($color-positive) + "' cx='7.2500086' cy='7.2500086' r='7.2500086'%3E%3C/circle%3E%3Cpolygon id='path6712' fill='" + vf-url-friendly-color($color-x-light) + "' points='11.0502986 4.1734486 10.9843986 4.2311486 6.2496486 8.3783686 3.4740786 5.9974286 2.6350186 6.9463086 6.2503386 10.7500186 11.7500086 4.9627786 11.0502986 4.1734886'%3E%3C/polygon%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-      padding-left: 2 * $sph-inner + map-get($icon-sizes, default);
+      padding-left: $response-icon-space;
     }
   }
 }
@@ -84,7 +86,7 @@
     .p-notification__response {
       // prettier-ignore
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h16v16H0z'/%3E%3Cpath stroke-linejoin='round' fill='#{vf-url-friendly-color($color-caution)}' transform='matrix%282.28 0 0 2.437 -2180.8 -490.52%29' stroke='#{vf-url-friendly-color($color-caution)}' stroke-width='.848' d='M963.07 207.03h-6.15l3.08-5.33z'/%3E%3Cpath d='M7 5v5h2V5H7zm0 6v2h2v-2H7z' fill='%23111'/%3E%3C/g%3E%3C/svg%3E");
-      padding-left: 2 * $sph-inner + map-get($icon-sizes, default);
+      padding-left: $response-icon-space;
     }
   }
 }
@@ -98,7 +100,7 @@
     .p-notification__response {
       // prettier-ignore
       background-image: url("data:image/svg+xml,%3Csvg width='16px' height='17px' viewBox='0 0 16 17' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='Page-3---colours' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='Notifications---single' transform='translate(-215.000000, -271.000000)'%3E%3Cg id='Group' transform='translate(205.000000, 254.000000)'%3E%3Cg id='ICON' transform='translate(10.000000, 17.000000)'%3E%3Crect id='rect6415' x='0' y='0.36218' width='16' height='16'%3E%3C/rect%3E%3Ccircle id='circle6417' stroke='" + vf-url-friendly-color($color-negative) + "' stroke-width='1.5' fill='" + vf-url-friendly-color($color-negative) + "' cx='8' cy='8.36218' r='7.2500086'%3E%3C/circle%3E%3Cpath d='M5.00001,5.36218 L11.00001,11.36218' id='path6479-8' stroke='" + vf-url-friendly-color($color-x-light) + "' stroke-width='1.5'%3E%3C/path%3E%3Cpath d='M11.00001,5.36218 L5.00001,11.36218' id='path6481-8' stroke='" + vf-url-friendly-color($color-x-light) + "' stroke-width='1.5'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-      padding-left: 2 * $sph-inner + map-get($icon-sizes, default);
+      padding-left: $response-icon-space;
     }
   }
 }


### PR DESCRIPTION
## Done

Fix https://github.com/canonical-web-and-design/vanilla-framework/issues/2512
Fix caution icon position when text wraps (currently it is vertically centered within the height of the wrapped text)

## QA

1 Pull code
2 Run `./run serve --watch`
3 Open http://192.168.64.2:8101/examples/patterns/notifications/notifications/ and http://192.168.64.2:8101/examples/patterns/notifications/caution/
4 Verify icon for caution in the caution example, and close button in the other example, are properly vertically centered within available space.
5 Set $multi to 1
6 Repeat step 4

## Screenshots
![image](https://user-images.githubusercontent.com/2741678/68761344-c9e73080-060b-11ea-85f1-e1791b6cf7bb.png)

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/2741678/68694000-3d3b6480-0570-11ea-8789-c7608d352ebd.png)

