### PR TITLE
Drop redundant text from notification examples

### DIFF
--- a/docs/examples/patterns/notifications/information.html
+++ b/docs/examples/patterns/notifications/information.html
@@ -6,6 +6,6 @@ category: _patterns
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-    <span class="p-notification__status">Information:</span>Anyone with access can view your invited users.
+    Anyone with access can view your invited users.
   </p>
 </div>

--- a/docs/examples/patterns/notifications/positive.html
+++ b/docs/examples/patterns/notifications/positive.html
@@ -6,5 +6,5 @@ category: _patterns
 
 <div class="p-notification--positive">
   <p class="p-notification__response">
-    <span class="p-notification__status">Success:</span>Code successfully reformatted.
+    Code successfully reformatted.
 </div>


### PR DESCRIPTION
## Done

- Drops redundant “Success:” from positive notification
- Drops redundant “Information:” from information notification

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/patterns/notification
- Read the examples

## Details

Twice this week I’ve seen the ~~`p-notification__response`~~ `p-notification__status` text from Vanilla’s examples copied into production code where it isn’t appropriate:
- [“Information: MicroStack requires at least 8 GB of RAM and a multi-core processor.”](https://github.com/canonical-web-and-design/microstack.run/pull/13#discussion_r347842298)
- [“Success: Thank you”](https://github.com/canonical-web-and-design/ubuntu.com/pull/6162#discussion_r349003857)

In most toolkits, the visual design and/or notification-specific text already conveys what kind of notification it is, so vague text like “Information” or “Success” is an anti-pattern.

So if Vanilla doesn’t have enough distinction between its alert varieties, that’s an issue best fixed in the visual design — for example, by adding ~~an icon or~~ a thicker coloured border or pattern.

If it was necessary, for accessibility, to provide a text equivalent to the visual design, that would be an appropriate use for `aria-label` (or `alt` text for the icon).