### PR TITLE
Remove bottom margin from label component

### DIFF
--- a/scss/_patterns_label.scss
+++ b/scss/_patterns_label.scss
@@ -4,6 +4,8 @@
 @mixin vf-p-label {
   %vf-label {
     @extend %x-small-text;
+    @extend %u-no-margin--bottom--small;
+
     border-radius: $border-radius;
     display: inline-block;
     font-weight: 400;


### PR DESCRIPTION
## Done

As label component is used mostly inline alongside text or in paragraphs it shouldn't have margin of it's own (as it usually needs to be removed with u-no-margin).

## QA

- Pull code
- Run `./run` http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2929.run.demo.haus/)
- Review Percy to see how spacing on labels is affected
