### PR TITLE
Borders exploration demo [wip] 

### DIFF
--- a/docs/examples/patterns/tables/table-mobile-card.html
+++ b/docs/examples/patterns/tables/table-mobile-card.html
@@ -3,7 +3,7 @@ layout: examples
 title: Table / Mobile card
 category: _patterns
 ---
-<table class="p-table--mobile-card" role="grid">
+<table class="p-table--mobile-card u-table-layout--auto" role="grid">
   <thead>
     <tr role="row">
       <th>FQDN</th>
@@ -62,5 +62,182 @@ category: _patterns
       <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
       <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
     </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+      <td role="gridcell" aria-label="Power">On</td>
+      <td role="gridcell" aria-label="Status">Failed testing</td>
+      <td role="gridcell" aria-label="Owner">Caleb</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+      <td role="gridcell" aria-label="Power">Off</td>
+      <td role="gridcell" aria-label="Status">Allocated</td>
+      <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">first-cattle</td>
+      <td role="gridcell" aria-label="Power">On</td>
+      <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+      <td role="gridcell" aria-label="Owner">admin</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+      <td role="gridcell" aria-label="Power">Off</td>
+      <td role="gridcell" aria-label="Status">Broken</td>
+      <td role="gridcell" aria-label="Owner">&mdash;</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+      <td role="gridcell" aria-label="Power">On</td>
+      <td role="gridcell" aria-label="Status">Failed testing</td>
+      <td role="gridcell" aria-label="Owner">Caleb</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+      <td role="gridcell" aria-label="Power">Off</td>
+      <td role="gridcell" aria-label="Status">Allocated</td>
+      <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">first-cattle</td>
+      <td role="gridcell" aria-label="Power">On</td>
+      <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+      <td role="gridcell" aria-label="Owner">admin</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+      <td role="gridcell" aria-label="Power">Off</td>
+      <td role="gridcell" aria-label="Status">Broken</td>
+      <td role="gridcell" aria-label="Owner">&mdash;</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+      <td role="gridcell" aria-label="Power">On</td>
+      <td role="gridcell" aria-label="Status">Failed testing</td>
+      <td role="gridcell" aria-label="Owner">Caleb</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+      <td role="gridcell" aria-label="Power">Off</td>
+      <td role="gridcell" aria-label="Status">Allocated</td>
+      <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">first-cattle</td>
+      <td role="gridcell" aria-label="Power">On</td>
+      <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+      <td role="gridcell" aria-label="Owner">admin</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+      <td role="gridcell" aria-label="Power">Off</td>
+      <td role="gridcell" aria-label="Status">Broken</td>
+      <td role="gridcell" aria-label="Owner">&mdash;</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+      <td role="gridcell" aria-label="Power">On</td>
+      <td role="gridcell" aria-label="Status">Failed testing</td>
+      <td role="gridcell" aria-label="Owner">Caleb</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+      <td role="gridcell" aria-label="Power">Off</td>
+      <td role="gridcell" aria-label="Status">Allocated</td>
+      <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">first-cattle</td>
+      <td role="gridcell" aria-label="Power">On</td>
+      <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+      <td role="gridcell" aria-label="Owner">admin</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+    </tr>
+    <tr role="row">
+      <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+      <td role="gridcell" aria-label="Power">Off</td>
+      <td role="gridcell" aria-label="Status">Broken</td>
+      <td role="gridcell" aria-label="Owner">&mdash;</td>
+      <td role="gridcell" aria-label="Zone">london</td>
+      <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+      <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+    </tr>
   </tbody>
+
 </table>

--- a/docs/examples/templates/maas-layout.html
+++ b/docs/examples/templates/maas-layout.html
@@ -126,83 +126,244 @@ category: _templates
         <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
         <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
       </form>
-      <table class="p-table--mobile-card">
-        <thead>
-          <tr>
-            <th>FQDN | MAC</th>
-            <th>Power</th>
-            <th>Status</th>
-            <th>Owner | Pool</th>
-            <th class="u-align--right">Cores</th>
-            <th class="u-align--right">RAM(GB)</th>
-            <th class="u-align--right">Disks</th>
-            <th class="u-align--right">Storage(GB)</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
-          </tr>
-          <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
-          </tr>
-          <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
-          </tr>
-          <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
-          </tr>
-          <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
-          </tr>
-          <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+      <table class="p-table--mobile-card u-truncate" role="grid">
+          <thead>
+            <tr role="row">
+              <th>FQDN</th>
+              <th>Power</th>
+              <th>Status</th>
+              <th>Owner</th>
+              <th>Zone</th>
+              <th class="u-align--right">Cores</th>
+              <th class="u-align--right">RAM</th>
+              <th class="u-align--right">Disks</th>
+              <th class="u-align--right">Storage</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN ">LongEnoughToCauseEllipsis</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed testing</td>
+              <td role="gridcell" aria-label="Owner">Caleb</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Allocated</td>
+              <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">first-cattle</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+              <td role="gridcell" aria-label="Owner">admin</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Broken</td>
+              <td role="gridcell" aria-label="Owner">&mdash;</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed testing</td>
+              <td role="gridcell" aria-label="Owner">Caleb</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Allocated</td>
+              <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">first-cattle</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+              <td role="gridcell" aria-label="Owner">admin</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Broken</td>
+              <td role="gridcell" aria-label="Owner">&mdash;</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed testing</td>
+              <td role="gridcell" aria-label="Owner">Caleb</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Allocated</td>
+              <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">first-cattle</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+              <td role="gridcell" aria-label="Owner">admin</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Broken</td>
+              <td role="gridcell" aria-label="Owner">&mdash;</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed testing</td>
+              <td role="gridcell" aria-label="Owner">Caleb</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Allocated</td>
+              <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">first-cattle</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+              <td role="gridcell" aria-label="Owner">admin</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Broken</td>
+              <td role="gridcell" aria-label="Owner">&mdash;</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed testing</td>
+              <td role="gridcell" aria-label="Owner">Caleb</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Allocated</td>
+              <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">first-cattle</td>
+              <td role="gridcell" aria-label="Power">On</td>
+              <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+              <td role="gridcell" aria-label="Owner">admin</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+            </tr>
+            <tr role="row">
+              <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+              <td role="gridcell" aria-label="Power">Off</td>
+              <td role="gridcell" aria-label="Status">Broken</td>
+              <td role="gridcell" aria-label="Owner">&mdash;</td>
+              <td role="gridcell" aria-label="Zone">london</td>
+              <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+              <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+              <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+              <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+            </tr>
+          </tbody>
+
+        </table>    </div>
   </div>
 </div>
 

--- a/docs/examples/templates/tick-element-comparison.html
+++ b/docs/examples/templates/tick-element-comparison.html
@@ -3,7 +3,7 @@ layout: examples
 title: Forms / Tick elements
 category: _templates
 ---
-<div class="p-strip is-shallow u-no-padding--top">
+<div class="p-strip is-shallow">
   <div class="row">
   </div>
   <div class="row">
@@ -47,7 +47,7 @@ category: _templates
       <label for="Radio2">Radio option 2</label>
     </div>
     <div class="col-3">
-      <input type="radio" name="RadioOptions" id="Radio3" value="option3" >
+      <input type="radio" name="RadioOptions" id="Radio3" value="option3">
       <label for="Radio3">Radio option 3</label>
       <input type="radio" name="RadioOptions" id="Radio4" value="option4">
       <label for="Radio4">Radio option 4</label>
@@ -61,60 +61,332 @@ category: _templates
 <div class="p-strip is-shallow u-no-padding--top">
   <div class="row">
     <hr>
-    <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use class "is-inline-label" on the label to achieve that.</p>
+    <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in
+      a tag. Use class "is-inline-label" on the label to achieve that.</p>
   </div>
 </div>
 <div class="p-strip is-shallow u-no-padding--top">
   <div class="row">
-    <table class="p-table--mobile-card">
+    <table class="u-truncate">
       <thead>
-        <tr>
+        <tr role="row">
           <th>
             <form>
-              <input type="checkbox" id="checkExample5" checked="">
-              <label for="checkExample5" class="is-inline-label">label</label>
+              <input type="checkbox" id="checkExample6" checked="">
+              <label for="checkExample6" class="is-inline-label">FQDN</label>
             </form>
           </th>
           <th>Power</th>
           <th>Status</th>
-          <th>Owner | Pool</th>
+          <th>Owner</th>
+          <th>Zone</th>
           <th class="u-align--right">Cores</th>
-          <th class="u-align--right">RAM(GB)</th>
+          <th class="u-align--right">RAM</th>
           <th class="u-align--right">Disks</th>
-          <th class="u-align--right">Storage(GB)</th>
+          <th class="u-align--right">Storage</th>
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <th aria-label="FQDN | MAC">
-            <form>
-              <input type="checkbox" id="checkExample6" checked="">
-              <label for="checkExample6" class="is-inline-label">label</label>
-            </form>
-          </th>
-          <td aria-label="Power">Off</td>
-          <td aria-label="Status">Ready</td>
-          <td aria-label="Owner | Pool">Maria</td>
-          <td aria-label="Cores" class="u-align--right">8</td>
-          <td aria-label="RAM(GB)" class="u-align--right">16</td>
-          <td aria-label="Disks" class="u-align--right">2</td>
-          <td aria-label="Storage(GB)" class="u-align--right">2</td>
+        <tr role="row">
+          <td role="rowheader" aria-label="FQDN">
+          <input type="checkbox" id="checkExample6" checked="">
+          <label for="checkExample6" class="is-inline-label">small-horse</label>
+
+          </td>
+          <td role="gridcell" aria-label="Power">On</td>
+          <td role="gridcell" aria-label="Status">Failed testing</td>
+          <td role="gridcell" aria-label="Owner">Caleb</td>
+          <td role="gridcell" aria-label="Zone">london</td>
+          <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+          <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+          <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+          <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
         </tr>
-        <tr>
-          <th aria-label="FQDN | MAC">
-            <form>
-              <input type="radio" name="RadioOptions" id="Radio5" value="option1" checked>
-              <label for="Radio5" class="is-inline-label">label</label>
-            </form>
-          </th>
-          <td aria-label="Power">Off</td>
-          <td aria-label="Status">Ready</td>
-          <td aria-label="Owner | Pool">Maria</td>
-          <td aria-label="Cores" class="u-align--right">8</td>
-          <td aria-label="RAM(GB)" class="u-align--right">16</td>
-          <td aria-label="Disks" class="u-align--right">2</td>
-          <td aria-label="Storage(GB)" class="u-align--right">2</td>
+        <tr role="row">
+          <td role="rowheader" aria-label="FQDN">
+          <input type="checkbox" id="checkExample6" checked="">
+          <label for="checkExample6" class="is-inline-label">slow-muscox</label>
+
+          </td>
+          <td role="gridcell" aria-label="Power">Off</td>
+          <td role="gridcell" aria-label="Status">Allocated</td>
+          <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+          <td role="gridcell" aria-label="Zone">london</td>
+          <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+          <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+          <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+          <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB
+          </td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="FQDN">
+          <input type="checkbox" id="checkExample6" checked="">
+          <label for="checkExample6" class="is-inline-label">actual-moose</label>
+
+          </td>
+          <td role="gridcell" aria-label="Power">On</td>
+          <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+          <td role="gridcell" aria-label="Owner">admin</td>
+          <td role="gridcell" aria-label="Zone">london</td>
+          <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+          <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+          <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+          <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="FQDN">
+          <input type="checkbox" id="checkExample6" checked="">
+          <label for="checkExample6" class="is-inline-label">real-buffalo</label>
+
+          </td>
+          <td role="gridcell" aria-label="Power">Off</td>
+          <td role="gridcell" aria-label="Status">Broken</td>
+          <td role="gridcell" aria-label="Owner">&mdash;</td>
+          <td role="gridcell" aria-label="Zone">london</td>
+          <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+          <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+          <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+          <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB
+          </td>
         </tr>
       </tbody>
     </table>
+    <table class="p-table--mobile-card u-table-layout--auto" role="grid">
+        <thead>
+          <tr role="row">
+            <th>FQDN</th>
+            <th>Power</th>
+            <th>Status</th>
+            <th>Owner</th>
+            <th>Zone</th>
+            <th class="u-align--right">Cores</th>
+            <th class="u-align--right">RAM</th>
+            <th class="u-align--right">Disks</th>
+            <th class="u-align--right">Storage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed testing</td>
+            <td role="gridcell" aria-label="Owner">Caleb</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Allocated</td>
+            <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">first-cattle</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+            <td role="gridcell" aria-label="Owner">admin</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Broken</td>
+            <td role="gridcell" aria-label="Owner">&mdash;</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed testing</td>
+            <td role="gridcell" aria-label="Owner">Caleb</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Allocated</td>
+            <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">first-cattle</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+            <td role="gridcell" aria-label="Owner">admin</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Broken</td>
+            <td role="gridcell" aria-label="Owner">&mdash;</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed testing</td>
+            <td role="gridcell" aria-label="Owner">Caleb</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Allocated</td>
+            <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">first-cattle</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+            <td role="gridcell" aria-label="Owner">admin</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Broken</td>
+            <td role="gridcell" aria-label="Owner">&mdash;</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed testing</td>
+            <td role="gridcell" aria-label="Owner">Caleb</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Allocated</td>
+            <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">first-cattle</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+            <td role="gridcell" aria-label="Owner">admin</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Broken</td>
+            <td role="gridcell" aria-label="Owner">&mdash;</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed testing</td>
+            <td role="gridcell" aria-label="Owner">Caleb</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Allocated</td>
+            <td role="gridcell" aria-label="Owner">sparkiegeek</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">first-cattle</td>
+            <td role="gridcell" aria-label="Power">On</td>
+            <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
+            <td role="gridcell" aria-label="Owner">admin</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+            <td role="gridcell" aria-label="Power">Off</td>
+            <td role="gridcell" aria-label="Status">Broken</td>
+            <td role="gridcell" aria-label="Owner">&mdash;</td>
+            <td role="gridcell" aria-label="Zone">london</td>
+            <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
+            <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
+            <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
+            <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+          </tr>
+        </tbody>
+
+      </table>
   </div>

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -79,12 +79,12 @@
   $button-background-color: $color-x-light,
   $button-text-color: $color-x-dark,
   $button-disabled-background-color: $color-transparent,
-  $button-disabled-border-color: $color-mid,
-  $button-border-color: $color-mid,
-  $button-hover-background-color: darken($color-x-light, 10%),
-  $button-hover-border-color: $color-mid,
-  $button-active-background-color: darken($color-x-light, 15%),
-  $button-active-border-color: $color-mid
+  $button-disabled-border-color: $color-mid-mid,
+  $button-border-color: $color-mid-mid,
+  $button-hover-background-color: $color-mid-x-light,
+  $button-hover-border-color: $color-mid-mid,
+  $button-active-background-color: $color-mid-x-light,
+  $button-active-border-color: $color-mid-mid
 ) {
   background-color: $button-background-color;
   border-color: $button-border-color;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -22,10 +22,13 @@
     appearance: textfield;
     // sass-lint:enable no-vendor-prefixes property-sort-order
 
-    background-color: $color-x-light;
-    border: 1px solid $color-mid;
-    border-radius: $border-radius;
-    box-shadow: inset 0 1px 1px $color-input-shadow;
+    background-color: $colors--light-theme--input-background;
+    border-top: 1px solid transparent;
+    border-left: none;
+    border-right: none;
+    border-bottom: 1px solid $colors--light-theme--border-high-contrast;
+    border-radius: 0 * $border-radius;
+    // box-shadow: inset 0 1px 1px $color-input-shadow;
     color: $color-dark;
     font-family: unquote($font-base-family);
     font-size: 1rem;
@@ -33,8 +36,8 @@
     line-height: map-get($line-heights, default-text);
     margin-bottom: $input-margin-bottom;
     min-width: 10em;
-    padding-left: $sph-inner--small;
-    padding-right: $sph-inner--small;
+    padding-left: $sph-inner;
+    padding-right: $sph-inner;
     vertical-align: baseline;
     width: 100%;
 
@@ -170,14 +173,13 @@
     -moz-appearance: none; // sass-lint:disable-line no-vendor-prefixes
     -webkit-appearance: none; // sass-lint:disable-line no-vendor-prefixes
     appearance: none;
-    background-color: $color-x-light;
-    background-position: right $sph-inner--small center;
+    background-position: right $sph-inner center;
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
     box-shadow: none;
     color: $color-dark;
     min-height: map-get($line-heights, default-text);
-    padding-right: calc(#{$default-icon-size} + #{2 * $sph-inner--small});
+    padding-right: calc(#{$default-icon-size} + #{2 * $sph-inner});
     text-indent: 0.01px;
     text-overflow: '';
 
@@ -194,7 +196,7 @@
       option {
         font-weight: 300;
         line-height: calc(#{$sp-unit * 2} - 2px);
-        padding: $spv-inner--small $sph-inner--small;
+        padding: $spv-inner--small $sph-inner;
       }
     }
   }
@@ -209,11 +211,11 @@
 
   // Fieldset styles
   fieldset {
-    background-color: $color-light;
+    // background-color: $color-light;
     border: 1px solid $color-mid-light;
     border-radius: $border-radius;
     color: $color-dark;
     margin-bottom: $spv-outer--scaleable;
-    padding: calc(#{$spv-inner--small} - 1px) $sph-inner--small;
+    padding: calc(#{$spv-inner--small} - 1px) $sph-inner;
   }
 }

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -31,13 +31,14 @@
 
   thead {
     th {
-      @extend %muted-heading;
+      @extend %default-text;
+      color: $color-mid-dark;
       line-height: map-get($line-heights, small);
       padding-bottom: $spv-inner--large - map-get($nudges, nudge--small);
     }
 
     tr {
-      border-bottom: 1px solid $color-dark;
+      border-bottom: 1px solid $color-mid-light;
       vertical-align: top;
     }
   }
@@ -57,6 +58,6 @@
   }
 
   %table-row-border {
-    border-top: 1px solid $color-mid-light;
+    border-top: 1px solid $color-mid-x-light;
   }
 }

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -79,8 +79,8 @@
 
   %search-box-input--light {
     //XXX: This should inherit from input color theming. Once that becomes available, delete this.
-    background-color: $colors--light-theme--background;
-    border-color: $colors--light-theme--border-high-contrast;
+    background-color: $colors--light-theme--input-background;
+    border-bottom-color: $colors--light-theme--border-high-contrast;
     color: $colors--light-theme--text-default;
 
     &:active,
@@ -91,8 +91,8 @@
     &:-webkit-autofill:focus,
     &:-internal-autofill-selected {
       // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
-      background-color: $colors--light-theme--background !important;
-      border-color: $colors--light-theme--border-high-contrast !important;
+      // background-color: $colors--light-theme--background !important;
+      border-bottom-color: $colors--light-theme--border-high-contrast !important;
     }
   }
 
@@ -111,7 +111,7 @@
     &:-internal-autofill-selected {
       // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
       background-color: $colors--dark-theme--background !important;
-      border-color: $colors--dark-theme--border-high-contrast !important;
+      border-bottom-color: $colors--dark-theme--border-high-contrast !important;
     }
   }
 

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -6,8 +6,9 @@ $color-link: #007aa6 !default;
 
 $color-x-light: #fff !default;
 $color-light: #f7f7f7 !default;
-$color-mid-x-light: #e5e5e5 !default;
+$color-mid-x-light: hsl(0, 0%, 88%) !default;
 $color-mid-light: #cdcdcd !default;
+$color-mid-mid: #cdcdcd;
 $color-mid: #999 !default;
 $color-mid-dark: #666 !default;
 $color-dark: #111 !default;
@@ -36,9 +37,10 @@ $states: (
 );
 
 $colors--light-theme--background: #fff !default;
+$colors--light-theme--input-background: #f7f7f7 !default;
 $colors--light-theme--background-highlighted: #f7f7f7 !default;
-$colors--light-theme--border-default: #cdcdcd !default;
-$colors--light-theme--border-high-contrast: #999 !default;
+$colors--light-theme--border-default: $color-mid-light !default;
+$colors--light-theme--border-high-contrast: $color-mid-light !default;
 $colors--light-theme--text-hover: #757575 !default;
 $colors--light-theme--text-disabled: #666 !default;
 $colors--light-theme--text-default: #111 !default;

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -1,6 +1,6 @@
 // Global placeholder settings
 
 $bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
-$border-radius: $sp-unit * 0.25 !default;
+$border-radius: 3px !default;
 $border: 1px solid $color-mid-light !default;
 $box-shadow: 0 1px 5px 1px transparentize($color-dark, 0.8) !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -1,5 +1,5 @@
 // Density multiplier
-$multi: 2 !default;
+$multi: 1 !default;
 
 // Options
 $pad-lists: true !default; // Adds padding to list items
@@ -90,7 +90,7 @@ $spv-inner--x-large: $sp-unit * 5.5;
 $spv-outer--small: $sp-unit !default; //labels
 $spv-outer--small-scaleable: $sp-unit * $multi !default;
 $spv-outer--medium: $sp-unit * 2 !default;
-$spv-outer--scaleable: $sp-unit * (1 + $multi) !default;
+$spv-outer--scaleable: $sp-unit * (3) !default;
 
 // 1.3 Vertical spacing between a group of components and its wrapper - strips, views, entire page
 $spv-outer--shallow-scaleable: $spv-outer--scaleable !default;


### PR DESCRIPTION
## Done

[ Not for review. Just a demo for internal visual design discussion ]

Adjust contrast of borders and creates a noticeable difference between inputs and buttons. Experiments with alternative table headings. Increases space under tables and other block elements using $spv-outer--scaleable.

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/templates/tick-element-comparison/ to see the demo

Proposal:

![image](https://user-images.githubusercontent.com/2741678/69341525-a2264700-0c61-11ea-9c21-ea4cbc3544fe.png)

Current state:

![image](https://user-images.githubusercontent.com/2741678/69355578-ecb3bd80-0c79-11ea-9f18-9bb45a33427e.png)
