### PR TITLE
Update docs to 2.7.0

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -76,10 +76,10 @@
                 <strong>Base elements</strong>
                 <ul class="p-sidebar-nav__list">
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/base/code' %}is-active{% endif %}" href="/base/code">Code</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/base/forms' %}is-active{% endif %}" href="/base/forms">Forms</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/base/forms' %}is-active{% endif %}" href="/base/forms">Forms</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/base/reset' %}is-active{% endif %}" href="/base/reset">Reset</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/base/tables' %}is-active{% endif %}" href="/base/tables">Tables</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/base/typography' %}is-active{% endif %}" href="/base/typography">Typography</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/base/typography' %}is-active{% endif %}" href="/base/typography">Typography</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
                 </ul>
               </li>
 
@@ -91,7 +91,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/breadcrumbs' %}is-active{% endif %}" href="/patterns/breadcrumbs">Breadcrumbs</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/buttons' %}is-active{% endif %}" href="/patterns/buttons">Buttons</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/card' %}is-active{% endif %}" href="/patterns/card">Cards</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/contextual-menu' %}is-active{% endif %}" href="/patterns/contextual-menu">Contextual menu</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/contextual-menu' %}is-active{% endif %}" href="/patterns/contextual-menu">Contextual menu</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/grid' %}is-active{% endif %}" href="/patterns/grid">Grid</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/heading-icon' %}is-active{% endif %}" href="/patterns/heading-icon">Heading icon</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/icons' %}is-active{% endif %}" href="/patterns/icons">Icons</a></li>
@@ -110,7 +110,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/pagination' %}is-active{% endif %}" href="/patterns/pagination">Pagination</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/pull-quote' %}is-active{% endif %}" href="/patterns/pull-quote">Quotes</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/search-box' %}is-active{% endif %}" href="/patterns/search-box">Search box</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/slider' %}is-active{% endif %}" href="/patterns/slider">Slider</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/slider' %}is-active{% endif %}" href="/patterns/slider">Slider</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/strip' %}is-active{% endif %}" href="/patterns/strip">Strip</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/switch' %}is-active{% endif %}" href="/patterns/switch">Switch</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/patterns/table-of-contents' %}is-active{% endif %}" href="/patterns/table-of-contents">Table of contents</a></li>

--- a/docs/component-status.md
+++ b/docs/component-status.md
@@ -10,7 +10,7 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### Current status
+### What's new in Vanilla 2.7
 
 <table>
   <thead>
@@ -22,6 +22,11 @@ When we add, make significant updates, or deprecate a component we update their 
   </thead>
   <tbody>
     <!-- 2.7.0 -->
+    <tr>
+      <th><a href="/patterns/contextual-menu#theming">Contextual menu</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>Added dark theme to contextual menu.</td>
+    </tr>
     <tr>
       <th><a href="/base/typography#heading-classes">Heading classes</a></th>
       <td><div class="p-label--updated">Updated</div></td>

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,12 +56,12 @@ You can use Vanilla in your projects in a few different ways. See [Building with
 <h3>Release notes</h3>
 <div class="row">
     <ul class="p-list--divided is-split">
+      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.7.0">Release v2.7.0 - 17 February, 2020</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.6.0">Release v2.6.0 - 28 January, 2020</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.5.0">Release v2.5.0 - 5 December, 2019</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.4.1">Release v2.4.1 - 23 October, 2019</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.4.0">Release v2.4.0 - 16 September, 2019</a></li>
       <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0">Release v2.3.0 - 9 August, 2019</a></li>
-      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.2.0">Release v2.2.0 - 1 August, 2019</a></li>
     </ul>
   </div>
   </div>

--- a/docs/patterns/contextual-menu.md
+++ b/docs/patterns/contextual-menu.md
@@ -7,6 +7,8 @@ context:
 
 ## Contextual menu
 
+<span class="p-label--updated">Updated</span>
+
 <hr>
 
 A contextual menu can be applied to any button, link or navigation item that requires a secondary menu. To interact with the menu it will require some javascript to hide/show each pattern. This is achieved by finding the toggle element `p-contextual-menu__toggle` and what it controls `aria-controls`.
@@ -51,6 +53,8 @@ Please ensure the `aria-control` attribute matches an ID of an element. If `aria
 
 ### Theming
 
+<span class="p-label--new">New</span>
+
 The contextual menu uses Vanilla's light theme by default. There are two ways to switch between the light and the dark themes:
 
 - Change the default: go to `_settings_themes.scss` and set `$theme-default-p-contextual-menu` to `dark`
@@ -58,10 +62,6 @@ The contextual menu uses Vanilla's light theme by default. There are two ways to
 
 <a href="/examples/patterns/contextual-menu/dark" class="js-example">
 View example of the contextual menu with an is-dark class
-</a>
-
-<a href="/examples/patterns/contextual-menu/light" class="js-example">
-View example of the contextual menu with an is-light class
 </a>
 
 ### Import

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.6.0",
+  "version": "2.7.0",
   "files": [
     "/scss"
   ],

--- a/scss/_settings_system.scss
+++ b/scss/_settings_system.scss
@@ -1,2 +1,2 @@
 // Global system settings
-$app-version: '2.6.0' !default;
+$app-version: '2.7.0' !default;


### PR DESCRIPTION
## Done

- Bumps version to 2.7.0
- Updates component status for 2.7 release.
- Removes nonexistent contextual menu light example from docs page

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/
- On home page make sure 2.7.0 is listed as latest release (link to GH will not work until release is done)
- Go to component status page
- Check if side navigation labels are in line with component status
