### PR TITLE
Use node 12 in image build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 10
+  - 12
 before_install:
   - rvm install 2.4.0
   # specifically install bundler 1.16.6 (as per Gemfile)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:10-slim AS yarn-dependencies
+FROM node:12-slim AS yarn-dependencies
 WORKDIR /srv
 ADD package.json package.json
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install


### PR DESCRIPTION
Node 12 is LTS, and it's used in the run script

## QA

``` bash
DOCKER_BUILDKIT=1 docker build --tag docs.vanillaframework.io .
docker run -ti -p 8177:80 docs.vanillaframework.io
```

Go to http://localhost:8177, see the site