### PR TITLE
Improve import sections of components' docs

### DIFF
--- a/docs/patterns/accordion.md
+++ b/docs/patterns/accordion.md
@@ -32,6 +32,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_accordion';
+@include vf-p-accordion;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/article-pagination.md
+++ b/docs/patterns/article-pagination.md
@@ -18,6 +18,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_article-pagination';
+@include vf-p-article-pagination;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/breadcrumbs.md
+++ b/docs/patterns/breadcrumbs.md
@@ -20,6 +20,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_breadcrumbs';
+@include vf-p-breadcrumbs;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/buttons.md
+++ b/docs/patterns/buttons.md
@@ -84,6 +84,11 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_buttons';
+@include vf-p-buttons;
+
+// when using icons within buttons you need to include icons as well
+@import '../patterns_icons';
+@include vf-p-icons;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/buttons.md
+++ b/docs/patterns/buttons.md
@@ -91,6 +91,8 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-p-icons;
 ```
 
+If you only need a small subset of the icons consider [including them individually](/patterns/icons/#import) to reduce the size of your CSS file.
+
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
 ### Design

--- a/docs/patterns/buttons.md
+++ b/docs/patterns/buttons.md
@@ -87,7 +87,7 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-p-buttons;
 
 // when using icons within buttons you need to include icons as well
-@import '../patterns_icons';
+@import 'patterns_icons';
 @include vf-p-icons;
 ```
 

--- a/docs/patterns/card.md
+++ b/docs/patterns/card.md
@@ -46,6 +46,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_card';
+@include vf-p-card;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -57,9 +57,12 @@ To import just this component into your project, copy the snippet below and incl
 @import 'patterns_contextual-menu';
 @include vf-p-contextual-menu;
 
-// when using indicator variant you need to include icons as well
+// when using the menu with dropdown button you need to include buttons and icon as well
+@import '../patterns_buttons';
+@include vf-p-buttons;
+
 @import '../patterns_icons';
-@include vf-p-icons;
+@include vf-p-icon-contextual-menu;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -58,10 +58,11 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-p-contextual-menu;
 
 // when using the menu with dropdown button you need to include buttons and icon as well
-@import '../patterns_buttons';
+@import 'patterns_buttons';
 @include vf-p-buttons;
 
-@import '../patterns_icons';
+@import 'patterns_icons';
+@include vf-p-icons-common;
 @include vf-p-icon-contextual-menu;
 ```
 

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -55,6 +55,11 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_contextual-menu';
+@include vf-p-contextual-menu;
+
+// when using indicator variant you need to include icons as well
+@import '../patterns_icons';
+@include vf-p-icons;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/grid.md
+++ b/docs/patterns/grid.md
@@ -10,9 +10,9 @@ Vanilla has a responsive grid with the following columns and gutters:
 
 | Screen size (px)                       | Columns | Grid gap (gutters) | Outer margins |
 | -------------------------------------- | ------- | ------------------ | ------------- |
-| 0 - $breakpoint-small                  | 4       | 1.5rem             | 1.0rem        |
+| 0 - \$breakpoint-small                 | 4       | 1.5rem             | 1.0rem        |
 | $breakpoint-small - $breakpoint-medium | 6       | 2.0rem             | 1.5rem        |
-| above $breakpoint-medium               | 12      | 2.0rem             | 1.5rem        |
+| above \$breakpoint-medium              | 12      | 2.0rem             | 1.5rem        |
 
 <br>
 
@@ -62,6 +62,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_grid';
+@include vf-p-grid;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/heading-icon.md
+++ b/docs/patterns/heading-icon.md
@@ -35,6 +35,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_heading-icon';
+@include vf-p-heading-icon;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/icons.md
+++ b/docs/patterns/icons.md
@@ -185,7 +185,7 @@ Our social icons are used to drive users to social content.
     </div>
     </div>
 
-<span class="p-label--deprecated">Deprecated</span> We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from our social icon set, they will no longer be available from our future release v3.0. 
+<span class="p-label--deprecated">Deprecated</span> We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from our social icon set, they will no longer be available from our future release v3.0.
 
   </div>
 </section>
@@ -216,6 +216,11 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_icons';
+@include vf-p-icons;
+
+// for spin animation on the spinner icon you need to include animations utility
+@import '../utilities_animations';
+@include vf-u-animations;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/icons.md
+++ b/docs/patterns/icons.md
@@ -223,6 +223,48 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-u-animations;
 ```
 
+If you use a limited set of icons you may want to include them individually to reduce the size of your CSS file.
+
+```scss
+@import 'patterns_icons';
+
+// include only the icons that you use in your project
+@include vf-p-icon-anchor;
+@include vf-p-icon-plus;
+@include vf-p-icon-minus;
+@include vf-p-icon-expand;
+@include vf-p-icon-collapse;
+@include vf-p-icon-contextual-menu;
+@include vf-p-icon-close;
+@include vf-p-icon-help;
+@include vf-p-icon-info;
+@include vf-p-icon-delete;
+@include vf-p-icon-error;
+@include vf-p-icon-warning;
+@include vf-p-icon-external-link;
+@include vf-p-icon-drag;
+@include vf-p-icon-code;
+@include vf-p-icon-menu;
+@include vf-p-icon-copy;
+@include vf-p-icon-search;
+@include vf-p-icon-success;
+@include vf-p-icon-share;
+@include vf-p-icon-user;
+@include vf-p-icon-question;
+@include vf-p-icon-spinner;
+@include vf-p-icon-facebook;
+@include vf-p-icon-twitter;
+@include vf-p-icon-instagram;
+@include vf-p-icon-linkedin;
+@include vf-p-icon-youtube;
+@include vf-p-icon-canonical;
+@include vf-p-icon-ubuntu;
+@include vf-p-icon-rss;
+@include vf-p-icon-email;
+@include vf-p-icon-sizes;
+@include vf-p-icon-in-button;
+```
+
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
 ### Design

--- a/docs/patterns/icons.md
+++ b/docs/patterns/icons.md
@@ -219,7 +219,7 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-p-icons;
 
 // for spin animation on the spinner icon you need to include animations utility
-@import '../utilities_animations';
+@import 'utilities_animations';
 @include vf-u-animations;
 ```
 
@@ -227,6 +227,9 @@ If you use a limited set of icons you may want to include them individually to r
 
 ```scss
 @import 'patterns_icons';
+
+// include common styles shared by all icons
+@include vf-p-icons-common;
 
 // include only the icons that you use in your project
 @include vf-p-icon-anchor;

--- a/docs/patterns/images.md
+++ b/docs/patterns/images.md
@@ -30,6 +30,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_image';
+@include vf-p-image;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/inline-images.md
+++ b/docs/patterns/inline-images.md
@@ -18,6 +18,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_inline-images';
+@include vf-p-inline-images;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/labels.md
+++ b/docs/patterns/labels.md
@@ -60,6 +60,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_label';
+@include vf-p-label;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/links.md
+++ b/docs/patterns/links.md
@@ -62,6 +62,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_links';
+@include vf-p-links;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/list-tree.md
+++ b/docs/patterns/list-tree.md
@@ -20,6 +20,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_list-tree';
+@include vf-p-list-tree;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/lists.md
+++ b/docs/patterns/lists.md
@@ -117,7 +117,7 @@ To add dividers into your project, copy the snippet below and include it in your
 @include vf-p-divider;
 
 // grid column classes are used within divider component, so you need to include grid pattern as well
-@import '../patterns_grid';
+@import 'patterns_grid';
 @include vf-p-grid;
 ```
 

--- a/docs/patterns/lists.md
+++ b/docs/patterns/lists.md
@@ -51,7 +51,7 @@ View example of the ticked divided list pattern
 
 ### Responsive divider
 
-A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-medium`), the divider lines appear horizontally. On screens bigger than $breakpoint-medium, the divider lines appear vertically, centered in the column gutters.
+A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-medium`), the divider lines appear horizontally. On screens bigger than \$breakpoint-medium, the divider lines appear vertically, centered in the column gutters.
 
 <a href="/examples/patterns/lists/divider/" class="js-example">
 View example of lists with a responsive divider
@@ -107,12 +107,18 @@ To import just this base element into your project, copy the snippet below and i
 
 ```scss
 @import 'patterns_lists';
+@include vf-p-lists;
 ```
 
 To add dividers into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
 @import 'patterns_divider';
+@include vf-p-divider;
+
+// grid column classes are used within divider component, so you need to include grid pattern as well
+@import '../patterns_grid';
+@include vf-p-grid;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/matrix.md
+++ b/docs/patterns/matrix.md
@@ -26,6 +26,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_matrix';
+@include vf-p-matrix;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/media-object.md
+++ b/docs/patterns/media-object.md
@@ -35,6 +35,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_media-object';
+@include vf-p-media-object;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/modal.md
+++ b/docs/patterns/modal.md
@@ -20,6 +20,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_modal';
+@include vf-p-modal;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/muted-heading.md
+++ b/docs/patterns/muted-heading.md
@@ -19,6 +19,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_muted-heading';
+@include vf-p-muted-heading;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -47,14 +47,15 @@ View example of the sub-navigation pattern
 
 ### Import
 
-To import just navigation or sub-navigation component into your project, copy either or both snippets below and include it in your main Sass file.
+To import just navigation or sub-navigation component into your project, copy snippets below and include it in your main Sass file.
 
 ```scss
 @import 'patterns_navigation';
-```
+@include vf-p-navigation;
 
-```scss
+// sub-navigation is optional you can include it alongside navigation component
 @import 'patterns_subnav';
+@include vf-p-subnav;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/notification.md
+++ b/docs/patterns/notification.md
@@ -70,6 +70,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_notifications';
+@include vf-p-notification;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/pagination.md
+++ b/docs/patterns/pagination.md
@@ -38,7 +38,7 @@ To import just this component into your project, copy the snippet below and incl
 
 // pagination uses icons for previous and next page buttons
 @import '../patterns_icons';
-@include vf-p-icons;
+@include vf-p-icon-contextual-menu;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/pagination.md
+++ b/docs/patterns/pagination.md
@@ -37,7 +37,8 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-p-pagination;
 
 // pagination uses icons for previous and next page buttons
-@import '../patterns_icons';
+@import 'patterns_icons';
+@include vf-p-icons-common;
 @include vf-p-icon-contextual-menu;
 ```
 

--- a/docs/patterns/pagination.md
+++ b/docs/patterns/pagination.md
@@ -34,6 +34,11 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_pagination';
+@include vf-p-pagination;
+
+// pagination uses icons for previous and next page buttons
+@import '../patterns_icons';
+@include vf-p-icons;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/pull-quote.md
+++ b/docs/patterns/pull-quote.md
@@ -43,6 +43,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_pull-quotes';
+@include vf-p-pull-quotes;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/search-box.md
+++ b/docs/patterns/search-box.md
@@ -32,9 +32,10 @@ To import just this component into your project, copy the snippet below and incl
 @import 'patterns_search-box';
 @include vf-p-search-box;
 
-// search box uses icons for its buttons, so you need to import icons as well
+// search box uses icons for its buttons, so you need to include them as well
 @import '../patterns_icons';
-@include vf-p-icons;
+@include vf-p-icon-close;
+@include vf-p-icon-search;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/search-box.md
+++ b/docs/patterns/search-box.md
@@ -30,6 +30,11 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_search-box';
+@include vf-p-search-box;
+
+// search box uses icons for its buttons, so you need to import icons as well
+@import '../patterns_icons';
+@include vf-p-icons;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/search-box.md
+++ b/docs/patterns/search-box.md
@@ -33,7 +33,8 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-p-search-box;
 
 // search box uses icons for its buttons, so you need to include them as well
-@import '../patterns_icons';
+@import 'patterns_icons';
+@include vf-p-icons-common;
 @include vf-p-icon-close;
 @include vf-p-icon-search;
 ```

--- a/docs/patterns/slider.md
+++ b/docs/patterns/slider.md
@@ -19,6 +19,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_slider';
+@include vf-p-slider;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/strip.md
+++ b/docs/patterns/strip.md
@@ -80,6 +80,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_strip';
+@include vf-p-strip;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/switch.md
+++ b/docs/patterns/switch.md
@@ -18,6 +18,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_switch';
+@include vf-p-switch;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/table-of-contents.md
+++ b/docs/patterns/table-of-contents.md
@@ -21,7 +21,7 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-p-table-of-contents;
 
 // list component is used within table of contents, so you need to include it as well
-@import '../patterns_lists';
+@import 'patterns_lists';
 @include vf-p-lists;
 ```
 

--- a/docs/patterns/table-of-contents.md
+++ b/docs/patterns/table-of-contents.md
@@ -18,6 +18,11 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_table-of-contents';
+@include vf-p-table-of-contents;
+
+// list component is used within table of contents, so you need to include it as well
+@import '../patterns_lists';
+@include vf-p-lists;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/tabs.md
+++ b/docs/patterns/tabs.md
@@ -40,6 +40,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_tabs';
+@include vf-p-tabs;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/docs/patterns/tooltips.md
+++ b/docs/patterns/tooltips.md
@@ -27,6 +27,7 @@ To import just this component into your project, copy the snippet below and incl
 
 ```scss
 @import 'patterns_tooltips';
+@include vf-p-tooltips;
 ```
 
 For more information see [Customising Vanilla](/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -1,6 +1,7 @@
 @import 'settings';
 
 @mixin vf-p-icons {
+  @include vf-p-icons-common;
   @include vf-p-icon-anchor;
   @include vf-p-icon-plus;
   @include vf-p-icon-minus;
@@ -35,7 +36,9 @@
   @include vf-p-icon-email;
   @include vf-p-icon-sizes;
   @include vf-p-icon-in-button;
+}
 
+@mixin vf-p-icons-common {
   %icon {
     @extend %vf-hide-text;
     @include vf-icon-size($default-icon-size);

--- a/scss/standalone/patterns_contextual-menu.scss
+++ b/scss/standalone/patterns_contextual-menu.scss
@@ -6,7 +6,7 @@
 
 // icons are needed for indicator variant
 @import '../patterns_icons';
-@include vf-p-icons;
+@include vf-p-icon-contextual-menu;
 
 @import '../patterns_contextual-menu';
 @include vf-p-contextual-menu;

--- a/scss/standalone/patterns_contextual-menu.scss
+++ b/scss/standalone/patterns_contextual-menu.scss
@@ -6,6 +6,7 @@
 
 // icons are needed for indicator variant
 @import '../patterns_icons';
+@include vf-p-icons-common;
 @include vf-p-icon-contextual-menu;
 
 @import '../patterns_contextual-menu';

--- a/scss/standalone/patterns_pagination.scss
+++ b/scss/standalone/patterns_pagination.scss
@@ -3,6 +3,7 @@
 
 // p-icon--contextual-menu needed as next/prev icon
 @import '../patterns_icons';
+@include vf-p-icons-common;
 @include vf-p-icon-contextual-menu;
 
 @import '../patterns_pagination';

--- a/scss/standalone/patterns_pagination.scss
+++ b/scss/standalone/patterns_pagination.scss
@@ -3,7 +3,7 @@
 
 // p-icon--contextual-menu needed as next/prev icon
 @import '../patterns_icons';
-@include vf-p-icons;
+@include vf-p-icon-contextual-menu;
 
 @import '../patterns_pagination';
 @include vf-p-pagination;

--- a/scss/standalone/patterns_search-box.scss
+++ b/scss/standalone/patterns_search-box.scss
@@ -11,6 +11,7 @@
 
 // icons are needed for search box buttons
 @import '../patterns_icons';
+@include vf-p-icons-common;
 @include vf-p-icon-close;
 @include vf-p-icon-search;
 

--- a/scss/standalone/patterns_search-box.scss
+++ b/scss/standalone/patterns_search-box.scss
@@ -11,7 +11,8 @@
 
 // icons are needed for search box buttons
 @import '../patterns_icons';
-@include vf-p-icons;
+@include vf-p-icon-close;
+@include vf-p-icon-search;
 
 @import '../patterns_search-box';
 @include vf-p-search-box;

--- a/scss/standalone/patterns_strip.scss
+++ b/scss/standalone/patterns_strip.scss
@@ -1,7 +1,7 @@
 @import '../base';
 @include vf-base;
 
-// needed by card overlay example
+// needed by some of the examples
 @import '../patterns_grid';
 @include vf-p-grid;
 @import '../utilities_vertically-center';


### PR DESCRIPTION

## Done

Improves "Import" section of each component docs to make sure they show both `@import` and `@include` needed for given component, also should mention any related components that are required.

This also adds `vf-p-icons-common` mixin that can be used to include individual icons instead of whole set.

Fixes #2777 

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or demo
- Go to pattern docs pages
- Scroll down to "Import" section of the docs
- Make sure docs include both `@import` and `@include` in SCSS snippet, some patterns (search box, table of contents, pagination, etc) should also mention other related patterns that need to be included


## Screenshots


<img width="1250" alt="Screenshot 2020-01-27 at 12 12 56" src="https://user-images.githubusercontent.com/83575/73170323-6050cb80-40fe-11ea-8066-4083f94a9859.png">
