### PR TITLE
Prevent table header border from disappearing when tbody contains no rows

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -31,8 +31,6 @@
 
   thead {
     &::after {
-      // prevent border on header tr from disappearing when there is no tbody
-      // https://github.com/canonical-web-and-design/vanilla-framework/issues/2662
       content: '';
     }
 

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -30,6 +30,12 @@
   }
 
   thead {
+    &::after {
+      // prevent border on header tr from disappearing when there is no tbody
+      // https://github.com/canonical-web-and-design/vanilla-framework/issues/2662
+      content: '';
+    }
+
     th {
       @extend %muted-heading;
       line-height: map-get($line-heights, small);


### PR DESCRIPTION
## Done



## QA

- Pull code
- Run `./run serve --watch`
- Open any table example, e.g. /examples/patterns/tables/table-sortable/
- Delete everything after the thead
- Verify border on thead tr does not disappear

## Details

Fix https://github.com/canonical-web-and-design/vanilla-framework/issues/2662

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/69360021-b11cf180-0c81-11ea-97c0-49e4dce24d04.png)
