### PR TITLE
fix search input placement in IE11

### DIFF
--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -38,6 +38,7 @@
     margin-bottom: 0;
     padding-right: calc(2 * #{2 * $spv-nudge + map-get($line-heights, default-text)});
     position: absolute;
+    right: 0;
 
     &::-webkit-search-cancel-button {
       -webkit-appearance: none; // sass-lint:disable-line no-vendor-prefixes


### PR DESCRIPTION
## Done

- Fixed placement of search input within form element on IE11

## QA

- Open the demo in [Browserstack](https://www.browserstack.com/), on IE11
- See that the search input isn't out of place (compare to [live version](https://docs.vanillaframework.io/examples/patterns/search-box/default))

Fixes: https://github.com/canonical-web-and-design/ubuntu.com/issues/6587

## Screenshots

IE11 before fix:
![Screenshot 2020-02-10 at 11 15 28](https://user-images.githubusercontent.com/2376968/74145797-965e7700-4bf7-11ea-96b4-3af2dc4a5fb0.png)
![Screenshot 2020-02-10 at 11 12 59](https://user-images.githubusercontent.com/2376968/74145802-99f1fe00-4bf7-11ea-856d-a40de813b725.png)

IE11 after fix:

![Screenshot 2020-02-10 at 11 15 38](https://user-images.githubusercontent.com/2376968/74145875-c279f800-4bf7-11ea-8730-ae743a88248f.png)
![Screenshot 2020-02-10 at 11 13 29](https://user-images.githubusercontent.com/2376968/74145888-c60d7f00-4bf7-11ea-98aa-dd8a0ae2a7bf.png)

