### PR TITLE
Update look of table header to match #2501

### DIFF
--- a/docs/_includes/base/forms/aligned-checkboxes.html
+++ b/docs/_includes/base/forms/aligned-checkboxes.html
@@ -28,7 +28,7 @@
       <tr>
         <th>
           <input type="checkbox" id="checkExample8">
-          <label for="checkExample8" class="is-muted-inline-heading">Table header text</label>
+          <label for="checkExample8" class="is-table-header">Table header text</label>
         </th>
         <th>Text in adjacent th</th>
       </tr>

--- a/docs/_includes/base/forms/aligned-radio.html
+++ b/docs/_includes/base/forms/aligned-radio.html
@@ -28,7 +28,7 @@
       <tr>
         <th>
           <input type="radio" name="RadioOptions" id="Radio7" value="option1" checked>
-          <label for="Radio7" class="is-muted-inline-heading">Table header text</label>
+          <label for="Radio7" class="is-table-header">Table header text</label>
         </th>
         <th>Text in adjacent th</th>
       </tr>

--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -43,7 +43,7 @@ View example of the base checkboxes
 </a>
 
 By default, checkboxes are vertically aligned to the baseline of text wrapped in a `label`, `h5`, `h6`, or `p` tag. If you need to align them to other elements, use one of the following classes:
-`is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`.
+`is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
 
 <a href="/examples/base/forms/aligned-checkboxes/" class="js-example">
 View example of checkboxes aligned to different headings
@@ -58,7 +58,7 @@ View example of the base radio buttons
 </a>
 
 By default, radio buttons are vertically aligned to the baseline of text wrapped in a `label`, `h5`, `h6`, or `p` tag. If you need to align them to other elements, use one of the following classes:
-`is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`.
+`is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
 
 <a href="/examples/base/forms/aligned-radio/" class="js-example">
 View example of the aligned radio buttons

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -14,7 +14,8 @@ $box-offsets-top: (
   default-text: 3.333,
   unpadded-text: 2.125,
   muted-heading: 2.333,
-  muted-inline-heading: 2
+  muted-inline-heading: 2,
+  table-header: 1.9
 ) !default;
 
 @mixin vf-b-tick-elements {
@@ -89,6 +90,11 @@ $box-offsets-top: (
         &.is-muted-inline-heading::before {
           top: #{$sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
         }
+
+        &.is-table-header::before {
+          top: #{$sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+        }
+
       }
 
       @media (min-width: $breakpoint-heading-threshold) {
@@ -128,6 +134,10 @@ $box-offsets-top: (
         &.is-muted-inline-heading::before {
           top: #{$sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
         }
+
+        &.is-table-header::before {
+          top: #{$sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+        }
       }
 
       // tick/circle
@@ -163,6 +173,12 @@ $box-offsets-top: (
 
       &.is-muted-inline-heading {
         @extend %muted-heading;
+        display: inline;
+        padding-top: 0;
+      }
+
+      &.is-table-header {
+        @extend %table-header-label;
         display: inline;
         padding-top: 0;
       }
@@ -244,6 +260,10 @@ $box-offsets-top: (
         &.is-muted-inline-heading::after {
           top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
         }
+
+        &.is-table-header::after {
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+        }
       }
 
       @media (min-width: $breakpoint-heading-threshold) {
@@ -282,6 +302,10 @@ $box-offsets-top: (
 
         &.is-muted-inline-heading::after {
           top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
+        }
+
+        &.is-table-header::after {
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $box-size};
         }
       }
     }
@@ -348,6 +372,11 @@ $box-offsets-top: (
         &.is-muted-inline-heading::after {
           top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
         }
+
+        &.is-table-header::after {
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+        }
+
       }
 
       @media (min-width: $breakpoint-heading-threshold) {
@@ -386,6 +415,10 @@ $box-offsets-top: (
 
         &.is-muted-inline-heading::after {
           top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
+        }
+
+        &.is-table-header::after {
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $box-size};
         }
       }
     }

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -35,9 +35,13 @@
     }
 
     th {
-      @extend %muted-heading;
-      line-height: map-get($line-heights, small);
-      padding-bottom: $spv-inner--large - map-get($nudges, nudge--small);
+      @extend %x-small-text;
+      color: $color-mid-dark;
+      font-weight: 400;
+      line-height: map-get($line-heights, x-small);
+      padding-top: map-get($nudges, nudge--x-small) + map-get($browser-rounding-compensations, small) + $sp-unit;
+      padding-bottom: $spv-inner--large - map-get($nudges, nudge--x-small);
+      text-transform: uppercase;
     }
 
     tr {

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -35,9 +35,7 @@
     }
 
     th {
-      @extend %x-small-text;
-      color: $color-mid-dark;
-      font-weight: 400;
+      @extend %table-header-label;
       line-height: map-get($line-heights, x-small);
       padding-bottom: $spv-inner--large - map-get($nudges, nudge--x-small);
       padding-top: map-get($nudges, nudge--x-small) + map-get($browser-rounding-compensations, small) + $sp-unit;

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -39,8 +39,8 @@
       color: $color-mid-dark;
       font-weight: 400;
       line-height: map-get($line-heights, x-small);
-      padding-top: map-get($nudges, nudge--x-small) + map-get($browser-rounding-compensations, small) + $sp-unit;
       padding-bottom: $spv-inner--large - map-get($nudges, nudge--x-small);
+      padding-top: map-get($nudges, nudge--x-small) + map-get($browser-rounding-compensations, small) + $sp-unit;
       text-transform: uppercase;
     }
 

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -210,6 +210,12 @@
     }
   }
 
+  %table-header-label {
+    @extend %x-small-text;
+    color: $color-mid-dark;
+    font-weight: 400;
+  }
+
   %muted-heading {
     @extend %small-text;
     color: $color-mid-dark;


### PR DESCRIPTION
## Done

- Make the column header text smaller and slightly more bold (regular weight instead of light),
 as agreed in https://github.com/canonical-web-and-design/vanilla-framework/issues/2501
- Add .5rem padding at the top to make the text vertically centered in the header
- Add is-table-header class to the aligned checkboxes and radios examples

## QA

- Pull code
- Run `./run serve --watch`
- Open /examples/base/table/, examples/base/forms/aligned-checkboxes/, examples/base/forms/aligned-radios/
- Verify the table headers, checkboxes and radios looks as in the screenshots bellow:

## Details

Fix https://github.com/canonical-web-and-design/vanilla-framework/issues/2501

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/2741678/73080485-cf8bad00-3ebd-11ea-9c37-86f65a2a4760.png)

After:
![image](https://user-images.githubusercontent.com/2741678/73080511-d87c7e80-3ebd-11ea-8e41-d953bce77201.png)

![image](https://user-images.githubusercontent.com/2741678/73085400-8db33480-3ec6-11ea-935d-a4b6d312584f.png)

![image](https://user-images.githubusercontent.com/2741678/73086201-1c748100-3ec8-11ea-8f81-1d57a6c2da46.png)

