### PR TITLE
Add bottom margin to definition list

### DIFF
--- a/docs/examples/templates/typographic-spacing.html
+++ b/docs/examples/templates/typographic-spacing.html
@@ -1597,6 +1597,36 @@
     </p>
   </div>
 </div>
+<hr>
+<div class="row">
+  <div class="col-6">
+    <h3>List styles and spacing</h3>
+    <p>This is just a line of text before unordered list:</p>
+    <ul>
+      <li>Unordered list</li>
+      <li>Unordered list unordered list unordered list unordered list unordered list unordered list unordered list unordered list</li>
+      <li>Unordered list</li>
+    </ul>
+    <p>This is just a line of text before ordered list:</p>
+    <ol>
+      <li>Ordered list</li>
+      <li>Ordered list ordered list ordered list ordered list ordered list ordered list ordered list ordered list ordered list</li>
+      <li>Ordered list</li>
+    </ol>
+    <p>This is just a line of text before definition list:</p>
+    <dl>
+      <dt>Definition item</dt>
+      <dd>Definition description</dd>
+      <dt>Definition item with two descriptions</dt>
+      <dd>Definition first description</dd>
+      <dd>Definition second description</dd>
+      <dt>Definition item with long description</dt>
+      <dd>Definition long description long description long description long description long description long description long description long description</dd>
+    </dl>
+    <p>This is just a line of text after the lists.</p>
+  </div>
+</div>
+<hr>
 <div class="row">
   <a target="_blank" rel="noopener noreferrer"
     href="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg"><img

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -25,9 +25,14 @@
     }
   }
 
-  li,
-  dl {
+  li {
     margin: 0;
+    padding: 0;
+  }
+
+  dl {
+    margin-bottom: $spv-outer--scaleable;
+    margin-top: 0;
     padding: 0;
   }
 

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -50,9 +50,5 @@
     &:first-of-type {
       border-top: 0;
     }
-
-    dd + & {
-      margin-top: $spv-outer--scaleable - $spv-nudge-compensation;
-    }
   }
 }

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -44,11 +44,5 @@
   dt {
     @extend %default-text;
     @extend %bold;
-
-    border-top: 1px solid $color-mid-light;
-
-    &:first-of-type {
-      border-top: 0;
-    }
   }
 }


### PR DESCRIPTION
## Done

Adds bottom margin to definition list to make it consistent with other list patterns.
Adds list examples to typography template example page.

Fixes #2791 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2849.run.demo.haus/)
- Go to [definition list example](https://vanilla-framework-canonical-web-and-design-pr-2849.run.demo.haus/examples/base/lists/definition-list), make sure there is bottom margin
- Go to [typography example](https://vanilla-framework-canonical-web-and-design-pr-2849.run.demo.haus/examples/templates/typographic-spacing), find "List styles and spacing", make sure they display correctly


## Screenshots


<img width="958" alt="Screenshot 2020-02-26 at 10 21 37" src="https://user-images.githubusercontent.com/83575/75330734-cbb6c600-5881-11ea-9983-28b107eede41.png">
