### PR TITLE
Remove unnecessary margin

### DIFF
--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -36,7 +36,7 @@ When we add, make significant updates, or deprecate a component we update their 
 
 #### Previously in Vanilla 2.5
 
-<table style="margin-bottom: 1rem;">
+<table>
   <thead>
     <tr>
       <th style="width: 25%">Component</th>


### PR DESCRIPTION
## Done

Follow up to #2733
Removes inline margin from another table as well that was forgot during merge.


## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2738.run.demo.haus/)
- Go to [components status page](https://vanilla-framework-canonical-web-and-design-pr-2738.run.demo.haus/component-status/)
- There should be no inline margin on tables

