### PR TITLE
Fix Firefox issues with component status table

### DIFF
--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -11,7 +11,7 @@ When we add, make significant updates, or deprecate a component we update their 
 
 ### Current status
 
-<table style="margin-bottom: 1rem;">
+<table>
   <thead>
     <tr>
       <th style="width: 25%">Component</th>


### PR DESCRIPTION
## Done

Removed unnecessary inline margin from the table, that was causing weird spacing issues in Firefox (and Percy).

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2733.run.demo.haus/)
- Go to [Component Status](https://vanilla-framework-canonical-web-and-design-pr-2733.run.demo.haus/component-status/) page in Firefox
- Reload couple of times, spacing should not change in the table between reloads
- Make sure percy doesn't complain about this page anymore

