### PR TITLE
Move search box to main nav

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,43 +23,44 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-    <div class="docs-container">
-      <header id="navigation" class="p-navigation">
-        <div class="p-navigation__row">
-          <div class="p-navigation__banner">
-            <div class="p-navigation__logo">
-              <a class="p-navigation__link" href="https://vanillaframework.io">
-                <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="Vanilla framework logo">
-              </a>
-            </div>
-            <div class="p-navigation__toggles">
-              <a href="#navigation" class="p-navigation__toggle--open" title="about menu">About</a>
-              <a href="#navigation-closed" class="p-navigation__toggle--close" title="close about menu">About</a>
-              <a class="p-sidebar__toggle u-hide--medium u-hide--large" href="#">Patterns</a>
-            </div>
+    <header id="navigation" class="p-navigation">
+      <div class="p-navigation__row--full-width">
+        <div class="p-navigation__banner">
+          <div class="p-navigation__logo">
+            <a class="p-navigation__link" href="https://vanillaframework.io">
+              <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="Vanilla framework logo">
+            </a>
           </div>
-          <nav class="p-navigation__nav">
-            <span class="u-off-screen">
-              <a href="#main-content">Jump to main content</a>
-            </span>
-            <ul class="p-navigation__links">
-                <li class="p-navigation__link {% if '/examples' not in path %}is-selected{% endif %}"><a href="/">Docs</a></li>
-                <li class="p-navigation__link {% if '/examples' in path %}is-selected{% endif %}"><a href="/examples">Examples</a></li>
-                <li class="p-navigation__link"><a href="https://vanillaframework.io/accessibility">Accessibility</a></li>
-              <li class="p-navigation__link"><a href="https://vanillaframework.io/browser-support">Browser support</a></li>
-              <li class="p-navigation__link"><a href="https://vanillaframework.io/contribute">Contribute</a></li>
-            </ul>
-          </nav>
+          <div class="p-navigation__toggles u-hide--large u-hide--medium">
+            <a href="#navigation" class="p-navigation__toggle--open" title="about menu">About</a>
+            <a href="#navigation-closed" class="p-navigation__toggle--close" title="close about menu">About</a>
+            <a class="p-sidebar__toggle u-hide--medium u-hide--large" href="#">Patterns</a>
+          </div>
         </div>
-      </header>
-      <hr class="u-no-margin u-hide--small">
-      <aside class="p-sidebar">
-        <div class="p-sidebar__content">
+        <nav class="p-navigation__nav">
+          <span class="u-off-screen">
+            <a href="#main-content">Jump to main content</a>
+          </span>
+          <ul class="p-navigation__links">
+              <li class="p-navigation__link {% if '/examples' not in path %}is-selected{% endif %}"><a href="/">Docs</a></li>
+              <li class="p-navigation__link {% if '/examples' in path %}is-selected{% endif %}"><a href="/examples">Examples</a></li>
+              <li class="p-navigation__link"><a href="https://vanillaframework.io/accessibility">Accessibility</a></li>
+            <li class="p-navigation__link"><a href="https://vanillaframework.io/browser-support">Browser support</a></li>
+            <li class="p-navigation__link"><a href="https://vanillaframework.io/contribute">Contribute</a></li>
+          </ul>
           <form class="p-search-box" action="/search">
             <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation" required />
             <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" alt="reset"><i class="p-icon--close"></i></button>
             <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
           </form>
+        </nav>
+      </div>
+    </header>
+
+    <div class="docs-container">
+      <hr class="u-no-margin u-hide--small">
+      <aside class="p-sidebar">
+        <div class="p-sidebar__content">
           <nav class="p-sidebar-nav">
             <ul class="p-sidebar-nav__list" id="docs-list-unsorted">
               <li class="p-sidebar-nav__item">

--- a/docs/search.html
+++ b/docs/search.html
@@ -4,16 +4,14 @@
 
 {% block content %}
 <div class="u-fixed-width">
-  <div class="p-strip is-shallow">
-    {% if results and results.entries %}
-      <h1 class="p-heading--two">We've found these results for your search <strong>"{{ query }}"</strong></h1>
-    {% else %}
-      <h1 class="p-heading--two">We haven't found any results for your search <strong>"{{ query }}"</strong>.</h1>
-    {% endif %}
-  </div>
+  {% if results and results.entries %}
+    <h1 class="p-heading--two">We've found these results for your search <strong>"{{ query }}"</strong></h1>
+  {% else %}
+    <h1 class="p-heading--two">We haven't found any results for your search <strong>"{{ query }}"</strong>.</h1>
+  {% endif %}
 
   {% if  results and results.entries %}
-  <div class="p-strip is-shallow u-no-padding--top">
+  <div class="p-strip is-shallow">
     {% for item in results.entries %}
       <h4><a href="{{ item.link }}">{{ item.htmlTitle | safe}}</a></h4>
       <p>

--- a/docs/static/scss/styles.scss
+++ b/docs/static/scss/styles.scss
@@ -76,10 +76,6 @@ hr {
   flex-wrap: wrap;
 }
 
-.p-navigation {
-  flex-basis: 100%;
-}
-
 .p-sidebar {
   background-color: $color-mid-x-light;
   flex: 0 0 18rem;
@@ -209,17 +205,6 @@ hr.is-deep {
 }
 
 /* Prototype sidebar + navigation toggles */
-.p-navigation__banner {
-  display: block;
-
-  @media only screen and (max-width: $breakpoint-medium) {
-    display: flex;
-  }
-
-  @media only screen and (min-width: $breakpoint-medium + 1px) {
-    max-width: 10.5rem;
-  }
-}
 
 .p-navigation__toggles {
   min-width: 15rem;
@@ -249,6 +234,23 @@ hr.is-deep {
   }
 }
 
+.p-sidebar__toggle {
+  &,
+  &:visited,
+  &:focus {
+    color: $colors--light-theme--text-default;
+  }
+
+  &:hover {
+    opacity: $navigation-hover-opacity;
+    text-decoration: none;
+  }
+
+  &.is-active:hover {
+    opacity: 1;
+  }
+}
+
 .p-sidebar__toggle.is-active,
 .p-navigation__toggle--close {
   &::after {
@@ -257,26 +259,10 @@ hr.is-deep {
 }
 
 .p-sidebar__toggle.is-active {
-  border-bottom: 1px solid $color-mid-x-light;
   background-color: $color-mid-x-light;
   z-index: 1;
 
   &:focus {
     outline: none;
   }
-}
-
-.p-navigation__toggle--close {
-  border-bottom: 1px solid $color-x-light;
-  z-index: 1;
-}
-
-.p-sidebar__toggle {
-  border-left: 1px solid $color-mid-light;
-}
-
-.p-navigation__toggle--open,
-.p-navigation__toggle--close {
-  border-left: 1px solid $color-mid-light;
-  border-right: 1px solid $color-mid-light;
 }


### PR DESCRIPTION
## Done

Moves search box to main nav.
Updates custom styling of mobile navigation toggles.

Fixes #2806 

## QA

To run search locally you need search API token. See https://github.com/canonical-web-and-design/vanilla-framework/pull/2812

Appearance of search box itself can be tested on demo server, but the search results page will throw an error.

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/
- See search box appearing in main nav instead of side bar
- Check on different screen widths (on small screens search box is inside 'About' menu with rest of navigation)


## Screenshots

<img width="516" alt="Screenshot 2020-02-11 at 11 46 57" src="https://user-images.githubusercontent.com/83575/74230300-65984380-4cc4-11ea-961f-6fb72873ad7a.png">

<img width="1063" alt="Screenshot 2020-02-11 at 11 46 35" src="https://user-images.githubusercontent.com/83575/74230308-67fa9d80-4cc4-11ea-91ae-569fb5aebcef.png">
