### PR TITLE
Dark sub navigation fixes

### DIFF
--- a/docs/examples/patterns/navigation/subnav-dark.html
+++ b/docs/examples/patterns/navigation/subnav-dark.html
@@ -1,0 +1,173 @@
+---
+layout: examples
+title: Navigation / Sub navigation dark
+category: _patterns
+---
+
+<header id="navigation" class="p-navigation is-dark">
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="" width="95" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
+          <a href="#link-1-menu" aria-controls="link-1-menu" class="p-subnav__toggle">LXC</a>
+          <ul class="p-subnav__items" id="link-1-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-subnav__item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started</a>
+            </li>
+          </ul>
+        </li>
+        <li class="p-navigation__link p-subnav" role="menuitem" id="link-2">
+          <a href="#link-2-menu" aria-controls="link-2-menu" class="p-subnav__toggle">LXD</a>
+          <ul class="p-subnav__items" id="link-2-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-subnav__item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started - Command line</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started - OpenStack</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started - OpenNebula</a>
+            </li>
+          </ul>
+        </li>
+        <li class="p-navigation__link p-subnav" role="menuitem" id="link-3">
+          <a href="#link-3-menu" aria-controls="link-3-menu" class="p-subnav__toggle">LXCFS</a>
+          <ul class="p-subnav__items" id="link-3-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-subnav__item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-subnav__item">Getting started</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
+          <a class="p-subnav__toggle" aria-controls="account-menu">
+            My account
+          </a>
+          <ul class="p-subnav__items--right" id="account-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-subnav__item">Sign out</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<script>
+/**
+  Opens a given subnav by applying is-active class to it
+  and setting aria-hidden attribute on dropdown contents.
+  @param {HTMLElement} subnav Root element of subnavigation to open.
+*/
+function openSubnav(subnav) {
+  subnav.classList.add('is-active');
+  var toggle = subnav.querySelector(".p-subnav__toggle");
+  var dropdown = document.getElementById(toggle.getAttribute('aria-controls'));
+  dropdown.setAttribute('aria-hidden', 'true');
+}
+
+/**
+  Closes a given subnav by removing is-active class to it
+  and setting aria-hidden attribute on dropdown contents.
+  @param {HTMLElement} subnav Root element of subnavigation to open.
+*/
+function closeSubnav(subnav) {
+  subnav.classList.remove('is-active');
+  var toggle = subnav.querySelector(".p-subnav__toggle");
+  var dropdown = document.getElementById(toggle.getAttribute('aria-controls'));
+  dropdown.setAttribute('aria-hidden', 'false');
+}
+
+/**
+  Closes all subnavs on the page.
+*/
+function closeAllSubnavs() {
+  var subnavs = document.querySelectorAll('.p-subnav');
+  for (var i = 0, l = subnavs.length; i < l; i++) {
+    closeSubnav(subnavs[i]);
+  }
+}
+
+/**
+  Attaches click event listener to subnav toggle.
+  @param {HTMLElement} subnavToggle Toggle element of subnavigation.
+*/
+function setupSubnavToggle(subnavToggle) {
+  subnavToggle.addEventListener('click', function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    var subnav = subnavToggle.parentElement;
+    var isActive = subnav.classList.contains('is-active');
+
+    closeAllSubnavs();
+    if (!isActive) {
+      openSubnav(subnav);
+    }
+  });
+}
+
+// Setup all subnav toggles on the page
+var subnavToggles = document.querySelectorAll('.p-subnav__toggle');
+
+for (var i = 0, l = subnavToggles.length; i < l; i++) {
+  setupSubnavToggle(subnavToggles[i]);
+}
+
+// Close all menus if anything else on the page is clicked
+document.addEventListener('click', function(event) {
+  var target = event.target;
+
+  if (target.closest) {
+    if (!target.closest('.p-subnav__toggle') && !target.closest('.p-subnav__item')) {
+      closeAllSubnavs();
+    }
+  } else if (target.msMatchesSelector) {
+    // IE friendly `Element.closest` equivalent
+    // as in https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+    do {
+      if (
+        target.msMatchesSelector('.p-subnav__toggle') ||
+        target.msMatchesSelector('.p-subnav__item')
+      ) {
+        return;
+      }
+      target = target.parentElement || target.parentNode;
+    } while (target !== null && target.nodeType === 1);
+
+    closeAllSubnavs();
+  }
+});
+</script>

--- a/docs/examples/patterns/navigation/subnav-dark.html
+++ b/docs/examples/patterns/navigation/subnav-dark.html
@@ -9,7 +9,7 @@ category: _patterns
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg" alt="" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -115,7 +115,7 @@
     white-space: nowrap;
 
     @media (max-width: $breakpoint-navigation-threshold) {
-      padding: $spv-inner--small $grid-margin-width;
+      padding: $spv-inner--small 0;
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
@@ -154,7 +154,7 @@
   }
 
   %subnav-item--dark-theme {
-    background-color: $colors--dark-theme--background;
+    background-color: $colors--dark-theme--background-highlighted;
 
     &,
     &:active,

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -50,9 +50,15 @@
       @extend %subnav-item--dark-theme;
     }
 
-    .p-subnav.is-light {
+    .p-subnav.is-light,
+    .p-navigation.is-light .p-subnav {
       &::after {
         @include vf-icon-chevron;
+      }
+
+      .p-subnav__items,
+      .p-subnav__items--right {
+        @extend %vf-is-bordered;
       }
 
       .p-subnav__item {
@@ -73,9 +79,15 @@
       @extend %subnav-item--light-theme;
     }
 
-    .p-subnav.is-dark {
+    .p-subnav.is-dark,
+    .p-navigation.is-dark .p-subnav {
       &::after {
         @include vf-icon-chevron;
+      }
+
+      .p-subnav__items,
+      .p-subnav__items--right {
+        border: 0;
       }
 
       .p-subnav__item {
@@ -101,7 +113,7 @@
     }
 
     @media (max-width: $breakpoint-navigation-threshold) {
-      border: 0;
+      border: 0 !important; // fight specificity of `.p-navigation.is-dark .p-subnav .p-subnav__items` from theme support
       box-shadow: none;
     }
   }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -43,7 +43,7 @@
   // Theming
   @if ($theme-default-nav == 'dark') {
     .p-subnav::after {
-      @include vf-icon-chevron($color-light);
+      @include vf-icon-chevron($colors--dark-theme--border-high-contrast);
     }
 
     .p-subnav__items,
@@ -58,7 +58,7 @@
     .p-subnav.is-light,
     .p-navigation.is-light .p-subnav {
       &::after {
-        @include vf-icon-chevron;
+        @include vf-icon-chevron($colors--light-theme--border-high-contrast);
       }
 
       .p-subnav__items,
@@ -72,7 +72,7 @@
     }
   } @else {
     .p-subnav::after {
-      @include vf-icon-chevron($color-mid-light);
+      @include vf-icon-chevron($colors--light-theme--border-high-contrast);
     }
 
     .p-subnav__items,
@@ -87,7 +87,7 @@
     .p-subnav.is-dark,
     .p-navigation.is-dark .p-subnav {
       &::after {
-        @include vf-icon-chevron;
+        @include vf-icon-chevron($colors--dark-theme--border-high-contrast);
       }
 
       .p-subnav__items,

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -46,6 +46,11 @@
       @include vf-icon-chevron($color-light);
     }
 
+    .p-subnav__items,
+    .p-subnav__items--right {
+      border-color: $colors--dark-theme--border-default;
+    }
+
     .p-subnav__item {
       @extend %subnav-item--dark-theme;
     }
@@ -58,7 +63,7 @@
 
       .p-subnav__items,
       .p-subnav__items--right {
-        @extend %vf-is-bordered;
+        border-color: $colors--light-theme--border-default;
       }
 
       .p-subnav__item {
@@ -72,7 +77,7 @@
 
     .p-subnav__items,
     .p-subnav__items--right {
-      @extend %vf-is-bordered;
+      border-color: $colors--light-theme--border-default;
     }
 
     .p-subnav__item {
@@ -87,7 +92,7 @@
 
       .p-subnav__items,
       .p-subnav__items--right {
-        border: 0;
+        border-color: $colors--dark-theme--border-default;
       }
 
       .p-subnav__item {
@@ -98,6 +103,7 @@
 
   .p-subnav__items,
   .p-subnav__items--right {
+    @extend %vf-is-bordered;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
     display: none;
@@ -113,7 +119,7 @@
     }
 
     @media (max-width: $breakpoint-navigation-threshold) {
-      border: 0 !important; // fight specificity of `.p-navigation.is-dark .p-subnav .p-subnav__items` from theme support
+      border: 0;
       box-shadow: none;
     }
   }


### PR DESCRIPTION
## Done

Fixes #2752 
Fixes #2753 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or demo
- Go to [dark subnavigation example](https://vanilla-framework-canonical-web-and-design-pr-2761.run.demo.haus/examples/patterns/navigation/subnav-dark/)
- Make sure subnav background is the same as main nav
- Make sure there is no light border around dark subnav dropdown
- On small screen there should be no additional indent and no border around subnav items


## Screenshots

<img width="596" alt="Screenshot 2020-01-20 at 16 49 48" src="https://user-images.githubusercontent.com/83575/72739905-ea4fe000-3ba4-11ea-82d2-3af04ae49a33.png">
<img width="702" alt="Screenshot 2020-01-20 at 16 49 33" src="https://user-images.githubusercontent.com/83575/72739934-f89dfc00-3ba4-11ea-820e-a81353bc0ec6.png">
