### PR TITLE
Only compensate margin on pararaphs that don't have heading classes

### DIFF
--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -167,7 +167,7 @@
     @extend %common-default-text-properties;
     margin-bottom: map-get($sp-after, p) - map-get($nudges, nudge--p);
 
-    & + & {
+    &:not([class*='p-heading--']):not([class*='p-muted-heading']) + & {
       margin-top: -#{$sp-unit};
     }
 


### PR DESCRIPTION
## Done

Fix margin between paragraph with heading class and following paragraph.

Fixes #2835 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2856.run.demo.haus/)
- Check typography examples, they should work as expected
- Check [codepen demo](
https://codepen.io/bartoszopka/pen/abOBOOq?=true) which uses styles from this PR
- Make sure all headings are properly aligned

## Screenshots

<img width="1442" alt="Screenshot 2020-02-27 at 11 42 57" src="https://user-images.githubusercontent.com/83575/75437353-5b2da900-5956-11ea-8456-c8358dbada13.png">

