### PR TITLE
Remove old path from testing URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 - Pull code
 - Run `./run serve --watch`
-- Open http://0.0.0.0:8101/vanilla-framework/
+- Open http://0.0.0.0:8101/
 - [Add additional steps]
 
 ## Details


### PR DESCRIPTION
## Done

Removed /vanilla-framework/ from test URL as it 404s.

