### PR TITLE
Fix middot position as it was in 2.3.0

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -30,7 +30,7 @@ $spv-list-item--inner: null;
 
 // Mixin for inline list items
 @mixin vf-inline-list-item {
-  display: inline-flex;
+  display: inline;
   list-style: none;
 
   &:not(:last-of-type),


### PR DESCRIPTION
## Done

Fixes #2557 by reverting to 2.3.0 styling of inline lists

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/patterns/lists/lists-mid-dot/
- QA middot position

## Details

The problem was that the display property was changed to inline-flex, which misaligns the dot. This reverts it to inline.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2557

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/70140750-56c25e80-168d-11ea-8888-4e605ec1f240.png)
