### PR TITLE
Update component status 2.5.0

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -127,7 +127,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/embedded-media/' %}is-active{% endif %}" href="/utilities/embedded-media/">Embedded media</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/equal-height/' %}is-active{% endif %}" href="/utilities/equal-height/">Equal height</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/floats/' %}is-active{% endif %}" href="/utilities/floats/">Floats</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/font-metrics/' %}is-active{% endif %}" href="/utilities/font-metrics/">Font metrics</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/font-metrics/' %}is-active{% endif %}" href="/utilities/font-metrics/">Font metrics</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/functions/' %}is-active{% endif %}" href="/utilities/functions/">Functions</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/hide/' %}is-active{% endif %}" href="/utilities/hide/">Hide</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/image-position/' %}is-active{% endif %}" href="/utilities/image-position/">Image position</a></li>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -74,7 +74,7 @@
               <li class="p-sidebar-nav__item">
                 <strong>Base elements</strong>
                 <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/code/' %}is-active{% endif %}" href="/base/code/">Code</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/code/' %}is-active{% endif %}" href="/base/code/">Code</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/forms/' %}is-active{% endif %}" href="/base/forms/">Forms</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/reset/' %}is-active{% endif %}" href="/base/reset/">Reset</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/tables/' %}is-active{% endif %}" href="/base/tables">Tables</a></li>
@@ -85,7 +85,7 @@
               <li class="p-sidebar-nav__item">
                 <strong>Components</strong>
                 <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/accordion/' %}is-active{% endif %}" href="/patterns/accordion/">Accordion</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/accordion/' %}is-active{% endif %}" href="/patterns/accordion/">Accordion</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/article-pagination/' %}is-active{% endif %}" href="/patterns/article-pagination/">Article pagination</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/breadcrumbs/' %}is-active{% endif %}" href="/patterns/breadcrumbs/">Breadcrumbs</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/buttons/' %}is-active{% endif %}" href="/patterns/buttons/">Buttons</a></li>
@@ -93,7 +93,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/contextual-menu/' %}is-active{% endif %}" href="/patterns/contextual-menu/">Contextual menu</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/grid/' %}is-active{% endif %}" href="/patterns/grid/">Grid</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/heading-icon/' %}is-active{% endif %}" href="/patterns/heading-icon/">Heading icon</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/icons/' %}is-active{% endif %}" href="/patterns/icons/">Icons</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/icons/' %}is-active{% endif %}" href="/patterns/icons/">Icons</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/images/' %}is-active{% endif %}" href="/patterns/images/">Images</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/inline-images/' %}is-active{% endif %}" href="/patterns/inline-images/">Inline images</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/labels/' %}is-active{% endif %}" href="/patterns/labels/">Labels</a></li>
@@ -104,9 +104,9 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/media-object/' %}is-active{% endif %}" href="/patterns/media-object/">Media object</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/modal/' %}is-active{% endif %}" href="/patterns/modal/">Modal</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/muted-heading/' %}is-active{% endif %}" href="/patterns/muted-heading/">Muted heading</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/navigation/' %}is-active{% endif %}" href="/patterns/navigation/">Navigation</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/navigation/' %}is-active{% endif %}" href="/patterns/navigation/">Navigation</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/notification/' %}is-active{% endif %}" href="/patterns/notification/">Notifications</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/pagination/' %}is-active{% endif %}" href="/patterns/pagination/">Pagination</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/pagination/' %}is-active{% endif %}" href="/patterns/pagination/">Pagination</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/pull-quote/' %}is-active{% endif %}" href="/patterns/pull-quote/">Quotes</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/search-box/' %}is-active{% endif %}" href="/patterns/search-box/">Search box</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/slider/' %}is-active{% endif %}" href="/patterns/slider/">Slider</a></li>
@@ -148,7 +148,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/settings/animation-settings/' %}is-active{% endif %}" href="/settings/animation-settings/">Animations</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/settings/assets-settings/' %}is-active{% endif %}" href="/settings/assets-settings/">Assets</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/settings/breakpoint-settings/' %}is-active{% endif %}" href="/settings/breakpoint-settings/">Breakpoints</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/settings/color-settings/' %}is-active{% endif %}" href="/settings/color-settings/">Color</a><div class="p-label--in-progress u-float-right u-no-margin--bottom">In progress</div>   </li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/settings/color-settings/' %}is-active{% endif %}" href="/settings/color-settings/">Color</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/settings/font-settings/' %}is-active{% endif %}" href="/settings/font-settings/">Font</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/settings/layout-settings/' %}is-active{% endif %}" href="/settings/layout-settings/">Layout</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/settings/placeholder-settings/' %}is-active{% endif %}" href="/settings/placeholder-settings/">Placeholders</a></li>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -136,7 +136,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/off-screen/' %}is-active{% endif %}" href="/utilities/off-screen/">Off-screen</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/padding-collapse/' %}is-active{% endif %}" href="/utilities/padding-collapse/">Padding collapse</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/table-cell-padding-overlap/' %}is-active{% endif %}" href="/utilities/table-cell-padding-overlap/">Table cell padding overlap</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/truncate/' %}is-active{% endif %}" href="/utilities/truncate/">Truncation</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/truncate/' %}is-active{% endif %}" href="/utilities/truncate/">Truncation</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/show/' %}is-active{% endif %}" href="/utilities/show/">Show</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/vertically-center/' %}is-active{% endif %}" href="/utilities/vertically-center/">Vertically center</a></li>
                 </ul>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -78,7 +78,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/forms/' %}is-active{% endif %}" href="/base/forms/">Forms</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/reset/' %}is-active{% endif %}" href="/base/reset/">Reset</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/tables/' %}is-active{% endif %}" href="/base/tables">Tables</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/typography/' %}is-active{% endif %}" href="/base/typography/">Typography</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/typography/' %}is-active{% endif %}" href="/base/typography/">Typography</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
                 </ul>
               </li>
 

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -97,6 +97,8 @@ View example of the mixed headings pattern
 
 ### Line length
 
+<span class="p-label--new">New</span>
+
 Line length, measured in number of characters per line (CPL), has been shown to affect reading speed and comprehension. While there is little consensus on what the optimal CPL value is, most studies test with values between 45 and 95 characters per line. <a href="https://en.wikipedia.org/wiki/Line_length">Wikipedia</a> has a good historical overview and a list of studies on the subject.
 
 The max-width of text elements in Vanilla Framework is limited using the `$max-width--default` variable, currently set to `40em`, or around 90 characters.

--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -41,6 +41,11 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>Added <code>u-table-cell-padding-overlap</code> utility to overlap table cell padding</td>
     </tr>
     <tr>
+      <th><a href="/utilities/truncate/">Truncation</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>Added <code>u-truncate</code> utility to truncate text with ellipsis</td>
+    </tr>
+    <tr>
       <th><a href="/patterns/icons/#social">Social icons</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>

--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -26,6 +26,11 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>Optional state indicator was added to contextual menu</td>
     </tr>
     <tr>
+      <th><a href="/utilities/font-metrics/">Font metrics</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>Added <code>u-visualise-font-metrics</code> utility to visualise font metrics</td>
+    </tr>
+    <tr>
       <th><a href="/patterns/icons/#social">Social icons</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>

--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -31,6 +31,11 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>Added <code>u-visualise-font-metrics</code> utility to visualise font metrics</td>
     </tr>
     <tr>
+      <th><a href="/base/typography/#line-length">Line length</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>Added <code>$max-width--default</code> variable and <code>u-no-max-width</code> utility to control line length</td>
+    </tr>
+    <tr>
       <th><a href="/patterns/icons/#social">Social icons</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>

--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -21,44 +21,19 @@ When we add, make significant updates, or deprecate a component we update their 
   </thead>
   <tbody>
     <tr>
-      <th><a href="/patterns/menu-button">Menu button</a></th>
-      <td><div class="p-label--in-progress">In progress</div></td>
-      <td><a href="https://github.com/canonical-web-and-design/design-vanilla-framework/tree/master/Menu%20button">Design spec</a> created and ready for build</td>
-    </tr>
-    <tr>
-      <th><a href="/patterns/navigation/#sub-navigation">Sub-navigation</a></th>
+      <th><a href="/patterns/contextual-menu/#indicator">Contextual menu</a></th>
       <td><div class="p-label--new">New</div></td>
-      <td>This component's functionality requires JavaScript</td>
+      <td>Optional state indicator was added to contextual menu</td>
     </tr>
     <tr>
-      <th><a href="/patterns/pagination/">Pagination</a></th>
-      <td><div class="p-label--new">New</div></td>
-      <td>Should be used to navigate between pages of content</td>
-    </tr>
-    <tr>
-      <th><a href="/patterns/accordion">Accordion</a></th>
+      <th><a href="/patterns/icons/#social">Social icons</a></th>
       <td><div class="p-label--updated">Updated</div></td>
-      <td>Icons now appear on the left rather than the right</td>
-    </tr>
-    <tr>
-      <th><a href="/base/code/#inline">Code</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
-      <td>Inline code elements now have a grey highlight to help them stand out from other text</td>
-    </tr>
-    <tr>
-      <th>Footer</th>
-      <td><div class="p-label--deprecated">Deprecated</div></td>
-      <td>Removed from release <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.0">v2.0.0</a></td>
-    </tr>
-    <tr>
-      <th>Sidebar navigation</th>
-      <td><div class="p-label--deprecated">Deprecated</div></td>
-      <td>Removed from release <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.0">v2.0.0</a></td>
+      <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>
     </tr>
     <tr>
       <th><a href="/patterns/icons/#social">Social icons</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
-      <td>Removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from social icon set</td>
+      <td>We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from social icon set in future release v3.0</td>
     </tr>
   </tbody>
   <tfoot>

--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -36,6 +36,11 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>Added <code>$max-width--default</code> variable and <code>u-no-max-width</code> utility to control line length</td>
     </tr>
     <tr>
+      <th><a href="/utilities/table-cell-padding-overlap/">Table cell padding overlap</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>Added <code>u-table-cell-padding-overlap</code> utility to overlap table cell padding</td>
+    </tr>
+    <tr>
       <th><a href="/patterns/icons/#social">Social icons</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>

--- a/docs/settings/color-settings.md
+++ b/docs/settings/color-settings.md
@@ -144,8 +144,6 @@ It’s important for us to meet all web accessibility standards. Vanilla encoura
 
 ### Color theming
 
-<span class="p-label--in-progress">In progress</span>
-
 Starting with the [2.3.0](https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0) release, Vanilla framework introduces a theming mechanism. The current default for all components is referred to as the light theme. A subset of elements and components now offer a dark theme:
 
 - `checkbox`

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -4,6 +4,8 @@ layout: default
 
 ## Font metrics
 
+<span class="p-label--new">New</span>
+
 <hr>
 
 Being able to visualise the <a target="_blank" href="https://en.wikipedia.org/wiki/Baseline_(typography)">baseline</a> position, <a target="_blank" href="https://en.wikipedia.org/wiki/Cap_height">cap-height</a> and <a target="_blank" href="https://en.wikipedia.org/wiki/X-height">x-height</a> of a typeface can be helpful, for example when trying to precisely align inline-block elements (like icons) to text.

--- a/docs/utilities/table-cell-padding-overlap.md
+++ b/docs/utilities/table-cell-padding-overlap.md
@@ -4,6 +4,8 @@ layout: default
 
 ## Table cell padding overlap
 
+<span class="p-label--new">New</span>
+
 <hr>
 
 Vanilla applies padding-top and padding bottom to table cells. This is done to prevent row borders from getting too close to text that is not wrapped in a `<p>` or other text element.

--- a/docs/utilities/truncate.md
+++ b/docs/utilities/truncate.md
@@ -4,6 +4,8 @@ layout: default
 
 ## Truncation
 
+<span class="p-label--new">New</span>
+
 <hr>
 
 To truncate text, use the class `u-truncate`.


### PR DESCRIPTION
## Done

- removed old component status labels and entries from component status page
- added newly added and updated components and utilities from 2.5.0

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/component-status/ or demo https://vanilla-framework-canonical-web-and-design-pr-2693.run.demo.haus/component-status/
- Check if current status of all new features from 2.5.0 are listed
- Check labels in the side navigation*
- Check for labels in the relevant pages

\* note "Table cell padding overlap" doesn't have "New" icon in the side navigation, because it doesn't fit next to long title

<img width="278" alt="Screenshot 2019-12-06 at 13 29 16" src="https://user-images.githubusercontent.com/83575/70323674-bbb4ba80-182d-11ea-979a-6745e3bb201d.png">


## Screenshot

<img width="1245" alt="Screenshot 2019-12-06 at 13 35 27" src="https://user-images.githubusercontent.com/83575/70323546-506ae880-182d-11ea-8dd7-af4ea5dd4f3b.png">
