### PR TITLE
Make footer consistent between site and docs layouts

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,35 +1,42 @@
 ---
 name: Report a bug
-about: Create a bug report to help us improve Vanilla
-
+about: Create a bug report to help us improve Vanilla framework or out site
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is.
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -1,0 +1,23 @@
+<footer class="p-strip is-shallow" role="contentinfo">
+  <div class="row p-content__row">
+    <div class="col-12">
+      &copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
+      <nav>
+        <ul class="p-inline-list--middot">
+          <li class="p-inline-list__item">
+            <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-link--external" href="https://www.ubuntu.com/legal">Legal info</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose">Report a bug with this site</a>
+          </li>
+        </ul>
+        <span class="u-off-screen">
+          <a href="#">Go to the top of the page</a>
+        </span>
+      </nav>
+    </div>
+  </div>
+</footer>

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -11,7 +11,7 @@
             <a class="p-link--external" href="https://www.ubuntu.com/legal">Legal info</a>
           </li>
           <li class="p-inline-list__item">
-            <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose">Report a bug with this site</a>
+            <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose">Report a bug</a>
           </li>
         </ul>
         <span class="u-off-screen">

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -164,29 +164,7 @@
 
         <hr>
 
-        <footer class="p-strip is-shallow" role="contentinfo">
-          <div class="p-content__row">
-            <div class="col-12">
-              &copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
-              <nav>
-                <ul class="p-inline-list--middot">
-                  <li class="p-inline-list__item">
-                    <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://www.ubuntu.com/legal">Legal info</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose">Report a bug with this site</a>
-                  </li>
-                </ul>
-                <span class="u-off-screen">
-                  <a href="#">Go to the top of the page</a>
-                </span>
-              </nav>
-            </div>
-          </div>
-        </footer>
+        {% include "_layouts/_footer.html" %}
       </main>
 
       <aside id="side-content" class="u-hide--small p-aside js-contents" style="display: none">

--- a/templates/_layouts/site.html
+++ b/templates/_layouts/site.html
@@ -40,27 +40,6 @@
     {% block content %}{{ content | safe }}{% endblock content %}
 
     <hr>
-    <footer class="p-strip is-shallow">
-      <div class="row">
-        <div class="col-12">
-          &copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
-          <nav>
-            <ul class="p-inline-list--middot">
-              <li class="p-inline-list__item">
-                <a href="https://www.ubuntu.com/legal">Legal info</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a href="https://github.com/canonical-web-and-design/vanillaframework.io/issues/new">Report a bug with this site</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose">Report a bug with Vanilla framework</a>
-              </li>
-            </ul>
-            <span class="u-off-screen">
-              <a href="#">Go to the top of the page</a>
-            </span>
-          </nav>
-        </div>
-      </div>
-    </footer>
+
+    {% include "_layouts/_footer.html" %}
 {% endblock %}

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -3,15 +3,19 @@ var sidebarToggle = document.querySelector('.p-sidebar__toggle');
 var sidebarContent = document.querySelector('.p-sidebar__content');
 var openMainNav = document.querySelector('.p-navigation__toggle--open');
 
-sidebarToggle.addEventListener('click', function(e) {
-  sidebarToggle.classList.toggle('is-active');
-  sidebarContent.classList.toggle('is-active');
-});
+if (sidebarToggle) {
+  sidebarToggle.addEventListener('click', function(e) {
+    sidebarToggle.classList.toggle('is-active');
+    sidebarContent.classList.toggle('is-active');
+  });
+}
 
-openMainNav.addEventListener('click', function(e) {
-  sidebarToggle.classList.remove('is-active');
-  sidebarContent.classList.remove('is-active');
-});
+if (openMainNav) {
+  openMainNav.addEventListener('click', function(e) {
+    sidebarToggle.classList.remove('is-active');
+    sidebarContent.classList.remove('is-active');
+  });
+}
 
 // Add classes to links
 var links = document.querySelectorAll('a');
@@ -30,8 +34,10 @@ links.forEach(function(link) {
 var searchDocsReset = document.getElementById('search-docs-reset');
 var searchBox = document.getElementById('search-docs');
 
-searchDocsReset.addEventListener('click', function(e) {
-  searchBox.value = '';
-  searchBox.focus();
-  e.preventDefault();
-});
+if (searchDocsReset) {
+  searchDocsReset.addEventListener('click', function(e) {
+    searchBox.value = '';
+    searchBox.focus();
+    e.preventDefault();
+  });
+}


### PR DESCRIPTION
## Done

- Updates the footer on vanilla site to correctly link to vanilla framework repo
- Reuses same footer in both layouts
- Fixes errors in script when elements are not in the layout

Fixes #2916

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2917.run.demo.haus/)
- Go to home page
- Make sure links in the footer work

