### PR TITLE
Don't build deprecate util, fix setting app-version before it's used

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1,3 +1,5 @@
+@import 'settings_system';
+
 // Vendor Sass utilities
 @import 'utilities_deprecate';
 
@@ -13,6 +15,5 @@
 @import 'settings_font';
 @import 'settings_grid';
 @import 'settings_placeholders';
-@import 'settings_system';
 @import 'settings_tables';
 @import 'settings_themes';

--- a/scss/deprecate/_index.scss
+++ b/scss/deprecate/_index.scss
@@ -28,7 +28,18 @@ $deprecate-mode: 'sensible' !default;
 @function _d-to-number($value) {
   $result: 0;
   $digits: 0;
-  $numbers: ('0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9);
+  $numbers: (
+    '0': 0,
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6,
+    '7': 7,
+    '8': 8,
+    '9': 9
+  );
 
   @for $i from 1 through str-length($value) {
     $character: str-slice($value, $i, $i);
@@ -101,7 +112,7 @@ $deprecate-mode: 'sensible' !default;
   @if ('disabled' == $deprecate-mode) {
     @content;
   } @else {
-    @if not ('silent' == $deprecate-mode) {
+    @if not('silent' == $deprecate-mode) {
       // Assume we found code that is (or is about to be) deprecated
       $deprecation-found: true;
 


### PR DESCRIPTION
## Done

Renamed `deprecate/index.scss` to `_index`, so it's not built into CSS.
Moved importing system settings to beginning of the file, so the `app-version` is defined before it's used by `deprecate`.

## QA

- Pull code
- Run `./run build`
- Only `build.css` should be built, not `deprecate/index.css`
