### PR TITLE
Add side navigation component with default styling

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -42,6 +42,13 @@
     padding-top: calc(#{$table-cell-vertical-padding} - 1px);
   }
 
+  // Default list styling
+  %vf-list {
+    list-style: none;
+    margin-left: 0;
+    padding-left: 0;
+  }
+
   // Bars and borders
   %vf-pseudo-border {
     background-color: $color-mid-light;
@@ -53,6 +60,8 @@
   }
 
   %vf-pseudo-border--bottom {
+    position: relative;
+
     &::after {
       @extend %vf-pseudo-border;
       bottom: 0;
@@ -60,6 +69,8 @@
   }
 
   %vf-pseudo-border--top {
+    position: relative;
+
     &::after {
       @extend %vf-pseudo-border;
       top: 0;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -10,9 +10,7 @@
   }
 
   .p-accordion__group {
-    position: relative;
-
-    & + &::after {
+    & + & {
       @extend %vf-pseudo-border--top;
     }
   }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -263,13 +263,6 @@ $spv-list-item--inner: null;
 @mixin vf-p-lists {
   //Placeholders
 
-  // Default list styling
-  %vf-list {
-    list-style: none;
-    margin-left: 0;
-    padding-left: 0;
-  }
-
   %numbered-step-container {
     counter-reset: li;
     display: flex;

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -58,15 +58,15 @@
 // theme
 @mixin vf-side-navigation-theme(
   // default text color in sidebar
-    $color-sidenav-text-default: $color-mid-dark,
+    $color-sidenav-text-default: $colors--light-theme--text-disabled,
   // text color of highlighted items
-    $color-sidenav-text-active: $color-dark,
+    $color-sidenav-text-active: $colors--light-theme--text-default,
   // background color of active/hovered items
-    $color-sidenav-item-background-highlight: $color-light,
+    $color-sidenav-item-background-highlight: $colors--light-theme--background-highlighted,
   // border color of active item
     $color-sidenav-item-border-highlight: $color-brand,
   // border color of items list
-    $color-sidenav-list-border: $color-mid-x-light
+    $color-sidenav-list-border: $colors--light-theme--border-default
 ) {
   .p-side-navigation {
     color: $color-sidenav-text-default;

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -9,12 +9,12 @@
   .p-side-navigation__list {
     @extend %vf-list;
 
-    &:not(:last-child) {
-      @extend %vf-pseudo-border--bottom;
+    & + & {
+      @extend %vf-pseudo-border--top;
 
       &::after {
-        bottom: -0.5 * $spv-outer--scaleable; // place border in the middle of the margin
         left: $sph-inner;
+        top: -0.5 * $spv-outer--scaleable; // place border in the middle of the margin
       }
     }
   }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -19,7 +19,7 @@
 
   .p-side-navigation {
     color: $color-sidenav-text-default;
-    padding-top: 2px;
+    padding-top: 0.5 * $spv-inner--x-small;
   }
 
   .p-side-navigation__list {
@@ -40,7 +40,7 @@
   .p-side-navigation__text,
   .p-side-navigation__link {
     display: block;
-    padding: 4px 0 4px 16px;
+    padding: $spv-inner--x-small $sph-inner--small $spv-inner--x-small $sph-inner;
   }
 
   .p-side-navigation__link,
@@ -52,24 +52,11 @@
   }
 
   .p-side-navigation__link.is-active {
+    @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
+
     background: $color-sidenav-item-background-highlight;
     color: $color-sidenav-text-active;
     font-weight: 400;
-  }
-
-  .p-side-navigation__link.is-selected {
-    color: $color-sidenav-text-active;
-    font-weight: 400;
-  }
-
-  .p-side-navigation__link.is-active::before {
-    background: $color-sidenav-item-border-highlight;
-    bottom: 0;
-    content: '';
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 3px;
   }
 
   .p-side-navigation__link:hover {
@@ -79,28 +66,24 @@
   }
 
   .p-side-navigation__group {
-    padding-bottom: 14px;
-    position: relative;
-  }
+    @extend %vf-pseudo-border--bottom;
 
-  .p-side-navigation__group::after {
-    background: $color-sidenav-group-border;
-    bottom: 0;
-    content: '';
-    display: block;
-    height: 1px;
-    left: 16px;
-    position: absolute;
-    right: 0;
+    padding-bottom: 0.875 * 1rem; // FIXME: 14px;
+    position: relative;
+
+    &::after {
+      background: $color-sidenav-group-border;
+      left: $sph-inner;
+    }
   }
 
   .p-side-navigation__group + .p-side-navigation__group {
-    padding-top: 10px;
+    padding-top: 0.625 * 1rem; // FIMXME: 10px;
   }
 
   // nested
   .p-side-navigation__item .p-side-navigation__item .p-side-navigation__text,
   .p-side-navigation__item .p-side-navigation__item .p-side-navigation__link {
-    padding-left: 32px;
+    padding-left: 2 * $sph-inner;
   }
 }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -58,7 +58,7 @@
 // theme
 @mixin vf-side-navigation-theme(
   // default text color in sidebar
-    $color-sidenav-text-default: $colors--light-theme--text-disabled,
+    $color-sidenav-text-default: $colors--light-theme--text-muted,
   // text color of highlighted items
     $color-sidenav-text-active: $colors--light-theme--text-default,
   // background color of active/hovered items

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -28,6 +28,11 @@
     display: block;
     padding: $spv-inner--x-small $sph-inner--small $spv-inner--x-small $sph-inner;
 
+    &.is-active,
+    &.is-selected {
+      font-weight: $font-weight-bold;
+    }
+
     // nested 2 or 3 levels
     .p-side-navigation__item .p-side-navigation__item & {
       padding-left: 2 * $sph-inner;
@@ -40,11 +45,6 @@
 
   .p-side-navigation__link {
     @include vf-focus;
-
-    &.is-active,
-    &.is-selected {
-      font-weight: $font-weight-bold;
-    }
 
     &:hover {
       text-decoration: none;
@@ -74,6 +74,10 @@
 
   .p-side-navigation__list::after {
     background: $color-sidenav-list-border;
+  }
+
+  .p-side-navigation__text.is-selected {
+    color: $color-sidenav-text-active;
   }
 
   .p-side-navigation__link {

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -2,6 +2,7 @@
 
 @mixin vf-p-side-navigation {
   .p-side-navigation {
+    // nudge from top to put text on baseline grid
     padding-top: 0.5 * $spv-inner--x-small;
   }
 
@@ -71,7 +72,7 @@
     color: $color-sidenav-text-default;
   }
 
-  .p-side-navigation__list:not(:last-child)::after {
+  .p-side-navigation__list::after {
     background: $color-sidenav-list-border;
   }
 
@@ -81,20 +82,19 @@
       color: $color-sidenav-text-default;
     }
 
-    &.is-active {
-      @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
-
-      background: $color-sidenav-item-background-highlight;
-      color: $color-sidenav-text-active;
-    }
-
+    &:hover,
+    &.is-active,
     &.is-selected {
       color: $color-sidenav-text-active;
     }
 
-    &:hover {
+    &:hover,
+    &.is-active {
       background: $color-sidenav-item-background-highlight;
-      color: $color-sidenav-text-active;
+    }
+
+    &.is-active {
+      @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
     }
   }
 }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -1,13 +1,13 @@
 @import 'settings';
 
 @mixin vf-p-side-navigation {
-  .p-side-navigation {
-    // nudge from top to put text on baseline grid
-    padding-top: 0.5 * $spv-inner--x-small;
-  }
-
   .p-side-navigation__list {
     @extend %vf-list;
+
+    .p-side-navigation > &:first-child {
+      // nudge from top to put text on baseline grid
+      padding-top: 0.5 * $spv-inner--x-small;
+    }
 
     & + & {
       @extend %vf-pseudo-border--top;

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -1,7 +1,7 @@
 @import 'settings';
 
 // TODO:
-// - [ ] remove px values for variables
+// - [x] remove px values for variables
 // - [ ] duplicated stuff in placeholders
 // - [x] define colors at the beginning
 
@@ -23,9 +23,7 @@
   }
 
   .p-side-navigation__list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+    @extend %vf-list;
   }
 
   .p-side-navigation__item,
@@ -34,7 +32,7 @@
   }
 
   .p-side-navigation__item--title {
-    font-weight: 400;
+    font-weight: $font-weight-bold;
   }
 
   .p-side-navigation__text,
@@ -46,9 +44,8 @@
   .p-side-navigation__link,
   .p-side-navigation__link:link,
   .p-side-navigation__link:visited {
+    @include vf-focus;
     color: $color-sidenav-text-default;
-    display: block;
-    position: relative;
   }
 
   .p-side-navigation__link.is-active {
@@ -56,7 +53,12 @@
 
     background: $color-sidenav-item-background-highlight;
     color: $color-sidenav-text-active;
-    font-weight: 400;
+    font-weight: $font-weight-bold;
+  }
+
+  .p-side-navigation__link.is-selected {
+    color: $color-sidenav-text-active;
+    font-weight: $font-weight-bold;
   }
 
   .p-side-navigation__link:hover {
@@ -65,20 +67,14 @@
     text-decoration: none;
   }
 
-  .p-side-navigation__group {
+  .p-side-navigation__group:not(:last-child) {
     @extend %vf-pseudo-border--bottom;
-
-    padding-bottom: 0.875 * 1rem; // FIXME: 14px;
-    position: relative;
 
     &::after {
       background: $color-sidenav-group-border;
+      bottom: -0.5 * $spv-outer--scaleable; // place border in the middle of the margin
       left: $sph-inner;
     }
-  }
-
-  .p-side-navigation__group + .p-side-navigation__group {
-    padding-top: 0.625 * 1rem; // FIMXME: 10px;
   }
 
   // nested

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -41,6 +41,12 @@
   .p-side-navigation__link {
     @include vf-focus;
 
+    // vf-highlight-bar is rendered above focus outline
+    // so we need to hide it on focus
+    &:focus::before {
+      display: none;
+    }
+
     &:hover {
       text-decoration: none;
     }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -1,8 +1,9 @@
 @import 'settings';
 
 // TODO:
+// - [ ] put colors definitions in theme mixin
 // - [x] remove px values for variables
-// - [ ] duplicated stuff in placeholders
+// - [x] duplicated stuff in placeholders
 // - [x] define colors at the beginning
 
 @mixin vf-p-side-navigation {
@@ -14,8 +15,8 @@
   $color-sidenav-item-background-highlight: $color-light;
   // color highlight border
   $color-sidenav-item-border-highlight: $color-brand;
-  // color group border
-  $color-sidenav-group-border: $color-mid-x-light;
+  // color list border
+  $color-sidenav-list-border: $color-mid-x-light;
 
   .p-side-navigation {
     color: $color-sidenav-text-default;
@@ -24,11 +25,16 @@
 
   .p-side-navigation__list {
     @extend %vf-list;
-  }
 
-  .p-side-navigation__item,
-  .p-side-navigation__item--title {
-    display: block;
+    &:not(:last-child) {
+      @extend %vf-pseudo-border--bottom;
+
+      &::after {
+        background: $color-sidenav-list-border;
+        bottom: -0.5 * $spv-outer--scaleable; // place border in the middle of the margin
+        left: $sph-inner;
+      }
+    }
   }
 
   .p-side-navigation__item--title {
@@ -39,47 +45,42 @@
   .p-side-navigation__link {
     display: block;
     padding: $spv-inner--x-small $sph-inner--small $spv-inner--x-small $sph-inner;
-  }
 
-  .p-side-navigation__link,
-  .p-side-navigation__link:link,
-  .p-side-navigation__link:visited {
-    @include vf-focus;
-    color: $color-sidenav-text-default;
-  }
+    // nested 2 or 3 levels
+    .p-side-navigation__item .p-side-navigation__item & {
+      padding-left: 2 * $sph-inner;
+    }
 
-  .p-side-navigation__link.is-active {
-    @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
-
-    background: $color-sidenav-item-background-highlight;
-    color: $color-sidenav-text-active;
-    font-weight: $font-weight-bold;
-  }
-
-  .p-side-navigation__link.is-selected {
-    color: $color-sidenav-text-active;
-    font-weight: $font-weight-bold;
-  }
-
-  .p-side-navigation__link:hover {
-    background: $color-sidenav-item-background-highlight;
-    color: $color-sidenav-text-active;
-    text-decoration: none;
-  }
-
-  .p-side-navigation__group:not(:last-child) {
-    @extend %vf-pseudo-border--bottom;
-
-    &::after {
-      background: $color-sidenav-group-border;
-      bottom: -0.5 * $spv-outer--scaleable; // place border in the middle of the margin
-      left: $sph-inner;
+    .p-side-navigation__item .p-side-navigation__item .p-side-navigation__item & {
+      padding-left: 3 * $sph-inner;
     }
   }
 
-  // nested
-  .p-side-navigation__item .p-side-navigation__item .p-side-navigation__text,
-  .p-side-navigation__item .p-side-navigation__item .p-side-navigation__link {
-    padding-left: 2 * $sph-inner;
+  .p-side-navigation__link {
+    &,
+    &:link,
+    &:visited {
+      @include vf-focus;
+      color: $color-sidenav-text-default;
+    }
+
+    &.is-active {
+      @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
+
+      background: $color-sidenav-item-background-highlight;
+      color: $color-sidenav-text-active;
+      font-weight: $font-weight-bold;
+    }
+
+    &.is-selected {
+      color: $color-sidenav-text-active;
+      font-weight: $font-weight-bold;
+    }
+
+    &:hover {
+      background: $color-sidenav-item-background-highlight;
+      color: $color-sidenav-text-active;
+      text-decoration: none;
+    }
   }
 }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -1,25 +1,7 @@
 @import 'settings';
 
-// TODO:
-// - [ ] put colors definitions in theme mixin
-// - [x] remove px values for variables
-// - [x] duplicated stuff in placeholders
-// - [x] define colors at the beginning
-
 @mixin vf-p-side-navigation {
-  // color default text
-  $color-sidenav-text-default: $color-mid-dark;
-  // color active text
-  $color-sidenav-text-active: $color-dark;
-  // color highlight background
-  $color-sidenav-item-background-highlight: $color-light;
-  // color highlight border
-  $color-sidenav-item-border-highlight: $color-brand;
-  // color list border
-  $color-sidenav-list-border: $color-mid-x-light;
-
   .p-side-navigation {
-    color: $color-sidenav-text-default;
     padding-top: 0.5 * $spv-inner--x-small;
   }
 
@@ -30,7 +12,6 @@
       @extend %vf-pseudo-border--bottom;
 
       &::after {
-        background: $color-sidenav-list-border;
         bottom: -0.5 * $spv-outer--scaleable; // place border in the middle of the margin
         left: $sph-inner;
       }
@@ -57,10 +38,46 @@
   }
 
   .p-side-navigation__link {
+    @include vf-focus;
+
+    &.is-active,
+    &.is-selected {
+      font-weight: $font-weight-bold;
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  // default light theme
+  @include vf-side-navigation-theme;
+}
+
+// theme
+@mixin vf-side-navigation-theme(
+  // default text color in sidebar
+    $color-sidenav-text-default: $color-mid-dark,
+  // text color of highlighted items
+    $color-sidenav-text-active: $color-dark,
+  // background color of active/hovered items
+    $color-sidenav-item-background-highlight: $color-light,
+  // border color of active item
+    $color-sidenav-item-border-highlight: $color-brand,
+  // border color of items list
+    $color-sidenav-list-border: $color-mid-x-light
+) {
+  .p-side-navigation {
+    color: $color-sidenav-text-default;
+  }
+
+  .p-side-navigation__list:not(:last-child)::after {
+    background: $color-sidenav-list-border;
+  }
+
+  .p-side-navigation__link {
     &,
-    &:link,
     &:visited {
-      @include vf-focus;
       color: $color-sidenav-text-default;
     }
 
@@ -69,18 +86,15 @@
 
       background: $color-sidenav-item-background-highlight;
       color: $color-sidenav-text-active;
-      font-weight: $font-weight-bold;
     }
 
     &.is-selected {
       color: $color-sidenav-text-active;
-      font-weight: $font-weight-bold;
     }
 
     &:hover {
       background: $color-sidenav-item-background-highlight;
       color: $color-sidenav-text-active;
-      text-decoration: none;
     }
   }
 }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -1,0 +1,106 @@
+@import 'settings';
+
+// TODO:
+// - [ ] remove px values for variables
+// - [ ] duplicated stuff in placeholders
+// - [x] define colors at the beginning
+
+@mixin vf-p-side-navigation {
+  // color default text
+  $color-sidenav-text-default: $color-mid-dark;
+  // color active text
+  $color-sidenav-text-active: $color-dark;
+  // color highlight background
+  $color-sidenav-item-background-highlight: $color-light;
+  // color highlight border
+  $color-sidenav-item-border-highlight: $color-brand;
+  // color group border
+  $color-sidenav-group-border: $color-mid-x-light;
+
+  .p-side-navigation {
+    color: $color-sidenav-text-default;
+    padding-top: 2px;
+  }
+
+  .p-side-navigation__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .p-side-navigation__item,
+  .p-side-navigation__item--title {
+    display: block;
+  }
+
+  .p-side-navigation__item--title {
+    font-weight: 400;
+  }
+
+  .p-side-navigation__text,
+  .p-side-navigation__link {
+    display: block;
+    padding: 4px 0 4px 16px;
+  }
+
+  .p-side-navigation__link,
+  .p-side-navigation__link:link,
+  .p-side-navigation__link:visited {
+    color: $color-sidenav-text-default;
+    display: block;
+    position: relative;
+  }
+
+  .p-side-navigation__link.is-active {
+    background: $color-sidenav-item-background-highlight;
+    color: $color-sidenav-text-active;
+    font-weight: 400;
+  }
+
+  .p-side-navigation__link.is-selected {
+    color: $color-sidenav-text-active;
+    font-weight: 400;
+  }
+
+  .p-side-navigation__link.is-active::before {
+    background: $color-sidenav-item-border-highlight;
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 3px;
+  }
+
+  .p-side-navigation__link:hover {
+    background: $color-sidenav-item-background-highlight;
+    color: $color-sidenav-text-active;
+    text-decoration: none;
+  }
+
+  .p-side-navigation__group {
+    padding-bottom: 14px;
+    position: relative;
+  }
+
+  .p-side-navigation__group::after {
+    background: $color-sidenav-group-border;
+    bottom: 0;
+    content: '';
+    display: block;
+    height: 1px;
+    left: 16px;
+    position: absolute;
+    right: 0;
+  }
+
+  .p-side-navigation__group + .p-side-navigation__group {
+    padding-top: 10px;
+  }
+
+  // nested
+  .p-side-navigation__item .p-side-navigation__item .p-side-navigation__text,
+  .p-side-navigation__item .p-side-navigation__item .p-side-navigation__link {
+    padding-left: 32px;
+  }
+}

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -28,11 +28,6 @@
     display: block;
     padding: $spv-inner--x-small $sph-inner--small $spv-inner--x-small $sph-inner;
 
-    &.is-active,
-    &.is-selected {
-      font-weight: $font-weight-bold;
-    }
-
     // nested 2 or 3 levels
     .p-side-navigation__item .p-side-navigation__item & {
       padding-left: 2 * $sph-inner;
@@ -76,10 +71,6 @@
     background: $color-sidenav-list-border;
   }
 
-  .p-side-navigation__text.is-selected {
-    color: $color-sidenav-text-active;
-  }
-
   .p-side-navigation__link {
     &,
     &:visited {
@@ -87,14 +78,9 @@
     }
 
     &:hover,
-    &.is-active,
-    &.is-selected {
-      color: $color-sidenav-text-active;
-    }
-
-    &:hover,
     &.is-active {
       background: $color-sidenav-item-background-highlight;
+      color: $color-sidenav-text-active;
     }
 
     &.is-active {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -41,6 +41,7 @@ $colors--light-theme--border-default: #cdcdcd !default;
 $colors--light-theme--border-high-contrast: #999 !default;
 $colors--light-theme--text-hover: #757575 !default;
 $colors--light-theme--text-disabled: #666 !default;
+$colors--light-theme--text-muted: #666 !default;
 $colors--light-theme--text-default: #111 !default;
 
 //text-hover: minimum contrast on primary that satisfies contrast checker AA
@@ -49,4 +50,6 @@ $colors--dark-theme--background-highlighted: hsl(0, 0%, 20%) !default;
 $colors--dark-theme--border-default: hsl(0, 0%, 27%) !default;
 $colors--dark-theme--border-high-contrast: hsl(0, 0%, 42%) !default;
 $colors--dark-theme--text-hover: hsl(0, 0%, 56%) !default;
+// TODO: add --text-disabled
+// TODO: add --text-muted
 $colors--dark-theme--text-default: hsl(0, 0%, 100%) !default;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -33,6 +33,7 @@
 @import 'patterns_pagination';
 @import 'patterns_pull-quotes';
 @import 'patterns_search-box';
+@import 'patterns_side-navigation';
 @import 'patterns_slider';
 @import 'patterns_strip';
 @import 'patterns_switch';
@@ -102,6 +103,7 @@
   @include vf-p-pagination;
   @include vf-p-pull-quotes;
   @include vf-p-search-box;
+  @include vf-p-side-navigation;
   @include vf-p-slider;
   @include vf-p-strip;
   @include vf-p-switch;

--- a/scss/standalone/patterns_side-navigation.scss
+++ b/scss/standalone/patterns_side-navigation.scss
@@ -1,0 +1,5 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_side-navigation';
+@include vf-p-side-navigation;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -88,7 +88,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/media-object' %}is-active{% endif %}" href="/docs/patterns/media-object">Media object</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/modal' %}is-active{% endif %}" href="/docs/patterns/modal">Modal</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/muted-heading' %}is-active{% endif %}" href="/docs/patterns/muted-heading">Muted heading</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/navigation' %}is-active{% endif %}" href="/docs/patterns/navigation">Navigation</a><div class="p-label--updated u-float-right u-no-margin--bottom">Updated</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/navigation' %}is-active{% endif %}" href="/docs/patterns/navigation">Navigation</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/notification' %}is-active{% endif %}" href="/docs/patterns/notification">Notifications</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/pagination' %}is-active{% endif %}" href="/docs/patterns/pagination">Pagination</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/pull-quote' %}is-active{% endif %}" href="/docs/patterns/pull-quote">Quotes</a></li>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -10,18 +10,40 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### What's new in Vanilla 2.8
+### What's new in Vanilla 2.9
 
 <table>
   <thead>
     <tr>
       <th style="width: 20%">Component</th>
-      <th style="width: 10%">Status</th>
+      <th style="width: 15%">Status</th>
       <th style="width: 10%">Version</th>
-      <th style="width: 60%">Notes</th>
+      <th style="width: 55%">Notes</th>
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.9.0</td>
+      <td>New side navigation component was added.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- 2.8.0 -->
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td><div class="p-label--updated">Updated</div></td>
@@ -34,21 +56,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.8.0</td>
       <td>Navigation classes <code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code> are deprecated and will be removed in future release v3.0. Please use new class names (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) instead.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 10%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 60%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.7.0 -->
     <tr>
       <th><a href="/docs/patterns/contextual-menu#theming">Contextual menu</a></th>

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -1,0 +1,54 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Side navigation{% endblock %}
+
+{% block standalone_css %}patterns_side-navigation{% endblock %}
+
+{% block content %}
+<div class="p-side-navigation">
+    <div class="p-side-navigation__group">
+      <span class="p-side-navigation__item--title">
+        <span class="p-side-navigation__text">Heading</span>
+      </span>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link is-selected" href="#">Snap Store buttons</a>
+                    <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link" href="#">Snap Store buttons</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link is-active" href="#">GitHub badges</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">Embeddable cards make it wrap</a>
+        </li>
+      </ul>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">GitHub badges</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">Embeddable cards</a>
+        </li>
+      </ul>
+    </div>
+    <div class="p-side-navigation__group">
+      <span class="p-side-navigation__item--title">
+        <a class="p-side-navigation__link">Heading</a>
+      </span>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item is-selected">
+          <a class="p-side-navigation__link" href="#">Snap Store buttons</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">GitHub badges</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">Embeddable cards</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Side navigation{% endblock %}
+{% block title %}Side navigation / Default{% endblock %}
 
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
@@ -7,52 +7,80 @@
 <div class="p-side-navigation">
   <ul class="p-side-navigation__list">
     <li class="p-side-navigation__item--title">
-      <span class="p-side-navigation__text">Heading</span>
+      <a class="p-side-navigation__link" href="#">Title that is a link</a>
     </li>
     <li class="p-side-navigation__item">
-      <a class="p-side-navigation__link is-selected" href="#">Snap Store buttons</a>
+      <a class="p-side-navigation__link" href="#">First level link</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link is-selected" href="#">Selected link</a>
       <ul class="p-side-navigation__list">
         <li class="p-side-navigation__item">
-          <a class="p-side-navigation__link" href="#">Snap Store buttons</a>
+          <a class="p-side-navigation__link" href="#">Second level link</a>
         </li>
         <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link" href="#">GitHub badges</a>
+          <span class="p-side-navigation__text">Second level text</span>
         </li>
         <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link is-selected" href="#">Embeddable cards make it wrap</a>
+          <a class="p-side-navigation__link is-selected" href="#">Second level selected link</a>
           <ul class="p-side-navigation__list">
             <li class="p-side-navigation__item">
-              <a class="p-side-navigation__link" href="#">Third level of side nav</a>
+              <span class="p-side-navigation__text">Third level text</span>
             </li>
             <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link is-active" href="#">GitHub badges on third level</a>
+              <a class="p-side-navigation__link is-active" href="#">Third level active link</a>
             </li>
             <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link" href="#">Embeddable cards on third level</a>
+              <a class="p-side-navigation__link" href="#">Third level link</a>
             </li>
           </ul>
         </li>
       </ul>
     </li>
     <li class="p-side-navigation__item ">
-      <a class="p-side-navigation__link" href="#">GitHub badges</a>
+      <span class="p-side-navigation__text">First level item that is not a link</span>
     </li>
     <li class="p-side-navigation__item ">
-      <a class="p-side-navigation__link" href="#">Embeddable cards</a>
+      <a class="p-side-navigation__link" href="#">First level link</a>
     </li>
   </ul>
   <ul class="p-side-navigation__list">
     <li class="p-side-navigation__item--title">
-      <a class="p-side-navigation__link">Heading</a>
+      <span class="p-side-navigation__text">Title that is not a link</span>
     </li>
     <li class="p-side-navigation__item">
-      <a class="p-side-navigation__link" href="#">Snap Store buttons</a>
+      <span class="p-side-navigation__text">First level text</span>
+    </li>
+    <li class="p-side-navigation__item">
+      <span class="p-side-navigation__text is-selected">Selected text item</span>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link" href="#">Second level link</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <span class="p-side-navigation__text">Second level text</span>
+        </li>
+        <li class="p-side-navigation__item ">
+          <span class="p-side-navigation__text is-selected">Second level selected text item</span>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <span class="p-side-navigation__text">Third level text</span>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link is-active" href="#">Third level active item</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Third level link</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
     </li>
     <li class="p-side-navigation__item ">
-      <a class="p-side-navigation__link" href="#">GitHub badges</a>
+      <span class="p-side-navigation__text">First level item that is not a link</span>
     </li>
     <li class="p-side-navigation__item ">
-      <a class="p-side-navigation__link" href="#">Embeddable cards</a>
+      <a class="p-side-navigation__link" href="#">First level link</a>
     </li>
   </ul>
 </div>

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -5,50 +5,55 @@
 
 {% block content %}
 <div class="p-side-navigation">
-    <div class="p-side-navigation__group">
-      <span class="p-side-navigation__item--title">
-        <span class="p-side-navigation__text">Heading</span>
-      </span>
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <span class="p-side-navigation__text">Heading</span>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link is-selected" href="#">Snap Store buttons</a>
       <ul class="p-side-navigation__list">
         <li class="p-side-navigation__item">
-          <a class="p-side-navigation__link is-selected" href="#">Snap Store buttons</a>
-                    <ul class="p-side-navigation__list">
-        <li class="p-side-navigation__item">
-          <a class="p-side-navigation__link" href="#">Snap Store buttons</a>
-        </li>
-        <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link is-active" href="#">GitHub badges</a>
-        </li>
-        <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link" href="#">Embeddable cards make it wrap</a>
-        </li>
-      </ul>
-        </li>
-        <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link" href="#">GitHub badges</a>
-        </li>
-        <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link" href="#">Embeddable cards</a>
-        </li>
-      </ul>
-    </div>
-    <div class="p-side-navigation__group">
-      <span class="p-side-navigation__item--title">
-        <a class="p-side-navigation__link">Heading</a>
-      </span>
-      <ul class="p-side-navigation__list">
-        <li class="p-side-navigation__item is-selected">
           <a class="p-side-navigation__link" href="#">Snap Store buttons</a>
         </li>
         <li class="p-side-navigation__item ">
           <a class="p-side-navigation__link" href="#">GitHub badges</a>
         </li>
         <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link" href="#">Embeddable cards</a>
+          <a class="p-side-navigation__link is-selected" href="#">Embeddable cards make it wrap</a>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" href="#">Third level of side nav</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link is-active" href="#">GitHub badges on third level</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Embeddable cards on third level</a>
+            </li>
+          </ul>
         </li>
       </ul>
-    </div>
-  </div>
-
-
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">GitHub badges</a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">Embeddable cards</a>
+    </li>
+  </ul>
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <a class="p-side-navigation__link">Heading</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#">Snap Store buttons</a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">GitHub badges</a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">Embeddable cards</a>
+    </li>
+  </ul>
+</div>
 {% endblock %}

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -13,7 +13,7 @@
       <a class="p-side-navigation__link" href="#">First level link</a>
     </li>
     <li class="p-side-navigation__item">
-      <a class="p-side-navigation__link is-selected" href="#">Selected link</a>
+      <a class="p-side-navigation__link" href="#">Link with children</a>
       <ul class="p-side-navigation__list">
         <li class="p-side-navigation__item">
           <a class="p-side-navigation__link" href="#">Second level link</a>
@@ -22,7 +22,7 @@
           <span class="p-side-navigation__text">Second level text</span>
         </li>
         <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link is-selected" href="#">Second level selected link</a>
+          <a class="p-side-navigation__link" href="#">Second level link with children</a>
           <ul class="p-side-navigation__list">
             <li class="p-side-navigation__item">
               <span class="p-side-navigation__text">Third level text</span>
@@ -52,7 +52,7 @@
       <span class="p-side-navigation__text">First level text</span>
     </li>
     <li class="p-side-navigation__item">
-      <span class="p-side-navigation__text is-selected">Selected text item</span>
+      <span class="p-side-navigation__text">Text item with children</span>
       <ul class="p-side-navigation__list">
         <li class="p-side-navigation__item">
           <a class="p-side-navigation__link" href="#">Second level link</a>
@@ -61,7 +61,7 @@
           <span class="p-side-navigation__text">Second level text</span>
         </li>
         <li class="p-side-navigation__item ">
-          <span class="p-side-navigation__text is-selected">Second level selected text item</span>
+          <span class="p-side-navigation__text">Second level text with children</span>
           <ul class="p-side-navigation__list">
             <li class="p-side-navigation__item">
               <span class="p-side-navigation__text">Third level text</span>

--- a/templates/docs/examples/patterns/side-navigation/docs.html
+++ b/templates/docs/examples/patterns/side-navigation/docs.html
@@ -27,7 +27,7 @@
       <a class="p-side-navigation__link" href="#">Commission machines</a>
     </li>
     <li class="p-side-navigation__item">
-      <span class="p-side-navigation__text is-selected">Testing</span>
+      <span class="p-side-navigation__text">Testing</span>
       <ul class="p-side-navigation__list">
         <li class="p-side-navigation__item">
           <a class="p-side-navigation__link" href="#">Hardware testings</a>

--- a/templates/docs/examples/patterns/side-navigation/docs.html
+++ b/templates/docs/examples/patterns/side-navigation/docs.html
@@ -1,0 +1,75 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Side navigation / MAAS docs{% endblock %}
+
+{% block standalone_css %}patterns_side-navigation{% endblock %}
+
+{% block content %}
+<div class="p-side-navigation">
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <a class="p-side-navigation__link" href="#">Introduction</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#">About MAAS</a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">Explore MAAS</a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">Quick start</a>
+    </li>
+  </ul>
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <a class="p-side-navigation__link" href="#">Machines</a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">Commission machines</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <span class="p-side-navigation__text is-selected">Testing</span>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link" href="#">Hardware testings</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">Network testing</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link is-active" href="#">Commissioning and hardware testing scripts</a>
+        </li>
+      </ul>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">Deploy machines</a>
+    </li>
+  </ul>
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <a class="p-side-navigation__link">Concepts & terms</a>
+    </li>
+  </ul>
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <a class="p-side-navigation__link">Troubleshoot</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#">Getting help</a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">MAAS 2.5 (and earlier) documentation</a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">Upgrading MAAS</a>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x</a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+{% endblock %}

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -65,14 +65,11 @@ View example of the sub-navigation pattern
 
 <span class="p-label--new">New</span>
 
-Side navigation pattern can be used to provide more detailed navigation alongside your content.
+The side navigation pattern can be used to provide more detailed navigation alongside your content.
 
-It provides grouping of the links and nesting them up to three levels.
+It allows grouping the links into navigation sections and nesting them up to three levels.
 
-Current page in the side navigation should be highlighted by adding `is-active` class to
-`p-side-navigation__link` element. If current active page is nested in the navigation
-all relevant parent `p-side-navigation__link` or `p-side-navigation__text` elements
-should be highlighted using `is-selected` class to give a better view on the hierarchy.
+Current page in the side navigation should be highlighted by adding `is-active` class to the corresponding `p-side-navigation__link` element.
 
 <a href="/docs/examples/patterns/side-navigation/docs" class="js-example">
 View example of the side navigation pattern

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -8,7 +8,7 @@ context:
 
 <hr>
 
-<span class="p-label--updated">Updated</span>
+### Global navigation
 
 Vanilla includes a simple navigation bar that you can add to the top of your
 sites.
@@ -61,6 +61,23 @@ By default the sub-navigation menus are left-aligned with their parent, if you'd
 View example of the sub-navigation pattern
 </a>
 
+### Side navigation
+
+<span class="p-label--new">New</span>
+
+Side navigation pattern can be used to provide more detailed navigation alongside your content.
+
+It provides grouping of the links and nesting them up to three levels.
+
+Current page in the side navigation should be highlighted by adding `is-active` class to
+`p-side-navigation__link` element. If current active page is nested in the navigation
+all relevant parent `p-side-navigation__link` or `p-side-navigation__text` elements
+should be highlighted using `is-selected` class to give a better view on the hierarchy.
+
+<a href="/docs/examples/patterns/side-navigation/docs" class="js-example">
+View example of the side navigation pattern
+</a>
+
 ### Import
 
 To import just navigation or sub-navigation component into your project, copy snippets below and include it in your main Sass file.
@@ -72,6 +89,13 @@ To import just navigation or sub-navigation component into your project, copy sn
 // sub-navigation is optional you can include it alongside navigation component
 @import 'patterns_subnav';
 @include vf-p-subnav;
+```
+
+To import side navigation, copy snippet below:
+
+```scss
+@import 'patterns_side-navigation';
+@include vf-p-side-navigation;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
## Done

- adds basic version of side navigation
- adds examples and simple docs

Fixes #2860 
Fixes #2861

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2915.run.demo.haus/docs/examples/patterns/side-navigation/default)
- Check new side navigation pattern examples, make sure they work correctly
  - [default](https://vanilla-framework-canonical-web-and-design-pr-2915.run.demo.haus/docs/examples/patterns/side-navigation/default)
  - [docs](https://vanilla-framework-canonical-web-and-design-pr-2915.run.demo.haus/docs/examples/patterns/side-navigation/docs)
- make sure side nav documentation is added: https://vanilla-framework-canonical-web-and-design-pr-2915.run.demo.haus/docs/patterns/navigation/#side-navigation
  - NOTE: codepen will not render the styles for sidenav, because it uses published version of Vanilla


## Screenshots

<img width="323" alt="Screenshot 2020-03-12 at 10 13 11" src="https://user-images.githubusercontent.com/83575/76505955-a2359700-644a-11ea-9838-74c1c6fa785b.png">

