### PR TITLE
Update docs titles

### DIFF
--- a/docs/_layouts/examples.html
+++ b/docs/_layouts/examples.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Vanilla framework documentation</title>
+    <title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Examples | Vanilla framework documentation</title>
 
     {% if is_standalone %}
     <link rel="stylesheet" type="text/css" href="/static/build/css/standalone/{% block standalone_css %}base{% endblock %}.css" />

--- a/docs/base/code.md
+++ b/docs/base/code.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Code
+  title: Code | Base elements
 ---
 
 ## Code

--- a/docs/base/forms.md
+++ b/docs/base/forms.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Forms
+  title: Forms | Base elements
 ---
 
 ## Forms

--- a/docs/base/reset.md
+++ b/docs/base/reset.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Reset
+  title: Reset | Base elements
 ---
 
 ## Reset

--- a/docs/base/tables.md
+++ b/docs/base/tables.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Tables
+  title: Tables | Base elements
 ---
 
 ## Tables

--- a/docs/base/typography.md
+++ b/docs/base/typography.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Typography
+  title: Typography | Base elements
 ---
 
 ## Typography

--- a/docs/patterns/accordion.md
+++ b/docs/patterns/accordion.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Accordion
+  title: Accordion | Components
 ---
 
 ## Accordion

--- a/docs/patterns/article-pagination.md
+++ b/docs/patterns/article-pagination.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Article pagination
+  title: Article pagination | Components
 ---
 
 ## Article pagination

--- a/docs/patterns/breadcrumbs.md
+++ b/docs/patterns/breadcrumbs.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Breadcrumbs
+  title: Breadcrumbs | Components
 ---
 
 ## Breadcrumbs

--- a/docs/patterns/buttons.md
+++ b/docs/patterns/buttons.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Buttons
+  title: Buttons | Components
 ---
 
 ## Buttons

--- a/docs/patterns/card.md
+++ b/docs/patterns/card.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Cards
+  title: Cards | Components
 ---
 
 ## Cards

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -2,7 +2,7 @@
 collection: patterns
 wrapper_template: '_layouts/default.html'
 context:
-  title: Contextual menu
+  title: Contextual menu | Components
 ---
 
 ## Contextual menu

--- a/docs/patterns/grid.md
+++ b/docs/patterns/grid.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Grid
+  title: Grid | Components
 ---
 
 ## Grid

--- a/docs/patterns/heading-icon.md
+++ b/docs/patterns/heading-icon.md
@@ -2,7 +2,7 @@
 collection: patterns
 wrapper_template: '_layouts/default.html'
 context:
-  title: Heading icon
+  title: Heading icon | Components
 ---
 
 ## Heading icon

--- a/docs/patterns/icons.md
+++ b/docs/patterns/icons.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Icons
+  title: Icons | Components
 ---
 
 ## Icons

--- a/docs/patterns/images.md
+++ b/docs/patterns/images.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Images
+  title: Images | Components
 ---
 
 ## Images

--- a/docs/patterns/inline-images.md
+++ b/docs/patterns/inline-images.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Inline images
+  title: Inline images | Components
 ---
 
 ## Inline images

--- a/docs/patterns/labels.md
+++ b/docs/patterns/labels.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Labels
+  title: Labels | Components
 ---
 
 ## Labels

--- a/docs/patterns/links.md
+++ b/docs/patterns/links.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Links
+  title: Links | Components
 ---
 
 ## Links

--- a/docs/patterns/list-tree.md
+++ b/docs/patterns/list-tree.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: List tree
+  title: List tree | Components
 ---
 
 ## List tree

--- a/docs/patterns/lists.md
+++ b/docs/patterns/lists.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Lists
+  title: Lists | Components
 ---
 
 ## Lists

--- a/docs/patterns/matrix.md
+++ b/docs/patterns/matrix.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Matrix
+  title: Matrix | Components
 ---
 
 ## Matrix

--- a/docs/patterns/media-object.md
+++ b/docs/patterns/media-object.md
@@ -2,7 +2,7 @@
 collection: patterns
 wrapper_template: '_layouts/default.html'
 context:
-  title: Media object
+  title: Media object | Components
 ---
 
 ## Media object

--- a/docs/patterns/modal.md
+++ b/docs/patterns/modal.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Modal
+  title: Modal | Components
 ---
 
 ## Modal

--- a/docs/patterns/muted-heading.md
+++ b/docs/patterns/muted-heading.md
@@ -2,7 +2,7 @@
 collection: patterns
 wrapper_template: '_layouts/default.html'
 context:
-  title: Muted heading
+  title: Muted heading | Components
 ---
 
 ## Muted heading

--- a/docs/patterns/navigation.md
+++ b/docs/patterns/navigation.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Navigation
+  title: Navigation | Components
 ---
 
 ## Navigation

--- a/docs/patterns/notification.md
+++ b/docs/patterns/notification.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Notification
+  title: Notification | Components
 ---
 
 ## Notification

--- a/docs/patterns/pagination.md
+++ b/docs/patterns/pagination.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Pagination
+  title: Pagination | Components
 ---
 
 ## Pagination

--- a/docs/patterns/pull-quote.md
+++ b/docs/patterns/pull-quote.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Pull quote
+  title: Pull quote | Components
 ---
 
 ## Pull quote

--- a/docs/patterns/search-box.md
+++ b/docs/patterns/search-box.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Search box
+  title: Search box | Components
 ---
 
 ## Search box

--- a/docs/patterns/slider.md
+++ b/docs/patterns/slider.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Slider
+  title: Slider | Components
 ---
 
 ## Slider

--- a/docs/patterns/strip.md
+++ b/docs/patterns/strip.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Strip
+  title: Strip | Components
 ---
 
 ## Strip

--- a/docs/patterns/switch.md
+++ b/docs/patterns/switch.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Switch
+  title: Switch | Components
 ---
 
 ## Switch

--- a/docs/patterns/table-of-contents.md
+++ b/docs/patterns/table-of-contents.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Table of contents
+  title: Table of contents | Components
 ---
 
 ## Table of contents

--- a/docs/patterns/tabs.md
+++ b/docs/patterns/tabs.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Tabs
+  title: Tabs | Components
 ---
 
 ## Tabs

--- a/docs/patterns/tooltips.md
+++ b/docs/patterns/tooltips.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Tooltips
+  title: Tooltips | Components
 ---
 
 ## Tooltips

--- a/docs/settings/animation-settings.md
+++ b/docs/settings/animation-settings.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Animations
+  title: Animations | Settings
 ---
 
 ## Animations

--- a/docs/settings/assets-settings.md
+++ b/docs/settings/assets-settings.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Assets
+  title: Assets | Settings
 ---
 
 ## Assets

--- a/docs/settings/breakpoint-settings.md
+++ b/docs/settings/breakpoint-settings.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Breakpoints
+  title: Breakpoints | Settings
 ---
 
 ## Breakpoints

--- a/docs/settings/color-settings.md
+++ b/docs/settings/color-settings.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Color
+  title: Color | Settings
 ---
 
 ## Color

--- a/docs/settings/font-settings.md
+++ b/docs/settings/font-settings.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Font
+  title: Font | Settings
 ---
 
 ## Font

--- a/docs/settings/layout-settings.md
+++ b/docs/settings/layout-settings.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Layout
+  title: Layout | Settings
 ---
 
 ## Layout

--- a/docs/settings/placeholder-settings.md
+++ b/docs/settings/placeholder-settings.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Placeholders
+  title: Placeholders | Settings
 ---
 
 ## Placeholders

--- a/docs/settings/spacing-settings.md
+++ b/docs/settings/spacing-settings.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Spacing
+  title: Spacing | Settings
 ---
 
 ## Spacing

--- a/docs/settings/table-layout.md
+++ b/docs/settings/table-layout.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Table layout
+  title: Table layout | Settings
 ---
 
 ## Table layout

--- a/docs/utilities/align.md
+++ b/docs/utilities/align.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Align
+  title: Align | Utilities
 ---
 
 ## Align

--- a/docs/utilities/baseline-grid.md
+++ b/docs/utilities/baseline-grid.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Font metrics
+  title: Font metrics | Utilities
 ---
 
 ## Font metrics

--- a/docs/utilities/clearfix.md
+++ b/docs/utilities/clearfix.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Clearfix
+  title: Clearfix | Utilities
 ---
 
 ## Clearfix

--- a/docs/utilities/embedded-media.md
+++ b/docs/utilities/embedded-media.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Embedded media
+  title: Embedded media | Utilities
 ---
 
 ## Embedded media

--- a/docs/utilities/equal-height.md
+++ b/docs/utilities/equal-height.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Equal height
+  title: Equal height | Utilities
 ---
 
 ## Equal height

--- a/docs/utilities/floats.md
+++ b/docs/utilities/floats.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Floats
+  title: Floats | Utilities
 ---
 
 ## Floats

--- a/docs/utilities/font-metrics.md
+++ b/docs/utilities/font-metrics.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Font metrics
+  title: Font metrics | Utilities
 ---
 
 ## Font metrics

--- a/docs/utilities/functions.md
+++ b/docs/utilities/functions.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Functions
+  title: Functions | Utilities
 ---
 
 ## Functions

--- a/docs/utilities/hide.md
+++ b/docs/utilities/hide.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Hide
+  title: Hide | Utilities
 ---
 
 ## Hide

--- a/docs/utilities/image-position.md
+++ b/docs/utilities/image-position.md
@@ -2,7 +2,7 @@
 collection: utilities
 wrapper_template: '_layouts/default.html'
 context:
-  title: Image position
+  title: Image position | Utilities
 ---
 
 ## Image position

--- a/docs/utilities/margin-collapse.md
+++ b/docs/utilities/margin-collapse.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Margin collapse
+  title: Margin collapse | Utilities
 ---
 
 ## Margin collapse

--- a/docs/utilities/no-print.md
+++ b/docs/utilities/no-print.md
@@ -2,7 +2,7 @@
 collection: utilities
 wrapper_template: '_layouts/default.html'
 context:
-  title: No print
+  title: No print | Utilities
 ---
 
 ## No print

--- a/docs/utilities/off-screen.md
+++ b/docs/utilities/off-screen.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Off screen
+  title: Off screen | Utilities
 ---
 
 ## Off screen

--- a/docs/utilities/padding-collapse.md
+++ b/docs/utilities/padding-collapse.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Padding collapse
+  title: Padding collapse | Utilities
 ---
 
 ## Padding collapse

--- a/docs/utilities/show.md
+++ b/docs/utilities/show.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Show
+  title: Show | Utilities
 ---
 
 ## Show

--- a/docs/utilities/table-cell-padding-overlap.md
+++ b/docs/utilities/table-cell-padding-overlap.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Table cell padding overlap
+  title: Table cell padding overlap | Utilities
 ---
 
 ## Table cell padding overlap

--- a/docs/utilities/truncate.md
+++ b/docs/utilities/truncate.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Truncation
+  title: Truncation | Utilities
 ---
 
 ## Truncation

--- a/docs/utilities/vertically-center.md
+++ b/docs/utilities/vertically-center.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/default.html'
 context:
-  title: Vertically center
+  title: Vertically center | Utilities
 ---
 
 ## Vertically center


### PR DESCRIPTION
## Done

Improves documentation titles for better search.
Adds category of a page ("Base elements", "Components", "Examples" to page title, so they will be easier to distinguish in search results).

Fixes #2824 

## QA

- Run `./run` and open http://0.0.0.0:8101/ or demo
- Go to any page from "Base elements", page title (`<title>`) should contain "Base elements"
- Go to any page from "Components", page title (`<title>`) should contain "Components"
- Go to any page from "Utilities", page title (`<title>`) should contain "Utilities"
- Go to any page from "Settings", page title (`<title>`) should contain "Settings"
- Go to any example, page title (`<title>`) should contain "Examples"
