### PR TITLE
Update specificity of navigation styles to fix issue with full width nav

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -67,11 +67,7 @@
   }
 
   // Grid
-  %fixed-width-container {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: $grid-max-width;
-    width: 100%;
+  %vf-grid-container-padding {
     // set static gutter width per breakpoint
     @media (max-width: $threshold-4-6-col) {
       padding-left: map-get($grid-margin-widths, small);
@@ -87,6 +83,14 @@
       padding-left: map-get($grid-margin-widths, large);
       padding-right: map-get($grid-margin-widths, large);
     }
+  }
+
+  %fixed-width-container {
+    @extend %vf-grid-container-padding;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: $grid-max-width;
+    width: 100%;
   }
 
   // Utilities

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -124,7 +124,6 @@ $navigation-hover-opacity: 0.58;
     }
 
     %navigation-row {
-      @extend %fixed-width-container;
       display: flex;
       flex-direction: column;
 
@@ -134,11 +133,13 @@ $navigation-hover-opacity: 0.58;
     }
 
     &__row {
+      @extend %fixed-width-container;
       @extend %navigation-row;
 
       &--full-width {
+        @extend %vf-grid-container-padding;
         @extend %navigation-row;
-        max-width: 100%;
+        width: 100%;
       }
     }
 


### PR DESCRIPTION
## Done

Fixes #2767

Updates specificity of navigation style selectors to fix issue with full width navigation not taking whole 100% of screen.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or demo
- Go to [full width navigation example](https://vanilla-framework-canonical-web-and-design-pr-2768.run.demo.haus/examples/patterns/navigation/full-width/) on a wide screen
- Make sure nav takes whole width
- Make sure other nav examples are constrained by grid width

