### PR TITLE
Add redirects for previous locations of static resources

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,3 +1,6 @@
 /en/?: /
 /en/(?P<path>.*): /{path}
 /(?P<path>.+)\.html: /{path}
+/build/(?P<path>.*): /static/build/{path}
+/css/(?P<path>.*): /static/css/{path}
+/js/(?P<path>.*): /static/js/{path}


### PR DESCRIPTION
## Done

Add redirects for previous locations of static resources

## QA

https://vanilla-framework-canonical-web-and-design-pr-2809.run.demo.haus/css/styles.css should be /static/css/styles.css
https://vanilla-framework-canonical-web-and-design-pr-2809.run.demo.haus/js/examples.js should be /static/js/examples.js 
https://vanilla-framework-canonical-web-and-design-pr-2809.run.demo.haus/build/css/build.css should be /static/build/css/build.css 