### PR TITLE
Add /search to docs site

### DIFF
--- a/docs/search.html
+++ b/docs/search.html
@@ -1,0 +1,65 @@
+{% extends "_layouts/default.html" %}
+
+{% block title %}Search results{% if query %} for "{{query}}"{% endif %}{% endblock %}
+
+{% block content %}
+<section id="search">
+  <div class="row">
+    <form class="p-search-box u-no-margin--bottom" action="/search">
+      <input type="search" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search Vanilla docs" required/>
+      <button type="button" class="p-search-box__reset" alt="reset" onclick="this.previousElementSibling.value = '';this.previousElementSibling.focus()"><i class="p-icon--close">Reset</i></button>
+      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
+    </form>
+  </div>
+</section>
+
+<div class="l-docs">
+  <div class="p-strip">
+    <div class="row">
+      <div class="col-12">
+        {% if results and results.entries %}
+          <h1 class="p-heading--two u-no-margin--bottom">We've found these results for your search <strong>"{{ query }}"</strong></h1>
+        {% else %}
+          <h1 class="p-heading--two u-no-margin--bottom">We haven't found any results for your search <strong>"{{ query }}"</strong>.</h1>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  {% if  results and results.entries %}
+    {% for item in results.entries %}
+      <div class="p-strip is-bordered is-shallow">
+        <div class="row">
+          <div class="col-12">
+            <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
+            <p>
+              {{ item.htmlSnippet | safe }}
+            </p>
+            <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
+          </div>
+        </div>
+      </div>
+    {% endfor %}
+      <div class="p-strip p-article-pagination">
+        {% if  results.queries and results.queries.previousPage %}
+          <a
+            class="p-article-pagination__link--previous"
+            href="/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
+          >
+            <span class="p-article-pagination__label">Previous</span>
+          </a>
+        {% endif %}
+        {% if results.queries and results.queries.nextPage %}
+          <a
+            class="p-article-pagination__link--next"
+            href="/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
+          >
+            <span class="p-article-pagination__label">Next</span>
+          </a>
+        {% endif %}
+      </div>
+    {% else %}
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 canonicalwebteam.flask-base==0.3.3
 gunicorn[gevent]
 canonicalwebteam.templatefinder==0.2.4
+canonicalwebteam.search==0.2.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -7,6 +7,7 @@ import os
 import flask
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
+from canonicalwebteam.search import build_search_view
 
 
 # Constants
@@ -92,4 +93,11 @@ def standalone_example(example_path):
 
 
 app.add_url_rule("/", view_func=template_finder_view)
+app.add_url_rule(
+    "/search",
+    "search",
+    build_search_view(
+        site="docs.vanillaframework.io", template_path="search.html"
+    ),
+)
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)


### PR DESCRIPTION
Make use of [canonicalwebteam.search v0.2.0](https://pypi.org/project/canonicalwebteam.search/) to provide search results at /search?q={query}.

I've added docs.vanillaframework.io to [our Custom Search engine](https://cse.google.com/cse/setup/basic?cx=009048213575199080868:i3zoqdwqk8o)

**NB:** This is to implement the back-end only. The HTML and styling for the search results page is only preliminary, and I haven't linked to `/search` from anywhere, so I'm hoping it's okay to merge this PR without a visual review and get @bartaz or something to do the styling of the search results page in a future PR, when they also add the search box.

QA
--

Get the "Custom Search API key" from [the Google Cloud Platform console](https://console.cloud.google.com/apis/credentials?project=ubuntu-search-1530889417216&pli=1),
and place it in a file called `.env.local` as `SEARCH_API_KEY`:

``` bash
$ cat .env.local 
SEARCH_API_KEY=xxxxx
```

Now do `./run` and go to e.g. http://0.0.0.0:8101/search?q=grid to see the search working.