### PR TITLE
Update release drafter template, use it as GH Workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,16 +2,17 @@
 
 [List of work items including drive-bys]
 
+Fixes [list issues/bugs if needed]
+
 ## QA
 
 - Pull code
-- Run `./run serve --watch`
-- Open http://0.0.0.0:8101/
+- Run `./run`
+- Open http://0.0.0.0:8101/ or [demo]
 - [Add additional steps]
 
-## Details
-
-[List of links to issues/bugs and cards if needed]
+Make sure PR has one of the following labels to automatically categorise it in release notes:
+`Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
 
 ## Screenshots
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,17 +1,15 @@
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
-  - title: '💣 Breaking Change'
-    labels:
-      - 'Breaking Change 💣'
   - title: '🚀 Features'
-    labels:
-      - 'Feature 🎁'
-      - 'Enhancement ✨'
+    label: 'Feature 🎁'
+  - title: '💣 Breaking Change'
+    label: 'Breaking Change 💣'
   - title: '🐛 Bug Fixes'
-    labels:
-      - 'Bug 🐛'
-  - title: '🔨 Maintenance '
+    label: 'Bug 🐛'
+  - title: '📝 Documentation'
+    label: 'Documentation 📝'
+  - title: '🔨 Maintenance'
     label: 'Maintenance 🔨'
 change-template: '- $TITLE (#$NUMBER)'
 template: |
@@ -20,6 +18,6 @@ template: |
   Install with NPM: https://www.npmjs.com/package/vanilla-framework
   Visit the documentation at https://docs.vanillaframework.io
 
-  ## New in v$NEXT_PATCH_VERSION
+  ## New in Vanilla v$NEXT_PATCH_VERSION
 
   $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft release notes
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Done

Updates release drafter template.
Uses Release Drafter as GH Actions Workflow.

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/771

## QA

There is no way to QA it until it's merged and runs on GH, so trust in code review...
