### PR TITLE
Update flask-base to prevent caching of _status endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==0.3.3
+canonicalwebteam.flask-base==0.4.0
 gunicorn[gevent]
 canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.search==0.2.0


### PR DESCRIPTION
## QA

Go to `/_status/check` and check you see a `cache-control: no-store` header or something.