### PR TITLE
Add individual examples for content patterns

### DIFF
--- a/docs/_includes/patterns/buttons/base.html
+++ b/docs/_includes/patterns/buttons/base.html
@@ -1,0 +1,2 @@
+<button class="p-button--base">Base</button>
+<button class="p-button--base" disabled>Base disabled</button>

--- a/docs/_includes/patterns/buttons/brand.html
+++ b/docs/_includes/patterns/buttons/brand.html
@@ -1,0 +1,2 @@
+<button class="p-button--brand">Brand button</button>
+<button class="p-button--brand" disabled>Brand button disabled</button>

--- a/docs/_includes/patterns/buttons/dense.html
+++ b/docs/_includes/patterns/buttons/dense.html
@@ -1,0 +1,2 @@
+<span>Everything you need to get started with Vanilla.</span>
+<button class="p-button--neutral is-dense">Dense button</button>

--- a/docs/_includes/patterns/buttons/icon.html
+++ b/docs/_includes/patterns/buttons/icon.html
@@ -1,0 +1,3 @@
+<button class="p-button--positive has-icon"><i class="p-icon--minus is-light"></i></button>
+<button class="p-button has-icon"><i class="p-icon--plus"></i><span>Icon before text</span></button>
+<button class="p-button has-icon"><span>Icon after text</span><i class="p-icon--contextual-menu"></i></button>

--- a/docs/_includes/patterns/buttons/inline.html
+++ b/docs/_includes/patterns/buttons/inline.html
@@ -1,0 +1,2 @@
+<span>Everything you need to get started with Vanilla.</span>
+<button class="p-button--neutral is-inline">Inline button</button>

--- a/docs/_includes/patterns/buttons/negative.html
+++ b/docs/_includes/patterns/buttons/negative.html
@@ -1,0 +1,2 @@
+<button class="p-button--negative">Negative button</button>
+<button class="p-button--negative" disabled>Negative button disabled</button>

--- a/docs/_includes/patterns/buttons/neutral.html
+++ b/docs/_includes/patterns/buttons/neutral.html
@@ -1,0 +1,2 @@
+<button class="p-button--neutral">Neutral button</button>
+<button class="p-button--neutral" disabled>Neutral button disabled</button>

--- a/docs/_includes/patterns/buttons/positive.html
+++ b/docs/_includes/patterns/buttons/positive.html
@@ -1,0 +1,2 @@
+<button class="p-button--positive">Positive button</button>
+<button class="p-button--positive" disabled>Positive button disabled</button>

--- a/docs/_includes/patterns/heading-icon/heading-icon-small.html
+++ b/docs/_includes/patterns/heading-icon/heading-icon-small.html
@@ -1,0 +1,7 @@
+<div class="p-heading-icon--small">
+  <div class="p-heading-icon__header">
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <h4 class="p-heading-icon__title">LXD — system containers</h4>
+  </div>
+  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
+</div>

--- a/docs/_includes/patterns/heading-icon/heading-icon-stacked.html
+++ b/docs/_includes/patterns/heading-icon/heading-icon-stacked.html
@@ -1,0 +1,7 @@
+<div class="p-heading-icon">
+  <div class="p-heading-icon__header is-stacked">
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <h3 class="p-heading-icon__title">LXD — system containers</h3>
+  </div>
+  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
+</div>

--- a/docs/_includes/patterns/heading-icon/heading-icon.html
+++ b/docs/_includes/patterns/heading-icon/heading-icon.html
@@ -1,0 +1,7 @@
+<div class="p-heading-icon">
+  <div class="p-heading-icon__header">
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <h3 class="p-heading-icon__title">LXD — system containers</h3>
+  </div>
+  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
+</div>

--- a/docs/_includes/patterns/headings/default.html
+++ b/docs/_includes/patterns/headings/default.html
@@ -1,0 +1,6 @@
+<p class="p-heading--one">Learn DevOps best practices</p>
+<p class="p-heading--two">Companies involved in OpenStack</p>
+<p class="p-heading--three">Latest news from our blog</p>
+<p class="p-heading--four">Further reading</p>
+<p class="p-heading--five">Kubernetes</p>
+<p class="p-heading--six">Ubuntu is an open source software operating system</p>

--- a/docs/_includes/patterns/headings/mixed.html
+++ b/docs/_includes/patterns/headings/mixed.html
@@ -1,0 +1,6 @@
+<h6 class="p-heading--one">Ubuntu is an open source software operating system</h6>
+<h5 class="p-heading--two">Kubernetes</h5>
+<h4 class="p-heading--three">Further reading</h4>
+<h3 class="p-heading--four">Latest news from our blog</h3>
+<h2 class="p-heading--five">Companies involved in OpenStack</h2>
+<h1 class="p-heading--six">Learn DevOps best practices</h1>

--- a/docs/_includes/patterns/headings/muted.html
+++ b/docs/_includes/patterns/headings/muted.html
@@ -1,0 +1,1 @@
+<h4 class="p-muted-heading">Influential contributors of openstack</h4>

--- a/docs/_includes/patterns/image/bordered.html
+++ b/docs/_includes/patterns/image/bordered.html
@@ -1,0 +1,1 @@
+<img class="p-image--bordered" src="https://assets.ubuntu.com/v1/584903f3-iot-drone.png" alt="">

--- a/docs/_includes/patterns/image/shadowed.html
+++ b/docs/_includes/patterns/image/shadowed.html
@@ -1,0 +1,1 @@
+<img class="p-image--shadowed" src="https://assets.ubuntu.com/v1/584903f3-iot-drone.png" alt="">

--- a/docs/_includes/patterns/inline-images.html
+++ b/docs/_includes/patterns/inline-images.html
@@ -1,0 +1,17 @@
+<ul class="p-inline-images">
+  <li class="p-inline-images__item">
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg" alt="Placeholder image" />
+  </li>
+  <li class="p-inline-images__item">
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg" alt="Placeholder image" />
+  </li>
+  <li class="p-inline-images__item">
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f9832168-AstraZeneca.png?w=144" alt="Placeholder image" />
+  </li>
+  <li class="p-inline-images__item">
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg" alt="Placeholder image" />
+  </li>
+  <li class="p-inline-images__item">
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png?w=144" alt="Placeholder image" />
+  </li>
+</ul>

--- a/docs/_includes/patterns/labels/deprecated.html
+++ b/docs/_includes/patterns/labels/deprecated.html
@@ -1,0 +1,1 @@
+<div class="p-label--deprecated">Deprecated</div>

--- a/docs/_includes/patterns/labels/in-progress.html
+++ b/docs/_includes/patterns/labels/in-progress.html
@@ -1,0 +1,1 @@
+<div class="p-label--in-progress">In progress</div>

--- a/docs/_includes/patterns/labels/new.html
+++ b/docs/_includes/patterns/labels/new.html
@@ -1,0 +1,1 @@
+<div class="p-label--new">New</div>

--- a/docs/_includes/patterns/labels/updated.html
+++ b/docs/_includes/patterns/labels/updated.html
@@ -1,0 +1,1 @@
+<div class="p-label--updated">Updated</div>

--- a/docs/_includes/patterns/labels/validated.html
+++ b/docs/_includes/patterns/labels/validated.html
@@ -1,0 +1,1 @@
+<div class="p-label--validated">Validated</div>

--- a/docs/_includes/patterns/links/links-back-to-top.html
+++ b/docs/_includes/patterns/links/links-back-to-top.html
@@ -1,0 +1,3 @@
+<div class="p-top">
+  <a href="#" class="p-top__link">Back to top</a>
+</div>

--- a/docs/_includes/patterns/links/links-external.html
+++ b/docs/_includes/patterns/links/links-external.html
@@ -1,0 +1,20 @@
+<h1>
+    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</h1>
+<h2>
+    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+            NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</h2>
+<h3>
+    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+    NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</h3>
+<h4>
+    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</h4>
+<p>
+    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</p>

--- a/docs/_includes/patterns/links/links-inverted.html
+++ b/docs/_includes/patterns/links/links-inverted.html
@@ -1,0 +1,7 @@
+<div class="p-strip--dark">
+  <div class="row">
+    <div class="col-12">
+      <a href="#" class="p-link--inverted">Package & publish your app</a>
+    </div>
+  </div>
+</div>

--- a/docs/_includes/patterns/links/links-inverted.html
+++ b/docs/_includes/patterns/links/links-inverted.html
@@ -1,7 +1,3 @@
-<div class="p-strip--dark">
-  <div class="row">
-    <div class="col-12">
-      <a href="#" class="p-link--inverted">Package & publish your app</a>
-    </div>
-  </div>
+<div class="p-strip--dark" style="background: #111">
+  <a href="#" class="p-link--inverted">Package & publish your app</a>
 </div>

--- a/docs/_includes/patterns/links/links-soft.html
+++ b/docs/_includes/patterns/links/links-soft.html
@@ -1,0 +1,1 @@
+<a href="#" class="p-link--soft">Learn about MAAS</a>

--- a/docs/_includes/patterns/muted-heading.html
+++ b/docs/_includes/patterns/muted-heading.html
@@ -1,0 +1,1 @@
+<h3 class="p-muted-heading">A SELECTION OF OUR OPENSTACK CLIENTS</h3>

--- a/docs/_includes/patterns/muted-heading.html
+++ b/docs/_includes/patterns/muted-heading.html
@@ -1,1 +1,0 @@
-<h3 class="p-muted-heading">A SELECTION OF OUR OPENSTACK CLIENTS</h3>

--- a/docs/_includes/patterns/notifications/action.html
+++ b/docs/_includes/patterns/notifications/action.html
@@ -1,0 +1,5 @@
+<div class="p-notification">
+  <p class="p-notification__response">
+    The bundle author has not provided a getstarted.md file.<a href="#" class="p-notification__action">Dismiss</a>
+  </p>
+</div>

--- a/docs/_includes/patterns/notifications/caution.html
+++ b/docs/_includes/patterns/notifications/caution.html
@@ -1,0 +1,5 @@
+<div class="p-notification--caution">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Blocked:</span>Custom storage configuration is only supported on Ubuntu, CentOS and RHEL.
+  </p>
+</div>

--- a/docs/_includes/patterns/notifications/information.html
+++ b/docs/_includes/patterns/notifications/information.html
@@ -1,0 +1,5 @@
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Information:</span>Anyone with access can view your invited users.
+  </p>
+</div>

--- a/docs/_includes/patterns/notifications/negative.html
+++ b/docs/_includes/patterns/notifications/negative.html
@@ -1,0 +1,5 @@
+<div class="p-notification--negative">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Error:</span>Node must be connected to a network.
+  </p>
+</div>

--- a/docs/_includes/patterns/notifications/notifications.html
+++ b/docs/_includes/patterns/notifications/notifications.html
@@ -1,0 +1,30 @@
+<div class="p-notification" id="notification">
+  <p class="p-notification__response">
+    We use cookies to improve your experience. By your continued use of this site you accept such use.
+  </p>
+  <button class="p-icon--close" aria-label="Close notification" aria-controls="notification">Close</button>
+</div>
+
+<script>
+/**
+  Attaches event listener for hide notification on close button click.
+  @param {HTMLElement} closeButton The notification close button element.
+*/
+function setupCloseButton(closeButton) {
+  closeButton.addEventListener('click', function(event) {
+    var target = event.target.getAttribute('aria-controls');
+    var notification = document.getElementById(target);
+
+    if (notification) {
+      notification.classList.add('u-hide');
+    }
+  });
+}
+
+// Set up all notification close buttons.
+var closeButtons = document.querySelectorAll('.p-notification [aria-controls]');
+
+for (var i = 0, l = closeButtons.length; i < l; i++) {
+  setupCloseButton(closeButtons[i]);
+}
+</script>

--- a/docs/_includes/patterns/notifications/positive.html
+++ b/docs/_includes/patterns/notifications/positive.html
@@ -1,0 +1,4 @@
+<div class="p-notification--positive">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Success:</span>Code successfully reformatted.
+</div>

--- a/docs/_includes/patterns/pull-quotes/default-image.html
+++ b/docs/_includes/patterns/pull-quotes/default-image.html
@@ -1,0 +1,5 @@
+<blockquote class="p-pull-quote has-image">
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
+  <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
+  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
+</blockquote>

--- a/docs/_includes/patterns/pull-quotes/default.html
+++ b/docs/_includes/patterns/pull-quotes/default.html
@@ -1,0 +1,4 @@
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+</blockquote>

--- a/docs/_includes/patterns/pull-quotes/large.html
+++ b/docs/_includes/patterns/pull-quotes/large.html
@@ -1,0 +1,4 @@
+<blockquote class="p-pull-quote--large">
+  <p class="p-pull-quote__quote">The support has been fabulous. The whole team stepped up and helped us work through issues.</p>
+  <cite class="p-pull-quote__citation">Director of Web Engineering, Best Buy Corp</cite>
+</blockquote>

--- a/docs/_includes/patterns/pull-quotes/small.html
+++ b/docs/_includes/patterns/pull-quotes/small.html
@@ -1,0 +1,4 @@
+<blockquote class="p-pull-quote--small">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+</blockquote>

--- a/docs/_includes/patterns/tooltips.html
+++ b/docs/_includes/patterns/tooltips.html
@@ -1,0 +1,34 @@
+<button class="p-tooltip" aria-describedby="default-tooltip">
+  Bottom left
+  <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Product name to be displayed on the storefront.</span>
+</button>
+<button class="p-tooltip--btm-center" aria-describedby="btm-cntr">
+  Bottom center
+  <span class="p-tooltip__message" role="tooltip" id="btm-cntr">Product name to be displayed on the storefront.</span>
+</button>
+<button class="p-tooltip--btm-right" aria-describedby="btm-rgt">
+  Bottom right
+  <span class="p-tooltip__message" role="tooltip" id="btm-rgt">Product name to be displayed on the storefront.</span>
+</button>
+<button class="p-tooltip--left" aria-describedby="left">
+  Left
+  <span class="p-tooltip__message" role="tooltip" id="left">Product name to be displayed on the storefront.</span>
+</button>
+<br />
+<br />
+<button class="p-tooltip--right" aria-describedby="rght">
+  Right
+  <span class="p-tooltip__message" role="tooltip" id="rght">Product name to be displayed on the storefront.</span>
+</button>
+<button class="p-tooltip--top-left" aria-describedby="tp-lft">
+  Top left
+  <span class="p-tooltip__message" role="tooltip" id="tp-lft">Product name to be displayed on the storefront.</span>
+</button>
+<button class="p-tooltip--top-center" aria-describedby="tp-cntr">
+  Top center
+  <span class="p-tooltip__message" role="tooltip" id="tp-cntr">Product name to be displayed on the storefront.</span>
+</button>
+<button class="p-tooltip--top-right" aria-describedby="tp-rght">
+  Top right
+  <span class="p-tooltip__message" role="tooltip" id="tp-rght">Product name to be displayed on the storefront.</span>
+</button>

--- a/docs/examples/individual/patterns/_table-of-contents.html
+++ b/docs/examples/individual/patterns/_table-of-contents.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Table of contents
+category: _patterns
+individual: patterns_table-of-contents
+---
+
+{% include patterns/table-of-contents.html %}

--- a/docs/examples/individual/patterns/buttons/base.html
+++ b/docs/examples/individual/patterns/buttons/base.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Buttons / Base
+category: _patterns
+individual: patterns_buttons
+---
+
+{% include patterns/buttons/base.html %}

--- a/docs/examples/individual/patterns/buttons/brand.html
+++ b/docs/examples/individual/patterns/buttons/brand.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Buttons / Brand
+category: _patterns
+individual: patterns_buttons
+---
+
+{% include patterns/buttons/brand.html %}

--- a/docs/examples/individual/patterns/buttons/dense.html
+++ b/docs/examples/individual/patterns/buttons/dense.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Buttons / Dense
+category: _patterns
+individual: patterns_buttons
+---
+
+{% include patterns/buttons/dense.html %}

--- a/docs/examples/individual/patterns/buttons/icon.html
+++ b/docs/examples/individual/patterns/buttons/icon.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Buttons / Icon
+category: _patterns
+individual: patterns_buttons
+---
+
+{% include patterns/buttons/icon.html %}

--- a/docs/examples/individual/patterns/buttons/inline.html
+++ b/docs/examples/individual/patterns/buttons/inline.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Buttons / Inline
+category: _patterns
+individual: patterns_buttons
+---
+
+{% include patterns/buttons/inline.html %}

--- a/docs/examples/individual/patterns/buttons/negative.html
+++ b/docs/examples/individual/patterns/buttons/negative.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Buttons / Negative
+category: _patterns
+individual: patterns_buttons
+---
+
+{% include patterns/buttons/negative.html %}

--- a/docs/examples/individual/patterns/buttons/neutral.html
+++ b/docs/examples/individual/patterns/buttons/neutral.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Buttons / Neutral
+category: _patterns
+individual: patterns_buttons
+---
+
+{% include patterns/buttons/neutral.html %}

--- a/docs/examples/individual/patterns/buttons/positive.html
+++ b/docs/examples/individual/patterns/buttons/positive.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Buttons / Positive
+category: _patterns
+individual: patterns_buttons
+---
+
+{% include patterns/buttons/positive.html %}

--- a/docs/examples/individual/patterns/heading-icon/heading-icon-small.html
+++ b/docs/examples/individual/patterns/heading-icon/heading-icon-small.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Heading icon / Small
+category: _patterns
+individual: patterns_heading-icon
+---
+
+{% include patterns/heading-icon/heading-icon-small.html %}

--- a/docs/examples/individual/patterns/heading-icon/heading-icon-stacked.html
+++ b/docs/examples/individual/patterns/heading-icon/heading-icon-stacked.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Heading icon / Stacked
+category: _patterns
+individual: patterns_heading-icon
+---
+
+{% include patterns/heading-icon/heading-icon-stacked.html %}

--- a/docs/examples/individual/patterns/heading-icon/heading-icon.html
+++ b/docs/examples/individual/patterns/heading-icon/heading-icon.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Heading icon / Default
+category: _patterns
+individual: patterns_heading-icon
+---
+
+{% include patterns/heading-icon/heading-icon.html %}

--- a/docs/examples/individual/patterns/headings/default.html
+++ b/docs/examples/individual/patterns/headings/default.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Headings / Default
+category: _patterns
+individual: patterns_headings
+---
+
+{% include patterns/headings/default.html %}

--- a/docs/examples/individual/patterns/headings/mixed.html
+++ b/docs/examples/individual/patterns/headings/mixed.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Headings / Mixed classes
+category: _patterns
+individual: patterns_headings
+---
+
+{% include patterns/headings/mixed.html %}

--- a/docs/examples/individual/patterns/headings/muted.html
+++ b/docs/examples/individual/patterns/headings/muted.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Headings / Muted
+category: _patterns
+individual: patterns_muted-heading
+---
+
+{% include patterns/headings/muted.html %}

--- a/docs/examples/individual/patterns/image/bordered.html
+++ b/docs/examples/individual/patterns/image/bordered.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Image / Border
+category: _patterns
+individual: patterns_image
+---
+
+{% include patterns/image/bordered.html %}

--- a/docs/examples/individual/patterns/image/shadowed.html
+++ b/docs/examples/individual/patterns/image/shadowed.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Image / Shadow
+category: _patterns
+individual: patterns_image
+---
+
+{% include patterns/image/shadowed.html %}

--- a/docs/examples/individual/patterns/inline-images.html
+++ b/docs/examples/individual/patterns/inline-images.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Inline images
+category: _patterns
+individual: patterns_inline-images
+---
+
+{% include patterns/inline-images.html %}

--- a/docs/examples/individual/patterns/labels/deprecated.html
+++ b/docs/examples/individual/patterns/labels/deprecated.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Labels / Deprecated
+category: _patterns
+individual: patterns_label
+---
+
+{% include patterns/labels/deprecated.html %}

--- a/docs/examples/individual/patterns/labels/in-progress.html
+++ b/docs/examples/individual/patterns/labels/in-progress.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Labels / In progress
+category: _patterns
+individual: patterns_label
+---
+
+{% include patterns/labels/in-progress.html %}

--- a/docs/examples/individual/patterns/labels/new.html
+++ b/docs/examples/individual/patterns/labels/new.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Labels / New
+category: _patterns
+individual: patterns_label
+---
+
+{% include patterns/labels/new.html %}

--- a/docs/examples/individual/patterns/labels/updated.html
+++ b/docs/examples/individual/patterns/labels/updated.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Labels / Updated
+category: _patterns
+individual: patterns_label
+---
+
+{% include patterns/labels/updated.html %}

--- a/docs/examples/individual/patterns/labels/validated.html
+++ b/docs/examples/individual/patterns/labels/validated.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Labels / Validated
+category: _patterns
+individual: patterns_label
+---
+
+{% include patterns/labels/validated.html %}

--- a/docs/examples/individual/patterns/links/links-back-to-top.html
+++ b/docs/examples/individual/patterns/links/links-back-to-top.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Links / Back to top
+category: _patterns
+individual: patterns_links
+---
+
+{% include patterns/links/links-back-to-top.html %}

--- a/docs/examples/individual/patterns/links/links-external.html
+++ b/docs/examples/individual/patterns/links/links-external.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Links / External
+category: _patterns
+individual: patterns_links
+---
+
+{% include patterns/links/links-external.html %}

--- a/docs/examples/individual/patterns/links/links-inverted.html
+++ b/docs/examples/individual/patterns/links/links-inverted.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Links / Inverted
+category: _patterns
+individual: patterns_links
+---
+
+{% include patterns/links/links-inverted.html %}

--- a/docs/examples/individual/patterns/links/links-soft.html
+++ b/docs/examples/individual/patterns/links/links-soft.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Links / Soft
+category: _patterns
+individual: patterns_links
+---
+
+{% include patterns/links/links-soft.html %}

--- a/docs/examples/individual/patterns/notifications/action.html
+++ b/docs/examples/individual/patterns/notifications/action.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Notifications / Action
+category: _patterns
+individual: patterns_notifications
+---
+
+{% include patterns/notifications/action.html %}

--- a/docs/examples/individual/patterns/notifications/caution.html
+++ b/docs/examples/individual/patterns/notifications/caution.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Notifications / Caution
+category: _patterns
+individual: patterns_notifications
+---
+
+{% include patterns/notifications/caution.html %}

--- a/docs/examples/individual/patterns/notifications/information.html
+++ b/docs/examples/individual/patterns/notifications/information.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Notifications / Information
+category: _patterns
+individual: patterns_notifications
+---
+
+{% include patterns/notifications/information.html %}

--- a/docs/examples/individual/patterns/notifications/negative.html
+++ b/docs/examples/individual/patterns/notifications/negative.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Notifications / Negative
+category: _patterns
+individual: patterns_notifications
+---
+
+{% include patterns/notifications/negative.html %}

--- a/docs/examples/individual/patterns/notifications/notifications.html
+++ b/docs/examples/individual/patterns/notifications/notifications.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Notifications / Default
+category: _patterns
+individual: patterns_notifications
+---
+
+{% include patterns/notifications/notifications.html %}

--- a/docs/examples/individual/patterns/notifications/positive.html
+++ b/docs/examples/individual/patterns/notifications/positive.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Notifications / Positive
+category: _patterns
+individual: patterns_notifications
+---
+
+{% include patterns/notifications/positive.html %}

--- a/docs/examples/individual/patterns/pull-quotes/default-image.html
+++ b/docs/examples/individual/patterns/pull-quotes/default-image.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Pull quote / Image
+category: _patterns
+individual: patterns_pull-quotes
+---
+
+{% include patterns/pull-quotes/default-image.html %}

--- a/docs/examples/individual/patterns/pull-quotes/default.html
+++ b/docs/examples/individual/patterns/pull-quotes/default.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Pull quote / Default
+category: _patterns
+individual: patterns_pull-quotes
+---
+
+{% include patterns/pull-quotes/default.html %}

--- a/docs/examples/individual/patterns/pull-quotes/large.html
+++ b/docs/examples/individual/patterns/pull-quotes/large.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Pull quote / Large
+category: _patterns
+individual: patterns_pull-quotes
+---
+
+{% include patterns/pull-quotes/large.html %}

--- a/docs/examples/individual/patterns/pull-quotes/small.html
+++ b/docs/examples/individual/patterns/pull-quotes/small.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Pull quote / Small
+category: _patterns
+individual: patterns_pull-quotes
+---
+
+{% include patterns/pull-quotes/small.html %}

--- a/docs/examples/individual/patterns/tooltips.html
+++ b/docs/examples/individual/patterns/tooltips.html
@@ -1,0 +1,8 @@
+---
+layout: examples
+title: Tooltips
+category: _patterns
+individual: patterns_tooltips
+---
+
+{% include patterns/tooltips.html %}

--- a/docs/examples/patterns/buttons/base.html
+++ b/docs/examples/patterns/buttons/base.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Base
 category: _patterns
 ---
-<button class="p-button--base">Base</button>
-<button class="p-button--base" disabled>Base disabled</button>
+
+{% include patterns/buttons/base.html %}

--- a/docs/examples/patterns/buttons/brand.html
+++ b/docs/examples/patterns/buttons/brand.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Brand
 category: _patterns
 ---
-<button class="p-button--brand">Brand button</button>
-<button class="p-button--brand" disabled>Brand button disabled</button>
+
+{% include patterns/buttons/brand.html %}

--- a/docs/examples/patterns/buttons/dense.html
+++ b/docs/examples/patterns/buttons/dense.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Dense
 category: _patterns
 ---
-<span>Everything you need to get started with Vanilla.</span>
-<button class="p-button--neutral is-dense">Dense button</button>
+
+{% include patterns/buttons/dense.html %}

--- a/docs/examples/patterns/buttons/icon.html
+++ b/docs/examples/patterns/buttons/icon.html
@@ -3,6 +3,5 @@ layout: examples
 title: Buttons / Icon
 category: _patterns
 ---
-<button class="p-button--positive has-icon"><i class="p-icon--minus is-light"></i></button>
-<button class="p-button has-icon"><i class="p-icon--plus"></i><span>Icon before text</span></button>
-<button class="p-button has-icon"><span>Icon after text</span><i class="p-icon--contextual-menu"></i></button>
+
+{% include patterns/buttons/icon.html %}

--- a/docs/examples/patterns/buttons/inline.html
+++ b/docs/examples/patterns/buttons/inline.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Inline
 category: _patterns
 ---
-<span>Everything you need to get started with Vanilla.</span>
-<button class="p-button--neutral is-inline">Inline button</button>
+
+{% include patterns/buttons/inline.html %}

--- a/docs/examples/patterns/buttons/negative.html
+++ b/docs/examples/patterns/buttons/negative.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Negative
 category: _patterns
 ---
-<button class="p-button--negative">Negative button</button>
-<button class="p-button--negative" disabled>Negative button disabled</button>
+
+{% include patterns/buttons/negative.html %}

--- a/docs/examples/patterns/buttons/neutral.html
+++ b/docs/examples/patterns/buttons/neutral.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Neutral
 category: _patterns
 ---
-<button class="p-button--neutral">Neutral button</button>
-<button class="p-button--neutral" disabled>Neutral button disabled</button>
+
+{% include patterns/buttons/neutral.html %}

--- a/docs/examples/patterns/buttons/positive.html
+++ b/docs/examples/patterns/buttons/positive.html
@@ -3,5 +3,5 @@ layout: examples
 title: Buttons / Positive
 category: _patterns
 ---
-<button class="p-button--positive">Positive button</button>
-<button class="p-button--positive" disabled>Positive button disabled</button>
+
+{% include patterns/buttons/positive.html %}

--- a/docs/examples/patterns/heading-icon/heading-icon-small.html
+++ b/docs/examples/patterns/heading-icon/heading-icon-small.html
@@ -4,10 +4,4 @@ title: Heading icon / Small
 category: _patterns
 ---
 
-<div class="p-heading-icon--small">
-  <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
-    <h4 class="p-heading-icon__title">LXD — system containers</h4>
-  </div>
-  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
-</div>
+{% include patterns/heading-icon/heading-icon-small.html %}

--- a/docs/examples/patterns/heading-icon/heading-icon-stacked.html
+++ b/docs/examples/patterns/heading-icon/heading-icon-stacked.html
@@ -4,10 +4,4 @@ title: Heading icon / Stacked
 category: _patterns
 ---
 
-<div class="p-heading-icon">
-  <div class="p-heading-icon__header is-stacked">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
-    <h3 class="p-heading-icon__title">LXD — system containers</h3>
-  </div>
-  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
-</div>
+{% include patterns/heading-icon/heading-icon-stacked.html %}

--- a/docs/examples/patterns/heading-icon/heading-icon.html
+++ b/docs/examples/patterns/heading-icon/heading-icon.html
@@ -4,10 +4,4 @@ title: Heading icon / Default
 category: _patterns
 ---
 
-<div class="p-heading-icon">
-  <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
-    <h3 class="p-heading-icon__title">LXD — system containers</h3>
-  </div>
-  <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>
-</div>
+{% include patterns/heading-icon/heading-icon.html %}

--- a/docs/examples/patterns/headings/default.html
+++ b/docs/examples/patterns/headings/default.html
@@ -4,9 +4,4 @@ title: Headings / Default
 category: _patterns
 ---
 
-<p class="p-heading--one">Learn DevOps best practices</p>
-<p class="p-heading--two">Companies involved in OpenStack</p>
-<p class="p-heading--three">Latest news from our blog</p>
-<p class="p-heading--four">Further reading</p>
-<p class="p-heading--five">Kubernetes</p>
-<p class="p-heading--six">Ubuntu is an open source software operating system</p>
+{% include patterns/headings/default.html %}

--- a/docs/examples/patterns/headings/mixed.html
+++ b/docs/examples/patterns/headings/mixed.html
@@ -4,9 +4,4 @@ title: Headings / Mixed classes
 category: _patterns
 ---
 
-<h6 class="p-heading--one">Ubuntu is an open source software operating system</h6>
-<h5 class="p-heading--two">Kubernetes</h5>
-<h4 class="p-heading--three">Further reading</h4>
-<h3 class="p-heading--four">Latest news from our blog</h3>
-<h2 class="p-heading--five">Companies involved in OpenStack</h2>
-<h1 class="p-heading--six">Learn DevOps best practices</h1>
+{% include patterns/headings/mixed.html %}

--- a/docs/examples/patterns/headings/muted.html
+++ b/docs/examples/patterns/headings/muted.html
@@ -4,4 +4,4 @@ title: Headings / Muted
 category: _patterns
 ---
 
-<h4 class="p-muted-heading">Influential contributors of openstack</h4>
+{% include patterns/headings/muted.html %}

--- a/docs/examples/patterns/image/bordered.html
+++ b/docs/examples/patterns/image/bordered.html
@@ -4,4 +4,4 @@ title: Image / Border
 category: _patterns
 ---
 
-<img class="p-image--bordered" src="https://assets.ubuntu.com/v1/584903f3-iot-drone.png" alt="">
+{% include patterns/image/bordered.html %}

--- a/docs/examples/patterns/image/shadowed.html
+++ b/docs/examples/patterns/image/shadowed.html
@@ -4,4 +4,4 @@ title: Image / Shadow
 category: _patterns
 ---
 
-<img class="p-image--shadowed" src="https://assets.ubuntu.com/v1/584903f3-iot-drone.png" alt="">
+{% include patterns/image/shadowed.html %}

--- a/docs/examples/patterns/inline-images.html
+++ b/docs/examples/patterns/inline-images.html
@@ -4,21 +4,4 @@ title: Inline images
 category: _patterns
 ---
 
-
-<ul class="p-inline-images">
-  <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg" alt="Placeholder image" />
-  </li>
-  <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg" alt="Placeholder image" />
-  </li>
-  <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f9832168-AstraZeneca.png?w=144" alt="Placeholder image" />
-  </li>
-  <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg" alt="Placeholder image" />
-  </li>
-  <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png?w=144" alt="Placeholder image" />
-  </li>
-</ul>
+{% include patterns/inline-images.html %}

--- a/docs/examples/patterns/labels/deprecated.html
+++ b/docs/examples/patterns/labels/deprecated.html
@@ -3,4 +3,5 @@ layout: examples
 title: Labels / Deprecated
 category: _patterns
 ---
-<div class="p-label--deprecated">Deprecated</div>
+
+{% include patterns/labels/deprecated.html %}

--- a/docs/examples/patterns/labels/in-progress.html
+++ b/docs/examples/patterns/labels/in-progress.html
@@ -3,4 +3,5 @@ layout: examples
 title: Labels / In progress
 category: _patterns
 ---
-<div class="p-label--in-progress">In progress</div>
+
+{% include patterns/labels/in-progress.html %}

--- a/docs/examples/patterns/labels/new.html
+++ b/docs/examples/patterns/labels/new.html
@@ -3,4 +3,5 @@ layout: examples
 title: Labels / New
 category: _patterns
 ---
-<div class="p-label--new">New</div>
+
+{% include patterns/labels/new.html %}

--- a/docs/examples/patterns/labels/updated.html
+++ b/docs/examples/patterns/labels/updated.html
@@ -3,4 +3,5 @@ layout: examples
 title: Labels / Updated
 category: _patterns
 ---
-<div class="p-label--updated">Updated</div>
+
+{% include patterns/labels/updated.html %}

--- a/docs/examples/patterns/labels/validated.html
+++ b/docs/examples/patterns/labels/validated.html
@@ -3,4 +3,5 @@ layout: examples
 title: Labels / Validated
 category: _patterns
 ---
-<div class="p-label--validated">Validated</div>
+
+{% include patterns/labels/validated.html %}

--- a/docs/examples/patterns/links/links-back-to-top.html
+++ b/docs/examples/patterns/links/links-back-to-top.html
@@ -4,6 +4,4 @@ title: Links / Back to top
 category: _patterns
 ---
 
-<div class="p-top">
-  <a href="#" class="p-top__link">Back to top</a>
-</div>
+{% include patterns/links/links-back-to-top.html %}

--- a/docs/examples/patterns/links/links-external.html
+++ b/docs/examples/patterns/links/links-external.html
@@ -4,23 +4,4 @@ title: Links / External
 category: _patterns
 ---
 
-<h1>
-    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</h1>
-<h2>
-    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-            NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</h2>
-<h3>
-    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-    NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</h3>
-<h4>
-    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</h4>
-<p>
-    <a href="https://www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</p>
+{% include patterns/links/links-external.html %}

--- a/docs/examples/patterns/links/links-inverted.html
+++ b/docs/examples/patterns/links/links-inverted.html
@@ -4,10 +4,4 @@ title: Links / Inverted
 category: _patterns
 ---
 
-<div class="p-strip--dark">
-  <div class="row">
-    <div class="col-12">
-      <a href="#" class="p-link--inverted">Package & publish your app</a>
-    </div>
-  </div>
-</div>
+{% include patterns/links/links-inverted.html %}

--- a/docs/examples/patterns/links/links-soft.html
+++ b/docs/examples/patterns/links/links-soft.html
@@ -4,4 +4,4 @@ title: Links / Soft
 category: _patterns
 ---
 
-<a href="#" class="p-link--soft">Learn about MAAS</a>
+{% include patterns/links/links-soft.html %}

--- a/docs/examples/patterns/muted-heading.html
+++ b/docs/examples/patterns/muted-heading.html
@@ -4,4 +4,4 @@ title: Muted heading
 category: _patterns
 ---
 
-<h3 class="p-muted-heading">A SELECTION OF OUR OPENSTACK CLIENTS</h3>
+{% include patterns/muted-heading.html %}

--- a/docs/examples/patterns/muted-heading.html
+++ b/docs/examples/patterns/muted-heading.html
@@ -1,7 +1,0 @@
----
-layout: examples
-title: Muted heading
-category: _patterns
----
-
-{% include patterns/muted-heading.html %}

--- a/docs/examples/patterns/notifications/action.html
+++ b/docs/examples/patterns/notifications/action.html
@@ -4,8 +4,4 @@ title: Notifications / Action
 category: _patterns
 ---
 
-<div class="p-notification">
-  <p class="p-notification__response">
-    The bundle author has not provided a getstarted.md file.<a href="#" class="p-notification__action">Dismiss</a>
-  </p>
-</div>
+{% include patterns/notifications/action.html %}

--- a/docs/examples/patterns/notifications/caution.html
+++ b/docs/examples/patterns/notifications/caution.html
@@ -4,8 +4,4 @@ title: Notifications / Caution
 category: _patterns
 ---
 
-<div class="p-notification--caution">
-  <p class="p-notification__response">
-    <span class="p-notification__status">Blocked:</span>Custom storage configuration is only supported on Ubuntu, CentOS and RHEL.
-  </p>
-</div>
+{% include patterns/notifications/caution.html %}

--- a/docs/examples/patterns/notifications/information.html
+++ b/docs/examples/patterns/notifications/information.html
@@ -4,8 +4,4 @@ title: Notifications / Information
 category: _patterns
 ---
 
-<div class="p-notification--information">
-  <p class="p-notification__response">
-    <span class="p-notification__status">Information:</span>Anyone with access can view your invited users.
-  </p>
-</div>
+{% include patterns/notifications/information.html %}

--- a/docs/examples/patterns/notifications/negative.html
+++ b/docs/examples/patterns/notifications/negative.html
@@ -4,8 +4,4 @@ title: Notifications / Negative
 category: _patterns
 ---
 
-<div class="p-notification--negative">
-  <p class="p-notification__response">
-    <span class="p-notification__status">Error:</span>Node must be connected to a network.
-  </p>
-</div>
+{% include patterns/notifications/negative.html %}

--- a/docs/examples/patterns/notifications/notifications.html
+++ b/docs/examples/patterns/notifications/notifications.html
@@ -4,33 +4,4 @@ title: Notifications / Default
 category: _patterns
 ---
 
-<div class="p-notification" id="notification">
-  <p class="p-notification__response">
-    We use cookies to improve your experience. By your continued use of this site you accept such use.
-  </p>
-  <button class="p-icon--close" aria-label="Close notification" aria-controls="notification">Close</button>
-</div>
-
-<script>
-/**
-  Attaches event listener for hide notification on close button click.
-  @param {HTMLElement} closeButton The notification close button element.
-*/
-function setupCloseButton(closeButton) {
-  closeButton.addEventListener('click', function(event) {
-    var target = event.target.getAttribute('aria-controls');
-    var notification = document.getElementById(target);
-
-    if (notification) {
-      notification.classList.add('u-hide');
-    }
-  });
-}
-
-// Set up all notification close buttons.
-var closeButtons = document.querySelectorAll('.p-notification [aria-controls]');
-
-for (var i = 0, l = closeButtons.length; i < l; i++) {
-  setupCloseButton(closeButtons[i]);
-}
-</script>
+{% include patterns/notifications/notifications.html %}

--- a/docs/examples/patterns/notifications/positive.html
+++ b/docs/examples/patterns/notifications/positive.html
@@ -4,7 +4,4 @@ title: Notifications / Positive
 category: _patterns
 ---
 
-<div class="p-notification--positive">
-  <p class="p-notification__response">
-    <span class="p-notification__status">Success:</span>Code successfully reformatted.
-</div>
+{% include patterns/notifications/positive.html %}

--- a/docs/examples/patterns/pull-quotes/default-image.html
+++ b/docs/examples/patterns/pull-quotes/default-image.html
@@ -4,8 +4,4 @@ title: Pull quote / Image
 category: _patterns
 ---
 
-<blockquote class="p-pull-quote has-image">
-  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
-  <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
-  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
-</blockquote>
+{% include patterns/pull-quotes/default-image.html %}

--- a/docs/examples/patterns/pull-quotes/default.html
+++ b/docs/examples/patterns/pull-quotes/default.html
@@ -4,7 +4,4 @@ title: Pull quote / Default
 category: _patterns
 ---
 
-<blockquote class="p-pull-quote">
-  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
-</blockquote>
+{% include patterns/pull-quotes/default.html %}

--- a/docs/examples/patterns/pull-quotes/large.html
+++ b/docs/examples/patterns/pull-quotes/large.html
@@ -4,7 +4,4 @@ title: Pull quote / Large
 category: _patterns
 ---
 
-<blockquote class="p-pull-quote--large">
-  <p class="p-pull-quote__quote">The support has been fabulous. The whole team stepped up and helped us work through issues.</p>
-  <cite class="p-pull-quote__citation">Director of Web Engineering, Best Buy Corp</cite>
-</blockquote>
+{% include patterns/pull-quotes/large.html %}

--- a/docs/examples/patterns/pull-quotes/small.html
+++ b/docs/examples/patterns/pull-quotes/small.html
@@ -4,7 +4,4 @@ title: Pull quote / Small
 category: _patterns
 ---
 
-<blockquote class="p-pull-quote--small">
-  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
-</blockquote>
+{% include patterns/pull-quotes/small.html %}

--- a/docs/examples/patterns/tooltips.html
+++ b/docs/examples/patterns/tooltips.html
@@ -3,37 +3,5 @@ layout: examples
 title: Tooltips
 category: _patterns
 ---
-<button class="p-tooltip" aria-describedby="default-tooltip">
-  Bottom left
-  <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Product name to be displayed on the storefront.</span>
-</button>
-<button class="p-tooltip--btm-center" aria-describedby="btm-cntr">
-  Bottom center
-  <span class="p-tooltip__message" role="tooltip" id="btm-cntr">Product name to be displayed on the storefront.</span>
-</button>
-<button class="p-tooltip--btm-right" aria-describedby="btm-rgt">
-  Bottom right
-  <span class="p-tooltip__message" role="tooltip" id="btm-rgt">Product name to be displayed on the storefront.</span>
-</button>
-<button class="p-tooltip--left" aria-describedby="left">
-  Left
-  <span class="p-tooltip__message" role="tooltip" id="left">Product name to be displayed on the storefront.</span>
-</button>
-<br />
-<br />
-<button class="p-tooltip--right" aria-describedby="rght">
-  Right
-  <span class="p-tooltip__message" role="tooltip" id="rght">Product name to be displayed on the storefront.</span>
-</button>
-<button class="p-tooltip--top-left" aria-describedby="tp-lft">
-  Top left
-  <span class="p-tooltip__message" role="tooltip" id="tp-lft">Product name to be displayed on the storefront.</span>
-</button>
-<button class="p-tooltip--top-center" aria-describedby="tp-cntr">
-  Top center
-  <span class="p-tooltip__message" role="tooltip" id="tp-cntr">Product name to be displayed on the storefront.</span>
-</button>
-<button class="p-tooltip--top-right" aria-describedby="tp-rght">
-  Top right
-  <span class="p-tooltip__message" role="tooltip" id="tp-rght">Product name to be displayed on the storefront.</span>
-</button>
+
+{% include patterns/tooltips.html %}

--- a/scss/individual/patterns_buttons.scss
+++ b/scss/individual/patterns_buttons.scss
@@ -1,0 +1,9 @@
+@import '../base';
+@include vf-base;
+
+// needed in buttons icon example
+@import '../patterns_icons';
+@include vf-p-icons;
+
+@import '../patterns_buttons';
+@include vf-p-buttons;

--- a/scss/individual/patterns_heading-icon.scss
+++ b/scss/individual/patterns_heading-icon.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_heading-icon';
+@include vf-p-heading-icon;

--- a/scss/individual/patterns_headings.scss
+++ b/scss/individual/patterns_headings.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_headings';
+@include vf-p-headings;

--- a/scss/individual/patterns_image.scss
+++ b/scss/individual/patterns_image.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_image';
+@include vf-p-image;

--- a/scss/individual/patterns_inline-images.scss
+++ b/scss/individual/patterns_inline-images.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_inline-images';
+@include vf-p-inline-images;

--- a/scss/individual/patterns_label.scss
+++ b/scss/individual/patterns_label.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_label';
+@include vf-p-label;

--- a/scss/individual/patterns_links.scss
+++ b/scss/individual/patterns_links.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_links';
+@include vf-p-links;

--- a/scss/individual/patterns_muted-heading.scss
+++ b/scss/individual/patterns_muted-heading.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_muted-heading';
+@include vf-p-muted-heading;

--- a/scss/individual/patterns_notifications.scss
+++ b/scss/individual/patterns_notifications.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_notifications';
+@include vf-p-notification;

--- a/scss/individual/patterns_pull-quotes.scss
+++ b/scss/individual/patterns_pull-quotes.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_pull-quotes';
+@include vf-p-pull-quotes;

--- a/scss/individual/patterns_tooltips.scss
+++ b/scss/individual/patterns_tooltips.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_tooltips';
+@include vf-p-tooltips;


### PR DESCRIPTION
## Done

Makes sure "content" related patterns can be built separately and add individual examples for them.

Fixes #2750 

## QA

NOTE: Visual side of the examples listed below was verified by CI on Percy, so QA steps are to make sure examples work as expected and detailed visual review of those is not needed.

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2762.run.demo.haus/)
- Go to [examples page](https://vanilla-framework-canonical-web-and-design-pr-2762.run.demo.haus/)
- Make sure that existing examples (full Vanilla) for components below work as before (check different variants for each pattern):
buttons
heading icon
headings
image
inline images
muted heading
links
label
notifications
pull quote
tooltips
- Make sure that individual examples for these components work the same as full ones



