### PR TITLE
Example pages fixes

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -43,8 +43,8 @@
               <a href="#main-content">Jump to main content</a>
             </span>
             <ul class="p-navigation__links">
-                <li class="p-navigation__link is-selected"><a href="/">Docs</a></li>
-                <li class="p-navigation__link"><a href="/examples">Examples</a></li>
+                <li class="p-navigation__link {% unless page.url contains '/examples' %}is-selected{% endunless %}"><a href="/">Docs</a></li>
+                <li class="p-navigation__link {% if page.url contains '/examples' %}is-selected{% endif %}"><a href="/examples">Examples</a></li>
                 <li class="p-navigation__link"><a href="https://vanillaframework.io/accessibility">Accessibility</a></li>
               <li class="p-navigation__link"><a href="https://vanillaframework.io/browser-support">Browser support</a></li>
               <li class="p-navigation__link"><a href="https://vanillaframework.io/contribute">Contribute</a></li>

--- a/docs/_layouts/examples.html
+++ b/docs/_layouts/examples.html
@@ -12,6 +12,7 @@
     {% else %}
     <link rel="stylesheet" type="text/css" href="/build/css/build.css" />
     {% endif %}
+    <link rel="icon" href="https://assets.ubuntu.com/v1/ab36e6ed-vanilla_favicon_32px.png" type="image/x-icon" />
 
     <style>
       html::after {


### PR DESCRIPTION
## Done

Marks "Examples" page selected in main nav.
Adds favicon to example pages

Fixes #2723 
Fixes #2725

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2778.run.demo.haus/)
- Go to [Examples page](https://vanilla-framework-canonical-web-and-design-pr-2778.run.demo.haus/examples)
- "Examples" should be marked selected in main nav instead of "Docs"
- Go to any example page, it should have favicon
