### PR TITLE
Align side navigation group border with text

### DIFF
--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -1,6 +1,9 @@
 @import 'settings';
 
 @mixin vf-p-side-navigation {
+  // space for the right hand icon with default inner spacing on the left
+  $sp-sidenav--icon-spacing-width: map-get($icon-sizes, default) + $sph-inner;
+
   .p-side-navigation,
   .p-side-navigation--icons {
     & > .p-side-navigation__list:first-child {
@@ -19,6 +22,10 @@
         left: $sph-inner;
         top: -0.5 * $spv-outer--scaleable; // place border in the middle of the margin
       }
+
+      .p-side-navigation--icons &::after {
+        left: $sph-inner + $sp-sidenav--icon-spacing-width;
+      }
     }
   }
 
@@ -31,11 +38,8 @@
     display: flex;
     padding: $spv-inner--x-small $sph-inner $spv-inner--x-small $sph-inner;
 
-    // space for the right hand icon with default inner spacing on the left
-    $icon-spacing-width: map-get($icon-sizes, default) + $sph-inner;
-
     .p-side-navigation--icons & {
-      padding-left: $sph-inner + $icon-spacing-width;
+      padding-left: $sph-inner + $sp-sidenav--icon-spacing-width;
       position: relative;
     }
 
@@ -45,7 +49,7 @@
 
       // add spacing for variant with right side icons
       .p-side-navigation--icons & {
-        padding-left: 2 * $sph-inner + $icon-spacing-width;
+        padding-left: 2 * $sph-inner + $sp-sidenav--icon-spacing-width;
       }
     }
 
@@ -55,7 +59,7 @@
 
       // add spacing for variant with right side icons
       .p-side-navigation--icons & {
-        padding-left: 3 * $sph-inner + $icon-spacing-width;
+        padding-left: 3 * $sph-inner + $sp-sidenav--icon-spacing-width;
       }
     }
   }


### PR DESCRIPTION
In side navigation with icons on left align group border with text rather than icon


## QA

- Run `./run` or [demo](https://vanilla-framework-canonical-web-and-design-pr-2935.run.demo.haus/docs/examples/patterns/side-navigation/icons)
- Check [side navigation with icons example](https://vanilla-framework-canonical-web-and-design-pr-2935.run.demo.haus/docs/examples/patterns/side-navigation/icons)
- Border between groups should be aligned with text rather than icons
- Make sure [variant without icons](https://vanilla-framework-canonical-web-and-design-pr-2935.run.demo.haus/docs/examples/patterns/side-navigation/default) is not affected

### Before

<img width="328" alt="Screenshot 2020-03-18 at 06 46 15" src="https://user-images.githubusercontent.com/83575/76929360-3a68cb80-68e4-11ea-8f9c-5b63d6b72136.png">


### After
<img width="328" alt="Screenshot 2020-03-18 at 06 44 22" src="https://user-images.githubusercontent.com/83575/76929238-ebbb3180-68e3-11ea-8c93-1667a415c1e1.png">

