### PR TITLE
Align side navigation item to grid margins

### DIFF
--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -43,27 +43,27 @@
     padding-top: $spv-inner--x-small;
 
     .p-side-navigation--icons & {
-      @include vf-side-navigation-spacing-left($sp-sidenav--icon-spacing-width);
+      @include vf-side-navigation-spacing-left($offset: $sp-sidenav--icon-spacing-width);
       position: relative;
     }
 
     // nested 2nd level of navigation
     .p-side-navigation__item .p-side-navigation__item & {
-      @include vf-side-navigation-spacing-left($sph-inner);
+      @include vf-side-navigation-spacing-left($multiplier: 2);
 
       // add spacing for variant with right side icons
       .p-side-navigation--icons & {
-        @include vf-side-navigation-spacing-left($sp-sidenav--icon-spacing-width + $sph-inner);
+        @include vf-side-navigation-spacing-left($multiplier: 2, $offset: $sp-sidenav--icon-spacing-width);
       }
     }
 
     // nested 3rd level of navigation
     .p-side-navigation__item .p-side-navigation__item .p-side-navigation__item & {
-      @include vf-side-navigation-spacing-left(2 * $sph-inner);
+      @include vf-side-navigation-spacing-left($multiplier: 3);
 
       // add spacing for variant with right side icons
       .p-side-navigation--icons & {
-        @include vf-side-navigation-spacing-left($sp-sidenav--icon-spacing-width + 2 * $sph-inner);
+        @include vf-side-navigation-spacing-left($multiplier: 3, $offset: $sp-sidenav--icon-spacing-width);
       }
     }
   }
@@ -103,17 +103,24 @@
 
 // elements in side nav should be aligned from left based on grid margin for given screen size
 // additional offset is added when icons are used or for nested navigation levels
-@mixin vf-side-navigation-spacing-left($offset: 0, $prop: padding-left) {
+@mixin vf-side-navigation-spacing-left(
+  // property to adjust spacing, defaults to `padding-left`
+    $prop: padding-left,
+  // how many times grid margin width should be multiplied (for nested navigation levels)
+    $multiplier: 1,
+  // offset to use for additional spacing (for icons)
+    $offset: 0
+) {
   @media (max-width: $threshold-4-6-col) {
-    #{$prop}: map-get($grid-margin-widths, small) + $offset;
+    #{$prop}: $multiplier * map-get($grid-margin-widths, small) + $offset;
   }
 
   @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
-    #{$prop}: map-get($grid-margin-widths, medium) + $offset;
+    #{$prop}: $multiplier * map-get($grid-margin-widths, medium) + $offset;
   }
 
   @media (min-width: $threshold-6-12-col) {
-    #{$prop}: map-get($grid-margin-widths, large) + $offset;
+    #{$prop}: $multiplier * map-get($grid-margin-widths, large) + $offset;
   }
 }
 

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -19,12 +19,12 @@
       @extend %vf-pseudo-border--top;
 
       &::after {
-        left: $sph-inner;
+        @include vf-side-navigation-spacing-left($prop: left);
         top: -0.5 * $spv-outer--scaleable; // place border in the middle of the margin
       }
 
       .p-side-navigation--icons &::after {
-        left: $sph-inner + $sp-sidenav--icon-spacing-width;
+        @include vf-side-navigation-spacing-left($prop: left, $offset: $sp-sidenav--icon-spacing-width);
       }
     }
   }
@@ -35,38 +35,42 @@
 
   .p-side-navigation__text,
   .p-side-navigation__link {
+    @include vf-side-navigation-spacing-left;
+
     display: flex;
-    padding: $spv-inner--x-small $sph-inner $spv-inner--x-small $sph-inner;
+    padding-bottom: $spv-inner--x-small;
+    padding-right: $sph-inner;
+    padding-top: $spv-inner--x-small;
 
     .p-side-navigation--icons & {
-      padding-left: $sph-inner + $sp-sidenav--icon-spacing-width;
+      @include vf-side-navigation-spacing-left($sp-sidenav--icon-spacing-width);
       position: relative;
     }
 
     // nested 2nd level of navigation
     .p-side-navigation__item .p-side-navigation__item & {
-      padding-left: 2 * $sph-inner;
+      @include vf-side-navigation-spacing-left($sph-inner);
 
       // add spacing for variant with right side icons
       .p-side-navigation--icons & {
-        padding-left: 2 * $sph-inner + $sp-sidenav--icon-spacing-width;
+        @include vf-side-navigation-spacing-left($sp-sidenav--icon-spacing-width + $sph-inner);
       }
     }
 
     // nested 3rd level of navigation
     .p-side-navigation__item .p-side-navigation__item .p-side-navigation__item & {
-      padding-left: 3 * $sph-inner;
+      @include vf-side-navigation-spacing-left(2 * $sph-inner);
 
       // add spacing for variant with right side icons
       .p-side-navigation--icons & {
-        padding-left: 3 * $sph-inner + $sp-sidenav--icon-spacing-width;
+        @include vf-side-navigation-spacing-left($sp-sidenav--icon-spacing-width + 2 * $sph-inner);
       }
     }
   }
 
   .p-side-navigation--icons {
     .p-side-navigation__icon {
-      left: $sph-inner;
+      @include vf-side-navigation-spacing-left($prop: left);
       position: absolute;
       top: $sph-inner--small;
     }
@@ -93,6 +97,24 @@
 
   // default light theme
   @include vf-side-navigation-theme;
+}
+
+// helper
+
+// elements in side nav should be aligned from left based on grid margin for given screen size
+// additional offset is added when icons are used or for nested navigation levels
+@mixin vf-side-navigation-spacing-left($offset: 0, $prop: padding-left) {
+  @media (max-width: $threshold-4-6-col) {
+    #{$prop}: map-get($grid-margin-widths, small) + $offset;
+  }
+
+  @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+    #{$prop}: map-get($grid-margin-widths, medium) + $offset;
+  }
+
+  @media (min-width: $threshold-6-12-col) {
+    #{$prop}: map-get($grid-margin-widths, large) + $offset;
+  }
 }
 
 // theme

--- a/scss/standalone/patterns_side-navigation.scss
+++ b/scss/standalone/patterns_side-navigation.scss
@@ -8,5 +8,9 @@
 @import '../patterns_icons';
 @include vf-p-icons;
 
+// grid is used in group example with differents side nav variants
+@import '../patterns_grid';
+@include vf-p-grid;
+
 @import '../patterns_side-navigation';
 @include vf-p-side-navigation;


### PR DESCRIPTION
## Done

Merge #2937 first

Updates left side spacing of side navigation items to follow grid margin values on different screen sizes.


## QA

- Run `./run` or [demo](https://vanilla-framework-canonical-web-and-design-pr-2940.run.demo.haus/docs/examples/patterns/side-navigation/default)
- Check side nav examples, make sure spacing on left side follows the grid margin on different screen sizes:
  - [variants](https://vanilla-framework-canonical-web-and-design-pr-2940.run.demo.haus/docs/examples/patterns/side-navigation/default)
  - [MAAS docs](https://vanilla-framework-canonical-web-and-design-pr-2940.run.demo.haus/docs/examples/templates/maas-docs)
  - [MAAS in grid](https://vanilla-framework-canonical-web-and-design-pr-2940.run.demo.haus/docs/examples/templates/maas-docs-grid)
  - [Snapcraft](https://vanilla-framework-canonical-web-and-design-pr-2940.run.demo.haus/docs/examples/templates/snapcraft-publicise)


