### PR TITLE
Side navigation status labels and icons

### DIFF
--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -25,7 +25,7 @@
 
   .p-side-navigation__text,
   .p-side-navigation__link {
-    display: block;
+    display: flex;
     padding: $spv-inner--x-small $sph-inner--small $spv-inner--x-small $sph-inner;
 
     // nested 2 or 3 levels
@@ -50,6 +50,11 @@
     &:hover {
       text-decoration: none;
     }
+  }
+
+  .p-side-navigation__status {
+    margin-left: auto;
+    padding-left: $spv-outer--small;
   }
 
   // default light theme

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -26,7 +26,7 @@
   .p-side-navigation__text,
   .p-side-navigation__link {
     display: flex;
-    padding: $spv-inner--x-small $sph-inner--small $spv-inner--x-small $sph-inner;
+    padding: $spv-inner--x-small $sph-inner $spv-inner--x-small $sph-inner;
 
     // nested 2 or 3 levels
     .p-side-navigation__item .p-side-navigation__item & {
@@ -54,7 +54,7 @@
 
   .p-side-navigation__status {
     margin-left: auto;
-    padding-left: $spv-outer--small;
+    padding-left: $spv-inner--small;
   }
 
   // default light theme

--- a/scss/standalone/patterns_side-navigation.scss
+++ b/scss/standalone/patterns_side-navigation.scss
@@ -1,5 +1,12 @@
 @import '../base';
 @include vf-base;
 
+// labels and icons for navigation statuses
+@import '../patterns_label';
+@include vf-p-label;
+
+@import '../patterns_icons';
+@include vf-p-icons;
+
 @import '../patterns_side-navigation';
 @include vf-p-side-navigation;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -88,7 +88,7 @@
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/media-object' %}is-active{% endif %}" href="/docs/patterns/media-object">Media object</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/modal' %}is-active{% endif %}" href="/docs/patterns/modal">Modal</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/muted-heading' %}is-active{% endif %}" href="/docs/patterns/muted-heading">Muted heading</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/navigation' %}is-active{% endif %}" href="/docs/patterns/navigation">Navigation</a><div class="p-label--new u-float-right u-no-margin--bottom">New</div></li>
+                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/navigation' %}is-active{% endif %}" href="/docs/patterns/navigation">Navigation</a><div class="p-label--new u-float-right">New</div></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/notification' %}is-active{% endif %}" href="/docs/patterns/notification">Notifications</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/pagination' %}is-active{% endif %}" href="/docs/patterns/pagination">Pagination</a></li>
                   <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/pull-quote' %}is-active{% endif %}" href="/docs/patterns/pull-quote">Quotes</a></li>

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -13,10 +13,13 @@
       <a class="p-side-navigation__link" href="#">First level link</a>
     </li>
     <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#">First level link with status<div class="p-side-navigation__status"><i class="p-icon--error"></i></div></a>
+    </li>
+    <li class="p-side-navigation__item">
       <a class="p-side-navigation__link" href="#">Link with children</a>
       <ul class="p-side-navigation__list">
         <li class="p-side-navigation__item">
-          <a class="p-side-navigation__link" href="#">Second level link</a>
+          <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning"></i></div></a>
         </li>
         <li class="p-side-navigation__item ">
           <span class="p-side-navigation__text">Second level text</span>
@@ -31,7 +34,7 @@
               <a class="p-side-navigation__link is-active" href="#">Third level active link</a>
             </li>
             <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link" href="#">Third level link</a>
+              <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success"></i></div></a>
             </li>
           </ul>
         </li>
@@ -41,7 +44,7 @@
       <span class="p-side-navigation__text">First level item that is not a link</span>
     </li>
     <li class="p-side-navigation__item ">
-      <a class="p-side-navigation__link" href="#">First level link</a>
+      <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
     </li>
   </ul>
   <ul class="p-side-navigation__list">

--- a/templates/docs/examples/patterns/side-navigation/docs.html
+++ b/templates/docs/examples/patterns/side-navigation/docs.html
@@ -16,7 +16,7 @@
       <a class="p-side-navigation__link" href="#">Explore MAAS</a>
     </li>
     <li class="p-side-navigation__item ">
-      <a class="p-side-navigation__link" href="#">Quick start</a>
+      <a class="p-side-navigation__link" href="#">Quick start<span class="p-side-navigation__status"><span class="p-label--new">New</span></span></a>
     </li>
   </ul>
   <ul class="p-side-navigation__list">
@@ -66,7 +66,7 @@
           <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
         </li>
         <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x</a>
+          <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x<span class="p-side-navigation__status"><i class="p-icon--warning"></i></span></a>
         </li>
       </ul>
     </li>

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -95,6 +95,13 @@ To import side navigation, copy snippet below:
 ```scss
 @import 'patterns_side-navigation';
 @include vf-p-side-navigation;
+
+// optionally add icons and/or labels if you use them in side navigation__nav
+@import 'patterns_label';
+@include vf-p-label;
+
+@import 'patterns_icons';
+@include vf-p-icons;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -71,6 +71,8 @@ It allows grouping the links into navigation sections and nesting them up to thr
 
 Current page in the side navigation should be highlighted by adding `is-active` class to the corresponding `p-side-navigation__link` element.
 
+Use `p-side-navigation__status` inside `p-side-navigation__link` elements to add status labels or icons on right side of navigation items.
+
 <a href="/docs/examples/patterns/side-navigation/docs" class="js-example">
 View example of the side navigation pattern
 </a>


### PR DESCRIPTION
## Done

Add right side status icons/labels to side navigation.

Part of #2862 

## QA

- `./run` or [demo](https://vanilla-framework-canonical-web-and-design-pr-2928.run.demo.haus/docs/examples/patterns/side-navigation/default)
- Check if labels and icons are displayed correctly on different levels of navigation

## Screenshots

<img width="280" alt="Screenshot 2020-03-16 at 16 22 57" src="https://user-images.githubusercontent.com/83575/76773214-6aa85100-67a2-11ea-959c-25cdbaf21dff.png">

