### PR TITLE
Bump version of Vanilla used by the docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "vanilla-framework": "vanilla-framework is included in devDependencies for use in styling the docs site"
   },
   "devDependencies": {
-    "vanilla-framework": "2.4.1",
+    "vanilla-framework": "2.5.0",
     "autoprefixer": "9.5.0",
     "husky": "1.3.1",
     "markdown-spellcheck": "1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,10 +3765,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.1.tgz#36ef374e90b8457a07e55cf33be1bcfd07092c84"
-  integrity sha512-St8LdmoMpWSFWvFRDBNjFcdfWo/nOMwrkRPJN+dR0vOHP/Jb1UqOSxw+wDxkiGrpeRb0VPFwCuz/2u0RWb0xuQ==
+vanilla-framework@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.5.0.tgz#b7f689d7583f4a215cde39b726091ffc2ec4f62a"
+  integrity sha512-8dY70fTDo2v/Lw96nMRyhi5e74KUk1krcEHEd1qt/hzMzAfy2NYddENS1bZahEg7hoAY1TZc8mQJr+bVu4qW7w==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Updated version of Vanilla used by the docs to 2.5.0

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/
- Make sure site looks ok

Fixes #2646 