### PR TITLE
Themify contextual menu

### DIFF
--- a/docs/examples/patterns/contextual-menu/dark.html
+++ b/docs/examples/patterns/contextual-menu/dark.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Contextual menu / dark{% endblock %}
+{% block title %}Contextual menu / Dark{% endblock %}
 
 {% block standalone_css %}patterns_contextual-menu{% endblock %}
 

--- a/docs/examples/patterns/contextual-menu/dark.html
+++ b/docs/examples/patterns/contextual-menu/dark.html
@@ -1,0 +1,135 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Contextual menu / Default{% endblock %}
+
+{% block standalone_css %}patterns_contextual-menu{% endblock %}
+
+{% block content %}
+<span class="p-contextual-menu--left is-dark">
+    <button href="#" class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
+    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Commission</a>
+            <a href="#" class="p-contextual-menu__link">Aquire</a>
+            <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Test harware</a>
+            <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+            <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span>
+
+<p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left is-dark">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">take action left</a>
+    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center is-dark">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
+    <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu is-dark">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
+    <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> vel eu.</p>
+
+<script>
+/**
+  Toggles the necessary aria- attributes' values on the menus
+  and handles to show or hide them.
+  @param {HTMLElement} element The menu link or button.
+  @param {Boolean} show Whether to show or hide the menu.
+*/
+function toggleMenu(element, show) {
+  var target = document.getElementById(element.getAttribute('aria-controls'));
+
+  if (target) {
+    element.setAttribute('aria-expanded', show);
+    target.setAttribute('aria-hidden', !show);
+  }
+}
+
+/**
+  Attaches event listeners for the menu toggle open and close click events.
+  @param {HTMLElement} menuToggle The menu container element.
+*/
+function setupContextualMenu(menuToggle) {
+  menuToggle.addEventListener('click', function(event) {
+    event.preventDefault();
+    var menuAlreadyOpen = menuToggle.getAttribute('aria-expanded') === 'true';
+    toggleMenu(menuToggle, !menuAlreadyOpen);
+  });
+}
+
+/**
+  Attaches event listeners for all the menu toggles in the document and
+  listeners to handle close when clicking outside the menu or using ESC key.
+  @param {String} contextualMenuToggleSelector The CSS selector matching menu toggle elements.
+*/
+function setupAllContextualMenus(contextualMenuToggleSelector) {
+  // Setup all menu toggles on the page.
+  var toggles = document.querySelectorAll(contextualMenuToggleSelector);
+
+  for (var i = 0, l = toggles.length; i < l; i++) {
+    setupContextualMenu(toggles[i]);
+  }
+
+  // Add handler for clicking outside the menu.
+  document.addEventListener('click', function(event) {
+    for (var i = 0, l = toggles.length; i < l; i++) {
+      var toggle = toggles[i];
+      var contextualMenu = document.getElementById(toggle.getAttribute('aria-controls'));
+      var clickOutside = !(toggle.contains(event.target) || contextualMenu.contains(event.target));
+
+      if (clickOutside) {
+        toggleMenu(toggle, false);
+      }
+    }
+  });
+
+  // Add handler for closing menus using ESC key.
+  document.addEventListener('keydown', function(e) {
+    e = e || window.event;
+
+    if (e.keyCode === 27) {
+      for (var i = 0, l = toggles.length; i < l; i++) {
+        toggleMenu(toggles[i], false);
+      }
+    }
+  });
+}
+
+setupAllContextualMenus('.p-contextual-menu__toggle');
+</script>
+{% endblock %}

--- a/docs/examples/patterns/contextual-menu/dark.html
+++ b/docs/examples/patterns/contextual-menu/dark.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Contextual menu / Default{% endblock %}
+{% block title %}Contextual menu / dark{% endblock %}
 
 {% block standalone_css %}patterns_contextual-menu{% endblock %}
 

--- a/docs/examples/patterns/contextual-menu/light.html
+++ b/docs/examples/patterns/contextual-menu/light.html
@@ -1,0 +1,135 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Contextual menu / Default{% endblock %}
+
+{% block standalone_css %}patterns_contextual-menu{% endblock %}
+
+{% block content %}
+<span class="p-contextual-menu--left is-light">
+    <button href="#" class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
+    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Commission</a>
+            <a href="#" class="p-contextual-menu__link">Aquire</a>
+            <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Test harware</a>
+            <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+            <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span>
+
+<p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left is-light">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">take action left</a>
+    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center is-light">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
+    <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu is-light">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
+    <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> vel eu.</p>
+
+<script>
+/**
+  Toggles the necessary aria- attributes' values on the menus
+  and handles to show or hide them.
+  @param {HTMLElement} element The menu link or button.
+  @param {Boolean} show Whether to show or hide the menu.
+*/
+function toggleMenu(element, show) {
+  var target = document.getElementById(element.getAttribute('aria-controls'));
+
+  if (target) {
+    element.setAttribute('aria-expanded', show);
+    target.setAttribute('aria-hidden', !show);
+  }
+}
+
+/**
+  Attaches event listeners for the menu toggle open and close click events.
+  @param {HTMLElement} menuToggle The menu container element.
+*/
+function setupContextualMenu(menuToggle) {
+  menuToggle.addEventListener('click', function(event) {
+    event.preventDefault();
+    var menuAlreadyOpen = menuToggle.getAttribute('aria-expanded') === 'true';
+    toggleMenu(menuToggle, !menuAlreadyOpen);
+  });
+}
+
+/**
+  Attaches event listeners for all the menu toggles in the document and
+  listeners to handle close when clicking outside the menu or using ESC key.
+  @param {String} contextualMenuToggleSelector The CSS selector matching menu toggle elements.
+*/
+function setupAllContextualMenus(contextualMenuToggleSelector) {
+  // Setup all menu toggles on the page.
+  var toggles = document.querySelectorAll(contextualMenuToggleSelector);
+
+  for (var i = 0, l = toggles.length; i < l; i++) {
+    setupContextualMenu(toggles[i]);
+  }
+
+  // Add handler for clicking outside the menu.
+  document.addEventListener('click', function(event) {
+    for (var i = 0, l = toggles.length; i < l; i++) {
+      var toggle = toggles[i];
+      var contextualMenu = document.getElementById(toggle.getAttribute('aria-controls'));
+      var clickOutside = !(toggle.contains(event.target) || contextualMenu.contains(event.target));
+
+      if (clickOutside) {
+        toggleMenu(toggle, false);
+      }
+    }
+  });
+
+  // Add handler for closing menus using ESC key.
+  document.addEventListener('keydown', function(e) {
+    e = e || window.event;
+
+    if (e.keyCode === 27) {
+      for (var i = 0, l = toggles.length; i < l; i++) {
+        toggleMenu(toggles[i], false);
+      }
+    }
+  });
+}
+
+setupAllContextualMenus('.p-contextual-menu__toggle');
+</script>
+{% endblock %}

--- a/docs/examples/patterns/contextual-menu/light.html
+++ b/docs/examples/patterns/contextual-menu/light.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Contextual menu / Default{% endblock %}
+{% block title %}Contextual menu / Light{% endblock %}
 
 {% block standalone_css %}patterns_contextual-menu{% endblock %}
 

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -57,7 +57,7 @@ The contextual menu uses Vanilla's light theme by default. There are two ways to
 - Override the default by adding a state to `p-contextual-menu`: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark:
 
 <a href="/examples/patterns/contextual-menu/dark" class="js-example">
-View example of the contextual menu with an is-light class
+View example of the contextual menu with an is-dark class
 </a>
 
 <a href="/examples/patterns/contextual-menu/light" class="js-example">

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -9,7 +9,7 @@ context:
 
 <hr>
 
-A contextual menu can be applied to any button, link or navigation item that requires a secondary menu. To interact with the menu it will require some javascript to hide/show each pattern. This achieved by finding the toggle element `p-contextual-menu__toggle` and what it controls `aria-controls`.
+A contextual menu can be applied to any button, link or navigation item that requires a secondary menu. To interact with the menu it will require some javascript to hide/show each pattern. This is achieved by finding the toggle element `p-contextual-menu__toggle` and what it controls `aria-controls`.
 
 The target element will be hidden or shown with `aria-hidden="true"` or `false`. The control element will change to `aria-expanded` so screen readers will know it's active.
 
@@ -48,6 +48,21 @@ View example of the contextual menu pattern
 ### Functionality
 
 Please ensure the `aria-control` attribute matches an ID of an element. If `aria-expanded` is true, then the contextual menu will be open by default. When clicking on the `p-contextual-menu__toggle`, you must toggle the `aria-expanded` attribute on the toggle and the `aria-hidden` attribute on the drop-down.
+
+### Theming
+
+The contextual menu uses Vanilla's light theme by default. There are two ways to switch between the light and the dark themes:
+
+- Change the default: go to `_settings_themes.scss` and set `$theme-default-p-contextual-menu` to `dark`
+- Override the default by adding a state to `p-contextual-menu`: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark:
+
+<a href="/examples/patterns/contextual-menu/dark" class="js-example">
+View example of the contextual menu with an is-light class
+</a>
+
+<a href="/examples/patterns/contextual-menu/light" class="js-example">
+View example of the contextual menu with an is-light class
+</a>
 
 ### Import
 

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -90,6 +90,15 @@
     margin-bottom: $spv-inner--small + ($spv-nudge-compensation * 2);
   }
 
+  .p-contextual-menu__dropdown {
+    // sass-lint:disable no-qualifying-elements
+    button.p-contextual-menu__toggle + &,
+    [class*='p-button'] {
+      margin-top: -#{$input-margin-bottom};
+    }
+    // sass-lint:enable no-qualifying-elements
+  }
+
   .p-contextual-menu__link {
     @include vf-focus;
     border: 0;

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -150,6 +150,7 @@
 
     .p-contextual-menu__dropdown.is-light {
       @extend %p-contextual-menu--dropdown--light-theme;
+
       .p-contextual-menu__group {
         @extend %p-contextual-menu--group--light-theme;
       }
@@ -162,6 +163,7 @@
     .p-contextual-menu__dropdown {
       @extend %p-contextual-menu--dropdown--light-theme;
     }
+
     .p-contextual-menu__group {
       @extend %p-contextual-menu--group--light-theme;
     }

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -49,7 +49,6 @@
 
   // Dropdown element for contextual menu
   .p-contextual-menu__dropdown {
-    @extend %vf-card;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
     display: none;
@@ -65,7 +64,9 @@
     &::before,
     &::after {
       border: {
-        bottom: 8px solid transparentize($color-dark, 0.95);
+        bottom-color: transparent;
+        bottom-style: solid;
+        bottom-width: 8px;
         left: 8px solid transparent;
         right: 8px solid transparent;
       }
@@ -80,7 +81,6 @@
 
     &::after {
       border: {
-        bottom: 6px solid $color-x-light;
         left: 6px solid transparent;
         right: 6px solid transparent;
       }
@@ -97,7 +97,8 @@
     display: block;
 
     + .p-contextual-menu__group {
-      border-top: 1px solid $color-mid-light;
+      border-top-width: 1px;
+      border-top-style: solid;
       margin: -1px 0 0 0;
     }
   }
@@ -114,9 +115,7 @@
     @include vf-focus;
     border: 0;
     clear: both;
-    color: $color-dark;
     display: block;
-    line-height: 1.5rem;
     margin: 0;
     overflow: hidden;
     padding: $spv-inner--x-small $sp-small;
@@ -126,12 +125,115 @@
     width: 100%;
 
     &:hover {
-      background-color: $color-light;
+      border-radius: $border-radius;
       text-decoration: none;
     }
   }
 
   .p-contextual-menu__toggle[aria-expanded='true'] .p-contextual-menu__indicator {
     transform: rotate(180deg);
+  }
+
+  // Theming
+  @if ($theme-default-p-contextual-menu == 'dark') {
+    .p-contextual-menu__dropdown {
+      @extend %p-contextual-menu__dropdown--dark-theme;
+    }
+
+    .p-contextual-menu__group {
+      @extend %p-contextual-menu__group--dark-theme;
+    }
+
+    .p-contextual-menu__link {
+      @extend %p-contextual-menu__link--dark-theme;
+    }
+
+    .p-contextual-menu__dropdown.is-light {
+      @extend %p-contextual-menu__dropdown--light-theme;
+      .p-contextual-menu__group {
+        @extend %p-contextual-menu__group--light-theme;
+      }
+
+      .p-contextual-menu__link {
+        @extend %p-contextual-menu__link--light-theme;
+      }
+    }
+  } @else {
+    .p-contextual-menu__dropdown {
+      @extend %p-contextual-menu__dropdown--light-theme;
+    }
+    .p-contextual-menu__group {
+      @extend %p-contextual-menu__group--light-theme;
+    }
+
+    .p-contextual-menu__link {
+      @extend %p-contextual-menu__link--light-theme;
+    }
+
+    .p-contextual-menu__dropdown.is-dark {
+      @extend %p-contextual-menu__dropdown--dark-theme;
+
+      .p-contextual-menu__group {
+        @extend %p-contextual-menu__group--dark-theme;
+      }
+
+      .p-contextual-menu__link {
+        @extend %p-contextual-menu__link--dark-theme;
+      }
+    }
+  }
+
+  %p-contextual-menu__dropdown--light-theme {
+    background: $colors--light-theme--background;
+
+    &::after {
+      border-bottom-color: $colors--light-theme--background;
+    }
+  }
+
+  %p-contextual-menu__group--light-theme {
+    & + & {
+      border-top-color: $colors--light-theme--border-default;
+    }
+  }
+
+  %p-contextual-menu__link--light-theme {
+    &,
+    &:active,
+    &:hover,
+    &:visited {
+      color: $colors--light-theme--text-default;
+    }
+
+    &:hover {
+      background-color: $colors--light-theme--background-highlighted;
+    }
+  }
+
+  %p-contextual-menu__dropdown--dark-theme {
+    background: $colors--dark-theme--background;
+
+    &::after {
+      border-bottom-color: $colors--dark-theme--background;
+    }
+  }
+
+  %p-contextual-menu__group--dark-theme {
+    & + & {
+      border-top-color: $colors--dark-theme--border-default;
+    }
+  }
+
+  %p-contextual-menu__link--dark-theme {
+    &,
+    &:active,
+    &:hover,
+    &:visited {
+      color: $colors--dark-theme--text-default;
+    }
+
+    &:hover {
+      background-color: $colors--dark-theme--background-highlighted;
+    }
   }
 }

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -64,10 +64,10 @@
       height: 0;
       pointer-events: none;
       position: absolute;
-      width: 0;
       right: $sph-inner;
       transform: rotate(-45deg);
       transform-origin: 100% 100%;
+      width: 0;
     }
 
     // When set to false will show the contextual menu

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -90,10 +90,6 @@
     margin-bottom: $spv-inner--small + ($spv-nudge-compensation * 2);
   }
 
-  .p-contextual-menu__dropdown {
-    margin-top: -#{$input-margin-bottom};
-  }
-
   .p-contextual-menu__link {
     @include vf-focus;
     border: 0;

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -1,48 +1,44 @@
 @import 'settings';
 
 @mixin vf-p-contextual-menu {
-  .p-contextual-menu {
+  %p-contextual-menu {
     display: inline-block;
     margin: 0;
     position: relative;
   }
 
+  .p-contextual-menu {
+    @extend %p-contextual-menu;
+  }
+
   // Alignment extension to align the menu to the left
   .p-contextual-menu--left {
-    @extend .p-contextual-menu; // sass-lint:disable-line placeholder-in-extend
+    @extend %p-contextual-menu;
 
     .p-contextual-menu__dropdown {
       left: 0;
 
-      &::before,
       &::after {
-        left: $sp-small;
+        left: $sph-inner;
         right: initial;
-      }
-
-      &::after {
-        left: $sp-small + 0.1rem;
       }
     }
   }
 
   // Alignment extension to align the menu to the center of the parent
   .p-contextual-menu--center {
-    @extend .p-contextual-menu; // sass-lint:disable-line placeholder-in-extend
+    @extend %p-contextual-menu;
 
     .p-contextual-menu__dropdown {
       // sass-lint:disable no-vendor-prefixes property-sort-order
       left: 50%;
       -webkit-transform: translateX(-50%);
       transform: translateX(-50%);
+      // sass-lint:enable no-vendor-prefixes property-sort-order
 
-      &::before,
       &::after {
         left: 50%;
         right: initial;
-        -webkit-transform: translateX(-50%);
-        transform: translateX(-50%);
-        // sass-lint:enable no-vendor-prefixes property-sort-order
       }
     }
   }
@@ -61,30 +57,17 @@
     width: fit-content;
     z-index: 1;
 
-    &::before,
     &::after {
-      border: {
-        bottom-color: transparent;
-        bottom-style: solid;
-        bottom-width: 8px;
-        left: 8px solid transparent;
-        right: 8px solid transparent;
-      }
+      border: 0.25rem solid transparent;
       bottom: 100%;
       content: '';
       height: 0;
       pointer-events: none;
       position: absolute;
-      right: $sp-small;
       width: 0;
-    }
-
-    &::after {
-      border: {
-        left: 6px solid transparent;
-        right: 6px solid transparent;
-      }
-      right: $sp-small + 0.1rem;
+      right: $sph-inner;
+      transform: rotate(-45deg);
+      transform-origin: 100% 100%;
     }
 
     // When set to false will show the contextual menu
@@ -118,7 +101,7 @@
     display: block;
     margin: 0;
     overflow: hidden;
-    padding: $spv-inner--x-small $sp-small;
+    padding: $spv-inner--x-small $sph-inner;
     text-align: left;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -148,8 +131,10 @@
       @extend %p-contextual-menu--link--dark-theme;
     }
 
-    .p-contextual-menu__dropdown.is-light {
-      @extend %p-contextual-menu--dropdown--light-theme;
+    [class*='p-contextual-menu'].is-light {
+      .p-contextual-menu__dropdown {
+        @extend %p-contextual-menu--dropdown--light-theme;
+      }
 
       .p-contextual-menu__group {
         @extend %p-contextual-menu--group--light-theme;
@@ -172,9 +157,10 @@
       @extend %p-contextual-menu--link--light-theme;
     }
 
-    .p-contextual-menu__dropdown.is-dark {
-      @extend %p-contextual-menu--dropdown--dark-theme;
-
+    [class*='p-contextual-menu'].is-dark {
+      .p-contextual-menu__dropdown {
+        @extend %p-contextual-menu--dropdown--dark-theme;
+      }
       .p-contextual-menu__group {
         @extend %p-contextual-menu--group--dark-theme;
       }
@@ -189,7 +175,8 @@
     background: $colors--light-theme--background;
 
     &::after {
-      border-bottom-color: $colors--light-theme--background;
+      border-color: $colors--light-theme--background $colors--light-theme--background transparent transparent;
+      box-shadow: 1px -1px 1.5px 0 transparentize($color-dark, 0.93);
     }
   }
 
@@ -217,6 +204,8 @@
 
     &::after {
       border-bottom-color: $colors--dark-theme--background;
+      border-color: $colors--dark-theme--background $colors--dark-theme--background transparent transparent;
+      box-shadow: 1px -1px 1.5px 0 transparentize($color-dark, 0.93);
     }
   }
 

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -97,8 +97,8 @@
     display: block;
 
     + .p-contextual-menu__group {
-      border-top-width: 1px;
       border-top-style: solid;
+      border-top-width: 1px;
       margin: -1px 0 0 0;
     }
   }
@@ -137,53 +137,53 @@
   // Theming
   @if ($theme-default-p-contextual-menu == 'dark') {
     .p-contextual-menu__dropdown {
-      @extend %p-contextual-menu__dropdown--dark-theme;
+      @extend %p-contextual-menu--dropdown--dark-theme;
     }
 
     .p-contextual-menu__group {
-      @extend %p-contextual-menu__group--dark-theme;
+      @extend %p-contextual-menu--group--dark-theme;
     }
 
     .p-contextual-menu__link {
-      @extend %p-contextual-menu__link--dark-theme;
+      @extend %p-contextual-menu--link--dark-theme;
     }
 
     .p-contextual-menu__dropdown.is-light {
-      @extend %p-contextual-menu__dropdown--light-theme;
+      @extend %p-contextual-menu--dropdown--light-theme;
       .p-contextual-menu__group {
-        @extend %p-contextual-menu__group--light-theme;
+        @extend %p-contextual-menu--group--light-theme;
       }
 
       .p-contextual-menu__link {
-        @extend %p-contextual-menu__link--light-theme;
+        @extend %p-contextual-menu--link--light-theme;
       }
     }
   } @else {
     .p-contextual-menu__dropdown {
-      @extend %p-contextual-menu__dropdown--light-theme;
+      @extend %p-contextual-menu--dropdown--light-theme;
     }
     .p-contextual-menu__group {
-      @extend %p-contextual-menu__group--light-theme;
+      @extend %p-contextual-menu--group--light-theme;
     }
 
     .p-contextual-menu__link {
-      @extend %p-contextual-menu__link--light-theme;
+      @extend %p-contextual-menu--link--light-theme;
     }
 
     .p-contextual-menu__dropdown.is-dark {
-      @extend %p-contextual-menu__dropdown--dark-theme;
+      @extend %p-contextual-menu--dropdown--dark-theme;
 
       .p-contextual-menu__group {
-        @extend %p-contextual-menu__group--dark-theme;
+        @extend %p-contextual-menu--group--dark-theme;
       }
 
       .p-contextual-menu__link {
-        @extend %p-contextual-menu__link--dark-theme;
+        @extend %p-contextual-menu--link--dark-theme;
       }
     }
   }
 
-  %p-contextual-menu__dropdown--light-theme {
+  %p-contextual-menu--dropdown--light-theme {
     background: $colors--light-theme--background;
 
     &::after {
@@ -191,13 +191,13 @@
     }
   }
 
-  %p-contextual-menu__group--light-theme {
+  %p-contextual-menu--group--light-theme {
     & + & {
       border-top-color: $colors--light-theme--border-default;
     }
   }
 
-  %p-contextual-menu__link--light-theme {
+  %p-contextual-menu--link--light-theme {
     &,
     &:active,
     &:hover,
@@ -210,7 +210,7 @@
     }
   }
 
-  %p-contextual-menu__dropdown--dark-theme {
+  %p-contextual-menu--dropdown--dark-theme {
     background: $colors--dark-theme--background;
 
     &::after {
@@ -218,13 +218,13 @@
     }
   }
 
-  %p-contextual-menu__group--dark-theme {
+  %p-contextual-menu--group--dark-theme {
     & + & {
       border-top-color: $colors--dark-theme--border-default;
     }
   }
 
-  %p-contextual-menu__link--dark-theme {
+  %p-contextual-menu--link--dark-theme {
     &,
     &:active,
     &:hover,

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -91,12 +91,7 @@
   }
 
   .p-contextual-menu__dropdown {
-    // sass-lint:disable no-qualifying-elements
-    button.p-contextual-menu__toggle + &,
-    [class*='p-button'] {
-      margin-top: -#{$input-margin-bottom};
-    }
-    // sass-lint:enable no-qualifying-elements
+    margin-top: -#{$input-margin-bottom};
   }
 
   .p-contextual-menu__link {

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -161,6 +161,7 @@
       .p-contextual-menu__dropdown {
         @extend %p-contextual-menu--dropdown--dark-theme;
       }
+
       .p-contextual-menu__group {
         @extend %p-contextual-menu--group--dark-theme;
       }

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -17,11 +17,6 @@
 
     .p-contextual-menu__dropdown {
       left: 0;
-
-      &::after {
-        left: $sph-inner;
-        right: initial;
-      }
     }
   }
 
@@ -35,11 +30,6 @@
       -webkit-transform: translateX(-50%);
       transform: translateX(-50%);
       // sass-lint:enable no-vendor-prefixes property-sort-order
-
-      &::after {
-        left: 50%;
-        right: initial;
-      }
     }
   }
 
@@ -56,19 +46,6 @@
     right: 0;
     width: fit-content;
     z-index: 1;
-
-    &::after {
-      border: 0.25rem solid transparent;
-      bottom: 100%;
-      content: '';
-      height: 0;
-      pointer-events: none;
-      position: absolute;
-      right: $sph-inner;
-      transform: rotate(-45deg);
-      transform-origin: 100% 100%;
-      width: 0;
-    }
 
     // When set to false will show the contextual menu
     &[aria-hidden='false'] {
@@ -174,11 +151,6 @@
 
   %p-contextual-menu--dropdown--light-theme {
     background: $colors--light-theme--background;
-
-    &::after {
-      border-color: $colors--light-theme--background $colors--light-theme--background transparent transparent;
-      box-shadow: 1px -1px 1.5px 0 transparentize($color-dark, 0.93);
-    }
   }
 
   %p-contextual-menu--group--light-theme {
@@ -202,12 +174,6 @@
 
   %p-contextual-menu--dropdown--dark-theme {
     background: $colors--dark-theme--background;
-
-    &::after {
-      border-bottom-color: $colors--dark-theme--background;
-      border-color: $colors--dark-theme--background $colors--dark-theme--background transparent transparent;
-      box-shadow: 1px -1px 1.5px 0 transparentize($color-dark, 0.93);
-    }
   }
 
   %p-contextual-menu--group--dark-theme {

--- a/scss/_settings_themes.scss
+++ b/scss/_settings_themes.scss
@@ -2,3 +2,4 @@ $theme-default-forms: 'light' !default;
 $theme-default-hr: 'light' !default;
 $theme-default-nav: 'light' !default;
 $theme-default-p-search-box: 'light' !default;
+$theme-default-p-contextual-menu: 'light' !default;


### PR DESCRIPTION
## Done

Juju [need ](https://github.com/canonical-web-and-design/juju-squad/issues/1097#issuecomment-581959672) a themed version of the contextual menu. This pr implements the theming mechanism, providing light and dark theme. Once this is merged, in juju a blue-ish theme can be created in the same way.

## QA

- Pull code
- Run `./run serve --watch`
- Open examples/patterns/contextual-menu/with-indicator
- add class is-dark, QA
- open _settings_themes.scss, change the value of $theme-default-p-contextual-menu to 'dark'
- QA
-add class is-light, QA again


## Screenshots

![image](https://user-images.githubusercontent.com/2741678/73767348-443cd200-476f-11ea-9594-e5f94ee517c7.png)
