### PR TITLE
Convert Vanilla JS in examples to ES5

### DIFF
--- a/docs/examples/patterns/accordion.html
+++ b/docs/examples/patterns/accordion.html
@@ -51,7 +51,7 @@ function setupAccordionListener(accordionContainerSelector) {
       accordion panes.
     @param {Boolean} show Whether to show or hide the accordion panel.
   */
-  const toggle = (element, show) => {
+  var toggle = (element, show) => {
     element.setAttribute('aria-expanded', show);
     document
       .querySelector(element.getAttribute('aria-controls'))
@@ -62,13 +62,17 @@ function setupAccordionListener(accordionContainerSelector) {
   document
     .querySelector(accordionContainerSelector)
     .addEventListener('click', e => {
-      const target = e.target;
-      const isTargetOpen = target.getAttribute('aria-expanded') === 'true';
+      var target = e.target;
+      var isTargetOpen = target.getAttribute('aria-expanded') === 'true';
       // Find any open panels within the container and close them.
       if (target.classList.contains('p-accordion__tab')) {
-        e.currentTarget
-          .querySelectorAll('[aria-expanded=true]')
-          .forEach(element => toggle(element, false));
+        var openPanels = e.currentTarget
+          .querySelectorAll('[aria-expanded=true]');
+
+        for (var i = 0, l = openPanels.length; i < l; i++) {
+          toggle(openPanels[i], false);
+        }
+
         // Toggle the target.
         toggle(target, !isTargetOpen);
       }

--- a/docs/examples/patterns/code-copyable.html
+++ b/docs/examples/patterns/code-copyable.html
@@ -11,38 +11,39 @@ redirect_from: "/examples/patterns/code-snippet/"
 </div>
 
 <script>
-const copyToClipboard = str => {
-  const el = document.createElement('textarea'); // Create a <textarea> element
-  el.value = str; // Set its value to the string that you want copied
-  el.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
-  el.style.position = 'absolute';
-  el.style.left = '-9999px'; // Move outside the screen to make it invisible
-  document.body.appendChild(el); // Append the <textarea> element to the HTML document
-  const selected =
-    document.getSelection().rangeCount > 0 // Check if there is any content selected previously
-      ? document.getSelection().getRangeAt(0) // Store selection if found
-      : false; // Mark as false to know no selection existed before
-  el.select(); // Select the <textarea> content
-  document.execCommand('copy'); // Copy - only works as a result of a user action (e.g. click events)
-  document.body.removeChild(el); // Remove the <textarea> element
-  if (selected) {
-    // If a selection existed before copying
-    document.getSelection().removeAllRanges(); // Unselect everything on the HTML document
-    document.getSelection().addRange(selected); // Restore the original selection
-  }
-};
+  var copyToClipboard = str => {
+    var el = document.createElement('textarea'); // Create a <textarea> element
+    el.value = str; // Set its value to the string that you want copied
+    el.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
+    el.style.position = 'absolute';
+    el.style.left = '-9999px'; // Move outside the screen to make it invisible
+    document.body.appendChild(el); // Append the <textarea> element to the HTML document
+    var selected =
+      document.getSelection().rangeCount > 0 // Check if there is any content selected previously
+        ? document.getSelection().getRangeAt(0) // Store selection if found
+        : false; // Mark as false to know no selection existed before
+    el.select(); // Select the <textarea> content
+    document.execCommand('copy'); // Copy - only works as a result of a user action (e.g. click events)
+    document.body.removeChild(el); // Remove the <textarea> element
+    if (selected) {
+      // If a selection existed before copying
+      document.getSelection().removeAllRanges(); // Unselect everything on the HTML document
+      document.getSelection().addRange(selected); // Restore the original selection
+    }
+  };
 
-var codeCopyableActions = document.querySelectorAll(
-  '.p-code-copyable__action'
-);
-for (var codeCopyableAction of codeCopyableActions) {
-  codeCopyableAction.addEventListener(
-    'click',
-    function(e) {
-      const clipboardValue = this.previousSibling.previousSibling.value;
-      copyToClipboard(clipboardValue);
-    },
-    false
+  var codeCopyableActions = document.querySelectorAll(
+    '.p-code-copyable__action'
   );
-}
+
+  for (var i = 0; i < codeCopyableActions.length; i++) {
+    codeCopyableActions[i].addEventListener(
+      'click',
+      function(e) {
+        var clipboardValue = this.previousSibling.previousSibling.value;
+        copyToClipboard(clipboardValue);
+      },
+      false
+    );
+  }
 </script>

--- a/docs/examples/patterns/contextual-menu/default.html
+++ b/docs/examples/patterns/contextual-menu/default.html
@@ -65,50 +65,49 @@ category: _patterns
 </span> vel eu.</p>
 
 <script>
-
 function toggleMenu(element, show) {
   element.setAttribute('aria-expanded', show);
-  document
-    .querySelector(element.getAttribute('aria-controls'))
-    .setAttribute('aria-hidden', !show);
+  document.querySelector(element.getAttribute('aria-controls')).setAttribute('aria-hidden', !show);
+}
+
+function initToggle(toggle) {
+  toggle.addEventListener('click', function(e) {
+    e.preventDefault();
+    var target = e.target;
+    var menuAlreadyOpen = toggle.getAttribute('aria-expanded') === 'true';
+    toggleMenu(toggle, !menuAlreadyOpen);
+  });
 }
 
 function setupContextualMenuListeners(contextualMenuToggleSelector) {
-  const toggles = document.querySelectorAll(contextualMenuToggleSelector);
+  var toggles = document.querySelectorAll(contextualMenuToggleSelector);
 
-  toggles.forEach(toggle => {
-    toggle.addEventListener('click', e => {
-      e.preventDefault();
+  for (var i = 0, l = toggles.length; i < l; i++) {
+    initToggle(toggles[i]);
+  }
 
-      const target = e.target;
-      const menuAlreadyOpen = target.getAttribute('aria-expanded') === 'true';
-
-      toggleMenu(target, !menuAlreadyOpen)
-    });
-  });
-
-  document.addEventListener('click', e => {
-    toggles.forEach(toggle => {
-      const contextualMenu = document.querySelector(toggle.getAttribute('aria-controls'));
-      const clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
+  document.addEventListener('click', function(e) {
+    for (var i = 0, l = toggles.length; i < l; i++) {
+      var toggle = toggles[i];
+      var contextualMenu = document.querySelector(toggle.getAttribute('aria-controls'));
+      var clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
 
       if (clickOutside) {
         toggleMenu(toggle, false);
       }
-    })
+    }
   });
 
-  document.onkeydown = e => {
+  document.addEventListener('keydown', function(e) {
     e = e || window.event;
 
     if (e.keyCode === 27) {
-      toggles.forEach(toggle => {
-        toggleMenu(toggle, false);
-      });
+      for (var i = 0, l = toggles.length; i < l; i++) {
+        toggleMenu(toggles[i], false);
+      }
     }
-  };
+  });
 }
 
 setupContextualMenuListeners('.p-contextual-menu__toggle');
-
 </script>

--- a/docs/examples/patterns/contextual-menu/with-indicator.html
+++ b/docs/examples/patterns/contextual-menu/with-indicator.html
@@ -28,39 +28,43 @@ category: _patterns
     document.querySelector(element.getAttribute('aria-controls')).setAttribute('aria-hidden', !show);
   }
 
+  function initToggle(toggle) {
+    toggle.addEventListener('click', function(e) {
+      e.preventDefault();
+      var target = e.target;
+      var menuAlreadyOpen = toggle.getAttribute('aria-expanded') === 'true';
+      toggleMenu(toggle, !menuAlreadyOpen);
+    });
+  }
+
   function setupContextualMenuListeners(contextualMenuToggleSelector) {
     var toggles = document.querySelectorAll(contextualMenuToggleSelector);
-    toggles.forEach(function (toggle) {
-      toggle.addEventListener('click', function (e) {
-        e.preventDefault();
-        var target = e.target;
-        var menuAlreadyOpen = toggle.getAttribute('aria-expanded') === 'true';
-        toggleMenu(toggle, !menuAlreadyOpen);
-      });
-    });
-    document.addEventListener('click', function (e) {
-      toggles.forEach(function (toggle) {
+
+    for (var i = 0, l = toggles.length; i < l; i++) {
+      initToggle(toggles[i]);
+    }
+
+    document.addEventListener('click', function(e) {
+      for (var i = 0, l = toggles.length; i < l; i++) {
+        var toggle = toggles[i];
         var contextualMenu = document.querySelector(toggle.getAttribute('aria-controls'));
-          if (contextualMenu === null) {
-          var clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
+        var clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
 
-          if (clickOutside) {
-            toggleMenu(toggle, false);
-          }
+        if (clickOutside) {
+          toggleMenu(toggle, false);
         }
-      });
+      }
     });
 
-    document.onkeydown = function (e) {
+    document.addEventListener('keydown', function(e) {
       e = e || window.event;
 
       if (e.keyCode === 27) {
-        // Capture Esc presses to close menu
-        toggles.forEach(function (toggle) {
-          toggleMenu(toggle, false);
-        });
+        for (var i = 0, l = toggles.length; i < l; i++) {
+          toggleMenu(toggles[i], false);
+        }
       }
-    };
+    });
   }
 
   setupContextualMenuListeners('.p-contextual-menu__toggle');

--- a/docs/examples/patterns/modal.html
+++ b/docs/examples/patterns/modal.html
@@ -4,13 +4,13 @@ title: Modal
 category: _patterns
 ---
 
-<button id="showModal">Show modal</button>
+<button id="showModal" aria-controls="modal">Show modal</button>
 
 <div class="p-modal" id="modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">Help</h2>
-      <button class="p-modal__close" aria-label="Close active modal">Close</button>
+      <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
     </header>
     <p id="modal-description">Learn how to operate production-ready clusters.</p>
     <div class="p-heading-icon--small">
@@ -27,24 +27,20 @@ category: _patterns
 </div>
 
 <script>
-  function showModal(target) {
-    var modal = document.getElementById(target);
-    if (modal.style.display === 'none') {
-      modal.style.display = 'flex';
-    } else {
-      modal.style.display = 'none';
-    }
+  var modalButtons = document.querySelectorAll("[aria-controls]");
+
+  for (var i = 0, l = modalButtons.length; i < l; i++) {
+    modalButtons[i].addEventListener('click', function(event) {
+      var target = event.target.getAttribute('aria-controls');
+      var modal = document.getElementById(target);
+
+      if (modal) {
+        if (modal.style.display === 'none') {
+          modal.style.display = 'flex';
+        } else {
+          modal.style.display = 'none';
+        }
+      }
+    })
   }
-
-  var showModalButton = document.getElementById('showModal');
-
-  showModalButton.addEventListener('click', function() {
-    showModal('modal');
-  });
-
-  var modal = document.getElementById('modal');
-  var closeModalButton = modal.querySelector('.p-modal__close')
-    .addEventListener('click', function() {
-      showModal('modal');
-    });
 </script>

--- a/docs/examples/patterns/modal.html
+++ b/docs/examples/patterns/modal.html
@@ -4,12 +4,13 @@ title: Modal
 category: _patterns
 ---
 
-<button onclick="showModal('modal')">Show modal</button>
+<button id="showModal">Show modal</button>
+
 <div class="p-modal" id="modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">Help</h2>
-      <button class="p-modal__close" aria-label="Close active modal" onclick="showModal('modal')">Close</button>
+      <button class="p-modal__close" aria-label="Close active modal">Close</button>
     </header>
     <p id="modal-description">Learn how to operate production-ready clusters.</p>
     <div class="p-heading-icon--small">
@@ -34,4 +35,16 @@ category: _patterns
       modal.style.display = 'none';
     }
   }
+
+  var showModalButton = document.getElementById('showModal');
+
+  showModalButton.addEventListener('click', function() {
+    showModal('modal');
+  });
+
+  var modal = document.getElementById('modal');
+  var closeModalButton = modal.querySelector('.p-modal__close')
+    .addEventListener('click', function() {
+      showModal('modal');
+    });
 </script>

--- a/docs/examples/patterns/navigation/subnav.html
+++ b/docs/examples/patterns/navigation/subnav.html
@@ -150,7 +150,20 @@ function showElement(element) {
 
 // Close all menus if anything else on the page is clicked
 document.addEventListener('click', function(event) {
-  if (!event.target.closest('.p-subnav__toggle') && !event.target.closest('.p-subnav__item')) {
+  var target = event.target;
+
+  if (target.closest) {
+    if (!target.closest('.p-subnav__toggle') && !target.closest('.p-subnav__item')) {
+      closeAllSubnavs();
+    }
+  } else if (target.msMatchesSelector) {
+    // IE friendly `Element.closest` equivalent
+    // as in https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+    do {
+      if (target.msMatchesSelector('.p-subnav__toggle') || target.msMatchesSelector('.p-subnav__item')) return;
+      target = target.parentElement || target.parentNode;
+    } while (target !== null && target.nodeType === 1);
+
     closeAllSubnavs();
   }
 });

--- a/docs/examples/patterns/navigation/subnav.html
+++ b/docs/examples/patterns/navigation/subnav.html
@@ -92,32 +92,33 @@ var subnavContainers = document.querySelectorAll('[class^="p-subnav__items"]');
 var subnavs = document.querySelectorAll('.p-subnav');
 var subnavToggles = document.querySelectorAll('.p-subnav__toggle');
 
-subnavToggles.forEach(function(subnavToggle) {
-  subnavToggle.addEventListener('click', function(event) {
+for (var i = 0, l = subnavToggles.length; i < l; i++) {
+  subnavToggles[i].addEventListener('click', function(event) {
     event.preventDefault();
   });
-});
+}
 
-subnavs.forEach(function(currentSubnav) {
-  currentSubnav.addEventListener('click', function(event) {
+for (i = 0, l = subnavs.length; i < l; i++) {
+  subnavs[i].addEventListener('click', function(event) {
     event.stopPropagation();
 
     var clickedDropdown = this;
 
-    subnavs.forEach(function(subnav) {
+    for (var i = 0, l = subnavs.length; i < l; i++) {
+      var subnav = subnavs[i];
       var subnavContent = subnav.querySelector('[class^="p-subnav__items"]');
       if (subnav === clickedDropdown) {
         if (subnav.classList.contains('is-active')) {
           closeSubnav(subnav, subnavContent);
         } else {
-          openSubnav(subnav, subnavContent)
+          openSubnav(subnav, subnavContent);
         }
       } else {
         closeSubnav(subnav, subnavContent);
       }
-    });
+    }
   });
-});
+}
 
 function openSubnav(subnav, subnavContent) {
   subnav.classList.add('is-active');
@@ -130,20 +131,21 @@ function closeSubnav(subnav, dropdownContent) {
 }
 
 function closeAllSubnavs() {
-  subnavs.forEach(function(element) {
-    element.classList.remove('is-active');
-  });
-  subnavContainers.forEach(function(element) {
-    hideElement(element);
-  });
+  for (var i = 0, l = subnavs.length; i < l; i++) {
+    subnavs[i].classList.remove('is-active');
+  }
+
+  for (i = 0, l = subnavContainers.length; i < l; i++) {
+    subnavs[i].classList.remove('is-active');
+  }
 }
 
 function hideElement(element) {
-  element.setAttribute("aria-hidden", "true");
+  element.setAttribute('aria-hidden', 'true');
 }
 
 function showElement(element) {
-  element.setAttribute("aria-hidden", "false");
+  element.setAttribute('aria-hidden', 'false');
 }
 
 // Close all menus if anything else on the page is clicked
@@ -152,5 +154,4 @@ document.addEventListener('click', function(event) {
     closeAllSubnavs();
   }
 });
-
 </script>

--- a/docs/examples/patterns/notifications/notifications.html
+++ b/docs/examples/patterns/notifications/notifications.html
@@ -8,17 +8,20 @@ category: _patterns
   <p class="p-notification__response">
     We use cookies to improve your experience. By your continued use of this site you accept such use.
   </p>
-  <button class="p-icon--close" aria-label="Close notification" data-close="notification">Close</button>
+  <button class="p-icon--close" aria-label="Close notification" aria-controls="notification">Close</button>
 </div>
 
 <script>
-  function closeNotification(id) {
-    var notification = document.getElementById(id);
-    notification.style.display = 'none';
-  }
+  var closeButtons = document.querySelectorAll('.p-notification [aria-controls]');
 
-  notification.querySelector('[data-close]').addEventListener('click', function(event) {
-    var target = event.target.getAttribute('data-close');
-    closeNotification(target);
-  });
+  for (var i = 0, l = closeButtons.length; i < l; i++) {
+    closeButtons[i].addEventListener('click', function(event) {
+      var target = event.target.getAttribute('aria-controls');
+      var notification = document.getElementById(target);
+
+      if (notification) {
+        notification.style.display = 'none';
+      }
+    });
+  }
 </script>

--- a/docs/examples/patterns/notifications/notifications.html
+++ b/docs/examples/patterns/notifications/notifications.html
@@ -8,12 +8,17 @@ category: _patterns
   <p class="p-notification__response">
     We use cookies to improve your experience. By your continued use of this site you accept such use.
   </p>
-  <button class="p-icon--close" aria-label="Close notification" onclick="closeNotification('notification')">Close</button>
+  <button class="p-icon--close" aria-label="Close notification" data-close="notification">Close</button>
 </div>
 
 <script>
-function closeNotification(target) {
-  var notification = document.getElementById(target);
-  notification.style.display = 'none';
-}
+  function closeNotification(id) {
+    var notification = document.getElementById(id);
+    notification.style.display = 'none';
+  }
+
+  notification.querySelector('[data-close]').addEventListener('click', function(event) {
+    var target = event.target.getAttribute('data-close');
+    closeNotification(target);
+  });
 </script>

--- a/docs/examples/patterns/slider/slider-input.html
+++ b/docs/examples/patterns/slider/slider-input.html
@@ -30,27 +30,17 @@ category: _patterns
       }
     }
 
-    var browser;
-    /Edge/i.test(navigator.userAgent) ? browser = 'Edge' :
-    /Chrome/i.test(navigator.userAgent) ? browser = 'Chrome' :
-    /Safari/i.test(navigator.userAgent) ? browser = 'Safari' :
-    /NET/i.test(navigator.userAgent) ? browser = 'IE' :
-    browser = 'Other';
-    var progressColour = '#335280';
-    var emptyColour = '#fff';
-    var sliders = Array.prototype.slice.call(document.querySelectorAll('.p-slider'));
-
-    sliders.forEach(function(slider) {
+    function initSlider(slider) {
       var input = document.getElementById(slider.id + '-input');
       renderSlider(slider, progressColour, emptyColour);
 
       if (input) {
         equaliseValues(input, slider);
-        input.oninput = function() {
+        input.addEventListener('input', function() {
           if (!input.value) input.value = 0;
           equaliseValues(slider, input);
           renderSlider(slider, progressColour, emptyColour);
-        }
+        });
       }
 
       // Fix for IE as it doesn't support 'oninput'
@@ -64,6 +54,20 @@ category: _patterns
           renderSlider(slider, progressColour, emptyColour);
         }
       }
-    });
+    }
+
+    var browser;
+    /Edge/i.test(navigator.userAgent) ? browser = 'Edge' :
+    /Chrome/i.test(navigator.userAgent) ? browser = 'Chrome' :
+    /Safari/i.test(navigator.userAgent) ? browser = 'Safari' :
+    /NET/i.test(navigator.userAgent) ? browser = 'IE' :
+    browser = 'Other';
+    var progressColour = '#335280';
+    var emptyColour = '#fff';
+    var sliders = document.querySelectorAll('.p-slider');
+
+    for (var i = 0, l = sliders.length; i < l; i++) {
+      initSlider(sliders[i]);
+    }
   })();
 </script>

--- a/docs/examples/patterns/slider/slider.html
+++ b/docs/examples/patterns/slider/slider.html
@@ -19,6 +19,14 @@ category: _patterns
       }
     }
 
+    function initSlider(slider) {
+      renderSlider(slider, progressColour, emptyColour);
+
+      slider.addEventListener('input', function() {
+        renderSlider(slider, progressColour, emptyColour);
+      });
+    }
+
     var browser;
     /Edge/i.test(navigator.userAgent) ? browser = 'Edge' :
     /Chrome/i.test(navigator.userAgent) ? browser = 'Chrome' :
@@ -28,14 +36,10 @@ category: _patterns
 
     var progressColour = '#335280';
     var emptyColour = '#fff';
-    var sliders = Array.prototype.slice.call(document.querySelectorAll('.p-slider'));
+    var sliders = document.querySelectorAll('.p-slider');
 
-    sliders.forEach(function(slider) {
-      renderSlider(slider, progressColour, emptyColour);
-
-      slider.oninput = function() {
-        renderSlider(slider, progressColour, emptyColour);
-      }
-    });
+    for (var i = 0, l = sliders.length; i < l; i++) {
+      initSlider(sliders[i]);
+    }
   })();
 </script>


### PR DESCRIPTION
Fixes #2604 
Fixes #2298

## Done

Updated (or maybe downgraded?) all JavaScript in the examples not to use ES6 and other modern API to make sure they work in most browsers (including IE10/11) without transpilation.
This mostly involved getting rid or `const`, `let` and `forEach`.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/vanilla-framework/ or demo https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/
- Check all the patterns with the JS in examples, make sure they still work
- Ideally test them in IE10 or IE11

Patterns updated in this PR:

- [x] [/patterns/accordion](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/accordion/)
- [x]  [/patterns/code-copyable](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/code-copyable)
- [ ] [/patterns/navigation/subnav](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/navigation/subnav)
- [x] [/patterns/contextual-menu/default/](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/contextual-menu/default/)
- [x] [/patterns/contextual-menu/with-indicator/](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/contextual-menu/with-indicator/)
- [x] [/notifications/notifications](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/notifications/notifications)
- [x] [/examples/patterns/modal](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/modal)
- [x] [/patterns/slider/slider-input](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/slider/slider-input)
- [x] [/patterns/slider/slider](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/slider/slider)


Other patterns with JS (not affected by this PR, still worth QAing):

- [x] [/patterns/list-tree](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/list-tree)
- [x] [/patterns/tables/table-sortable](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/tables/table-sortable)
- [x] [/patterns/tables/table-expanding](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/patterns/tables/table-expanding)
- [x] [/utilities/baseline-grid](https://vanilla-framework-canonical-web-and-design-pr-2698.run.demo.haus/examples/utilities/baseline-grid)
