### PR TITLE
Only animate necessary props in navigation links

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -34,7 +34,8 @@ $navigation-hover-opacity: 0.58;
       }
 
       & > a {
-        @include vf-animation;
+        $properties: #{background-color, color, opacity};
+        @include vf-animation($properties);
         display: block;
         line-height: map-get($line-heights, default-text);
         margin-bottom: 0;


### PR DESCRIPTION
## Done

Updated navigation links animation to only include color, background color and opacity props.

Fixes #2770 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2783.run.demo.haus/)
- Go to one of [navigation examples](https://vanilla-framework-canonical-web-and-design-pr-2783.run.demo.haus/examples/patterns/navigation/default/)
- Reload couple of times (with or without dev tools open)
- There should be no animation visible on load
- Hover on navigation items
- There should still be a subtle navigation when color of nav item changes

