### PR TITLE
Fix external link background leaking

### DIFF
--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -73,7 +73,7 @@ $external-icon-size--headings: #{map-get($icon-sizes, heading-icon--x-small)};
         no-repeat 0.25em 0 / #{$mask-size};
       background-color: currentColor;
       content: '\00A0';
-      display: inline;
+      display: inline-block;
       mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E")
         no-repeat 0.25em 0 / #{$size};
       padding-right: $size;


### PR DESCRIPTION
## Done

- [x] Fix external link icon
Fixes #2728 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/
- See external links on Safari and Edge

Note: I don't have a machine to install Edge, somebody QA on Edge. Thanks

## Screenshots

<img width="1328" alt="Screenshot 2020-02-26 at 16 01 52" src="https://user-images.githubusercontent.com/14939793/75363038-7a262f80-58b1-11ea-962c-ce03ef076936.png">