### PR TITLE
Indent p-stepped-list__content

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -138,8 +138,8 @@ $spv-list-item--inner: null;
   .p-stepped-list {
     @extend %vf-clearfix;
     @extend %numbered-step-container;
-
     margin-bottom: 0; // spacing has been moved onto __item; this ensures that the heading / paragraph spacing matches that of regular headings / paragraphs
+    margin-left: 0;
   }
 
   .p-stepped-list__item {

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -185,6 +185,16 @@ $spv-list-item--inner: null;
           width: $bullet-width;
         }
       }
+
+      & + .p-stepped-list__content {
+        @media (max-width: $breakpoint-heading-threshold) {
+          margin-left: $bullet-width-mobile + $sph-inner;
+        }
+
+        @media (min-width: $breakpoint-heading-threshold) {
+          margin-left: $bullet-width + $sph-inner;
+        }
+      }
     }
   }
 }
@@ -211,10 +221,7 @@ $spv-list-item--inner: null;
 
     .p-stepped-list__item {
       @extend %row;
-
-      .row & {
-        @include row-reset;
-      }
+      @include row-reset;
     }
   }
 }


### PR DESCRIPTION

## Done
- Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2649
- Removes a couple of unnecessary left indents

## QA

- Pull code
- Run `./run serve --watch`
- Open patterns/lists/lists-stepped/,  /patterns/lists/lists-stepped-detailed/
- Verify they content is aligned with titles:

 ![image](https://user-images.githubusercontent.com/2741678/69967578-9adc2480-1510-11ea-835e-9d2dec8c1abf.png)
