### PR TITLE
Add workflow to publish Vanilla to npm and assets on release

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -1,0 +1,56 @@
+name: Publish Vanilla release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    name: Build Vanilla
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Read Vanilla version from package.json
+        run: |
+          node -p "require('./package.json').version" > VANILLA_VERSION
+          echo "Building Vanilla v$(cat VANILLA_VERSION)"
+      - run: yarn install
+      - run: yarn build
+      - run: yarn test
+      - run: cp VANILLA_VERSION build/css
+      - uses: actions/upload-artifact@v1
+        with:
+          name: css
+          path: build/css
+
+  publish-npm:
+    name: Publish to NPM
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+  publish-assets:
+    name: Publish to assets server
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: css
+      - name: Install upload-assets snap
+        run: sudo snap install upload-assets
+      - name: Upload to assets server
+        run: upload-assets --url-path vanilla-framework-version-$(cat css/VANILLA_VERSION).min.css css/build.css
+        env:
+          UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -42,7 +42,7 @@ jobs:
 
   publish-assets:
     name: Publish to assets server
-    needs: build
+    needs: [build, publish-npm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v1


### PR DESCRIPTION
## Done

Add GitHub workflow to build Vanilla and publish it to npm and assets server when release in GitHub is created.

Fixes #2327
Fixes #2328 

## QA

There is no good way to QA it in place until it's merged and release is triggered.

You can review [test run of the workflow](https://github.com/bartaz/vanilla-framework/actions/runs/42250611) in the fork.
Note - test run fails to publish, because version in package.json didn't change, but you can review if all steps are called correctly.

