### PR TITLE
Fix highlighting link for standalone examples

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -42,7 +42,7 @@
             <a href="#main-content">Jump to main content</a>
           </span>
           <ul class="p-navigation__items">
-            <li class="p-navigation__item {% if path.startswith('/docs') and path != '/docs/examples' %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
+            <li class="p-navigation__item {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
             <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
             <li class="p-navigation__item"><a class="p-navigation__link" href="/accessibility">Accessibility</a></li>
             <li class="p-navigation__item"><a class="p-navigation__link" href="/browser-support">Browser support</a></li>


### PR DESCRIPTION
## Done

Fixes selecting Docs/Examples in main nav


## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- Go to standalone examples
- Only Examples should be selected, not Docs
- Go to any docs page, Docs should be selected, not Examples

