### PR TITLE
Contextual menu: add focus state to links; expand to fit content until it hits its max-width

### DIFF
--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -59,6 +59,7 @@
     padding: 0;
     position: absolute;
     right: 0;
+    width: fit-content;
     z-index: 1;
 
     &::before,

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -110,6 +110,7 @@
   }
 
   .p-contextual-menu__link {
+    @include vf-focus;
     border: 0;
     clear: both;
     color: $color-dark;

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 200000,
+      threshold: 250000,
       result: results['total-stylesheet-size']
     },
     {


### PR DESCRIPTION
## Done

Fixes  #2081
Fixes #2053

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/patterns/contextual-menu/with-indicator/
- Open menu, tab through links and verify they get the vanilla blue focus state

## Details


## Screenshots

![image](https://user-images.githubusercontent.com/2741678/68878449-a0a7cc80-06ff-11ea-9b93-31f57558fd00.png)
