### PR TITLE
Update component status as for v2.6.0

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -75,7 +75,7 @@
                 <strong>Base elements</strong>
                 <ul class="p-sidebar-nav__list">
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/code/' %}is-active{% endif %}" href="/base/code/">Code</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/forms/' %}is-active{% endif %}" href="/base/forms/">Forms</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/forms/' %}is-active{% endif %}" href="/base/forms/">Forms</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/reset/' %}is-active{% endif %}" href="/base/reset/">Reset</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/tables/' %}is-active{% endif %}" href="/base/tables">Tables</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/typography/' %}is-active{% endif %}" href="/base/typography/">Typography</a></li>
@@ -109,7 +109,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/pagination/' %}is-active{% endif %}" href="/patterns/pagination/">Pagination</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/pull-quote/' %}is-active{% endif %}" href="/patterns/pull-quote/">Quotes</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/search-box/' %}is-active{% endif %}" href="/patterns/search-box/">Search box</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/slider/' %}is-active{% endif %}" href="/patterns/slider/">Slider</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/slider/' %}is-active{% endif %}" href="/patterns/slider/">Slider</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/strip/' %}is-active{% endif %}" href="/patterns/strip/">Strip</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/switch/' %}is-active{% endif %}" href="/patterns/switch/">Switch</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/table-of-contents/' %}is-active{% endif %}" href="/patterns/table-of-contents/">Table of contents</a></li>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -78,7 +78,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/forms/' %}is-active{% endif %}" href="/base/forms/">Forms</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/reset/' %}is-active{% endif %}" href="/base/reset/">Reset</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/tables/' %}is-active{% endif %}" href="/base/tables">Tables</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/typography/' %}is-active{% endif %}" href="/base/typography/">Typography</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/base/typography/' %}is-active{% endif %}" href="/base/typography/">Typography</a></li>
                 </ul>
               </li>
 
@@ -90,10 +90,10 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/breadcrumbs/' %}is-active{% endif %}" href="/patterns/breadcrumbs/">Breadcrumbs</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/buttons/' %}is-active{% endif %}" href="/patterns/buttons/">Buttons</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/card/' %}is-active{% endif %}" href="/patterns/card/">Cards</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/contextual-menu/' %}is-active{% endif %}" href="/patterns/contextual-menu/">Contextual menu</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/contextual-menu/' %}is-active{% endif %}" href="/patterns/contextual-menu/">Contextual menu</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/grid/' %}is-active{% endif %}" href="/patterns/grid/">Grid</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/heading-icon/' %}is-active{% endif %}" href="/patterns/heading-icon/">Heading icon</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/icons/' %}is-active{% endif %}" href="/patterns/icons/">Icons</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/icons/' %}is-active{% endif %}" href="/patterns/icons/">Icons</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/images/' %}is-active{% endif %}" href="/patterns/images/">Images</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/inline-images/' %}is-active{% endif %}" href="/patterns/inline-images/">Inline images</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/patterns/labels/' %}is-active{% endif %}" href="/patterns/labels/">Labels</a></li>
@@ -127,7 +127,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/embedded-media/' %}is-active{% endif %}" href="/utilities/embedded-media/">Embedded media</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/equal-height/' %}is-active{% endif %}" href="/utilities/equal-height/">Equal height</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/floats/' %}is-active{% endif %}" href="/utilities/floats/">Floats</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/font-metrics/' %}is-active{% endif %}" href="/utilities/font-metrics/">Font metrics</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/font-metrics/' %}is-active{% endif %}" href="/utilities/font-metrics/">Font metrics</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/functions/' %}is-active{% endif %}" href="/utilities/functions/">Functions</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/hide/' %}is-active{% endif %}" href="/utilities/hide/">Hide</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/image-position/' %}is-active{% endif %}" href="/utilities/image-position/">Image position</a></li>
@@ -136,7 +136,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/off-screen/' %}is-active{% endif %}" href="/utilities/off-screen/">Off-screen</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/padding-collapse/' %}is-active{% endif %}" href="/utilities/padding-collapse/">Padding collapse</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/table-cell-padding-overlap/' %}is-active{% endif %}" href="/utilities/table-cell-padding-overlap/">Table cell padding overlap</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/truncate/' %}is-active{% endif %}" href="/utilities/truncate/">Truncation</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/truncate/' %}is-active{% endif %}" href="/utilities/truncate/">Truncation</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/show/' %}is-active{% endif %}" href="/utilities/show/">Show</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if page.url == '/utilities/vertically-center/' %}is-active{% endif %}" href="/utilities/vertically-center/">Vertically center</a></li>
                 </ul>

--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -42,6 +42,8 @@ Use checkboxes to select one or more options, default checkboxes can appear in t
 View example of the base checkboxes
 </a>
 
+<span class="p-label--updated">Updated</span>
+
 By default, checkboxes are vertically aligned to the baseline of text wrapped in a `label`, `h5`, `h6`, or `p` tag. If you need to align them to other elements, use one of the following classes:
 `is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
 
@@ -56,6 +58,8 @@ Use radio buttons to select one or more options, our radio buttons can appear in
 <a href="/examples/base/forms/radio-buttons/" class="js-example">
 View example of the base radio buttons
 </a>
+
+<span class="p-label--updated">Updated</span>
 
 By default, radio buttons are vertically aligned to the baseline of text wrapped in a `label`, `h5`, `h6`, or `p` tag. If you need to align them to other elements, use one of the following classes:
 `is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.

--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -80,6 +80,8 @@ View example of the base multiple selects
 
 ### Range
 
+<span class="p-label--new">New</span>
+
 The `<input type="range">` allows a user to select from a specified range of values, where the precise value is not considered important.
 
 <a href="/examples/base/forms/range/" class="js-example">

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -94,8 +94,6 @@ View example of the mixed headings pattern
 
 ### Line length
 
-<span class="p-label--new">New</span>
-
 Line length, measured in number of characters per line (CPL), has been shown to affect reading speed and comprehension. While there is little consensus on what the optimal CPL value is, most studies test with values between 45 and 95 characters per line. <a href="https://en.wikipedia.org/wiki/Line_length">Wikipedia</a> has a good historical overview and a list of studies on the subject.
 
 The max-width of text elements in Vanilla Framework is limited using the `$max-width--default` variable, currently set to `40em`, or around 90 characters.

--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -27,6 +27,11 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
     </tr>
     <tr>
+      <th><a href="/base/forms/#checkbox">Checkbox, radio button</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>New `is-table-header` added to properly align checkboxes and radio buttons used in table headers.</td>
+    </tr>
+    <tr>
       <th><a href="/patterns/slider">Slider</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -31,8 +31,6 @@ View example of the contextual menu pattern
 
 ### Indicator
 
-<span class="p-label--new">New</span>
-
 If you require a drop-down button with a state indicator then the `p-contextual-menu__toggle` class can be used alongside the `p-icon` and `p-button` components.
 
 <div class="p-notification--information">

--- a/docs/patterns/slider.md
+++ b/docs/patterns/slider.md
@@ -14,7 +14,7 @@ View example of the slider pattern
 </a>
 
 <span class="p-label--updated">Updated</span> In version 2.6.0 Vanilla framework added slider styling as default for
-all range inputs, so adding `p-slider` class just to style `<input type="range">` is not necessary anymore.
+all range inputs, so adding `p-slider` class just to style `<input type="range">` is not necessary any more.
 
 ### Import
 

--- a/docs/patterns/slider.md
+++ b/docs/patterns/slider.md
@@ -13,6 +13,9 @@ when you want to provide a numeric representation of the slider value, as well a
 View example of the slider pattern
 </a>
 
+<span class="p-label--updated">Updated</span> In version 2.6.0 Vanilla framework added slider styling as default for
+all range inputs, so adding `p-slider` class just to style `<input type="range">` is not necessary anymore.
+
 ### Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -4,8 +4,6 @@ layout: default
 
 ## Font metrics
 
-<span class="p-label--new">New</span>
-
 <hr>
 
 Being able to visualise the <a target="_blank" href="https://en.wikipedia.org/wiki/Baseline_(typography)">baseline</a> position, <a target="_blank" href="https://en.wikipedia.org/wiki/Cap_height">cap-height</a> and <a target="_blank" href="https://en.wikipedia.org/wiki/X-height">x-height</a> of a typeface can be helpful, for example when trying to precisely align inline-block elements (like icons) to text.

--- a/docs/utilities/table-cell-padding-overlap.md
+++ b/docs/utilities/table-cell-padding-overlap.md
@@ -4,8 +4,6 @@ layout: default
 
 ## Table cell padding overlap
 
-<span class="p-label--new">New</span>
-
 <hr>
 
 Vanilla applies padding-top and padding bottom to table cells. This is done to prevent row borders from getting too close to text that is not wrapped in a `<p>` or other text element.

--- a/docs/utilities/truncate.md
+++ b/docs/utilities/truncate.md
@@ -4,8 +4,6 @@ layout: default
 
 ## Truncation
 
-<span class="p-label--new">New</span>
-
 <hr>
 
 To truncate text, use the class `u-truncate`.


### PR DESCRIPTION
## Done

Update component status page and labels for 2.6.0 release.

## QA

- Pull code
- Run `./run serve --watch`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2787.run.demo.haus/)
- Go to [component status page](https://vanilla-framework-canonical-web-and-design-pr-2787.run.demo.haus/component-status/), make sure recent changes are listed
- Check if corresponding changes are marked in side navigation with labels
- Check if corresponding changes are marked with labels in the page contents

## Screenshots

<img width="1274" alt="Screenshot 2020-01-27 at 17 16 57" src="https://user-images.githubusercontent.com/83575/73192127-ea158e80-4128-11ea-8302-fd32fb83e9c7.png">

