### PR TITLE
Update docs home page to remove list of latest releaes

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -69,6 +69,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/' %}is-active{% endif %}" href="/">Get started</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/building-vanilla' %}is-active{% endif %}" href="/building-vanilla">Building with Vanilla</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/customising-vanilla' %}is-active{% endif %}" href="/customising-vanilla">Customising Vanilla</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">What’s new in {{ version }}</a></li>
                 </ul>
               </li>
 
@@ -163,7 +164,7 @@
                 <ul class="p-sidebar-nav__list">
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/examples' %}is-active{% endif %}" href="/examples">Component examples</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/component-status' %}is-active{% endif %}" href="/component-status">Component status</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == 'https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch' %}is-active{% endif %}" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></li>
                 </ul>
               </li>
             </ul>
@@ -187,6 +188,9 @@
               &copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
               <nav>
                 <ul class="p-inline-list--middot">
+                  <li class="p-inline-list__item">
+                    <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
+                  </li>
                   <li class="p-inline-list__item">
                     <a href="https://www.ubuntu.com/legal">Legal info</a>
                   </li>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -172,14 +172,7 @@
       </aside>
 
       <main class="p-content" id="main-content">
-        {% if path == "/" %}
-        <div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png'); background-position: 75% 50%;">
-          <div class="p-content__row">
-            <h1>Vanilla documentation</h1>
-            <p class="p-heading--four">Everything you need to get your project started with Vanilla.</p>
-          </div>
-        </div>
-        {% endif %}
+        {% block banner %}{% endblock %}
         <div class="p-strip is-shallow">
           <div class="p-content__row">
             {% block content %}{{ content | safe }}{% endblock content %}

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,58 +35,24 @@
 @include vanilla;</code></pre>
 
     <p><em>For information on overriding settings and importing only parts of Vanilla, see <a href="/customising-vanilla">Customising Vanilla</a>.</em></p>
-
   </div>
 </div>
 
-<div class="row">
-  <div class="col-12">
-    <h3>Hotlink</h3>
-    <p>You can add Vanilla directly to your markup:</p>
-    <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-{{ version }}.min.css" /&gt;</code></pre>
-  </div>
-</div>
+<h3>Hotlink</h3>
+<p>You can add Vanilla directly to your markup:</p>
+<pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-{{ version }}.min.css" /&gt;</code></pre>
 
-<br>
+<h3>Download</h3>
+<p>Download the latest version of Vanilla from GitHub.</p>
+<p><a class="p-button--positive" href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v{{ version }}.zip">Download v{{ version }}</a></p>
+<p>See the <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest updates.</p>
 
-<div class="row">
-  <div class="col-12">
-    <h3>Download</h3>
-    <p>Download the latest version of Vanilla from GitHub.</p>
-    <button class="p-button--positive"><a href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v{{ version }}.zip">Download v{{ version }}</a></button>
-  </div>
-</div>
+<h3>Local development</h3>
+<p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-framework" class="p-link--external">README.md</a>.</p>
+<ul class="p-inline-list">
+  <li class="p-inline-list__item"><i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Join our channel</a></li>
+  <li class="p-inline-list__item"><i class="p-list__icon--twitter"></i><a href="https://twitter.com/vanillaframewrk">Tweet us</a></li>
+  <li class="p-inline-list__item"><i class="p-list__icon--github"></i><a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new">Fork us on GitHub</a></li>
+</ul>
 
-<br>
-
-<div class="row">
-<h3>Release notes</h3>
-<div class="row">
-    <ul class="p-list--divided is-split">
-      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.7.0">Release v2.7.0 - 17 February, 2020</a></li>
-      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.6.0">Release v2.6.0 - 28 January, 2020</a></li>
-      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.5.0">Release v2.5.0 - 5 December, 2019</a></li>
-      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.4.1">Release v2.4.1 - 23 October, 2019</a></li>
-      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.4.0">Release v2.4.0 - 16 September, 2019</a></li>
-      <li class="p-list__item"><a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0">Release v2.3.0 - 9 August, 2019</a></li>
-    </ul>
-  </div>
-  </div>
-
-  <br>
-
-  <div class="row">
-  <div class="col-12">
-  <h3>Local development</h3>
-  <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-framework" class="p-link--external">README.md</a>.</p>
-
-  <br>
-
-  <ul class="p-inline-list">
-    <li class="p-inline-list__item"><i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Join our channel</a></li>
-    <li class="p-inline-list__item"><i class="p-list__icon--twitter"></i><a href="https://twitter.com/vanillaframewrk">Tweet us</a></li>
-    <li class="p-inline-list__item"><i class="p-list__icon--github"></i><a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new">Fork us on GitHub</a></li>
-  </ul>
-  </div>
-</div>
 {% endblock %}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,14 +1,12 @@
----
-wrapper_template: '_layouts/default.html'
-context:
-  title: Get started
----
+{% extends "_layouts/default.html" %}
+{% block title %}Get started{% endblock %}
 
-## Get started
+{% block content %}
+<h2>Get started</h2>
 
 <hr>
 
-You can use Vanilla in your projects in a few different ways. See [Building with Vanilla](/building-vanilla) and [Customising Vanilla](/customising-vanilla) for more in-depth setup instructions.
+<p>You can use Vanilla in your projects in a few different ways. See <a href="/building-vanilla">Building with Vanilla</a> and <a href="/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
 
 <h3>Install</h3>
 <div class="row">
@@ -82,3 +80,4 @@ You can use Vanilla in your projects in a few different ways. See [Building with
   </ul>
   </div>
 </div>
+{% endblock %}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,15 @@
 {% extends "_layouts/default.html" %}
 {% block title %}Get started{% endblock %}
 
+{% block banner %}
+<div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png'); background-position: 75% 50%;">
+  <div class="p-content__row">
+    <h1>Vanilla documentation</h1>
+    <p class="p-heading--four">Everything you need to get your project started with Vanilla.</p>
+  </div>
+</div>
+{% endblock %}
+
 {% block content %}
 <h2>Get started</h2>
 


### PR DESCRIPTION
## Done

Removes manually maintained list of latest releases from docs home page, replaces it with a link to GH release notes.
This will help us avoid the need to update this list with every single release.

Adds a link to release notes (with current version) to sidebar nav and footer.
Fixes #2823 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or try [demo](https://vanilla-framework-canonical-web-and-design-pr-2842.run.demo.haus/) (if it works...)
- There should be no list of latest releases, but a link to release notes on GH (below download button)
- There should be a "What's new" link in sidebar and "Vanilla v.X.X.X" in footer

<img width="1083" alt="Screenshot 2020-02-21 at 09 31 28" src="https://user-images.githubusercontent.com/83575/75017368-24a2ea80-548d-11ea-840c-76ed2b6ed458.png">


