### PR TITLE
Pass Vanilla version from package.json to scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/canonical-web-and-design/vanilla-framework"
   },
   "scripts": {
-    "build": "node-sass --include-paths node_modules scss --output-style compressed --output build/css && postcss --use autoprefixer --replace 'build/css/**/*.css' --no-map",
+    "build": "node-sass scss --functions sass-functions.js --output-style compressed --output build/css && postcss --use autoprefixer --replace 'build/css/**/*.css' --no-map",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "test": "yarn run lint-scss && mdspell docs/**/*.md -r -n -a --en-gb && node -e 'require(\"./tests/parker\").parkerTest()'",
     "lint-scss": "sass-lint 'scss/**/*.scss' --verbose --no-exit --max-warnings=0",

--- a/sass-functions.js
+++ b/sass-functions.js
@@ -1,0 +1,8 @@
+var sass = require('node-sass');
+var version = require('./package.json').version;
+
+module.exports = {
+  'vanilla-version': function() {
+    return sass.types.String(version);
+  }
+};

--- a/scss/_settings_system.scss
+++ b/scss/_settings_system.scss
@@ -1,2 +1,7 @@
 // Global system settings
-$app-version: '2.7.0' !default;
+@if function-exists(vanilla-version) {
+  $app-version: vanilla-version();
+} @else {
+  // update the fallback with major releases
+  $app-version: '2.0.0' !default;
+}


### PR DESCRIPTION
## Done

Adds a Sass function to read version from package.json, so it doesn't have to be updated in multiple places on release.

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/772 

## QA

- Pull code
- Run `./run build`
- Scss should build without any errors
- Update version field in package.json to 3.0.0
- `./run build`
- Deprecation warnings should show up during the build
