### PR TITLE
Increase input margin bottom by .5rem

### DIFF
--- a/docs/examples/templates/tick-element-comparison.html
+++ b/docs/examples/templates/tick-element-comparison.html
@@ -19,6 +19,10 @@ category: _templates
       <form action="">
         <input type="text">
         <button>Button</button>
+        <button>Button</button>
+        <button>Button</button>
+        <button>Button</button>
+
       </form>
     </div>
     <div class="col-3">

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -1,8 +1,6 @@
 @import 'settings';
 @import 'base_forms-tick-elements';
 
-$input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
-
 // Form element styles
 @mixin vf-b-forms {
   @include vf-b-tick-elements;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -1,3 +1,6 @@
+// Density multiplier
+$multi: 2 !default;
+
 // Options
 $pad-lists: true !default; // Adds padding to list items
 
@@ -70,9 +73,6 @@ $browser-rounding-compensations: (
   h1: 0.001rem
 ) !default;
 
-//scaling factor
-$multi: 2 !default;
-
 ////////////////////////////////////////////////////////
 // Variables connecting spacings that should be identical
 
@@ -126,7 +126,7 @@ $sp-after: (
 // commonly occuring calculations available as variables
 $spv-nudge: map-get($nudges, nudge--p) !default; // top: nudge; bottom: unit - nudge; result: height = exact multiple of base unit
 $spv-nudge-compensation: $sp-unit - $spv-nudge !default;
-$input-margin-bottom: $spv-outer--scaleable - $spv-nudge * 2;
+$input-margin-bottom: $spv-outer--scaleable + $sp-unit - $spv-nudge * 2;
 
 $max-width--default: 40em !default;
 


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2497

## QA

- Pull code
- Run `./run serve --watch`
- set $multi to 1
- Open http://192.168.64.2:8101/examples/templates/tick-element-comparison/
- Verify margin-bottom on the inputs is .7rem 

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/68880249-cf737200-0702-11ea-9a1a-33e8edf0a148.png)

