### PR TITLE
Fix release workflow to be triggered on release publish event

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -2,7 +2,7 @@ name: Publish Vanilla release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
## Done

Uses `release published` event instead of `created` to properly release Vanilla when release is published on GH.

## QA

No way to QA it other than merging and trying on a repo...