### PR TITLE
Encapsulate pagination

### DIFF
--- a/docs/_includes/patterns/article-pagination.html
+++ b/docs/_includes/patterns/article-pagination.html
@@ -1,0 +1,10 @@
+<footer class="p-article-pagination">
+  <a class="p-article-pagination__link--previous" href="#previous">
+    <span class="p-article-pagination__label">Previous</span>
+    <span class="p-article-pagination__title">Lorem ipsum dolor sit amet</span>
+  </a>
+  <a class="p-article-pagination__link--next" href="#next">
+    <span class="p-article-pagination__label">Next</span>
+    <span class="p-article-pagination__title">Consectetur adipisicing elit</span>
+  </a>
+</footer>

--- a/docs/_includes/patterns/pagination/pagination-disabled.html
+++ b/docs/_includes/patterns/pagination/pagination-disabled.html
@@ -1,0 +1,23 @@
+<ol class="p-pagination">
+  <li class="p-pagination__item">
+    <span class="p-pagination__link--previous is-disabled"><i class="p-icon--contextual-menu">Previous page</i></span>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link is-active" href="#1">1</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#2">2</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#3">3</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#4">4</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#5">5</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
+  </li>
+</ol>

--- a/docs/_includes/patterns/pagination/pagination-truncated.html
+++ b/docs/_includes/patterns/pagination/pagination-truncated.html
@@ -1,0 +1,29 @@
+<ol class="p-pagination">
+  <li class="p-pagination__item">
+    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--contextual-menu">Previous page</i></a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#1">1</a>
+  </li>
+  <li class="p-pagination__item p-pagination__item--truncation">
+    &hellip;
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#33">33</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link is-active" href="#34">34</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#35">35</a>
+  </li>
+  <li class="p-pagination__item p-pagination__item--truncation">
+    &hellip;
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#7">100</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
+  </li>
+</ol>

--- a/docs/_includes/patterns/pagination/pagination.html
+++ b/docs/_includes/patterns/pagination/pagination.html
@@ -1,0 +1,23 @@
+<ol class="p-pagination">
+  <li class="p-pagination__item">
+    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--contextual-menu">Previous page</i></a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#1">1</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#2">2</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link is-active" href="#3">3</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#4">4</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link" href="#5">5</a>
+  </li>
+  <li class="p-pagination__item">
+    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
+  </li>
+</ol>

--- a/docs/examples/individual/article-pagination.html
+++ b/docs/examples/individual/article-pagination.html
@@ -2,6 +2,7 @@
 layout: examples
 title: Article pagination
 category: _patterns
+individual: patterns_article-pagination
 ---
 
 {% include patterns/article-pagination.html %}

--- a/docs/examples/individual/pagination/pagination-disabled.html
+++ b/docs/examples/individual/pagination/pagination-disabled.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Pagination / Disabled
+category: _patterns
+individual: patterns_pagination
+---
+
+{% include patterns/pagination/pagination-disabled.html %}

--- a/docs/examples/individual/pagination/pagination-truncated.html
+++ b/docs/examples/individual/pagination/pagination-truncated.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Pagination / Truncated
+category: _patterns
+individual: patterns_pagination
+---
+
+{% include patterns/pagination/pagination-truncated.html %}

--- a/docs/examples/individual/pagination/pagination.html
+++ b/docs/examples/individual/pagination/pagination.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Pagination / Default
+category: _patterns
+individual: patterns_pagination
+---
+
+{% include patterns/pagination/pagination.html %}

--- a/docs/examples/patterns/pagination/pagination-disabled.html
+++ b/docs/examples/patterns/pagination/pagination-disabled.html
@@ -3,26 +3,5 @@ layout: examples
 title: Pagination / Disabled
 category: _patterns
 ---
-<ol class="p-pagination">
-  <li class="p-pagination__item">
-    <span class="p-pagination__link--previous is-disabled"><i class="p-icon--contextual-menu">Previous page</i></span>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link is-active" href="#1">1</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#2">2</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#3">3</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#4">4</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#5">5</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
-  </li>
-</ol>
+
+{% include patterns/pagination/pagination-disabled.html %}

--- a/docs/examples/patterns/pagination/pagination-truncated.html
+++ b/docs/examples/patterns/pagination/pagination-truncated.html
@@ -4,32 +4,4 @@ title: Pagination / Truncated
 category: _patterns
 ---
 
-<ol class="p-pagination">
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--contextual-menu">Previous page</i></a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#1">1</a>
-  </li>
-  <li class="p-pagination__item p-pagination__item--truncation">
-    &hellip;
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#33">33</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link is-active" href="#34">34</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#35">35</a>
-  </li>
-  <li class="p-pagination__item p-pagination__item--truncation">
-    &hellip;
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#7">100</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
-  </li>
-</ol>
+{% include patterns/pagination/pagination-truncated.html %}

--- a/docs/examples/patterns/pagination/pagination.html
+++ b/docs/examples/patterns/pagination/pagination.html
@@ -4,26 +4,4 @@ title: Pagination / Default
 category: _patterns
 ---
 
-<ol class="p-pagination">
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--contextual-menu">Previous page</i></a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#1">1</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#2">2</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link is-active" href="#3">3</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#4">4</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#5">5</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
-  </li>
-</ol>
+{% include patterns/pagination/pagination.html %}

--- a/scss/individual/patterns_article-pagination.scss
+++ b/scss/individual/patterns_article-pagination.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_article-pagination';
+@include vf-p-article-pagination;

--- a/scss/individual/patterns_pagination.scss
+++ b/scss/individual/patterns_pagination.scss
@@ -1,0 +1,9 @@
+@import '../base';
+@include vf-base;
+
+// p-icon--contextual-menu needed as next/prev icon
+@import '../patterns_icons';
+@include vf-p-icons;
+
+@import '../patterns_pagination';
+@include vf-p-pagination;


### PR DESCRIPTION
## Done

Makes sure pagination styles can be build individually, adds examples for them.

Fixes #2209

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or demo
- Check if previous examples full Vanilla examples look as before:
[pagination](https://vanilla-framework-canonical-web-and-design-pr-2744.run.demo.haus/examples/patterns/pagination/pagination/)
[disabled pagination](https://vanilla-framework-canonical-web-and-design-pr-2744.run.demo.haus/examples/patterns/pagination/pagination-disabled/)
[truncated pagination](https://vanilla-framework-canonical-web-and-design-pr-2744.run.demo.haus/examples/patterns/pagination/pagination-truncated/)
[article pagination](https://vanilla-framework-canonical-web-and-design-pr-2744.run.demo.haus/examples/patterns/pagination/article-pagination/)
- Check if new individual CSS examples look as original examples
[pagination](https://vanilla-framework-canonical-web-and-design-pr-2744.run.demo.haus/examples/individual/pagination/pagination/)
[disabled pagination](https://vanilla-framework-canonical-web-and-design-pr-2744.run.demo.haus/examples/individual/pagination/pagination-disabled/)
[truncated pagination](https://vanilla-framework-canonical-web-and-design-pr-2744.run.demo.haus/examples/individual/pagination/pagination-truncated/)
[article pagination](https://vanilla-framework-canonical-web-and-design-pr-2744.run.demo.haus/examples/individual/pagination/article-pagination/)



