### PR TITLE
Consistent JS examples in docs

### DIFF
--- a/docs/examples/patterns/accordion.html
+++ b/docs/examples/patterns/accordion.html
@@ -7,7 +7,7 @@ category: _patterns
 <aside class="p-accordion" role="tablist" aria-multiselect="true">
   <ul class="p-accordion__list">
     <li class="p-accordion__group">
-      <button type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="#tab1-section" aria-expanded="true">Advanced topics</button>
+      <button type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="tab1-section" aria-expanded="true">Advanced topics</button>
       <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab1-section">
         <p>Charm bundles</p>
         <p>Machine authentication</p>
@@ -20,7 +20,7 @@ category: _patterns
       </section>
     </li>
     <li class="p-accordion__group">
-      <button type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="#tab2-section" aria-expanded="false">Networking</button>
+      <button type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="tab2-section" aria-expanded="false">Networking</button>
       <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
         <p>Working offline</p>
         <p>Fan container networking</p>
@@ -28,7 +28,7 @@ category: _patterns
       </section>
     </li>
     <li class="p-accordion__group">
-      <button type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="#tab3-section" aria-expanded="false">Miscellaneous</button>
+      <button type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="tab3-section" aria-expanded="false">Miscellaneous</button>
       <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
         <p>Juju GUI</p>
         <p>CentOS support</p>
@@ -40,44 +40,54 @@ category: _patterns
 
 <script>
 /**
-  Attaches event listeners for the accordion open and close click events.
-  @param {String} accordionContainerSelector The selector of the accordion container.
+  Toggles the necessary aria- attributes' values on the accordion panels
+  and handles to show or hide them.
+  @param {HTMLElement} element The tab that acts as the handles.
+  @param {Boolean} show Whether to show or hide the accordion panel.
 */
-function setupAccordionListener(accordionContainerSelector) {
-  /**
-    Toggles the necessary values on the accordion panels and handles to show or
-    hide depending on the supplied values.
-    @param {HTMLElement} element The tab that acts as the handles for the
-      accordion panes.
-    @param {Boolean} show Whether to show or hide the accordion panel.
-  */
-  var toggle = (element, show) => {
+function toggleExpanded(element, show) {
+  var target = document.getElementById(element.getAttribute('aria-controls'));
+
+  if (target) {
     element.setAttribute('aria-expanded', show);
-    document
-      .querySelector(element.getAttribute('aria-controls'))
-      .setAttribute('aria-hidden', !show);
+    target.setAttribute('aria-hidden', !show);
   }
-  // Set up an event listener on the container so that panels can be added
-  // and removed and events do not need to be managed separately.
-  document
-    .querySelector(accordionContainerSelector)
-    .addEventListener('click', e => {
-      var target = e.target;
-      var isTargetOpen = target.getAttribute('aria-expanded') === 'true';
-      // Find any open panels within the container and close them.
-      if (target.classList.contains('p-accordion__tab')) {
-        var openPanels = e.currentTarget
-          .querySelectorAll('[aria-expanded=true]');
-
-        for (var i = 0, l = openPanels.length; i < l; i++) {
-          toggle(openPanels[i], false);
-        }
-
-        // Toggle the target.
-        toggle(target, !isTargetOpen);
-      }
-    });
 }
 
-setupAccordionListener('.p-accordion__list');
+/**
+  Attaches event listeners for the accordion open and close click events.
+  @param {HTMLElement} accordionContainer The accordion container element.
+*/
+function setupAccordion(accordionContainer) {
+  // Finds any open panels within the container and closes them.
+  function closeAllPanels() {
+    var openPanels = accordionContainer
+      .querySelectorAll('[aria-expanded=true]');
+
+    for (var i = 0, l = openPanels.length; i < l; i++) {
+      toggleExpanded(openPanels[i], false);
+    }
+  }
+
+  // Set up an event listener on the container so that panels can be added
+  // and removed and events do not need to be managed separately.
+  accordionContainer.addEventListener('click', function(event) {
+    var target = event.target;
+    var isTargetOpen = target.getAttribute('aria-expanded') === 'true';
+
+    if (target.classList.contains('p-accordion__tab')) {
+      closeAllPanels();
+
+      // Toggle visibility of the target panel.
+      toggleExpanded(target, !isTargetOpen);
+    }
+  });
+}
+
+// Setup all accordions on the page.
+var accordions = document.querySelectorAll('.p-accordion');
+
+for (var i = 0, l = accordions.length; i < l; i++) {
+  setupAccordion(accordions[i]);
+}
 </script>

--- a/docs/examples/patterns/code-copyable.html
+++ b/docs/examples/patterns/code-copyable.html
@@ -11,39 +11,56 @@ redirect_from: "/examples/patterns/code-snippet/"
 </div>
 
 <script>
-  var copyToClipboard = str => {
-    var el = document.createElement('textarea'); // Create a <textarea> element
-    el.value = str; // Set its value to the string that you want copied
-    el.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
-    el.style.position = 'absolute';
-    el.style.left = '-9999px'; // Move outside the screen to make it invisible
-    document.body.appendChild(el); // Append the <textarea> element to the HTML document
-    var selected =
-      document.getSelection().rangeCount > 0 // Check if there is any content selected previously
-        ? document.getSelection().getRangeAt(0) // Store selection if found
-        : false; // Mark as false to know no selection existed before
-    el.select(); // Select the <textarea> content
-    document.execCommand('copy'); // Copy - only works as a result of a user action (e.g. click events)
-    document.body.removeChild(el); // Remove the <textarea> element
-    if (selected) {
-      // If a selection existed before copying
-      document.getSelection().removeAllRanges(); // Unselect everything on the HTML document
-      document.getSelection().addRange(selected); // Restore the original selection
-    }
-  };
+/**
+  Copies text given as a parameter to clipboard.
+  @param {String} str The text value to copy.
+*/
+function copyToClipboard(str) {
+  // Crate an offscreen textarea to handle copying.
+  var copyEl = document.createElement('textarea');
+  copyEl.value = str;
+  copyEl.setAttribute('readonly', '');
+  copyEl.style.position = 'absolute';
+  copyEl.style.left = '-9999px';
+  document.body.appendChild(copyEl);
 
-  var codeCopyableActions = document.querySelectorAll(
-    '.p-code-copyable__action'
-  );
+  // Check for any existing selection range.
+  var selectedRange =
+    document.getSelection().rangeCount > 0
+      ? document.getSelection().getRangeAt(0)
+      : false;
 
-  for (var i = 0; i < codeCopyableActions.length; i++) {
-    codeCopyableActions[i].addEventListener(
-      'click',
-      function(e) {
-        var clipboardValue = this.previousSibling.previousSibling.value;
-        copyToClipboard(clipboardValue);
-      },
-      false
-    );
+  // Select and copy textarea contents.
+  // Copy command only works as a result of a user action (e.g. click events).
+  copyEl.select();
+  document.execCommand('copy');
+
+  document.body.removeChild(copyEl);
+
+  // Restore any previous selection
+  if (selectedRange) {
+    document.getSelection().removeAllRanges();
+    document.getSelection().addRange(selectedRange);
   }
+}
+
+/**
+  Attaches event listener to the copy button
+  @param {HTMLElement} codeCopyable The code copyable container element.
+*/
+function setupCodeCopyable(codeCopyable) {
+  var copyButton = codeCopyable.querySelector('.p-code-copyable__action');
+
+  copyButton.addEventListener('click', function() {
+    var clipboardValue = this.previousSibling.previousSibling.value;
+    copyToClipboard(clipboardValue);
+  });
+}
+
+// Setup all code copyable blocks on the page.
+var codeCopyables = document.querySelectorAll('.p-code-copyable');
+
+for (var i = 0, l = codeCopyables.length; i < l; i++) {
+  setupCodeCopyable(codeCopyables[i]);
+}
 </script>

--- a/docs/examples/patterns/contextual-menu/default.html
+++ b/docs/examples/patterns/contextual-menu/default.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <span class="p-contextual-menu--left">
-    <button href="#" class="p-contextual-menu__toggle" aria-controls="#menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
+    <button href="#" class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
     <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>
@@ -21,7 +21,7 @@ category: _patterns
 </span>
 
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">take action left</a>
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">take action left</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="submenu">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
@@ -35,7 +35,7 @@ category: _patterns
         </span>
     </span>
 </span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center">
-    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
     <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true" aria-label="submenu">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
@@ -49,7 +49,7 @@ category: _patterns
         </span>
     </span>
 </span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu">
-    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
     <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true" aria-label="submenu">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
@@ -65,32 +65,52 @@ category: _patterns
 </span> vel eu.</p>
 
 <script>
+/**
+  Toggles the necessary aria- attributes' values on the menus
+  and handles to show or hide them.
+  @param {HTMLElement} element The menu link or button.
+  @param {Boolean} show Whether to show or hide the menu.
+*/
 function toggleMenu(element, show) {
-  element.setAttribute('aria-expanded', show);
-  document.querySelector(element.getAttribute('aria-controls')).setAttribute('aria-hidden', !show);
+  var target = document.getElementById(element.getAttribute('aria-controls'));
+
+  if (target) {
+    element.setAttribute('aria-expanded', show);
+    target.setAttribute('aria-hidden', !show);
+  }
 }
 
-function initToggle(toggle) {
-  toggle.addEventListener('click', function(e) {
-    e.preventDefault();
-    var target = e.target;
-    var menuAlreadyOpen = toggle.getAttribute('aria-expanded') === 'true';
-    toggleMenu(toggle, !menuAlreadyOpen);
+/**
+  Attaches event listeners for the menu toggle open and close click events.
+  @param {HTMLElement} menuToggle The menu container element.
+*/
+function setupContextualMenu(menuToggle) {
+  menuToggle.addEventListener('click', function(event) {
+    event.preventDefault();
+    var menuAlreadyOpen = menuToggle.getAttribute('aria-expanded') === 'true';
+    toggleMenu(menuToggle, !menuAlreadyOpen);
   });
 }
 
-function setupContextualMenuListeners(contextualMenuToggleSelector) {
+/**
+  Attaches event listeners for all the menu toggles in the document and
+  listeners to handle close when clicking outside the menu or using ESC key.
+  @param {String} contextualMenuToggleSelector The CSS selector matching menu toggle elements.
+*/
+function setupAllContextualMenus(contextualMenuToggleSelector) {
+  // Setup all menu toggles on the page.
   var toggles = document.querySelectorAll(contextualMenuToggleSelector);
 
   for (var i = 0, l = toggles.length; i < l; i++) {
-    initToggle(toggles[i]);
+    setupContextualMenu(toggles[i]);
   }
 
-  document.addEventListener('click', function(e) {
+  // Add handler for clicking outside the menu.
+  document.addEventListener('click', function(event) {
     for (var i = 0, l = toggles.length; i < l; i++) {
       var toggle = toggles[i];
-      var contextualMenu = document.querySelector(toggle.getAttribute('aria-controls'));
-      var clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
+      var contextualMenu = document.getElementById(toggle.getAttribute('aria-controls'));
+      var clickOutside = !(toggle.contains(event.target) || contextualMenu.contains(event.target));
 
       if (clickOutside) {
         toggleMenu(toggle, false);
@@ -98,6 +118,7 @@ function setupContextualMenuListeners(contextualMenuToggleSelector) {
     }
   });
 
+  // Add handler for closing menus using ESC key.
   document.addEventListener('keydown', function(e) {
     e = e || window.event;
 
@@ -109,5 +130,5 @@ function setupContextualMenuListeners(contextualMenuToggleSelector) {
   });
 }
 
-setupContextualMenuListeners('.p-contextual-menu__toggle');
+setupAllContextualMenus('.p-contextual-menu__toggle');
 </script>

--- a/docs/examples/patterns/contextual-menu/with-indicator.html
+++ b/docs/examples/patterns/contextual-menu/with-indicator.html
@@ -5,7 +5,7 @@ category: _patterns
 ---
 
 <span class="p-contextual-menu--left">
-  <button href="#" class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="#menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--contextual-menu is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
+  <button href="#" class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--contextual-menu is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
   <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
     <span class="p-contextual-menu__group">
       <a href="#" class="p-contextual-menu__link">Commission</a>
@@ -20,52 +20,71 @@ category: _patterns
   </span>
 </span>
 
-
-
 <script>
-  function toggleMenu(element, show) {
+/**
+  Toggles the necessary aria- attributes' values on the menus
+  and handles to show or hide them.
+  @param {HTMLElement} element The menu link or button.
+  @param {Boolean} show Whether to show or hide the menu.
+*/
+function toggleMenu(element, show) {
+  var target = document.getElementById(element.getAttribute('aria-controls'));
+
+  if (target) {
     element.setAttribute('aria-expanded', show);
-    document.querySelector(element.getAttribute('aria-controls')).setAttribute('aria-hidden', !show);
+    target.setAttribute('aria-hidden', !show);
+  }
+}
+
+/**
+  Attaches event listeners for the menu toggle open and close click events.
+  @param {HTMLElement} menuToggle The menu container element.
+*/
+function setupContextualMenu(menuToggle) {
+  menuToggle.addEventListener('click', function(event) {
+    event.preventDefault();
+    var menuAlreadyOpen = menuToggle.getAttribute('aria-expanded') === 'true';
+    toggleMenu(menuToggle, !menuAlreadyOpen);
+  });
+}
+
+/**
+  Attaches event listeners for all the menu toggles in the document and
+  listeners to handle close when clicking outside the menu or using ESC key.
+  @param {String} contextualMenuToggleSelector The CSS selector matching menu toggle elements.
+*/
+function setupAllContextualMenus(contextualMenuToggleSelector) {
+  // Setup all menu toggles on the page.
+  var toggles = document.querySelectorAll(contextualMenuToggleSelector);
+
+  for (var i = 0, l = toggles.length; i < l; i++) {
+    setupContextualMenu(toggles[i]);
   }
 
-  function initToggle(toggle) {
-    toggle.addEventListener('click', function(e) {
-      e.preventDefault();
-      var target = e.target;
-      var menuAlreadyOpen = toggle.getAttribute('aria-expanded') === 'true';
-      toggleMenu(toggle, !menuAlreadyOpen);
-    });
-  }
-
-  function setupContextualMenuListeners(contextualMenuToggleSelector) {
-    var toggles = document.querySelectorAll(contextualMenuToggleSelector);
-
+  // Add handler for clicking outside the menu.
+  document.addEventListener('click', function(event) {
     for (var i = 0, l = toggles.length; i < l; i++) {
-      initToggle(toggles[i]);
+      var toggle = toggles[i];
+      var contextualMenu = document.getElementById(toggle.getAttribute('aria-controls'));
+      var clickOutside = !(toggle.contains(event.target) || contextualMenu.contains(event.target));
+
+      if (clickOutside) {
+        toggleMenu(toggle, false);
+      }
     }
+  });
 
-    document.addEventListener('click', function(e) {
+  // Add handler for closing menus using ESC key.
+  document.addEventListener('keydown', function(e) {
+    e = e || window.event;
+
+    if (e.keyCode === 27) {
       for (var i = 0, l = toggles.length; i < l; i++) {
-        var toggle = toggles[i];
-        var contextualMenu = document.querySelector(toggle.getAttribute('aria-controls'));
-        var clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
-
-        if (clickOutside) {
-          toggleMenu(toggle, false);
-        }
+        toggleMenu(toggles[i], false);
       }
-    });
+    }
+  });
+}
 
-    document.addEventListener('keydown', function(e) {
-      e = e || window.event;
-
-      if (e.keyCode === 27) {
-        for (var i = 0, l = toggles.length; i < l; i++) {
-          toggleMenu(toggles[i], false);
-        }
-      }
-    });
-  }
-
-  setupContextualMenuListeners('.p-contextual-menu__toggle');
+setupAllContextualMenus('.p-contextual-menu__toggle');
 </script>

--- a/docs/examples/patterns/list-tree.html
+++ b/docs/examples/patterns/list-tree.html
@@ -33,14 +33,36 @@ category: _patterns
 </ul>
 
 <script>
-  var listTreeToggle = document.querySelectorAll('.p-list-tree__toggle');
-  for (var i = 0; i < listTreeToggle.length; i++) {
-    listTreeToggle[i].addEventListener('click', function(e) {
-      e.preventDefault();
-      var listTree = this.nextElementSibling;
-      var expand = this.getAttribute('aria-expanded') === 'true' ? false : true;
-      this.setAttribute('aria-expanded', expand);
-      listTree.setAttribute('aria-hidden', !expand);
-    });
+/**
+  Toggles the necessary aria- attributes' values on the elements
+  to handle showing and hiding them.
+  @param {HTMLElement} element The toggle element controlling the visibility.
+  @param {Boolean} show Whether to show or hide the target.
+*/
+function toggleElement(element, show) {
+  var target = document.getElementById(element.getAttribute('aria-controls'));
+
+  if (target) {
+    element.setAttribute('aria-expanded', show);
+    target.setAttribute('aria-hidden', !show);
   }
+}
+
+/**
+  Attaches event listeners for the list tree toggle.
+  @param {HTMLElement} listTreeToggle The list tree toggle element.
+*/
+function setupListTreeToggle(listTreeToggle) {
+  listTreeToggle.addEventListener('click', function(event) {
+    event.preventDefault();
+    var expand = this.getAttribute('aria-expanded') === 'true' ? false : true;
+    toggleElement(listTreeToggle, expand);
+  });
+}
+
+// Set up all list trees on the page.
+var listTreeToggles = document.querySelectorAll('.p-list-tree__toggle');
+for (var i = 0, l = listTreeToggles.length; i < l; i++) {
+  setupListTreeToggle(listTreeToggles[i]);
+}
 </script>

--- a/docs/examples/patterns/modal.html
+++ b/docs/examples/patterns/modal.html
@@ -27,20 +27,25 @@ category: _patterns
 </div>
 
 <script>
-  var modalButtons = document.querySelectorAll("[aria-controls]");
-
-  for (var i = 0, l = modalButtons.length; i < l; i++) {
-    modalButtons[i].addEventListener('click', function(event) {
-      var target = event.target.getAttribute('aria-controls');
-      var modal = document.getElementById(target);
-
-      if (modal) {
-        if (modal.style.display === 'none') {
-          modal.style.display = 'flex';
-        } else {
-          modal.style.display = 'none';
-        }
-      }
-    })
+/**
+  Toggles visibility of modal dialog.
+  @param {HTMLElement} modal Modal dialog to show or hide.
+*/
+function toggleModal(modal) {
+  if (modal && modal.classList.contains('p-modal')) {
+    if (modal.style.display === 'none') {
+      modal.style.display = 'flex';
+    } else {
+      modal.style.display = 'none';
+    }
   }
+}
+
+// Add click handler for clicks on elements with aria-controls
+document.addEventListener('click', function(event) {
+  var targetControls = event.target.getAttribute('aria-controls');
+  if (targetControls) {
+    toggleModal(document.getElementById(targetControls));
+  }
+});
 </script>

--- a/docs/examples/patterns/navigation/subnav.html
+++ b/docs/examples/patterns/navigation/subnav.html
@@ -21,8 +21,7 @@ category: _patterns
       </span>
       <ul class="p-navigation__links" role="menu">
         <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
-          <a href="#link-1-menu" class="p-subnav__toggle">LXC</i>
-          </a>
+          <a href="#link-1-menu" aria-controls="link-1-menu" class="p-subnav__toggle">LXC</a>
           <ul class="p-subnav__items" id="link-1-menu" aria-hidden="true">
             <li>
               <a href="#" class="p-subnav__item">Introduction</a>
@@ -36,8 +35,7 @@ category: _patterns
           </ul>
         </li>
         <li class="p-navigation__link p-subnav" role="menuitem" id="link-2">
-          <a href="#link-2-menu" class="p-subnav__toggle">LXD</i>
-          </a>
+          <a href="#link-2-menu" aria-controls="link-2-menu" class="p-subnav__toggle">LXD</a>
           <ul class="p-subnav__items" id="link-2-menu" aria-hidden="true">
             <li>
               <a href="#" class="p-subnav__item">Introduction</a>
@@ -57,7 +55,7 @@ category: _patterns
           </ul>
         </li>
         <li class="p-navigation__link p-subnav" role="menuitem" id="link-3">
-          <a href="#link-3-menu" class="p-subnav__toggle">LXCFS</a>
+          <a href="#link-3-menu" aria-controls="link-3-menu" class="p-subnav__toggle">LXCFS</a>
           <ul class="p-subnav__items" id="link-3-menu" aria-hidden="true">
             <li>
               <a href="#" class="p-subnav__item">Introduction</a>
@@ -73,12 +71,12 @@ category: _patterns
       </ul>
       <ul class="p-navigation__links" role="menu">
         <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
-          <a class="p-subnav__toggle" aria-controls="account-menu" aria-expanded="false">
+          <a class="p-subnav__toggle" aria-controls="account-menu">
             My account
           </a>
           <ul class="p-subnav__items--right" id="account-menu" aria-hidden="true">
             <li>
-              <a href="/logout" class="p-subnav__item">Sign out</a>
+              <a href="#" class="p-subnav__item">Sign out</a>
             </li>
           </ul>
         </li>
@@ -88,64 +86,64 @@ category: _patterns
 </header>
 
 <script>
-var subnavContainers = document.querySelectorAll('[class^="p-subnav__items"]');
-var subnavs = document.querySelectorAll('.p-subnav');
-var subnavToggles = document.querySelectorAll('.p-subnav__toggle');
-
-for (var i = 0, l = subnavToggles.length; i < l; i++) {
-  subnavToggles[i].addEventListener('click', function(event) {
-    event.preventDefault();
-  });
+/**
+  Opens a given subnav by applying is-active class to it
+  and setting aria-hidden attribute on dropdown contents.
+  @param {HTMLElement} subnav Root element of subnavigation to open.
+*/
+function openSubnav(subnav) {
+  subnav.classList.add('is-active');
+  var toggle = subnav.querySelector(".p-subnav__toggle");
+  var dropdown = document.getElementById(toggle.getAttribute('aria-controls'));
+  dropdown.setAttribute('aria-hidden', 'true');
 }
 
-for (i = 0, l = subnavs.length; i < l; i++) {
-  subnavs[i].addEventListener('click', function(event) {
+/**
+  Closes a given subnav by removing is-active class to it
+  and setting aria-hidden attribute on dropdown contents.
+  @param {HTMLElement} subnav Root element of subnavigation to open.
+*/
+function closeSubnav(subnav) {
+  subnav.classList.remove('is-active');
+  var toggle = subnav.querySelector(".p-subnav__toggle");
+  var dropdown = document.getElementById(toggle.getAttribute('aria-controls'));
+  dropdown.setAttribute('aria-hidden', 'false');
+}
+
+/**
+  Closes all subnavs on the page.
+*/
+function closeAllSubnavs() {
+  var subnavs = document.querySelectorAll('.p-subnav');
+  for (var i = 0, l = subnavs.length; i < l; i++) {
+    closeSubnav(subnavs[i]);
+  }
+}
+
+/**
+  Attaches click event listener to subnav toggle.
+  @param {HTMLElement} subnavToggle Toggle element of subnavigation.
+*/
+function setupSubnavToggle(subnavToggle) {
+  subnavToggle.addEventListener('click', function(event) {
+    event.preventDefault();
     event.stopPropagation();
 
-    var clickedDropdown = this;
+    var subnav = subnavToggle.parentElement;
+    var isActive = subnav.classList.contains('is-active');
 
-    for (var i = 0, l = subnavs.length; i < l; i++) {
-      var subnav = subnavs[i];
-      var subnavContent = subnav.querySelector('[class^="p-subnav__items"]');
-      if (subnav === clickedDropdown) {
-        if (subnav.classList.contains('is-active')) {
-          closeSubnav(subnav, subnavContent);
-        } else {
-          openSubnav(subnav, subnavContent);
-        }
-      } else {
-        closeSubnav(subnav, subnavContent);
-      }
+    closeAllSubnavs();
+    if (!isActive) {
+      openSubnav(subnav);
     }
   });
 }
 
-function openSubnav(subnav, subnavContent) {
-  subnav.classList.add('is-active');
-  showElement(subnavContent);
-}
+// Setup all subnav toggles on the page
+var subnavToggles = document.querySelectorAll('.p-subnav__toggle');
 
-function closeSubnav(subnav, dropdownContent) {
-  subnav.classList.remove('is-active');
-  hideElement(dropdownContent);
-}
-
-function closeAllSubnavs() {
-  for (var i = 0, l = subnavs.length; i < l; i++) {
-    subnavs[i].classList.remove('is-active');
-  }
-
-  for (i = 0, l = subnavContainers.length; i < l; i++) {
-    subnavs[i].classList.remove('is-active');
-  }
-}
-
-function hideElement(element) {
-  element.setAttribute('aria-hidden', 'true');
-}
-
-function showElement(element) {
-  element.setAttribute('aria-hidden', 'false');
+for (var i = 0, l = subnavToggles.length; i < l; i++) {
+  setupSubnavToggle(subnavToggles[i]);
 }
 
 // Close all menus if anything else on the page is clicked
@@ -160,7 +158,12 @@ document.addEventListener('click', function(event) {
     // IE friendly `Element.closest` equivalent
     // as in https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
     do {
-      if (target.msMatchesSelector('.p-subnav__toggle') || target.msMatchesSelector('.p-subnav__item')) return;
+      if (
+        target.msMatchesSelector('.p-subnav__toggle') ||
+        target.msMatchesSelector('.p-subnav__item')
+      ) {
+        return;
+      }
       target = target.parentElement || target.parentNode;
     } while (target !== null && target.nodeType === 1);
 

--- a/docs/examples/patterns/notifications/notifications.html
+++ b/docs/examples/patterns/notifications/notifications.html
@@ -12,16 +12,25 @@ category: _patterns
 </div>
 
 <script>
-  var closeButtons = document.querySelectorAll('.p-notification [aria-controls]');
+/**
+  Attaches event listener for hide notification on close button click.
+  @param {HTMLElement} closeButton The notification close button element.
+*/
+function setupCloseButton(closeButton) {
+  closeButton.addEventListener('click', function(event) {
+    var target = event.target.getAttribute('aria-controls');
+    var notification = document.getElementById(target);
 
-  for (var i = 0, l = closeButtons.length; i < l; i++) {
-    closeButtons[i].addEventListener('click', function(event) {
-      var target = event.target.getAttribute('aria-controls');
-      var notification = document.getElementById(target);
+    if (notification) {
+      notification.classList.add('u-hide');
+    }
+  });
+}
 
-      if (notification) {
-        notification.style.display = 'none';
-      }
-    });
-  }
+// Set up all notification close buttons.
+var closeButtons = document.querySelectorAll('.p-notification [aria-controls]');
+
+for (var i = 0, l = closeButtons.length; i < l; i++) {
+  setupCloseButton(closeButtons[i]);
+}
 </script>

--- a/docs/examples/patterns/slider/slider-input.html
+++ b/docs/examples/patterns/slider/slider-input.html
@@ -14,60 +14,67 @@ category: _patterns
 </div>
 
 <script>
-  (function() {
+var isWebkit =
+  /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
+var isIE = /NET/i.test(navigator.userAgent);
 
-    function equaliseValues(receive, give) {
-      receive.value = give.value;
-      give.value = receive.value;
-    }
+var PROGRESS_COLOUR = '#335280';
+var EMPTY_COLOUR = '#fff';
 
-    // Fix for Chrome and Safari as they don't support CSS slider progress
-    function renderSlider(slider, progressColour, emptyColour) {
-      if (browser === 'Chrome' || browser === 'Safari') {
-        var value = (slider.value - slider.min) / (slider.max - slider.min);
-        slider.style.backgroundImage = '-webkit-gradient(linear, left top, right top, color-stop('
-        + value + ', ' + progressColour + '), color-stop(' + value + ', ' + emptyColour + '))';
+/**
+ Renders gradient to fake progress color in webkit browsers.
+ @param {HTMLElement} slider Slider element to render background on.
+*/
+function renderSlider(slider) {
+  if (isWebkit) {
+    var value = (slider.value - slider.min) / (slider.max - slider.min);
+    slider.style.backgroundImage = (
+      '-webkit-gradient(linear, left top, right top, color-stop('
+      + value + ', ' + PROGRESS_COLOUR + '), color-stop('
+      + value + ', ' + EMPTY_COLOUR + '))'
+    );
+  }
+}
+
+function equaliseValues(receive, give) {
+  receive.value = give.value;
+  give.value = receive.value;
+}
+
+/**
+  Attaches change listener to sliders to update their background color.
+  @param {HTMLElement} slider Slider element to render background on.
+*/
+function initSlider(slider) {
+  var input = document.getElementById(slider.id + '-input');
+  renderSlider(slider);
+
+  if (input) {
+    // Synchronise values of input and slider
+    equaliseValues(input, slider);
+    input.addEventListener('input', function() {
+      if (!input.value) {
+        input.value = 0;
       }
+      equaliseValues(slider, input);
+      renderSlider(slider);
+    });
+  }
+
+  // Attach change listener to slider to update input value
+  // Fix for IE as it doesn't support 'oninput'
+  slider.addEventListener(isIE ? 'change' : 'input', function() {
+    if (input) {
+      equaliseValues(input, slider);
     }
+    renderSlider(slider);
+  });
+}
 
-    function initSlider(slider) {
-      var input = document.getElementById(slider.id + '-input');
-      renderSlider(slider, progressColour, emptyColour);
+// Setup all sliders on the page.
+var sliders = document.querySelectorAll('.p-slider');
 
-      if (input) {
-        equaliseValues(input, slider);
-        input.addEventListener('input', function() {
-          if (!input.value) input.value = 0;
-          equaliseValues(slider, input);
-          renderSlider(slider, progressColour, emptyColour);
-        });
-      }
-
-      // Fix for IE as it doesn't support 'oninput'
-      if (browser === 'IE') {
-        slider.onchange = function() {
-          if (input) equaliseValues(input, slider)
-        }
-      } else {
-        slider.oninput = function() {
-          if (input) equaliseValues(input, slider);
-          renderSlider(slider, progressColour, emptyColour);
-        }
-      }
-    }
-
-    var browser;
-    /Edge/i.test(navigator.userAgent) ? browser = 'Edge' :
-    /Chrome/i.test(navigator.userAgent) ? browser = 'Chrome' :
-    /Safari/i.test(navigator.userAgent) ? browser = 'Safari' :
-    /NET/i.test(navigator.userAgent) ? browser = 'IE' :
-    browser = 'Other';
-    var progressColour = '#335280';
-    var emptyColour = '#fff';
-    var sliders = document.querySelectorAll('.p-slider');
-
-    for (var i = 0, l = sliders.length; i < l; i++) {
-      initSlider(sliders[i]);
-    }
-  })();
+for (var i = 0, l = sliders.length; i < l; i++) {
+  initSlider(sliders[i]);
+}
 </script>

--- a/docs/examples/patterns/slider/slider.html
+++ b/docs/examples/patterns/slider/slider.html
@@ -8,38 +8,45 @@ category: _patterns
 <input class="p-slider" type="range" min="0" max="100" value="50" step="1" id="slider2" disabled>
 
 <script>
-  (function() {
+var isWebkit =
+  /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
+var PROGRESS_COLOUR = '#335280';
+var EMPTY_COLOUR = '#fff';
 
-    // Fix for Chrome and Safari as they don't support CSS slider progress
-    function renderSlider(slider, progressColour, emptyColour) {
-      if (browser === 'Chrome' || browser === 'Safari') {
-        var value = (slider.value - slider.min) / (slider.max - slider.min);
-        slider.style.backgroundImage = '-webkit-gradient(linear, left top, right top, color-stop('
-        + value + ', ' + progressColour + '), color-stop(' + value + ', ' + emptyColour + '))';
-      }
-    }
+/**
+ Renders gradient to fake progress color in webkit browsers.
+ @param {HTMLElement} slider Slider element to render background on.
+*/
+function renderSlider(slider) {
+  if (isWebkit) {
+    var value = (slider.value - slider.min) / (slider.max - slider.min);
+    slider.style.backgroundImage = (
+      '-webkit-gradient(linear, left top, right top, color-stop('
+      + value + ', ' + PROGRESS_COLOUR + '), color-stop('
+      + value + ', ' + EMPTY_COLOUR + '))'
+    );
+  }
+}
 
-    function initSlider(slider) {
-      renderSlider(slider, progressColour, emptyColour);
+/**
+  Attaches change listener to sliders to update their background color.
+  @param {HTMLElement} slider Slider element to render background on.
+*/
+function initSlider(slider) {
+  renderSlider(slider);
 
-      slider.addEventListener('input', function() {
-        renderSlider(slider, progressColour, emptyColour);
-      });
-    }
+  slider.addEventListener('input', function() {
+    renderSlider(slider);
+  });
+}
 
-    var browser;
-    /Edge/i.test(navigator.userAgent) ? browser = 'Edge' :
-    /Chrome/i.test(navigator.userAgent) ? browser = 'Chrome' :
-    /Safari/i.test(navigator.userAgent) ? browser = 'Safari' :
-    /NET/i.test(navigator.userAgent) ? browser = 'IE' :
-    browser = 'Other';
+// Fix for Chrome and Safari as they don't support CSS slider progress
+if (isWebkit) {
+  // Setup all sliders on the page.
+  var sliders = document.querySelectorAll('.p-slider');
 
-    var progressColour = '#335280';
-    var emptyColour = '#fff';
-    var sliders = document.querySelectorAll('.p-slider');
-
-    for (var i = 0, l = sliders.length; i < l; i++) {
-      initSlider(sliders[i]);
-    }
-  })();
+  for (var i = 0, l = sliders.length; i < l; i++) {
+    initSlider(sliders[i]);
+  }
+}
 </script>

--- a/docs/examples/patterns/tables/table-expanding.html
+++ b/docs/examples/patterns/tables/table-expanding.html
@@ -26,7 +26,7 @@ category: _patterns
             <td role="gridcell" aria-label="Units">karura</td>
             <td role="gridcell" aria-label="Units">Thu, 25 Oct. 2018 13:55:21</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle is-dense" aria-controls="#expanded-row" aria-expanded="false" data-shown-text="Hide"
+                <button class="u-toggle is-dense" aria-controls="expanded-row" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row" class="p-table-expanding__panel" aria-hidden="true">
@@ -47,7 +47,7 @@ category: _patterns
             <td role="gridcell" aria-label="Units">karura</td>
             <td role="gridcell" aria-label="Units">Wed, 3 Oct. 2018 23:08:06</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle is-dense" aria-controls="#expanded-row-2" aria-expanded="false" data-shown-text="Hide"
+                <button class="u-toggle is-dense" aria-controls="expanded-row-2" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-2" class="p-table-expanding__panel" aria-hidden="true">
@@ -68,7 +68,7 @@ category: _patterns
             <td role="gridcell" aria-label="Units">karura</td>
             <td role="gridcell" aria-label="Units">Wed, 17 Oct. 2018 12:18:18</td>
             <td role="gridcell" class="u-align--right">
-                <button class="u-toggle is-dense" aria-controls="#expanded-row-3" aria-expanded="false" data-shown-text="Hide"
+                <button class="u-toggle is-dense" aria-controls="expanded-row-3" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-3" class="p-table-expanding__panel" aria-hidden="true">
@@ -86,49 +86,51 @@ category: _patterns
 </table>
 
 <script>
-    (function () {
-        /**
-         * Toggle target elements with aria controls, hidden and expanded
-         *
-         * @param {String} toggleCtrl
-         *
-         * @example
-         * <button class="u-toggle" aria-controls="#menu" aria-expanded="false">Toggle</button>
-         * <div id="menu" aria-hidden="true">
-         *     <p>Example menu</p>
-         * </div>
-         */
+/**
+  Toggles the necessary aria- attributes' values on the table panels
+  to show or hide them.
+  @param {HTMLElement} element The tab that acts as the handles.
+  @param {Boolean} show Whether to show or hide the expanded row panel.
+*/
+function toggleExpanded(element, show) {
+  var target = document.getElementById(element.getAttribute('aria-controls'));
 
-        function toggle(toggleCtrl) {
+  if (target) {
+    element.setAttribute('aria-expanded', show);
 
-            // Select all toggle control elements
-            var t = document.querySelectorAll(toggleCtrl);
+    // Adjust the text of the toggle button
+    if (show) {
+      element.innerHTML = element.getAttribute('data-shown-text');
+    } else {
+      element.innerHTML = element.getAttribute('data-hidden-text');
+    }
 
-            // Loop through all toggle control elements
-            for (i = 0; i < t.length; i++) {
+    target.setAttribute('aria-hidden', !show);
+  }
+}
 
-                // Set click event to each toggle control element
-                t[i].addEventListener('click', function (event) {
+/**
+  Attaches event listeners for the expandable table open and close click events.
+  @param {HTMLElement} table The expandable table container element.
+*/
+function setupExpandableTable(table) {
+  // Set up an event listener on the container so that panels can be added
+  // and removed and events do not need to be managed separately.
+  table.addEventListener('click', function(event) {
+    var target = event.target;
+    var isTargetOpen = target.getAttribute('aria-expanded') === 'true';
 
-                    // Get toggle aria-control target
-                    var target = document.querySelector(
-                        this.getAttribute('aria-controls'));
+    if (target.classList.contains('u-toggle')) {
+      // Toggle visibility of the target panel.
+      toggleExpanded(target, !isTargetOpen);
+    }
+  });
+}
 
-                    // If target hidden is already true set to fale and toggle
-                    // control expanded to be true / false
-                    if (target.getAttributeNode("aria-hidden").value == 'true') {
-                        this.setAttribute('aria-expanded', 'true');
-                        this.innerHTML = this.getAttribute('data-shown-text');
-                        target.setAttribute('aria-hidden', 'false');
-                    } else {
-                        this.setAttribute('aria-expanded', 'false');
-                        this.innerHTML = this.getAttribute('data-hidden-text');
-                        target.setAttribute('aria-hidden', 'true');
-                    }
-                });
-            }
-        }
+// Setup all expandable tables on the page.
+var tables = document.querySelectorAll('.p-table-expanding');
 
-        toggle('.u-toggle');
-    })()
+for (var i = 0, l = tables.length; i < l; i++) {
+  setupExpandableTable(tables[i]);
+}
 </script>

--- a/docs/examples/patterns/tables/table-sortable.html
+++ b/docs/examples/patterns/tables/table-sortable.html
@@ -36,117 +36,103 @@ category: _patterns
 </table>
 
 <script>
-  (function () {
-    /**
-     * Sort a table by the column specified.
-     *
-     * @param {HTMLTableElement} table
-     * @param {Number} col
-     */
-    function sortTable(table, col) {
-      // For readability set the scope to the header.
-      var header = this;
+/**
+ * Sorts a table by the column specified.
+ * @param {HTMLElement} header Sortable header element that was clicked.
+ * @param {HTMLTableElement} table Table to sort.
+ */
+function sortTable(header, table) {
+  var SORTABLE_STATES = {
+    none: 0,
+    ascending: -1,
+    descending: 1,
+    ORDER: ['none', 'ascending', 'descending']
+  };
 
-      // Helper 'contant'.
-      var SORTABLE_STATES = {
-        none: 0,
-        ascending: -1,
-        descending: 1,
-        ORDER: ['none', 'ascending', 'descending']
-      };
+  // Get index of column based on position of header cell in <thead>
+  // We assume there is only one row in the table head.
+  var col = [].slice.call(table.tHead.rows[0].cells).indexOf(header);
 
-      // Based on the current aria-sort, get the next state.
-      var newOrder = SORTABLE_STATES.ORDER.indexOf(header.getAttribute('aria-sort')) + 1;
-      newOrder = newOrder > SORTABLE_STATES.ORDER.length - 1 ? 0 : newOrder;
-      newOrder = SORTABLE_STATES.ORDER[newOrder];
-      var currentSort = table.querySelectorAll('[aria-sort]');
+  // Based on the current aria-sort value, get the next state.
+  var newOrder = SORTABLE_STATES.ORDER.indexOf(header.getAttribute('aria-sort')) + 1;
+  newOrder = newOrder > SORTABLE_STATES.ORDER.length - 1 ? 0 : newOrder;
+  newOrder = SORTABLE_STATES.ORDER[newOrder];
 
-      // Reset all header sorts.
-      for (var i = 0, ii = currentSort.length; i < ii; i += 1) {
-        currentSort[i].setAttribute('aria-sort', 'none');
-      }
+  // Reset all header sorts.
+  var headerSorts = table.querySelectorAll('[aria-sort]');
 
-      // Set the new header sort.
-      header.setAttribute('aria-sort', newOrder);
+  for (var i = 0, ii = headerSorts.length; i < ii; i += 1) {
+    headerSorts[i].setAttribute('aria-sort', 'none');
+  }
 
-      // Get the direction of the sort and assume only one tbody.
-      // For this example only assume one tbody.
-      var direction = SORTABLE_STATES[newOrder];
-      var body = table.tBodies[0];
+  // Set the new header sort.
+  header.setAttribute('aria-sort', newOrder);
 
-      // Convert the HTML element list to an array.
-      var newRows = Array.prototype.slice.call(body.rows, 0);
+  // Get the direction of the sort and assume only one tbody.
+  // For this example only assume one tbody.
+  var direction = SORTABLE_STATES[newOrder];
+  var body = table.tBodies[0];
 
-      // If the direction is 0 - aria-sort="none".
-      if (direction === 0) {
-        // Reset to the default order.
-        newRows.sort(function (a, b) {
-          return a.getAttribute('data-index') - b.getAttribute('data-index');
-        });
-      } else {
-        newRows.sort(function (a, b) {
-          // Trim the cell contents.
-          var c = a.cells[col].textContent.trim();
-          var d = b.cells[col].textContent.trim();
+  // Convert the HTML element list to an array.
+  var newRows = Array.prototype.slice.call(body.rows, 0);
 
-          // If the content contains a number, parse it as a number.
-          // This is very crude and should not be considered production ready.
-          if (c.replace(/[^0-9]/gi, '') !== '' && !isNaN(c.replace(/[^0-9]/gi, ''))) {
-            c = parseInt(c.replace(/[^0-9]/gi, ''));
-            // Ascending for numbers and the alphabet are opposite.
-            direction *= -1;
-          }
-          if (d.replace(/[^0-9]/gi, '') !== '' && !isNaN(d.replace(/[^0-9]/gi, ''))) {
-            d = parseInt(d.replace(/[^0-9]/gi, ''));
-            // Ascending for numbers and the alphabet are opposite.
-            direction *= -1;
-          }
+  // If the direction is 0 - aria-sort="none".
+  if (direction === 0) {
+    // Reset to the default order.
+    newRows.sort(function (a, b) {
+      return a.getAttribute('data-index') - b.getAttribute('data-index');
+    });
+  } else {
+    // Sort based on a cell contents
+    newRows.sort(function (rowA, rowB) {
+      // Trim the cell contents.
+      var contentA = rowA.cells[col].textContent.trim();
+      var contentB = rowB.cells[col].textContent.trim();
 
-          // Based on the direction, do the sort.
-          if (direction === 1) {
-            return d - c;
-          } else {
-            return c - d;
-          }
-        });
-      }
-      // Append each row into the table, replacing the current elements.
-      for (var i = 0, ii = body.rows.length; i < ii; i += 1) {
-        body.appendChild(newRows[i]);
-      }
-    }
+      // Based on the direction, do the sort.
+      //
+      // This example only sorts based on alphabetical order, to sort based on
+      // number value a more specific implementation would be needed, to provide
+      // number parsing and comparison function between text strings and numbers.
+      return contentA < contentB ? direction : -direction;
+    });
+  }
+  // Append each row into the table, replacing the current elements.
+  for (i = 0, ii = body.rows.length; i < ii; i += 1) {
+    body.appendChild(newRows[i]);
+  }
+}
 
-    /**
-     * Create a sortable table from a table.
-     * @param {HTMLTableElement} table
-     */
-    function createSortableTable(table) {
-      // Select sortable column headers.
-      var clickableHeaders = table.querySelectorAll('th[aria-sort]');
-      // For this example, assume only one tbody.
-      var rows = table.tBodies[0].rows;
-      // Set an index for the default order.
-      for (var row = 0, totalRows = rows.length; row < totalRows; row += 1) {
-        rows[row].setAttribute('data-index', row);
-      }
+function setupClickableHeader(table, header) {
+  header.addEventListener('click', function() {
+    sortTable(header, table);
+  });
+}
 
-      // Attach the click event for each header.
-      for (var i = 0, ii = clickableHeaders.length; i < ii; i += 1) {
-        // Ensure we bind the event to the header and pass the table and column.
-        clickableHeaders[i].addEventListener('click', sortTable.bind(clickableHeaders[i], table, i));
-      }
-    }
+/**
+ * Initializes a sortable table by assigning event listeners to sortable column headers.
+ * @param {HTMLTableElement} table
+ */
+function setupSortableTable(table) {
+  // For this example, assume only one tbody.
+  var rows = table.tBodies[0].rows;
+  // Set an index for the default order.
+  for (var row = 0, totalRows = rows.length; row < totalRows; row += 1) {
+    rows[row].setAttribute('data-index', row);
+  }
 
-    /**
-     * Make all --sortable tables on the page sortable.
-     */
-    function createSortableTables() {
-      var tables = document.querySelectorAll('table.p-table--sortable');
-      for (var i = 0, ii = tables.length; i < ii; i += 1) {
-        createSortableTable(tables[i]);
-      }
-    }
+  // Select sortable column headers.
+  var clickableHeaders = table.querySelectorAll('th[aria-sort]');
+  // Attach the click event for each header.
+  for (var i = 0, ii = clickableHeaders.length; i < ii; i += 1) {
+    setupClickableHeader(table, clickableHeaders[i]);
+  }
+}
 
-    createSortableTables();
-  })()
+// Make all --sortable tables on the page sortable.
+var tables = document.querySelectorAll('table.p-table--sortable');
+
+for (var i = 0, ii = tables.length; i < ii; i += 1) {
+  setupSortableTable(tables[i]);
+}
 </script>

--- a/docs/examples/utilities/baseline-grid.html
+++ b/docs/examples/utilities/baseline-grid.html
@@ -4,7 +4,7 @@ title: Baseline grid
 category: _utilities
 ---
 
-<div class="u-baseline-grid">
+<div class="u-baseline-grid" id="baseline">
   <h1>Heading one</h1>
   <h2>Heading two</h2>
   <h3>Heading three</h3>
@@ -12,18 +12,33 @@ category: _utilities
   <h5>Heading five</h5>
   <h6>Heading six</h6>
   <label>
-    <input type="checkbox" class="p-switch" checked />
+    <input type="checkbox" class="p-switch" checked aria-controls="baseline" />
     <div class="p-switch__slider"></div>
   </label>
 </div>
 
 <script>
-  document.addEventListener('DOMContentLoaded', function() {
-    var target = document.querySelector('.u-baseline-grid');
-    var toggle = document.querySelector('.p-switch');
+/**
+  Attaches event listener to switch baseline grid visibility on click.
+  @param {HTMLElement} toggle Switch element to toggle baseline grid.
+*/
+function setupBaselineGridSwitch(toggle) {
+  var target = toggle.getAttribute('aria-controls');
 
-    toggle.addEventListener('click', function (event) {
+  if (target) {
+    target = document.getElementById(target);
+  }
+
+  if (target) {
+    toggle.addEventListener('click', function () {
       target.classList.toggle('u-baseline-grid');
     });
-  });
+  }
+}
+
+// Set up switch element on page
+var toggle = document.querySelector('.p-switch[aria-controls]');
+if (toggle) {
+  setupBaselineGridSwitch(toggle);
+}
 </script>


### PR DESCRIPTION
## Done

Fixes #2700 

Makes JS code of the examples more consistent in terms of:
- making sure JS it attached to all instances of components on the page
- making sure JS doesn't error if there is no given pattern on the page
- giving all JS examples similar structure of functions
- making sure JS uses `aria-` attributes where applicable

Affected examples:

- accordion
- code copyable
- contextual menu
- list tree
- modal
- notification
- baseline grid
- table expanding
- slider
- sortable table
- subnav

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or demo https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/
- Make sure all the example pages work without errors in the console
  - [x] [/examples/patterns/accordion/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/accordion/)
  - [x] [/examples/patterns/code-copyable/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/code-copyable/)
  - [x] [/examples/patterns/contextual-menu/default/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/contextual-menu/default/)
  - [x] [/examples/patterns/contextual-menu/with-indicator/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/contextual-menu/with-indicator/)
  - [x] [/examples/patterns/list-tree/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/list-tree/)
  - [x] [/examples/patterns/modal/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/modal/)
  - [x] [/examples/patterns/navigation/subnav/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/navigation/subnav/)
  - [x] [/examples/patterns/notifications/notifications/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/notifications/notifications/)
  - [x] [/examples/patterns/slider/slider/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/slider/slider/)
  - [x] [/examples/patterns/slider/slider-input/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/slider/slider-input/)
  - [x] [/examples/patterns/tables/table-expanding/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/tables/table-expanding/)
  - [x] [/examples/patterns/tables/table-sortable/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/patterns/tables/table-sortable/)
  - [x] [/examples/utilities/baseline-grid/](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/examples/utilities/baseline-grid/)
- Make sure all the examples work in docs (CodePen)
  - [x] [Code copyable](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/base/code/)
  - [x] [Tables (expandable and sortable)](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/base/tables/)
  - [x] [Accordion](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/patterns/accordion/)
  - [x] [Contextual menu (default and with indicator)](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/patterns/contextual-menu/)
  - [x] [List tree](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/patterns/list-tree/)
  - [x] [Modal](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/patterns/modal/)
  - [x] [Sub navigation](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/patterns/navigation/)
  - [x] [Notifications](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/patterns/notification/)
  - [x] [Slider (default and with input)](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/patterns/slider/)
  - [x] [Baseline grid](https://vanilla-framework-canonical-web-and-design-pr-2707.run.demo.haus/utilities/baseline-grid/)


