### PR TITLE
Fix middot list

### DIFF
--- a/docs/examples/patterns/lists/lists-mid-dot.html
+++ b/docs/examples/patterns/lists/lists-mid-dot.html
@@ -5,13 +5,15 @@ category: _patterns
 ---
 
 <ul class="p-inline-list--middot">
-  <li class="p-inline-list__item">
-    Legal information
-  </li>
-  <li class="p-inline-list__item">
-    Data privacy
-  </li>
-  <li class="p-inline-list__item">
-    Report a bug on this site
-  </li>
+  <li class="p-inline-list__item">Legal information</li>
+  <li class="p-inline-list__item">Data privacy</li>
+  <li class="p-inline-list__item">Report a bug on this site</li>
+</ul>
+<ul class="p-inline-list--middot">
+  <li class="p-inline-list__item"><a href="/telecommunications">Telco</a></li>
+  <li class="p-inline-list__item"><a href="/financial-services">Finance</a></li>
+  <li class="p-inline-list__item"><a href="/internet-of-things/digital-signage">Signage</a></li>
+  <li class="p-inline-list__item"><a href="/internet-of-things/robotics">Robotics</a></li>
+  <li class="p-inline-list__item"><a href="/internet-of-things/gateways">Gateways</a></li>
+  <li class="p-inline-list__item"><a href="/desktop/organisations">Organisations</a></li>
 </ul>

--- a/docs/examples/patterns/lists/lists-mid-dot.html
+++ b/docs/examples/patterns/lists/lists-mid-dot.html
@@ -17,3 +17,18 @@ category: _patterns
   <li class="p-inline-list__item"><a href="/internet-of-things/gateways">Gateways</a></li>
   <li class="p-inline-list__item"><a href="/desktop/organisations">Organisations</a></li>
 </ul>
+<ul class="p-inline-list--middot">
+  <li class="p-inline-list__item">T</li>
+  <li class="p-inline-list__item">T</li>
+  <li class="p-inline-list__item">T</li>
+</ul>
+<ul class="p-inline-list--middot">
+  <h1 class="p-inline-list__item">T</h1>
+  <h1 class="p-inline-list__item">T</h1>
+  <h1 class="p-inline-list__item">T</h1>
+</ul>
+<ul class="p-inline-list--middot">
+  <h1 class="p-inline-list__item">T</h1>
+  <h1 class="p-inline-list__item">T</h1>
+  <h1 class="p-inline-list__item">T</h1>
+</ul>

--- a/docs/examples/patterns/lists/lists-mid-dot.html
+++ b/docs/examples/patterns/lists/lists-mid-dot.html
@@ -5,9 +5,9 @@ category: _patterns
 ---
 
 <ul class="p-inline-list--middot">
-  <li class="p-inline-list__item">Legal information</li>
-  <li class="p-inline-list__item">Data privacy</li>
-  <li class="p-inline-list__item">Report a bug on this site</li>
+    <li class="p-inline-list__item">Legal information</li>
+    <li class="p-inline-list__item">Data privacy</li>
+    <li class="p-inline-list__item">Report a bug on this site</li>
 </ul>
 <ul class="p-inline-list--middot">
   <li class="p-inline-list__item"><a href="#">Telco</a></li>

--- a/docs/examples/patterns/lists/lists-mid-dot.html
+++ b/docs/examples/patterns/lists/lists-mid-dot.html
@@ -10,10 +10,10 @@ category: _patterns
   <li class="p-inline-list__item">Report a bug on this site</li>
 </ul>
 <ul class="p-inline-list--middot">
-  <li class="p-inline-list__item"><a href="/telecommunications">Telco</a></li>
-  <li class="p-inline-list__item"><a href="/financial-services">Finance</a></li>
-  <li class="p-inline-list__item"><a href="/internet-of-things/digital-signage">Signage</a></li>
-  <li class="p-inline-list__item"><a href="/internet-of-things/robotics">Robotics</a></li>
-  <li class="p-inline-list__item"><a href="/internet-of-things/gateways">Gateways</a></li>
-  <li class="p-inline-list__item"><a href="/desktop/organisations">Organisations</a></li>
+  <li class="p-inline-list__item"><a href="#">Telco</a></li>
+  <li class="p-inline-list__item"><a href="#">Finance</a></li>
+  <li class="p-inline-list__item"><a href="#">Signage</a></li>
+  <li class="p-inline-list__item"><a href="#">Robotics</a></li>
+  <li class="p-inline-list__item"><a href="#">Gateways</a></li>
+  <li class="p-inline-list__item"><a href="#">Organisations</a></li>
 </ul>

--- a/docs/examples/patterns/lists/lists-mid-dot.html
+++ b/docs/examples/patterns/lists/lists-mid-dot.html
@@ -17,18 +17,3 @@ category: _patterns
   <li class="p-inline-list__item"><a href="/internet-of-things/gateways">Gateways</a></li>
   <li class="p-inline-list__item"><a href="/desktop/organisations">Organisations</a></li>
 </ul>
-<ul class="p-inline-list--middot">
-  <li class="p-inline-list__item">T</li>
-  <li class="p-inline-list__item">T</li>
-  <li class="p-inline-list__item">T</li>
-</ul>
-<ul class="p-inline-list--middot">
-  <h1 class="p-inline-list__item">T</h1>
-  <h1 class="p-inline-list__item">T</h1>
-  <h1 class="p-inline-list__item">T</h1>
-</ul>
-<ul class="p-inline-list--middot">
-  <h1 class="p-inline-list__item">T</h1>
-  <h1 class="p-inline-list__item">T</h1>
-  <h1 class="p-inline-list__item">T</h1>
-</ul>

--- a/docs/patterns/lists.md
+++ b/docs/patterns/lists.md
@@ -76,6 +76,8 @@ View example of the inline list pattern
 Apply the class `.p-inline-list--middot` to add a middot character between
 inline list items.
 
+As with any inline/inline-block element, any amount of white space (one or more spaces, tabs, etc.) in the markup is rendered as a single white space character. Vanilla uses the <a href="https://css-tricks.com/fighting-the-space-between-inline-block-elements/#article-header-id-3">font size method</a> to elliminate white space within a `p-inline-list--middot`, that is not inside a `p-inline-list__item`. White space within the `p-inline-list__item` however will displace the dot.
+
 <a href="/examples/patterns/lists/lists-mid-dot/"
     class="js-example">
 View example of the middot list pattern

--- a/docs/patterns/lists.md
+++ b/docs/patterns/lists.md
@@ -76,7 +76,7 @@ View example of the inline list pattern
 Apply the class `.p-inline-list--middot` to add a middot character between
 inline list items.
 
-As with any inline/inline-block element, any amount of white space (one or more spaces, tabs, etc.) in the markup is rendered as a single white space character. Vanilla uses the <a href="https://css-tricks.com/fighting-the-space-between-inline-block-elements/">font size method</a> to eliminate white space within a `p-inline-list--middot`, that is not inside a `p-inline-list__item`. White space within the `p-inline-list__item` however will displace the dot.
+As with any inline/inline-block element, any amount of white space (one or more spaces, tabs, etc.) in the markup is rendered as a single white space character. Vanilla uses the <a href="https://css-tricks.com/fighting-the-space-between-inline-block-elements/" target="_blank">font size method</a> to eliminate white space within a `p-inline-list--middot`, that is not inside a `p-inline-list__item`. White space within the `p-inline-list__item` however will displace the dot.
 
 <a href="/examples/patterns/lists/lists-mid-dot/"
     class="js-example">

--- a/docs/patterns/lists.md
+++ b/docs/patterns/lists.md
@@ -76,7 +76,7 @@ View example of the inline list pattern
 Apply the class `.p-inline-list--middot` to add a middot character between
 inline list items.
 
-As with any inline/inline-block element, any amount of white space (one or more spaces, tabs, etc.) in the markup is rendered as a single white space character. Vanilla uses the <a href="https://css-tricks.com/fighting-the-space-between-inline-block-elements/#article-header-id-3">font size method</a> to elliminate white space within a `p-inline-list--middot`, that is not inside a `p-inline-list__item`. White space within the `p-inline-list__item` however will displace the dot.
+As with any inline/inline-block element, any amount of white space (one or more spaces, tabs, etc.) in the markup is rendered as a single white space character. Vanilla uses the <a href="https://css-tricks.com/fighting-the-space-between-inline-block-elements/#article-header-id-3">font size method</a> to eliminate white space within a `p-inline-list--middot`, that is not inside a `p-inline-list__item`. White space within the `p-inline-list__item` however will displace the dot.
 
 <a href="/examples/patterns/lists/lists-mid-dot/"
     class="js-example">

--- a/docs/patterns/lists.md
+++ b/docs/patterns/lists.md
@@ -76,7 +76,7 @@ View example of the inline list pattern
 Apply the class `.p-inline-list--middot` to add a middot character between
 inline list items.
 
-As with any inline/inline-block element, any amount of white space (one or more spaces, tabs, etc.) in the markup is rendered as a single white space character. Vanilla uses the <a href="https://css-tricks.com/fighting-the-space-between-inline-block-elements/#article-header-id-3">font size method</a> to eliminate white space within a `p-inline-list--middot`, that is not inside a `p-inline-list__item`. White space within the `p-inline-list__item` however will displace the dot.
+As with any inline/inline-block element, any amount of white space (one or more spaces, tabs, etc.) in the markup is rendered as a single white space character. Vanilla uses the <a href="https://css-tricks.com/fighting-the-space-between-inline-block-elements/">font size method</a> to eliminate white space within a `p-inline-list--middot`, that is not inside a `p-inline-list__item`. White space within the `p-inline-list__item` however will displace the dot.
 
 <a href="/examples/patterns/lists/lists-mid-dot/"
     class="js-example">

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -1,4 +1,21 @@
 @mixin vf-b-typography-definitions {
+
+  %increase-font-size-on-larger-screens {
+    @if ($increase-font-size-on-larger-screens) {
+      @media screen and (max-width: $breakpoint-x-large) {
+        font-size: map-get($base-font-sizes, base);
+      }
+
+      @media screen and (min-width: $breakpoint-x-large) {
+        font-size: map-get($base-font-sizes, large);
+        line-height: map-get($line-heights, default-text) * $font-size-ratio--largescreen;
+      }
+
+    } @else {
+      font-size: map-get($base-font-sizes, base);
+    }
+  }
+
   //@section Heading styling in placeholders
   %vf-heading-1 {
     @include heading-max-width--short;

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -26,19 +26,7 @@
     // set default line height to match p
     line-height: map-get($line-heights, default-text);
 
-    @if ($increase-font-size-on-larger-screens) {
-      @media screen and (max-width: $breakpoint-x-large) {
-        font-size: map-get($base-font-sizes, base);
-      }
-
-      @media screen and (min-width: $breakpoint-x-large) {
-        font-size: map-get($base-font-sizes, large);
-        //the rem value is not affected by the change in font-size; it needs to be multiplied by the ratio new font-size/default font-size
-        line-height: map-get($line-heights, default-text) * $font-size-ratio--largescreen;
-      }
-    } @else {
-      font-size: map-get($base-font-sizes, base);
-    }
+    @extend %increase-font-size-on-larger-screens;
   }
 
   // headings

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -12,6 +12,8 @@
   }
 
   html {
+    @extend %increase-font-size-on-larger-screens;
+
     // sass-lint:disable no-vendor-prefixes
     // These vendor prefixes are unique and cannot be added by autoprefixer
     -moz-osx-font-smoothing: grayscale;
@@ -25,8 +27,6 @@
     font-weight: 300;
     // set default line height to match p
     line-height: map-get($line-heights, default-text);
-
-    @extend %increase-font-size-on-larger-screens;
   }
 
   // headings

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -33,6 +33,8 @@ $spv-list-item--inner: null;
   display: inline;
   list-style: none;
 
+  @extend %increase-font-size-on-larger-screens;
+
   & + & {
     margin-left: -#{$strut-width};
   }
@@ -95,6 +97,7 @@ $spv-list-item--inner: null;
 // Displays a list inline with spacing
 @mixin vf-p-inline-list {
   .p-inline-list {
+    font-size: 0;
     margin-left: 0;
     padding-left: 0;
   }
@@ -107,6 +110,7 @@ $spv-list-item--inner: null;
 // Displays a list inline with items separated by dots
 @mixin vf-p-inline-list-middot {
   .p-inline-list--middot {
+    font-size: 0;
     margin-left: 0;
     padding-left: 0;
 
@@ -114,7 +118,7 @@ $spv-list-item--inner: null;
       @include vf-inline-list-item;
 
       &:not(:last-of-type):not(.last-item)::after {
-        content: '\00a0\00a0\00b7\00a0\00a0';
+        content: '\00a0\00a0\00a0\00b7\00a0\00a0\00a0';
         margin-left: -#{$strut-width};
       }
     }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -113,10 +113,8 @@ $spv-list-item--inner: null;
     .p-inline-list__item {
       @include vf-inline-list-item;
 
-      &:not(:last-of-type):not(.last-item) {
-        &::after {
-          content: '\00a0\2022\00a0';
-        }
+      &:not(:last-of-type):not(.last-item)::after {
+        content: '\00a0\2022\00a0';
       }
     }
   }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -35,12 +35,8 @@ $spv-list-item--inner: null;
   display: inline;
   list-style: none;
 
-  & + & {
-    margin-left: -#{$strut-width};
-  }
-
   &:not(:last-of-type):not(.last-item) {
-    padding-right: $sph-outer;
+    padding-right: calc(#{$sph-outer} - #{$strut-width});
 
     &::after {
       content: '';

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -37,10 +37,9 @@ $spv-list-item--inner: null;
     margin-left: -#{$strut-width};
   }
 
-  &:not(:last-of-type),
-  &:not(.last-item) {
+  &:not(:last-of-type):not(.last-item) {
     &::after {
-      content: '\00a0';
+      content: '\00a0\00a0\00a0';
     }
   }
 }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -30,12 +30,18 @@ $spv-list-item--inner: null;
 
 // Mixin for inline list items
 @mixin vf-inline-list-item {
-  display: inline-flex;
+  display: inline;
   list-style: none;
+
+  & + & {
+    margin-left: -#{$strut-width};
+  }
 
   &:not(:last-of-type),
   &:not(.last-item) {
-    margin-right: $sph-outer;
+    &::after {
+      content: '\00a0';
+    }
   }
 }
 
@@ -107,26 +113,10 @@ $spv-list-item--inner: null;
 
     .p-inline-list__item {
       @include vf-inline-list-item;
-      position: relative;
 
-      &::after {
-        color: $color-mid-dark;
-        content: '\00b7';
-        font-size: 1.4em;
-        line-height: 0;
-        position: absolute;
-        right: #{-0.5 * $sph-outer};
-        top: 0.4em;
-      }
-
-      &:hover::after {
-        color: $color-mid-dark;
-      }
-
-      &:last-of-type,
-      .last-item {
+      &:not(:last-of-type):not(.last-item) {
         &::after {
-          content: '';
+          content: '\00a0\2022\00a0';
         }
       }
     }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -114,7 +114,8 @@ $spv-list-item--inner: null;
       @include vf-inline-list-item;
 
       &:not(:last-of-type):not(.last-item)::after {
-        content: '\00a0\2022\00a0';
+        content: '\00a0\00a0\00b7\00a0\00a0';
+        margin-left: -#{$strut-width};
       }
     }
   }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -30,10 +30,10 @@ $spv-list-item--inner: null;
 
 // Mixin for inline list items
 @mixin vf-inline-list-item {
+  @extend %increase-font-size-on-larger-screens;
+
   display: inline;
   list-style: none;
-
-  @extend %increase-font-size-on-larger-screens;
 
   & + & {
     margin-left: -#{$strut-width};

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -40,8 +40,10 @@ $spv-list-item--inner: null;
   }
 
   &:not(:last-of-type):not(.last-item) {
+    padding-right: $sph-outer;
+
     &::after {
-      content: '\00a0\00a0\00a0';
+      content: '';
     }
   }
 }
@@ -116,10 +118,11 @@ $spv-list-item--inner: null;
 
     .p-inline-list__item {
       @include vf-inline-list-item;
+      padding-right: $sph-inner * 2;
 
       &:not(:last-of-type):not(.last-item)::after {
-        content: '\00a0\00a0\00a0\00b7\00a0\00a0\00a0';
-        margin-left: -#{$strut-width};
+        content: '\00b7';
+        margin-left: calc(#{$sph-inner} - #{$strut-width});
       }
     }
   }

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -161,5 +161,5 @@ $sp-xxx-large: $sp-unit * 6 !default;
 $sp-xxxx-large: $sp-unit * 8 !default;
 $sp-xxxxx-large: $sp-unit * 12 !default;
 
-// width of white space between inline and inline-block elements
+// width of white space between inline or inline-block elements
 $strut-width: 4px !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -161,5 +161,5 @@ $sp-xxx-large: $sp-unit * 6 !default;
 $sp-xxxx-large: $sp-unit * 8 !default;
 $sp-xxxxx-large: $sp-unit * 12 !default;
 
-// width of white space added beteween inline and inline-block elements
+// width of white space between inline and inline-block elements
 $strut-width: 4px !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -160,3 +160,6 @@ $sp-xx-large: $sp-unit * 5 !default;
 $sp-xxx-large: $sp-unit * 6 !default;
 $sp-xxxx-large: $sp-unit * 8 !default;
 $sp-xxxxx-large: $sp-unit * 12 !default;
+
+// width of white space added beteween inline and inline-block elements
+$strut-width: 4px !default;


### PR DESCRIPTION
## Done

Refactors the middot element:
- replaces the small dot made bigger by a font size increase with the bullet unicode character, which is what the typeface designer has deemed correct dot size relative to rest of text at that font-size
- compensates for the width to which white space is collapsed between inline elements - in my experiments, this width is around 3.6px, which is then rounded to 3 or 4 depending on whether it starts on a round pixel or not; therefore, I've created a new variable called $strut-width, which is constant and shouldn't depend on font, browser, or font size. (tested with ubuntu light, bold, thin, in ff and chrome). It will need to be documented with a subsequent pr

(Strut in red):
![image](https://user-images.githubusercontent.com/2741678/69437481-4c25d200-0d3b-11ea-895b-1de22dadfab5.png)

-removes some patches (e.g. text color) as the current implementation doesn't need it (I've expanded the example to include a list of links to demonstrate):
![image](https://user-images.githubusercontent.com/2741678/69437258-d91c5b80-0d3a-11ea-949e-c0b45ae28679.png)
- removes some other unneeded styles and replaces them with a better targeted selector

- improve wrapping of dot (it wraps as soon as there's enough width for the dot to wrap, as opposed to staying on the preceding line)

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/patterns/lists/lists-mid-dot/
- QA

## Details

https://github.com/canonical-web-and-design/vanilla-framework/issues/2557

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/69437619-94dd8b00-0d3b-11ea-8a7c-89a78dd5585a.png)

