### PR TITLE
Store Vanilla version in jekyll config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,5 @@
 name: Vanilla framework documentation
+version: 2.5.0
 
 # Makes pretty (descriptive) permalinks. See Jekyll docs for alternatives.
 permalink: pretty

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ You can use Vanilla in your projects in a few different ways. See [Building with
   <div class="col-12">
     <h3>Hotlink</h3>
     <p>You can add Vanilla directly to your markup:</p>
-    <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-2.5.0.min.css" /&gt;</code></pre>
+    <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-{{ site.version }}.min.css" /&gt;</code></pre>
   </div>
 </div>
 
@@ -45,7 +45,7 @@ You can use Vanilla in your projects in a few different ways. See [Building with
   <div class="col-12">
     <h3>Download</h3>
     <p>Download the latest version of Vanilla from GitHub.</p>
-    <button class="p-button--positive"><a href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v2.5.0.zip">Download v2.5.0</a></button>
+    <button class="p-button--positive"><a href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v{{ site.version }}.zip">Download v{{ site.version }}</a></button>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

Stores latest Vanilla version number in jekyll config to have less places needing updating on 
release.

Also prepares us to being able to inject latest version of Vanilla CSS into CodePen examples.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or https://vanilla-framework-canonical-web-and-design-pr-2703.run.demo.haus/
- Check if hotlink and download instructions are correct for latest version of Vanilla

