### PR TITLE
Update Vanilla docs to use new side navigation

### DIFF
--- a/scss/docs/docs.scss
+++ b/scss/docs/docs.scss
@@ -26,47 +26,6 @@ hr {
 }
 /* --- */
 
-/* Sidebar navigation */
-.p-sidebar-nav {
-  &__list {
-    @extend .p-list; // sass-lint:disable-line placeholder-in-extend
-    margin-bottom: $spv-inner--small;
-    margin-top: -$spv-inner--x-small;
-  }
-
-  &__item {
-    padding-bottom: $spv-inner--x-small / 2;
-    padding-top: $spv-inner--x-small / 2;
-
-    &:first-of-type {
-      padding-top: $spv-inner--small;
-    }
-
-    &:last-of-type {
-      padding-bottom: $spv-inner--small + $spv-inner--x-small;
-    }
-
-    .is-active {
-      position: relative;
-
-      &::before {
-        background-color: $color-accent;
-        bottom: -$spv-inner--x-small;
-        content: '';
-        left: -$sph-inner;
-        position: absolute;
-        top: -$spv-inner--x-small;
-        width: $bar-thickness;
-      }
-    }
-  }
-
-  &__item > &__list {
-    padding-left: $sph-inner;
-  }
-}
-/* --- */
-
 /* Flex layout */
 .docs-container {
   display: flex;
@@ -74,7 +33,7 @@ hr {
 }
 
 .p-sidebar {
-  background-color: $color-mid-x-light;
+  border-right: 1px solid $colors--light-theme--border-default;
   flex: 0 0 18rem;
 
   @supports (position: sticky) {
@@ -136,19 +95,14 @@ hr {
   .p-sidebar {
     border-bottom: $border;
     border-right: 0;
+    display: none;
     flex: auto;
     height: inherit;
     overflow: hidden;
     position: static;
 
-    &__content {
-      display: none;
-      padding: 0 $sp-large $sp-large $sp-large;
-
-      &.is-active {
-        display: block;
-        padding: $sp-large;
-      }
+    &.is-active {
+      display: block;
     }
   }
 
@@ -252,7 +206,6 @@ hr {
 }
 
 .p-sidebar__toggle.is-active {
-  background-color: $color-mid-x-light;
   z-index: 1;
 
   &:focus {

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -16,7 +16,7 @@
           <div class="p-navigation__toggles u-hide--large u-hide--medium">
             <a href="#navigation" class="p-navigation__toggle--open" title="about menu">About</a>
             <a href="#navigation-closed" class="p-navigation__toggle--close" title="close about menu">About</a>
-            <a class="p-sidebar__toggle u-hide--medium u-hide--large" href="#">Patterns</a>
+            <a class="p-sidebar__toggle u-hide--medium u-hide--large" href="#">Docs</a>
           </div>
         </div>
         <nav class="p-navigation__nav">
@@ -24,7 +24,7 @@
             <a href="#main-content">Jump to main content</a>
           </span>
           <ul class="p-navigation__items">
-            <li class="p-navigation__item {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
+            <li class="p-navigation__item u-hide--small {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
             <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
             <li class="p-navigation__item"><a class="p-navigation__link" href="/accessibility">Accessibility</a></li>
             <li class="p-navigation__item"><a class="p-navigation__link" href="/browser-support">Browser support</a></li>
@@ -42,116 +42,111 @@
     <div class="docs-container">
       <hr class="u-no-margin u-hide--small">
       <aside class="p-sidebar">
-        <div class="p-sidebar__content">
-          <nav class="p-sidebar-nav">
-            <ul class="p-sidebar-nav__list" id="docs-list-unsorted">
-              <li class="p-sidebar-nav__item">
-                <strong>Welcome</strong>
-                <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs' %}is-active{% endif %}" href="/docs">Get started</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/building-vanilla' %}is-active{% endif %}" href="/docs/building-vanilla">Building with Vanilla</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/customising-vanilla' %}is-active{% endif %}" href="/docs/customising-vanilla">Customising Vanilla</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">What’s new in {{ version }}</a></li>
-                </ul>
-              </li>
+        <nav class="p-side-navigation">
 
-              <li class="p-sidebar-nav__item">
-                <strong>Base elements</strong>
-                <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/base/code' %}is-active{% endif %}" href="/docs/base/code">Code</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/base/forms' %}is-active{% endif %}" href="/docs/base/forms">Forms</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/base/reset' %}is-active{% endif %}" href="/docs/base/reset">Reset</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/base/tables' %}is-active{% endif %}" href="/docs/base/tables">Tables</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/base/typography' %}is-active{% endif %}" href="/docs/base/typography">Typography</a></li>
-                </ul>
-              </li>
-
-              <li class="p-sidebar-nav__item">
-                <strong>Components</strong>
-                <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/accordion' %}is-active{% endif %}" href="/docs/patterns/accordion">Accordion</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/article-pagination' %}is-active{% endif %}" href="/docs/patterns/article-pagination">Article pagination</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/breadcrumbs' %}is-active{% endif %}" href="/docs/patterns/breadcrumbs">Breadcrumbs</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/buttons' %}is-active{% endif %}" href="/docs/patterns/buttons">Buttons</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/card' %}is-active{% endif %}" href="/docs/patterns/card">Cards</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/contextual-menu' %}is-active{% endif %}" href="/docs/patterns/contextual-menu">Contextual menu</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/grid' %}is-active{% endif %}" href="/docs/patterns/grid">Grid</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/heading-icon' %}is-active{% endif %}" href="/docs/patterns/heading-icon">Heading icon</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/icons' %}is-active{% endif %}" href="/docs/patterns/icons">Icons</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/images' %}is-active{% endif %}" href="/docs/patterns/images">Images</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/inline-images' %}is-active{% endif %}" href="/docs/patterns/inline-images">Inline images</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/labels' %}is-active{% endif %}" href="/docs/patterns/labels">Labels</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/links' %}is-active{% endif %}" href="/docs/patterns/links">Links</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/list-tree' %}is-active{% endif %}" href="/docs/patterns/list-tree">List tree</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/lists' %}is-active{% endif %}" href="/docs/patterns/lists">Lists</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/matrix' %}is-active{% endif %}" href="/docs/patterns/matrix">Matrix</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/media-object' %}is-active{% endif %}" href="/docs/patterns/media-object">Media object</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/modal' %}is-active{% endif %}" href="/docs/patterns/modal">Modal</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/muted-heading' %}is-active{% endif %}" href="/docs/patterns/muted-heading">Muted heading</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/navigation' %}is-active{% endif %}" href="/docs/patterns/navigation">Navigation</a><div class="p-label--new u-float-right">New</div></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/notification' %}is-active{% endif %}" href="/docs/patterns/notification">Notifications</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/pagination' %}is-active{% endif %}" href="/docs/patterns/pagination">Pagination</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/pull-quote' %}is-active{% endif %}" href="/docs/patterns/pull-quote">Quotes</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/search-box' %}is-active{% endif %}" href="/docs/patterns/search-box">Search box</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/slider' %}is-active{% endif %}" href="/docs/patterns/slider">Slider</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/strip' %}is-active{% endif %}" href="/docs/patterns/strip">Strip</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/switch' %}is-active{% endif %}" href="/docs/patterns/switch">Switch</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/table-of-contents' %}is-active{% endif %}" href="/docs/patterns/table-of-contents">Table of contents</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/tabs' %}is-active{% endif %}" href="/docs/patterns/tabs">Tabs</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/patterns/tooltips' %}is-active{% endif %}" href="/docs/patterns/tooltips">Tooltips</a></li>
-                </ul>
-              </li>
-
-              <li class="p-sidebar-nav__item">
-                <strong>Utilities</strong>
-                <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/align' %}is-active{% endif %}" href="/docs/utilities/align">Alignment</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/baseline-grid' %}is-active{% endif %}" href="/docs/utilities/baseline-grid">Baseline grid</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/clearfix' %}is-active{% endif %}" href="/docs/utilities/clearfix">Clearfix</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/embedded-media' %}is-active{% endif %}" href="/docs/utilities/embedded-media">Embedded media</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/equal-height' %}is-active{% endif %}" href="/docs/utilities/equal-height">Equal height</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/floats' %}is-active{% endif %}" href="/docs/utilities/floats">Floats</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/font-metrics' %}is-active{% endif %}" href="/docs/utilities/font-metrics">Font metrics</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/functions' %}is-active{% endif %}" href="/docs/utilities/functions">Functions</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/hide' %}is-active{% endif %}" href="/docs/utilities/hide">Hide</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/image-position' %}is-active{% endif %}" href="/docs/utilities/image-position">Image position</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/margin-collapse' %}is-active{% endif %}" href="/docs/utilities/margin-collapse">Margin collapse</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/no-print' %}is-active{% endif %}" href="/docs/utilities/no-print">No print</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/off-screen' %}is-active{% endif %}" href="/docs/utilities/off-screen">Off-screen</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/padding-collapse' %}is-active{% endif %}" href="/docs/utilities/padding-collapse">Padding collapse</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/table-cell-padding-overlap' %}is-active{% endif %}" href="/docs/utilities/table-cell-padding-overlap">Table cell padding overlap</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/truncate' %}is-active{% endif %}" href="/docs/utilities/truncate">Truncation</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/show' %}is-active{% endif %}" href="/docs/utilities/show">Show</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/utilities/vertically-center' %}is-active{% endif %}" href="/docs/utilities/vertically-center">Vertically center</a></li>
-                </ul>
-              </li>
-
-              <li class="p-sidebar-nav__item">
-                <strong>Settings</strong>
-                <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/animation-settings' %}is-active{% endif %}" href="/docs/settings/animation-settings">Animations</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/assets-settings' %}is-active{% endif %}" href="/docs/settings/assets-settings">Assets</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/breakpoint-settings' %}is-active{% endif %}" href="/docs/settings/breakpoint-settings">Breakpoints</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/color-settings' %}is-active{% endif %}" href="/docs/settings/color-settings">Color</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/font-settings' %}is-active{% endif %}" href="/docs/settings/font-settings">Font</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/layout-settings' %}is-active{% endif %}" href="/docs/settings/layout-settings">Layout</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/placeholder-settings' %}is-active{% endif %}" href="/docs/settings/placeholder-settings">Placeholders</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/spacing-settings' %}is-active{% endif %}" href="/docs/settings/spacing-settings">Spacing</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/settings/table-layout' %}is-active{% endif %}" href="/docs/settings/table-layout">Table layout</a></li>
-                </ul>
-              </li>
-
-              <li class="p-sidebar-nav__item">
-                <strong>Resources</strong>
-                <ul class="p-sidebar-nav__list">
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/examples' %}is-active{% endif %}" href="/docs/examples">Component examples</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft {% if path == '/docs/component-status' %}is-active{% endif %}" href="/docs/component-status">Component status</a></li>
-                  <li class="p-sidebar-nav__item"><a class="p-link--soft" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></li>
-                </ul>
-              </li>
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Welcome</span></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs' %}is-active{% endif %}" href="/docs">Get started</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/building-vanilla' %}is-active{% endif %}" href="/docs/building-vanilla">Building with Vanilla</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/customising-vanilla' %}is-active{% endif %}" href="/docs/customising-vanilla">Customising Vanilla</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">What’s new in {{ version }}</a></li>
             </ul>
-          </nav>
-        </div>
+
+
+
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/base/code' %}is-active{% endif %}" href="/docs/base/code">Code</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/base/forms' %}is-active{% endif %}" href="/docs/base/forms">Forms</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/base/reset' %}is-active{% endif %}" href="/docs/base/reset">Reset</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/base/tables' %}is-active{% endif %}" href="/docs/base/tables">Tables</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/base/typography' %}is-active{% endif %}" href="/docs/base/typography">Typography</a></li>
+            </ul>
+
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/accordion' %}is-active{% endif %}" href="/docs/patterns/accordion">Accordion</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/article-pagination' %}is-active{% endif %}" href="/docs/patterns/article-pagination">Article pagination</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/breadcrumbs' %}is-active{% endif %}" href="/docs/patterns/breadcrumbs">Breadcrumbs</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/buttons' %}is-active{% endif %}" href="/docs/patterns/buttons">Buttons</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/card' %}is-active{% endif %}" href="/docs/patterns/card">Cards</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/contextual-menu' %}is-active{% endif %}" href="/docs/patterns/contextual-menu">Contextual menu</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/grid' %}is-active{% endif %}" href="/docs/patterns/grid">Grid</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/heading-icon' %}is-active{% endif %}" href="/docs/patterns/heading-icon">Heading icon</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/icons' %}is-active{% endif %}" href="/docs/patterns/icons">Icons</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/images' %}is-active{% endif %}" href="/docs/patterns/images">Images</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/inline-images' %}is-active{% endif %}" href="/docs/patterns/inline-images">Inline images</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/labels' %}is-active{% endif %}" href="/docs/patterns/labels">Labels</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/links' %}is-active{% endif %}" href="/docs/patterns/links">Links</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/list-tree' %}is-active{% endif %}" href="/docs/patterns/list-tree">List tree</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/lists' %}is-active{% endif %}" href="/docs/patterns/lists">Lists</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/matrix' %}is-active{% endif %}" href="/docs/patterns/matrix">Matrix</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/media-object' %}is-active{% endif %}" href="/docs/patterns/media-object">Media object</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/modal' %}is-active{% endif %}" href="/docs/patterns/modal">Modal</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/muted-heading' %}is-active{% endif %}" href="/docs/patterns/muted-heading">Muted heading</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/navigation' %}is-active{% endif %}" href="/docs/patterns/navigation">Navigation<span class="p-side-navigation__status"><span class="p-label--new">New</span></span></a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/notification' %}is-active{% endif %}" href="/docs/patterns/notification">Notifications</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/pagination' %}is-active{% endif %}" href="/docs/patterns/pagination">Pagination</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/pull-quote' %}is-active{% endif %}" href="/docs/patterns/pull-quote">Quotes</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/search-box' %}is-active{% endif %}" href="/docs/patterns/search-box">Search box</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/slider' %}is-active{% endif %}" href="/docs/patterns/slider">Slider</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/strip' %}is-active{% endif %}" href="/docs/patterns/strip">Strip</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/switch' %}is-active{% endif %}" href="/docs/patterns/switch">Switch</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/table-of-contents' %}is-active{% endif %}" href="/docs/patterns/table-of-contents">Table of contents</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/tabs' %}is-active{% endif %}" href="/docs/patterns/tabs">Tabs</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/tooltips' %}is-active{% endif %}" href="/docs/patterns/tooltips">Tooltips</a></li>
+            </ul>
+
+
+
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Utilities</span></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/align' %}is-active{% endif %}" href="/docs/utilities/align">Alignment</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/baseline-grid' %}is-active{% endif %}" href="/docs/utilities/baseline-grid">Baseline grid</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/clearfix' %}is-active{% endif %}" href="/docs/utilities/clearfix">Clearfix</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/embedded-media' %}is-active{% endif %}" href="/docs/utilities/embedded-media">Embedded media</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/equal-height' %}is-active{% endif %}" href="/docs/utilities/equal-height">Equal height</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/floats' %}is-active{% endif %}" href="/docs/utilities/floats">Floats</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/font-metrics' %}is-active{% endif %}" href="/docs/utilities/font-metrics">Font metrics</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/functions' %}is-active{% endif %}" href="/docs/utilities/functions">Functions</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/hide' %}is-active{% endif %}" href="/docs/utilities/hide">Hide</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/image-position' %}is-active{% endif %}" href="/docs/utilities/image-position">Image position</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/margin-collapse' %}is-active{% endif %}" href="/docs/utilities/margin-collapse">Margin collapse</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/no-print' %}is-active{% endif %}" href="/docs/utilities/no-print">No print</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/off-screen' %}is-active{% endif %}" href="/docs/utilities/off-screen">Off-screen</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/padding-collapse' %}is-active{% endif %}" href="/docs/utilities/padding-collapse">Padding collapse</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/table-cell-padding-overlap' %}is-active{% endif %}" href="/docs/utilities/table-cell-padding-overlap">Table cell padding overlap</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/truncate' %}is-active{% endif %}" href="/docs/utilities/truncate">Truncation</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/show' %}is-active{% endif %}" href="/docs/utilities/show">Show</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/vertically-center' %}is-active{% endif %}" href="/docs/utilities/vertically-center">Vertically center</a></li>
+            </ul>
+
+
+
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Settings</span></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/animation-settings' %}is-active{% endif %}" href="/docs/settings/animation-settings">Animations</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/assets-settings' %}is-active{% endif %}" href="/docs/settings/assets-settings">Assets</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/breakpoint-settings' %}is-active{% endif %}" href="/docs/settings/breakpoint-settings">Breakpoints</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/color-settings' %}is-active{% endif %}" href="/docs/settings/color-settings">Color</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/font-settings' %}is-active{% endif %}" href="/docs/settings/font-settings">Font</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/layout-settings' %}is-active{% endif %}" href="/docs/settings/layout-settings">Layout</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/placeholder-settings' %}is-active{% endif %}" href="/docs/settings/placeholder-settings">Placeholders</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/spacing-settings' %}is-active{% endif %}" href="/docs/settings/spacing-settings">Spacing</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/table-layout' %}is-active{% endif %}" href="/docs/settings/table-layout">Table layout</a></li>
+            </ul>
+
+
+
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Resources</span></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/examples' %}is-active{% endif %}" href="/docs/examples">Component examples</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/component-status' %}is-active{% endif %}" href="/docs/component-status">Component status</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></li>
+            </ul>
+
+        </nav>
+
       </aside>
 
       <main class="p-content" id="main-content">

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -1,6 +1,6 @@
 // Toggle mobile sidebar nav
 var sidebarToggle = document.querySelector('.p-sidebar__toggle');
-var sidebarContent = document.querySelector('.p-sidebar__content');
+var sidebarContent = document.querySelector('.p-sidebar');
 var openMainNav = document.querySelector('.p-navigation__toggle--open');
 
 if (sidebarToggle) {


### PR DESCRIPTION
## Done

Updates Vanilla docs to use new side navigation

Fixes #2864 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2936.run.demo.haus/docs)
- Review docs side navigation, make sure it works as expected on different screen sizes


## Screenshots

### Desktop

<img width="1885" alt="Screenshot 2020-03-19 at 15 23 28" src="https://user-images.githubusercontent.com/83575/77077518-9d965300-69f5-11ea-812b-89fa6feaa3b0.png">


### Mobile

<img width="427" alt="Screenshot 2020-03-18 at 09 36 57" src="https://user-images.githubusercontent.com/83575/76941806-f59d5e80-68fc-11ea-9440-c30067b5f9b7.png">

