### PR TITLE
Install bundler@1 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - '10.15.3'
 before_install:
   - rvm install 2.4.0
+  # specifically install bundler 1.16.6 (as per Gemfile)
+  - gem install bundler:1.16.6
 install:
   - gem install percy-cli
   - gem install sass


### PR DESCRIPTION
## Done

Making sure bundler v.1.16.6 is installed on travis to make the builds run properly.

Since the end of December builds on Travis were (kind of randomly) [failing](https://travis-ci.org/canonical-web-and-design/vanilla-framework/builds/633315089) with

```
/home/travis/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems.rb:275:in `find_spec_for_exe': Could not find 'bundler' (1.16.6) required by your /home/travis/build/canonical-web-and-design/vanilla-framework/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.16.6`
```

This PR makes sure that bundler 1.16.6 (version used in Gemfile) is installed in travis.

## QA

- Check if travis builds pass

## Details

https://docs.travis-ci.com/user/languages/ruby/
