### PR TITLE
Update search site URL

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -97,9 +97,7 @@ app.add_url_rule(
     "/docs/search",
     "search",
     build_search_view(
-        # temporarly keep docs.vanillaframework.io until /docs are live and indexed
-        # change to vanillaframework.io/docs
-        site="docs.vanillaframework.io", template_path="docs/search.html"
+        site="vanillaframework.io/docs", template_path="docs/search.html"
     ),
 )
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)


### PR DESCRIPTION
## Done

Point search to vanillaframeowork.io/docs rather than docs.vanillaframework.io

Fixes #2907 

## QA

- Pull code
- Run `./run` and open http://0.0.0.0:8101/docs
- Search for something
- search results should contain results for vanillaframework.io/docs rather than docs.vanillaframework.io
