### PR TITLE
Side navigation examples 

### DIFF
--- a/scss/_patterns_label.scss
+++ b/scss/_patterns_label.scss
@@ -12,6 +12,7 @@
     padding: map-get($nudges, nudge--x-small) $sph-inner--small;
     text-align: center;
     text-decoration: none;
+    white-space: nowrap;
   }
 
   @include vf-p-label-validated;

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -1,0 +1,95 @@
+<div class="p-side-navigation">
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <a class="p-side-navigation__link" href="#">Title that is a link</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#">First level link</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#">First level link with status<div class="p-side-navigation__status"><i class="p-icon--error"></i></div></a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#">Link with children</a>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning"></i></div></a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <span class="p-side-navigation__text">Second level text</span>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">Second level link with children</a>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <span class="p-side-navigation__text">Third level text</span>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status"><span class="p-label--in-progress">In progress</span></div></a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link is-active" href="#">Third level active link</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success"></i></div></a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="p-side-navigation__item ">
+      <span class="p-side-navigation__text">First level item that is not a link</span>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status"><span class="p-label--updated">Updated</span></div></a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status"><span class="p-label--validated">Validated</span></div></a>
+    </li>
+  </ul>
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <span class="p-side-navigation__text">Title that is not a link</span>
+    </li>
+    <li class="p-side-navigation__item">
+      <span class="p-side-navigation__text">First level text</span>
+    </li>
+    <li class="p-side-navigation__item">
+      <span class="p-side-navigation__text">Text item with children</span>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link" href="#">Second level link</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <span class="p-side-navigation__text">Second level text</span>
+        </li>
+        <li class="p-side-navigation__item ">
+          <span class="p-side-navigation__text">Second level text with children</span>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <span class="p-side-navigation__text">Third level text</span>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link is-active" href="#">Third level active item that is long and wraps wraps wraps wraps wraps wraps</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link that is truncated because it's long long long long long long long</span></a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Third level link</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="p-side-navigation__item ">
+      <span class="p-side-navigation__text">First level item that is not a link</span>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">First level link</a>
+    </li>
+  </ul>
+</div>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -1,0 +1,95 @@
+<div class="p-side-navigation--icons">
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <a class="p-side-navigation__link" href="#">Title that is a link</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#"><i class="p-icon--information p-side-navigation__icon"></i>First level link</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#"><i class="p-icon--help p-side-navigation__icon"></i>First level link with status<div class="p-side-navigation__status"><i class="p-icon--error"></i></div></a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#"><i class="p-icon--user p-side-navigation__icon"></i>Link with children</a>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning"></i></div></a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <span class="p-side-navigation__text">Second level text</span>
+        </li>
+        <li class="p-side-navigation__item ">
+          <a class="p-side-navigation__link" href="#">Second level link with children</a>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <span class="p-side-navigation__text">Third level text</span>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status"><span class="p-label--in-progress">In progress</span></div></a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link is-active" href="#">Third level active link</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success"></i></div></a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="p-side-navigation__item ">
+      <span class="p-side-navigation__text"><i class="p-icon--collapse p-side-navigation__icon"></i>First level item that is not a link</span>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#"><i class="p-icon--search p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status"><span class="p-label--updated">Updated</span></div></a>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status"><span class="p-label--validated">Validated</span></div></a>
+    </li>
+  </ul>
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item--title">
+      <span class="p-side-navigation__text">Title that is not a link</span>
+    </li>
+    <li class="p-side-navigation__item">
+      <span class="p-side-navigation__text">First level text</span>
+    </li>
+    <li class="p-side-navigation__item">
+      <span class="p-side-navigation__text">Text item with children</span>
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item">
+          <a class="p-side-navigation__link" href="#">Second level link</a>
+        </li>
+        <li class="p-side-navigation__item ">
+          <span class="p-side-navigation__text">Second level text</span>
+        </li>
+        <li class="p-side-navigation__item ">
+          <span class="p-side-navigation__text">Second level text with children</span>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <span class="p-side-navigation__text">Third level text</span>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link is-active" href="#">Third level active item that is long and wraps wraps wraps wraps wraps wraps</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link that is truncated because it's long long long long long long long</span></a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Third level link</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="p-side-navigation__item ">
+      <span class="p-side-navigation__text">First level item that is not a link</span>
+    </li>
+    <li class="p-side-navigation__item ">
+      <a class="p-side-navigation__link" href="#">First level link</a>
+    </li>
+  </ul>
+</div>

--- a/templates/docs/examples/patterns/side-navigation/_script.js
+++ b/templates/docs/examples/patterns/side-navigation/_script.js
@@ -1,0 +1,14 @@
+// small script to make the example interactive
+// not intended to be used in projects
+var links = [].slice.call(document.querySelectorAll('.p-side-navigation__link'));
+
+links.forEach(function(link) {
+  link.addEventListener('click', function() {
+    var active = [].slice.call(document.querySelectorAll('.is-active'));
+    active.forEach(function(link) {
+      link.classList.remove('is-active');
+    });
+    this.classList.add('is-active');
+    this.blur();
+  });
+});

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -12,4 +12,8 @@
       {% include "docs/examples/patterns/side-navigation/_icons.html" %}
   </div>
 </div>
+
+<script>
+  {% include "docs/examples/patterns/side-navigation/_script.js" %}
+</script>
 {% endblock %}

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -1,90 +1,15 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Side navigation / Default{% endblock %}
+{% block title %}Side navigation / Variants{% endblock %}
 
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
 {% block content %}
-<div class="p-side-navigation">
-  <ul class="p-side-navigation__list">
-    <li class="p-side-navigation__item--title">
-      <a class="p-side-navigation__link" href="#">Title that is a link</a>
-    </li>
-    <li class="p-side-navigation__item">
-      <a class="p-side-navigation__link" href="#">First level link</a>
-    </li>
-    <li class="p-side-navigation__item">
-      <a class="p-side-navigation__link" href="#">First level link with status<div class="p-side-navigation__status"><i class="p-icon--error"></i></div></a>
-    </li>
-    <li class="p-side-navigation__item">
-      <a class="p-side-navigation__link" href="#">Link with children</a>
-      <ul class="p-side-navigation__list">
-        <li class="p-side-navigation__item">
-          <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning"></i></div></a>
-        </li>
-        <li class="p-side-navigation__item ">
-          <span class="p-side-navigation__text">Second level text</span>
-        </li>
-        <li class="p-side-navigation__item ">
-          <a class="p-side-navigation__link" href="#">Second level link with children</a>
-          <ul class="p-side-navigation__list">
-            <li class="p-side-navigation__item">
-              <span class="p-side-navigation__text">Third level text</span>
-            </li>
-            <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link is-active" href="#">Third level active link</a>
-            </li>
-            <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success"></i></div></a>
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </li>
-    <li class="p-side-navigation__item ">
-      <span class="p-side-navigation__text">First level item that is not a link</span>
-    </li>
-    <li class="p-side-navigation__item ">
-      <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
-    </li>
-  </ul>
-  <ul class="p-side-navigation__list">
-    <li class="p-side-navigation__item--title">
-      <span class="p-side-navigation__text">Title that is not a link</span>
-    </li>
-    <li class="p-side-navigation__item">
-      <span class="p-side-navigation__text">First level text</span>
-    </li>
-    <li class="p-side-navigation__item">
-      <span class="p-side-navigation__text">Text item with children</span>
-      <ul class="p-side-navigation__list">
-        <li class="p-side-navigation__item">
-          <a class="p-side-navigation__link" href="#">Second level link</a>
-        </li>
-        <li class="p-side-navigation__item ">
-          <span class="p-side-navigation__text">Second level text</span>
-        </li>
-        <li class="p-side-navigation__item ">
-          <span class="p-side-navigation__text">Second level text with children</span>
-          <ul class="p-side-navigation__list">
-            <li class="p-side-navigation__item">
-              <span class="p-side-navigation__text">Third level text</span>
-            </li>
-            <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link is-active" href="#">Third level active item</a>
-            </li>
-            <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link" href="#">Third level link</a>
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </li>
-    <li class="p-side-navigation__item ">
-      <span class="p-side-navigation__text">First level item that is not a link</span>
-    </li>
-    <li class="p-side-navigation__item ">
-      <a class="p-side-navigation__link" href="#">First level link</a>
-    </li>
-  </ul>
+<div class="row">
+  <div class="col-4">
+      {% include "docs/examples/patterns/side-navigation/_default.html" %}
+  </div>
+  <div class="col-4">
+      {% include "docs/examples/patterns/side-navigation/_icons.html" %}
+  </div>
 </div>
 {% endblock %}

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -179,4 +179,8 @@
     </div>
   </nav>
 </footer>
+
+<script>
+  {% include "docs/examples/patterns/side-navigation/_script.js" %}
+</script>
 {% endblock %}

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -1,19 +1,8 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}MAAS docs / Custom docs layout{% endblock %}
+{% block title %}MAAS docs / Grid layout{% endblock %}
 
 {% block content %}
 <style>
-  .l-docs-wrapper {
-      border-bottom: 1px solid #cdcdcd
-  }
-
-  .l-docs {
-      display: flex;
-      flex-wrap: wrap;
-      margin: 0 auto;
-      max-width: 72rem
-  }
-
   @media only screen and (min-width: 1030px) {
       .l-docs-title,.l-docs-title[class^='p-strip'] {
           background-color:transparent;
@@ -31,52 +20,6 @@
   .l-docs-title__heading {
       border-bottom: 1px solid #cdcdcd;
       padding-bottom: 1rem
-  }
-
-  .l-docs-sidebar {
-      border-right: 1px solid #cdcdcd;
-      flex: 0 0 18rem
-  }
-
-  @media only screen and (max-width: 772px) {
-      .l-docs-sidebar {
-          border-right:0;
-          flex: auto;
-          height: inherit;
-          overflow: hidden;
-          position: static;
-          width: 100%
-      }
-  }
-
-  .l-docs-content {
-      flex: 5;
-      margin-top: 0
-  }
-
-  @media only screen and (max-width: 772px) {
-      .l-docs-content {
-          flex:auto
-      }
-  }
-
-  .l-docs-content .meta {
-      display: none
-  }
-
-  .l-docs-content details+p,.l-docs-content details+h3 {
-      margin-top: 1.5rem
-  }
-
-  .l-docs-row {
-      margin-left: inherit;
-      padding: 0 3rem
-  }
-
-  @media only screen and (max-width: 772px) {
-      .l-docs-row {
-          padding-left:1.5rem
-      }
   }
 </style>
 
@@ -126,8 +69,8 @@
       </form>
     </div>
   </section>
-  <div class="l-docs">
-    <aside class="l-docs-sidebar" id="navigation">
+  <div class="row">
+    <aside class="col-3">
       <nav class="p-side-navigation">
         <ul class="p-side-navigation__list">
           <li class="p-side-navigation__item--title">
@@ -192,7 +135,7 @@
       </nav>
     </aside>
 
-    <main class="l-docs-content" id="main-content">
+    <main class="col-9" id="main-content">
       <div class="p-strip--light is-shallow l-docs-title">
         <div class="l-docs-row row">
           <h1 class="u-no-margin--bottom l-docs-title__heading">MAAS Documentation</h1>

--- a/templates/docs/examples/templates/maas-docs.html
+++ b/templates/docs/examples/templates/maas-docs.html
@@ -1,0 +1,239 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}MAAS docs{% endblock %}
+
+{% block content %}
+<style>
+  .l-docs-wrapper {
+      border-bottom: 1px solid #cdcdcd
+  }
+
+  .l-docs {
+      display: flex;
+      flex-wrap: wrap;
+      margin: 0 auto;
+      max-width: 72rem
+  }
+
+  @media only screen and (min-width: 1030px) {
+      .l-docs-title,.l-docs-title[class^='p-strip'] {
+          background-color:transparent;
+          padding-bottom: 0
+      }
+  }
+
+  @media only screen and (max-width: 1030px) {
+      .l-docs-title,.l-docs-title[class^='p-strip'] {
+          background-color:transparent;
+          padding-bottom: 0
+      }
+  }
+
+  .l-docs-title__heading {
+      border-bottom: 1px solid #cdcdcd;
+      padding-bottom: 1rem
+  }
+
+  .l-docs-sidebar {
+      border-right: 1px solid #cdcdcd;
+      flex: 0 0 18rem
+  }
+
+  @media only screen and (max-width: 772px) {
+      .l-docs-sidebar {
+          border-right:0;
+          flex: auto;
+          height: inherit;
+          overflow: hidden;
+          position: static;
+          width: 100%
+      }
+  }
+
+  .l-docs-content {
+      flex: 5;
+      margin-top: 0
+  }
+
+  @media only screen and (max-width: 772px) {
+      .l-docs-content {
+          flex:auto
+      }
+  }
+
+  .l-docs-content .meta {
+      display: none
+  }
+
+  .l-docs-content details+p,.l-docs-content details+h3 {
+      margin-top: 1.5rem
+  }
+
+  .l-docs-row {
+      margin-left: inherit;
+      padding: 0 3rem
+  }
+
+  @media only screen and (max-width: 772px) {
+      .l-docs-row {
+          padding-left:1.5rem
+      }
+  }
+</style>
+
+<header id="navigation" class="p-navigation is-dark">
+  <div class="p-navigation__row row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a href="#" class="p-navigation__link">
+          <svg class="p-navigation__image" xmlns="http://www.w3.org/2000/svg" width="100" height="25.2" viewBox="545.3 412.6 100 25.2">
+            <title>MAAS logo</title>
+            <path fill="#E95420" d="M557.9 412.6c-7 0-12.6 5.7-12.6 12.6 0 7 5.7 12.6 12.6 12.6 7 0 12.6-5.7 12.6-12.6 0-7-5.6-12.6-12.6-12.6z"></path>
+            <g fill="#FFF">
+              <path d="M563.8 419.2h-11.9c-.3 0-.5.2-.5.5v.7c0 .3.2.5.5.5h11.9c.3 0 .5-.2.5-.5v-.7c.1-.3-.2-.5-.5-.5zM563.8 422.6h-11.9c-.3 0-.5.2-.5.5v.7c0 .3.2.5.5.5h11.9c.3 0 .5-.2.5-.5v-.7c.1-.3-.2-.5-.5-.5zM563.8 426h-11.9c-.3 0-.5.2-.5.5v.7c0 .3.2.5.5.5h11.9c.3 0 .5-.2.5-.5v-.7c.1-.2-.2-.5-.5-.5zM563.8 429.4h-11.9c-.3 0-.5.2-.5.5v.7c0 .3.2.5.5.5h11.9c.3 0 .5-.2.5-.5v-.6c.1-.3-.2-.6-.5-.6z"></path>
+            </g>
+            <g fill="#FFF">
+              <path d="M587.1 431.3c-.2-.4-.4-1-.7-1.7-.3-.7-.7-1.5-1.1-2.3-.4-.8-.8-1.7-1.2-2.5-.4-.9-.8-1.7-1.2-2.5l-1-2-.6-1.2c-.2 2.1-.4 4.4-.5 6.9-.1 2.5-.2 5.1-.3 7.8h-1.7c.2-3.2.3-6.3.5-9.2s.4-5.8.7-8.4h1.5c.5.9 1.1 1.8 1.6 2.9.6 1.1 1.2 2.3 1.7 3.5.6 1.2 1.1 2.4 1.7 3.5s1 2.2 1.4 3.1c.4-.9.9-2 1.4-3.1.5-1.2 1.1-2.3 1.7-3.5.6-1.2 1.1-2.4 1.7-3.5.6-1.1 1.1-2.1 1.6-2.9h1.5c.3 2.7.5 5.5.7 8.4s.4 6 .5 9.2h-1.8c-.1-2.7-.2-5.3-.3-7.8-.1-2.5-.3-4.8-.5-6.9l-.6 1.2-1 2c-.4.8-.8 1.6-1.2 2.5-.4.9-.8 1.7-1.2 2.5-.4.8-.7 1.6-1.1 2.3-.3.7-.6 1.3-.7 1.7h-1.5zM613.1 433.9c-.3-.9-.6-1.7-.9-2.5-.3-.8-.6-1.6-.8-2.3h-8.6c-.3.8-.6 1.5-.9 2.3-.3.8-.6 1.6-.9 2.5h-1.8c.7-1.8 1.3-3.6 1.9-5.1.6-1.6 1.2-3.1 1.8-4.5.6-1.4 1.1-2.8 1.7-4.1l1.8-3.9h1.5l1.8 3.9c.6 1.3 1.1 2.7 1.7 4.1.6 1.4 1.2 2.9 1.7 4.5.6 1.6 1.2 3.3 1.9 5.1h-1.9zm-6-15.7c-.6 1.5-1.3 3-1.9 4.5-.6 1.5-1.2 3.1-1.9 4.9h7.5c-.7-1.8-1.3-3.4-1.9-4.9-.6-1.6-1.2-3.1-1.8-4.5zM630.4 433.9c-.3-.9-.6-1.7-.9-2.5-.3-.8-.6-1.6-.8-2.3H620c-.3.8-.6 1.5-.9 2.3-.3.8-.6 1.6-.9 2.5h-1.8c.7-1.8 1.3-3.6 1.9-5.1.6-1.6 1.2-3.1 1.8-4.5.6-1.4 1.1-2.8 1.7-4.1l1.8-3.9h1.5l1.8 3.9c.6 1.3 1.1 2.7 1.7 4.1s1.2 2.9 1.7 4.5c.6 1.6 1.2 3.3 1.9 5.1h-1.8zm-6.1-15.7c-.6 1.5-1.3 3-1.9 4.5-.6 1.5-1.2 3.1-1.9 4.9h7.5c-.7-1.8-1.3-3.4-1.9-4.9-.5-1.6-1.1-3.1-1.8-4.5zM639.1 432.7c1.4 0 2.4-.3 3.2-.8.8-.5 1.1-1.3 1.1-2.4 0-.6-.1-1.2-.4-1.6-.2-.4-.6-.8-1-1.1s-.9-.6-1.4-.8c-.5-.2-1.1-.4-1.7-.7-.7-.3-1.4-.6-2-.9-.6-.3-1.1-.6-1.5-1-.4-.4-.7-.8-.9-1.3-.2-.5-.3-1.1-.3-1.7 0-1.5.5-2.7 1.5-3.4s2.4-1.2 4.2-1.2c.5 0 .9 0 1.4.1s.9.2 1.3.3c.4.1.8.2 1.1.4.3.1.6.3.8.4l-.6 1.5c-.5-.3-1.1-.6-1.8-.8s-1.5-.3-2.3-.3c-.6 0-1.1.1-1.5.2-.5.1-.9.3-1.2.5s-.6.6-.8.9c-.2.4-.3.8-.3 1.4 0 .5.1 1 .3 1.4.2.4.5.7.9 1 .4.3.8.5 1.3.7.5.2 1 .5 1.6.7.7.3 1.4.6 2 .9.6.3 1.2.6 1.6 1 .5.4.8.9 1.1 1.4.3.6.4 1.2.4 2.1 0 1.6-.6 2.8-1.7 3.6s-2.6 1.2-4.5 1.2c-.7 0-1.3 0-1.9-.1s-1.1-.2-1.5-.3c-.4-.1-.8-.3-1.1-.4-.3-.1-.5-.3-.7-.4l.6-1.5c.2.1.4.2.7.4.3.1.6.3 1 .4.4.1.8.2 1.3.3.6-.1 1.1-.1 1.7-.1z"></path>
+            </g>
+          </svg>
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+
+    <nav class="p-navigation__nav">
+      <ul id="main-navigation" class="p-navigation__links u-clearfix">
+        <li class="p-navigation__link"><a href="#install">Install</a></li>
+        <li class="p-navigation__link"><a href="#how-it-works">How it works</a></li>
+        <li class="p-navigation__link"><a href="#tour">Tour</a></li>
+        <li class="p-navigation__link is-selected" aria-current="page"><a href="#docs">Docs</a></li>
+        <li class="p-navigation__link"><a href="#tutorials">Tutorials</a></li>
+        <li class="p-navigation__link"><a href="#discourse">Discourse</a></li>
+        <li class="p-navigation__link"><a href="#contact-us">Contact us</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<div class="u-no-margin--top l-docs-wrapper" id="main-content">
+
+  <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">
+    <div class="row">
+      <form class="p-search-box u-no-margin--bottom" action="#">
+        <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="">
+        <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close">Close</i></button>
+        <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
+      </form>
+    </div>
+  </section>
+  <div class="l-docs">
+    <aside class="l-docs-sidebar" id="navigation">
+      <nav class="p-side-navigation">
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item--title">
+            <a class="p-side-navigation__link">Machines</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Add machines</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Power management</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Commision machines</a>
+          </li>
+          <li class="p-side-navigation__item">
+            <span class="p-side-navigation__text is-selected">Testing</span>
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item">
+                <a class="p-side-navigation__link" href="#">Hardware testing</a>
+              </li>
+              <li class="p-side-navigation__item ">
+                <a class="p-side-navigation__link is-active" href="#">Network testing</a>
+              </li>
+              <li class="p-side-navigation__item ">
+                <a class="p-side-navigation__link" href="#">Commissioning and hardware testing scripts</a>
+              </li>
+            </ul>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Deploy machines</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Tags</a>
+          </li>
+        </ul>
+
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item--title">
+            <a class="p-side-navigation__link">Troubleshoot</a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a class="p-side-navigation__link" href="#">Getting help</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Non-snap MAAS installs</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">MAAS 2.5 (and earlier) documentation</a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#" class="p-side-navigation__link is-selected">Upgrading MAAS</a>
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item">
+                <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
+              </li>
+              <li class="p-side-navigation__item ">
+                <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+
+    <main class="l-docs-content" id="main-content">
+      <div class="p-strip--light is-shallow l-docs-title">
+        <div class="l-docs-row row">
+          <h1 class="u-no-margin--bottom l-docs-title__heading">MAAS Documentation</h1>
+        </div>
+      </div>
+
+      <div class="p-strip is-shallow">
+        <div class="l-docs-row row">
+          <p>MAAS is <strong>Metal As A Service</strong>, a service that lets you treat physical servers like virtual
+            machines – instances – in the cloud. No need to manage servers individually: MAAS turns your bare metal into
+            an elastic, cloud-like resource.</p>
+          <hr>
+          <p>Quick questions you might have:</p>
+          <ul>
+            <li><a href="#docs/what-is-maas">What is MAAS – and what does it really do for me?</a></li>
+            <li><a href="#docs/maas-example-config">Can you show me an example datacentre using MAAS?</a></li>
+            <li><a href="#docs/what-is-maas#heading--how-maas-works">How does MAAS work, in detail?</a></li>
+            <li><a href="#docs/concepts-and-terms">What concepts might I need to understand before starting?</a></li>
+            <li><a href="#docs/explore-maas">Can I just install it and try it for myself?</a></li>
+          </ul>
+          <hr>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<footer class="p-strip">
+  <nav class="row">
+    <div class="has-cookie">
+      <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item">
+          <a href="#"><small>Legal information</small></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="#"><small>Report a bug on this site</small></a>
+        </li>
+      </ul>
+      <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
+    </div>
+  </nav>
+</footer>
+{% endblock %}

--- a/templates/docs/examples/templates/maas-docs.html
+++ b/templates/docs/examples/templates/maas-docs.html
@@ -236,4 +236,8 @@
     </div>
   </nav>
 </footer>
+
+<script>
+  {% include "docs/examples/patterns/side-navigation/_script.js" %}
+</script>
 {% endblock %}

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}MAAS{% endblock %}
+{% block title %}MAAS layout{% endblock %}
 
 {% block content %}
 <header id="navigation" class="p-navigation">

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -1,0 +1,349 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Snapcraft publicise page{% endblock %}
+
+{% block content %}
+<style>
+  @media only screen and (min-width: 1030px) {
+      .l-docs-title,.l-docs-title[class^='p-strip'] {
+          background-color:transparent;
+          padding-bottom: 0
+      }
+  }
+
+  @media only screen and (max-width: 1030px) {
+      .l-docs-title,.l-docs-title[class^='p-strip'] {
+          background-color:transparent;
+          padding-bottom: 0
+      }
+  }
+
+  .l-docs-title__heading {
+      border-bottom: 1px solid #cdcdcd;
+      padding-bottom: 1rem
+  }
+</style>
+
+<header id="navigation" class="p-navigation is-dark">
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg" alt="Snapcraft">
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link " role="menuitem">
+          <a href="#store">
+            Store
+          </a>
+        </li>
+        <li class="p-navigation__link " role="menuitem">
+          <a href="#blog">
+            Blog
+          </a>
+        </li>
+        <li class="p-navigation__link " role="menuitem">
+          <a href="#iot">
+            IoT
+          </a>
+        </li>
+        <li class="p-navigation__link " role="menuitem">
+          <a href="#build">
+            Build
+          </a>
+        </li>
+        <li class="p-navigation__link " role="menuitem">
+          <a href="#docs/">
+            Docs
+          </a>
+        </li>
+        <li class="p-navigation__link " role="menuitem">
+          <a href="#tutorials">
+            Tutorials
+          </a>
+        </li>
+        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="#">Forum</a></li>
+      </ul>
+
+      <ul class="p-navigation__links" role="menu">
+          <li class="p-navigation__link p-subnav" role="menuitem" id="link-1">
+            <a class="p-subnav__toggle" aria-controls="account-menu" aria-expanded="false">
+              Bartosz Szopka
+            </a>
+            <ul class="p-subnav__items--right" id="account-menu" aria-hidden="true">
+              <li>
+                <a href="#account/snaps" class="p-subnav__item">My published snaps</a>
+              </li>
+              <li>
+                <a href="#build" class="p-subnav__item">Build with GitHub</a>
+              </li>
+              <li>
+                <a href="#account/details" class="p-subnav__item">Account details</a>
+              </li>
+              <li>
+                <a href="#logout" class="p-subnav__item">Sign out</a>
+              </li>
+            </ul>
+          </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<div id="main-content">
+  <section class="p-strip is-shallow u-no-padding--bottom">
+    <div class="u-fixed-width">
+      <a href="#snaps">‹ My snaps</a>
+      <h1 class="p-heading--three">
+        my-awesome-snap
+      </h1>
+
+      <nav class="p-tabs">
+        <ul class="p-tabs__list u-float-right u-no-margin--bottom" role="tablist">
+          <li class="p-tabs__item" role="presentation">
+            <a data-tour="listing-intro" href="#listing" class="p-tabs__link" tabindex="0" role="tab">
+              Listing
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#builds" class="p-tabs__link" tabindex="0" role="tab">
+            Builds
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#releases" class="p-tabs__link" tabindex="0" role="tab">
+              Releases
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#metrics" class="p-tabs__link" tabindex="0" role="tab">
+              Metrics
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#publicise" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">
+              Publicise
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#settings" class="p-tabs__link" tabindex="0" role="tab">
+              Settings
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </section>
+
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-3">
+        <nav class="p-side-navigation">
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link is-active" href="#publicise/">Snap Store buttons</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" href="#publicise/badges">GitHub badges</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" href="#publicise/cards">Embeddable cards</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+
+      <div class="col-9">
+
+        <div class="row">
+          <h4>Promote your snap using Snap Store badges</h4>
+        </div>
+        <div class="row">
+          <div class="col-2">
+            <label>Language:</label>
+          </div>
+          <div class="col-7">
+            <form class="p-form--inline js-language-select">
+              <select name="language" checked="checked">
+                  <option value="de">Deutsch</option>
+                  <option value="en" selected="">English</option>
+                  <option value="es">Español</option>
+                  <option value="fr">Français</option>
+                  <option value="it">Italiano</option>
+                  <option value="jp">日本語</option>
+                  <option value="pl">Polski</option>
+                  <option value="pt">Português</option>
+                  <option value="ru">русский язык</option>
+                  <option value="tw">中文（台灣）</option>
+              </select>
+            </form>
+            <p>You can help translate these buttons <a href="#" target="_blank" class="p-link--external">in this repository</a>.</p>
+          </div>
+        </div>
+
+        <div class="row">
+          <hr>
+        </div>
+
+        <div id="en_content" class="js-language-content">
+          <div class="row">
+            <div class="col-2">
+            </div>
+            <div class="col-7">
+              <div class="row">
+                <div class="col-5">
+                  <p class="snapcraft-publicise__images">
+
+                    <a href="#">
+                      <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg?v=49a12f8">
+                    </a>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-2">
+              <label>HTML:</label>
+            </div>
+            <div class="col-7">
+              <pre ><code id="snippet-en-black-html">&lt;a href="https://snapcraft.io/my-awesome-snap"&gt;
+  &lt;img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" /&gt;
+&lt;/a&gt;</code></pre>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-2">
+              <label>Markdown:</label>
+            </div>
+            <div class="col-7">
+              <pre><code id="snippet-en-black-md">[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/my-awesome-snap)</code></pre>
+            </div>
+          </div>
+
+          <div class="row">
+            <hr>
+          </div>
+
+          <div class="row">
+            <div class="col-2">
+            </div>
+            <div class="col-7">
+              <div class="row">
+                <div class="col-5">
+                  <p class="snapcraft-publicise__images">
+
+                    <a href="#">
+                      <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-white.svg?v=d2596f2">
+                    </a>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-2">
+              <label>HTML:</label>
+            </div>
+            <div class="col-7">
+              <pre ><code id="snippet-en-black-html">&lt;a href="https://snapcraft.io/my-awesome-snap"&gt;
+  &lt;img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-white.svg" /&gt;
+&lt;/a&gt;</code></pre>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-2">
+              <label>Markdown:</label>
+            </div>
+            <div class="col-7">
+              <pre><code id="snippet-en-black-md">[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-white.svg)](https://snapcraft.io/my-awesome-snap)</code></pre>
+            </div>
+          </div>
+        </div>
+
+        <div class="row">
+          <hr>
+        </div>
+
+        <div class="row">
+          <div class="col-2">
+            Download all:
+          </div>
+          <div class="col-7">
+            <a href="#" class="p-button">zip</a>
+            <a href="#" class="p-button">tar.gz</a>
+            <a href="#" target="_blank" class="p-link--external">View image licence</a>
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<footer class="p-strip--light p-sticky-footer" id="footer">
+  <div class="row">
+    <div class="col-9">
+      <p>
+        <a class="p-link--soft" href="#">Back to top<i class="p-icon--top"></i></a>
+      </p>
+      <p>
+        © 2020 Canonical Ltd. <br>
+        Ubuntu and Canonical are registered trademarks of Canonical Ltd.
+        <br>
+        Powered by <a href="#">Charmed Kubernetes</a>
+      </p>
+      <p class="u-no-limit">
+        <small>
+          <a class="p-link--external" href="#">Join the forum</a>, contribute to or report problems with,
+          <a class="p-link--external" href="#">snapd</a>,
+          <a class="p-link--external" href="#">Snapcraft</a>,
+          or
+          <a class="p-link--external" href="#">this site</a>.
+        </small>
+      </p>
+    </div>
+    <div class="col-3">
+       <ul class="p-inline-list u-align--right">
+         <li class="p-inline-list__item">
+           <a href="#" class="p-icon--twitter">Share on Twitter</a>
+         </li>
+         <li class="p-inline-list__item">
+           <a href="#" class="p-icon--facebook">Share on Facebook</a>
+         </li>
+         <li class="p-inline-list__item">
+           <a href="#" class="p-icon--youtube">Share on YouTube</a>
+         </li>
+       </ul>
+     </div>
+  </div>
+  <div class="u-fixed-width">
+    <ul class="p-inline-list--middot u-no-margin--bottom">
+      <li class="p-inline-list__item">
+        <a class="p-link--soft" accesskey="6" href="#"><small>Legal information</small></a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="p-link--soft" accesskey="7" href="#"><small>Data privacy</small></a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="p-link--soft" accesskey="8" href="#"><small>Service status</small></a>
+      </li>
+      <li class="p-inline-list__item">
+        <a class="p-link--soft" accesskey="9" href="#"><small>Other functions</small></a>
+      </li>
+    </ul>
+  </div>
+</footer>
+{% endblock %}

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -346,4 +346,8 @@
     </ul>
   </div>
 </footer>
+
+<script>
+  {% include "docs/examples/patterns/side-navigation/_script.js" %}
+</script>
 {% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -32,7 +32,8 @@ def _get_title(title):
 
 
 def _get_examples():
-    example_files = glob.glob("templates/docs/examples/*/**/*.html", recursive=True)
+    # get all example files (but ignore partials that start with _)
+    example_files = glob.glob("templates/docs/examples/*/**/[!_]*.html", recursive=True)
     examples = {}
 
     for filepath in sorted(example_files):


### PR DESCRIPTION
## Done

Adds more examples for side navigation

Fixes #2865

## QA

- Run `./run` or [demo]
- Clicking on side nav in these examples is possible (JS is now added to make them interactive without navigating to other pages)

Check updated side nav examples (with wrapping, truncating, icons, etc):
https://vanilla-framework-canonical-web-and-design-pr-2937.run.demo.haus/docs/examples/patterns/side-navigation/default

<img width="725" alt="Screenshot 2020-03-18 at 15 50 26" src="https://user-images.githubusercontent.com/83575/76973471-48dcd480-6930-11ea-8030-435e61ee9980.png">


MAAS current custom docs layout: https://vanilla-framework-canonical-web-and-design-pr-2937.run.demo.haus/docs/examples/templates/maas-docs

<img width="1249" alt="Screenshot 2020-03-18 at 13 49 03" src="https://user-images.githubusercontent.com/83575/76962428-82591400-691f-11ea-83b8-3623bd6a10a9.png">



MAAS docs in grid: https://vanilla-framework-canonical-web-and-design-pr-2937.run.demo.haus/docs/examples/templates/maas-docs-grid

<img width="1250" alt="Screenshot 2020-03-18 at 13 49 17" src="https://user-images.githubusercontent.com/83575/76962433-85540480-691f-11ea-9953-6e522b4a525a.png">


Snapcraft publicise: https://vanilla-framework-canonical-web-and-design-pr-2937.run.demo.haus/docs/examples/templates/snapcraft-publicise

<img width="1249" alt="Screenshot 2020-03-18 at 13 49 35" src="https://user-images.githubusercontent.com/83575/76962435-86853180-691f-11ea-88c8-81a8a6a71b54.png">


