### PR TITLE
Fix code-copyable (#2690)

### DIFF
--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -36,6 +36,8 @@ $cc-button-size: 36px;
     color: $color-mid-dark;
     font-family: unquote($font-monospace);
     line-height: map-get($line-heights, default-text);
+    margin-bottom: 0;
+    margin-top: 0;
     padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 $sph-inner * 1.5;
     width: 100%;
   }


### PR DESCRIPTION
## Done
Exploicitly set margin top and bottom of the input in code-copyable to 0, as safari is adding 2px.

## QA
- Pull code
- Run `./run serve --watch`
- Open /examples/patterns/code-copyable/
- Verify no gap appearsa above/beneath button

## Details
Fixes #2690 

## Screenshots
![image](https://user-images.githubusercontent.com/2741678/71827088-5e639180-3097-11ea-98fa-21a95770b668.png)

