### PR TITLE
Prevent pretty-quick from commiting changes in husky hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,6 @@
     "/scss",
     "!/scss/docs"
   ],
-  "devDependenciesComments": {
-    "vanilla-framework": "vanilla-framework is included in devDependencies for use in styling the docs site",
-    "pretty-quick": "keep pretty-quick on v1, pretty-quick@2 requires version of node that we can't install on jenkins"
-  },
   "devDependencies": {
     "@percy/script": "1.0.3",
     "autoprefixer": "9.7.4",
@@ -61,7 +57,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "pretty-quick --check --staged"
     }
   }
 }


### PR DESCRIPTION
## Done

Makes sure pretty-quick only checks commited files, not autofixes them.
Removes outdated package.json comments.

## QA

- Pull code, (`yarn install` if you haven't set up vanilla before)
- Make some changes that would fail prettier (remove `;` in any SCSS file)
- Try to commit this change
- Precommit hook should fail and prevent the commit

<img width="663" alt="Screenshot 2020-03-19 at 15 13 58" src="https://user-images.githubusercontent.com/83575/77076568-46dc4980-69f4-11ea-8124-6b1922642e59.png">
