### PR TITLE
Ensure nested fixed-witdh containers clear their side padding

### DIFF
--- a/docs/examples/utilities/fixed-width-container.html
+++ b/docs/examples/utilities/fixed-width-container.html
@@ -7,29 +7,3 @@ category: _utilities
 <div class="u-fixed-width">
   Content inside a container with the class `u-fixed-width` matches the width and position of content inside a grid.
 </div>
-
-<script>
-/**
-  Attaches event listener to switch baseline grid visibility on click.
-  @param {HTMLElement} toggle Switch element to toggle baseline grid.
-*/
-function setupBaselineGridSwitch(toggle) {
-  var target = toggle.getAttribute('aria-controls');
-
-  if (target) {
-    target = document.getElementById(target);
-  }
-
-  if (target) {
-    toggle.addEventListener('click', function () {
-      target.classList.toggle('u-baseline-grid');
-    });
-  }
-}
-
-// Set up switch element on page
-var toggle = document.querySelector('.p-switch[aria-controls]');
-if (toggle) {
-  setupBaselineGridSwitch(toggle);
-}
-</script>

--- a/docs/examples/utilities/fixed-width-container.html
+++ b/docs/examples/utilities/fixed-width-container.html
@@ -1,0 +1,35 @@
+---
+layout: examples
+title: Fixed width container
+category: _utilities
+---
+
+<div class="u-fixed-width">
+  Content inside a container with the class `u-fixed-width` matches the width and position of content inside a grid.
+</div>
+
+<script>
+/**
+  Attaches event listener to switch baseline grid visibility on click.
+  @param {HTMLElement} toggle Switch element to toggle baseline grid.
+*/
+function setupBaselineGridSwitch(toggle) {
+  var target = toggle.getAttribute('aria-controls');
+
+  if (target) {
+    target = document.getElementById(target);
+  }
+
+  if (target) {
+    toggle.addEventListener('click', function () {
+      target.classList.toggle('u-baseline-grid');
+    });
+  }
+}
+
+// Set up switch element on page
+var toggle = document.querySelector('.p-switch[aria-controls]');
+if (toggle) {
+  setupBaselineGridSwitch(toggle);
+}
+</script>

--- a/docs/patterns/grid.md
+++ b/docs/patterns/grid.md
@@ -10,9 +10,9 @@ Vanilla has a responsive grid with the following columns and gutters:
 
 | Screen size (px)                       | Columns | Grid gap (gutters) | Outer margins |
 | -------------------------------------- | ------- | ------------------ | ------------- |
-| 0 - $breakpoint-small                  | 4       | 1.5rem             | 1.0rem        |
+| 0 - \$breakpoint-small                 | 4       | 1.5rem             | 1.0rem        |
 | $breakpoint-small - $breakpoint-medium | 6       | 2.0rem             | 1.5rem        |
-| above $breakpoint-medium               | 12      | 2.0rem             | 1.5rem        |
+| above \$breakpoint-medium              | 12      | 2.0rem             | 1.5rem        |
 
 <br>
 
@@ -26,6 +26,14 @@ Read also: [Breakpoints](/settings/breakpoint-settings)
 
 <a href="/examples/patterns/grid/default/" class="js-example">
     View example of the default grid
+</a>
+
+### Fixed width containers
+
+If you only want to constrain content so it matches the grid's fixed width, you can use the utility `.u-fixed-width`. It behaves as a grid `.row` with a single 12-column container inside:
+
+<a href="/examples/utilities/fixed-width-container/" class="js-example">
+    View example of a fixed width container
 </a>
 
 ### Nested columns

--- a/docs/patterns/grid.md
+++ b/docs/patterns/grid.md
@@ -30,7 +30,7 @@ Read also: [Breakpoints](/settings/breakpoint-settings)
 
 ### Fixed width containers
 
-If you only want to constrain content so it matches the grid's fixed width, you can use the utility `.u-fixed-width`. It behaves as a grid `.row` with a single 12-column container inside:
+If you only want to constrain content so it matches the grid's fixed width, you can use the utility `.u-fixed-width`. It behaves as a grid `.row` with a single 12 column container inside:
 
 <a href="/examples/utilities/fixed-width-container/" class="js-example">
     View example of a fixed width container

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -6,6 +6,14 @@
 }
 
 @mixin vf-b-grid-definitions {
+  %fixed-width-container {
+    @extend %vf-grid-container-padding;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: $grid-max-width;
+    width: 100%;
+  }
+
   %vf-row {
     @extend %fixed-width-container;
 
@@ -52,9 +60,8 @@
     }
   }
 
-  // Grid
   %vf-grid-container-padding {
-    // set static gutter width per breakpoint
+    // set static outside padding per breakpoint
     @media (max-width: $threshold-4-6-col) {
       padding-left: map-get($grid-margin-widths, small);
       padding-right: map-get($grid-margin-widths, small);
@@ -69,13 +76,5 @@
       padding-left: map-get($grid-margin-widths, large);
       padding-right: map-get($grid-margin-widths, large);
     }
-  }
-
-  %fixed-width-container {
-    @extend %vf-grid-container-padding;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: $grid-max-width;
-    width: 100%;
   }
 }

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -51,4 +51,31 @@
       }
     }
   }
+
+  // Grid
+  %vf-grid-container-padding {
+    // set static gutter width per breakpoint
+    @media (max-width: $threshold-4-6-col) {
+      padding-left: map-get($grid-margin-widths, small);
+      padding-right: map-get($grid-margin-widths, small);
+    }
+
+    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+      padding-left: map-get($grid-margin-widths, medium);
+      padding-right: map-get($grid-margin-widths, medium);
+    }
+
+    @media (min-width: $threshold-6-12-col) {
+      padding-left: map-get($grid-margin-widths, large);
+      padding-right: map-get($grid-margin-widths, large);
+    }
+  }
+
+  %fixed-width-container {
+    @extend %vf-grid-container-padding;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: $grid-max-width;
+    width: 100%;
+  }
 }

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -66,33 +66,6 @@
     }
   }
 
-  // Grid
-  %vf-grid-container-padding {
-    // set static gutter width per breakpoint
-    @media (max-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, small);
-      padding-right: map-get($grid-margin-widths, small);
-    }
-
-    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
-      padding-left: map-get($grid-margin-widths, medium);
-      padding-right: map-get($grid-margin-widths, medium);
-    }
-
-    @media (min-width: $threshold-6-12-col) {
-      padding-left: map-get($grid-margin-widths, large);
-      padding-right: map-get($grid-margin-widths, large);
-    }
-  }
-
-  %fixed-width-container {
-    @extend %vf-grid-container-padding;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: $grid-max-width;
-    width: 100%;
-  }
-
   // Utilities
   %vf-hide-text {
     overflow: hidden;

--- a/scss/_utilities_layout.scss
+++ b/scss/_utilities_layout.scss
@@ -1,6 +1,11 @@
 @mixin vf-u-layout {
   .u-fixed-width {
     @extend %fixed-width-container;
+
+    & &,
+    .row & {
+      @include vf-b-row-reset;
+    }
   }
 
   @if ($table-layout-fixed) {


### PR DESCRIPTION
## Done

- Fix https://github.com/canonical-web-and-design/vanilla-framework/issues/2784
- Minor refactor

## QA

- Pull code
- Run `./run serve --watch`
- Open any example page 
- add `.u-fixed-width` inside a '.row'
- observe padding is cleared

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/73169935-229b7500-40f5-11ea-99d7-feb984e34ec3.png)
