### PR TITLE
Fix the table sorting pattern functionality on Chrome

### DIFF
--- a/docs/examples/patterns/tables/table-sortable.html
+++ b/docs/examples/patterns/tables/table-sortable.html
@@ -104,9 +104,9 @@ category: _patterns
 
           // Based on the direction, do the sort.
           if (direction === 1) {
-            return c < d;
+            return d - c;
           } else {
-            return c > d;
+            return c - d;
           }
         });
       }


### PR DESCRIPTION
## Done
Fix the table sorting pattern functionality on Chrome

## QA
- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/base/tables
- Click the sortable table headings on both Firefox and Chrome
- See that the table sorts correctly

## Details
Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2635
Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2661
