### PR TITLE
Fix :visited link styles in subnav

### DIFF
--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -136,7 +136,8 @@
 
     &,
     &:active,
-    &:focus &:visited {
+    &:focus,
+    &:visited {
       color: $colors--light-theme--text-default;
     }
 
@@ -157,7 +158,8 @@
 
     &,
     &:active,
-    &:focus &:visited {
+    &:focus,
+    &:visited {
       color: $colors--dark-theme--text-default;
     }
 


### PR DESCRIPTION
## Done

Fixes selector for :focus and :visited links in subnav to give them correct colour.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or demo https://vanilla-framework-canonical-web-and-design-pr-2708.run.demo.haus/
- Open subnav examples [/examples/patterns/navigation/subnav/]( https://vanilla-framework-canonical-web-and-design-pr-2708.run.demo.haus/examples/patterns/navigation/subnav/)
- Click on links in the dropdowns
- Make sure their colour is black even when visited (they shouldn't use visited blue link colour)

<img width="1321" alt="Screenshot 2019-12-18 at 16 46 19" src="https://user-images.githubusercontent.com/83575/71100817-f287ba80-21b5-11ea-95a5-fbd46a4ad786.png">
