### PR TITLE
Remove border from subnav dropdowns

### DIFF
--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -54,11 +54,6 @@
       @include vf-icon-chevron($colors--dark-theme--border-high-contrast);
     }
 
-    .p-subnav__items,
-    .p-subnav__items--right {
-      border-color: $colors--dark-theme--border-default;
-    }
-
     .p-subnav__item {
       @extend %subnav-item--dark-theme;
     }
@@ -69,11 +64,6 @@
         @include vf-icon-chevron($colors--light-theme--border-high-contrast);
       }
 
-      .p-subnav__items,
-      .p-subnav__items--right {
-        border-color: $colors--light-theme--border-default;
-      }
-
       .p-subnav__item {
         @extend %subnav-item--light-theme;
       }
@@ -81,11 +71,6 @@
   } @else {
     .p-subnav::after {
       @include vf-icon-chevron($colors--light-theme--border-high-contrast);
-    }
-
-    .p-subnav__items,
-    .p-subnav__items--right {
-      border-color: $colors--light-theme--border-default;
     }
 
     .p-subnav__item {
@@ -98,11 +83,6 @@
         @include vf-icon-chevron($colors--dark-theme--border-high-contrast);
       }
 
-      .p-subnav__items,
-      .p-subnav__items--right {
-        border-color: $colors--dark-theme--border-default;
-      }
-
       .p-subnav__item {
         @extend %subnav-item--dark-theme;
       }
@@ -111,7 +91,6 @@
 
   .p-subnav__items,
   .p-subnav__items--right {
-    @extend %vf-is-bordered;
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
     display: none;
@@ -127,7 +106,6 @@
     }
 
     @media (max-width: $breakpoint-navigation-threshold) {
-      border: 0;
       box-shadow: none;
     }
   }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -100,9 +100,8 @@
     z-index: 5;
 
     @media (min-width: $breakpoint-navigation-threshold + 1) {
-      clip: rect(0, 1000px, 1000px, -10px); /* Clip the top of the box-shadow off */
       position: absolute;
-      top: calc(#{$spv-inner--medium * 4} - 1px);
+      top: $spv-inner--medium * 4;
     }
 
     @media (max-width: $breakpoint-navigation-threshold) {


### PR DESCRIPTION
## Done

Removes border from subnav dropdowns

Fixes #2765 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2925.run.demo.haus/)
- Check subnav examples (light and dark) if they look ok

## Screenshots

<img width="1077" alt="Screenshot 2020-03-12 at 14 49 40" src="https://user-images.githubusercontent.com/83575/76528243-c906c400-6470-11ea-9cd8-e598da008052.png">
<img width="1079" alt="Screenshot 2020-03-12 at 14 50 02" src="https://user-images.githubusercontent.com/83575/76528248-cad08780-6470-11ea-8110-603f433c1f9a.png">

