### PR TITLE
Add basic flexbox implementation of grid for IE

### DIFF
--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -17,45 +17,50 @@
   %vf-row {
     @extend %fixed-width-container;
 
-    display: grid;
-    grid-template-rows: auto;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: $grid-max-width;
-
-    [class*='#{$grid-column-prefix}'] {
-      grid-column-start: auto;
-    }
+    // default to flexbox for IE
+    display: flex;
 
     & & {
       @include vf-b-row-reset;
     }
 
-    // set static gutter width per breakpoint
-    @media (max-width: $threshold-4-6-col) {
-      grid-gap: 0 map-get($grid-gutter-widths, small);
-      grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
+    @supports (display: grid) {
+      display: grid;
+      grid-template-rows: auto;
+      margin-left: auto;
+      margin-right: auto;
+      max-width: $grid-max-width;
 
-      & > * {
-        grid-column-end: span $grid-columns-small;
+      [class*='#{$grid-column-prefix}'] {
+        grid-column-start: auto;
       }
-    }
 
-    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
-      grid-gap: 0 map-get($grid-gutter-widths, medium);
-      grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
+      // set static gutter width per breakpoint
+      @media (max-width: $threshold-4-6-col) {
+        grid-gap: 0 map-get($grid-gutter-widths, small);
+        grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
 
-      & > * {
-        grid-column-end: span $grid-columns-medium;
+        & > * {
+          grid-column-end: span $grid-columns-small;
+        }
       }
-    }
 
-    @media (min-width: $threshold-6-12-col) {
-      grid-gap: 0 map-get($grid-gutter-widths, large);
-      grid-template-columns: repeat($grid-columns, minmax(0, 1fr));
+      @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+        grid-gap: 0 map-get($grid-gutter-widths, medium);
+        grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
 
-      & > * {
-        grid-column-end: span $grid-columns;
+        & > * {
+          grid-column-end: span $grid-columns-medium;
+        }
+      }
+
+      @media (min-width: $threshold-6-12-col) {
+        grid-gap: 0 map-get($grid-gutter-widths, large);
+        grid-template-columns: repeat($grid-columns, minmax(0, 1fr));
+
+        & > * {
+          grid-column-end: span $grid-columns;
+        }
       }
     }
   }

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -88,10 +88,10 @@
 }
 
 // flexbox approximation of grid column styles for IE
-// this needs to be a @mixin rather than %placeholder because it's ised inside @media queries
-@mixin vf-grid-flex-column {
+// this needs to be a @mixin rather than %placeholder because it's used inside @media queries
+@mixin vf-grid-flex-column($size: 1) {
   flex-basis: 0;
-  flex-grow: 1;
+  flex-grow: $size;
   flex-shrink: 1;
 
   // set static gutter width

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -19,6 +19,7 @@
 
     // default to flexbox for IE
     display: flex;
+    flex-wrap: wrap;
 
     & & {
       @include vf-b-row-reset;
@@ -81,5 +82,20 @@
       padding-left: map-get($grid-margin-widths, large);
       padding-right: map-get($grid-margin-widths, large);
     }
+  }
+}
+
+// flexbox approximation of grid column styles for IE
+// this needs to be a @mixin rather than %placeholder because it's ised inside @media queries
+@mixin vf-grid-flex-column {
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 1;
+
+  // set static gutter width
+  margin-left: map-get($grid-gutter-widths, large);
+
+  &:first-child {
+    margin-left: 0;
   }
 }

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -17,9 +17,11 @@
   %vf-row {
     @extend %fixed-width-container;
 
-    // default to flexbox for IE
-    display: flex;
-    flex-wrap: wrap;
+    // default to flexbox for IE on large screens
+    // on small screens we let columns render one under another
+    @media (min-width: $threshold-6-12-col) {
+      display: flex;
+    }
 
     & & {
       @include vf-b-row-reset;

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -86,7 +86,7 @@
       .#{$grid-large-col-prefix}#{$i} {
         // on large screens provide flex box column implementation for IE
         // on smaller screens let them display full width one under another
-        @include vf-grid-flex-column;
+        @include vf-grid-flex-column($i);
         @include vf-grid-column($i);
       }
     }

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -8,23 +8,8 @@
   }
 }
 
-@mixin vf-grid-column($col, $screen: large) {
-  // on large screens provide flex box column implementation for IE
-  // on smaller screens let them display full width one under another
-  @if $screen == large {
-    flex-basis: 0;
-    flex-grow: 1;
-    flex-shrink: 1;
-
-    // set static gutter width
-    margin-left: map-get($grid-gutter-widths, $screen);
-
-    &:first-child {
-      margin-left: 0;
-    }
-  }
-
-  // CSS grid implementation of columns for all screens sizes
+// CSS grid implementation of columns for all screens sizes
+@mixin vf-grid-column($col) {
   @supports (display: grid) {
     grid-column-end: span #{$col};
 
@@ -78,7 +63,7 @@
   @media (max-width: $threshold-4-6-col) {
     @for $i from $grid-columns-small through 1 {
       .#{$grid-small-col-prefix}#{$i} {
-        @include vf-grid-column($i, small);
+        @include vf-grid-column($i);
         width: 100%;
       }
     }
@@ -88,7 +73,7 @@
   @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
     @for $i from $grid-columns-medium through 1 {
       .#{$grid-medium-col-prefix}#{$i} {
-        @include vf-grid-column($i, medium);
+        @include vf-grid-column($i);
         width: 100%;
       }
     }
@@ -99,6 +84,9 @@
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
       .#{$grid-large-col-prefix}#{$i} {
+        // on large screens provide flex box column implementation for IE
+        // on smaller screens let them display full width one under another
+        @include vf-grid-flex-column;
         @include vf-grid-column($i);
       }
     }

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -8,6 +8,39 @@
   }
 }
 
+@mixin vf-grid-column($col, $screen: large) {
+  // on large screens provide flex box column implementation for IE
+  // on smaller screens let them display full width one under another
+  @if $screen == large {
+    flex-basis: 0;
+    flex-grow: 1;
+    flex-shrink: 1;
+
+    // set static gutter width
+    margin-left: map-get($grid-gutter-widths, $screen);
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+
+  // CSS grid implementation of columns for all screens sizes
+  @supports (display: grid) {
+    grid-column-end: span #{$col};
+
+    // reset flex box fallback styles
+    margin-left: 0;
+    width: auto;
+
+    //nesting
+    @if $col > 1 {
+      & .row {
+        grid-template-columns: repeat($col, minmax(0, 1fr));
+      }
+    }
+  }
+}
+
 @mixin vf-p-grid {
   %span-full-grid-on-mobile {
     @media (max-width: $threshold-4-6-col) {
@@ -45,14 +78,8 @@
   @media (max-width: $threshold-4-6-col) {
     @for $i from $grid-columns-small through 1 {
       .#{$grid-small-col-prefix}#{$i} {
-        grid-column-end: span #{$i};
-
-        //nesting
-        @if $i > 1 {
-          & .row {
-            grid-template-columns: repeat($i, minmax(0, 1fr));
-          }
-        }
+        @include vf-grid-column($i, small);
+        width: 100%;
       }
     }
   }
@@ -61,14 +88,8 @@
   @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
     @for $i from $grid-columns-medium through 1 {
       .#{$grid-medium-col-prefix}#{$i} {
-        grid-column-end: span #{$i};
-
-        //nesting
-        @if $i > 1 {
-          & .row {
-            grid-template-columns: repeat($i, minmax(0, 1fr));
-          }
-        }
+        @include vf-grid-column($i, medium);
+        width: 100%;
       }
     }
   }
@@ -78,14 +99,7 @@
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
       .#{$grid-large-col-prefix}#{$i} {
-        grid-column-end: span #{$i};
-
-        //nesting
-        @if $i > 1 {
-          & .row {
-            grid-template-columns: repeat($i, minmax(0, 1fr));
-          }
-        }
+        @include vf-grid-column($i);
       }
     }
   }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -206,17 +206,27 @@ $spv-list-item--inner: null;
 
     margin-left: auto;
 
-    .p-stepped-list__content {
-      @media (min-width: $threshold-6-12-col) {
-        grid-column-end: span 6;
-        margin-top: 0;
+    // fallback for IE flex box grid implementation
+    @media (min-width: $threshold-6-12-col) {
+      .p-stepped-list__content,
+      .p-stepped-list__title {
+        @include vf-grid-flex-column;
       }
     }
 
-    .p-stepped-list__title {
-      display: flex;
-      grid-column-end: span 6;
-      margin-left: 0;
+    @supports (display: grid) {
+      .p-stepped-list__content {
+        @media (min-width: $threshold-6-12-col) {
+          grid-column-end: span 6;
+          margin-top: 0;
+        }
+      }
+
+      .p-stepped-list__title {
+        display: flex;
+        grid-column-end: span 6;
+        margin-left: 0;
+      }
     }
 
     .p-stepped-list__item {

--- a/scss/docs/docs.scss
+++ b/scss/docs/docs.scss
@@ -29,7 +29,6 @@ hr {
 /* Flex layout */
 .docs-container {
   display: flex;
-  flex-wrap: wrap;
 }
 
 .p-sidebar {
@@ -62,7 +61,11 @@ hr {
   margin-top: 0;
 
   &__row {
-    @extend .row; // sass-lint:disable-line placeholder-in-extend
+    @extend %fixed-width-container;
+    // FIXME: for some reason this makes the content behave as expected
+    // we should revisit it when working on docs layouts
+    display: grid;
+
     margin-left: inherit;
     padding: $content-padding;
   }

--- a/scss/docs/docs.scss
+++ b/scss/docs/docs.scss
@@ -68,6 +68,10 @@ hr {
 
     margin-left: inherit;
     padding: $content-padding;
+
+    .row {
+      @include vf-b-row-reset;
+    }
   }
 }
 

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -39,8 +39,8 @@
       </div>
     </header>
 
+    <hr class="u-no-margin u-hide--small">
     <div class="docs-container">
-      <hr class="u-no-margin u-hide--small">
       <aside class="p-sidebar">
         <nav class="p-side-navigation">
 
@@ -181,7 +181,7 @@
         item.classList.add('p-toc__item');
 
         // Add all H3s with IDs to the "Contents" list
-        document.querySelectorAll('main h3[id]').forEach(
+        [].slice.call(document.querySelectorAll('main h3[id]')).forEach(
           function(heading) {
             let thisItem = item.cloneNode();
             let thisAnchor = anchor.cloneNode();

--- a/templates/docs/examples/patterns/grid/default.html
+++ b/templates/docs/examples/patterns/grid/default.html
@@ -31,7 +31,7 @@
       <span>.col-9</span>
     </div>
     <div class="col-3">
-      <span>.col-9</span>
+      <span>.col-3</span>
     </div>
   </div>
   <div class="row">
@@ -96,6 +96,89 @@
     </div>
     <div class="col-11">
       <span>.col-11</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <span>.col-3</span>
+    </div>
+    <div class="col-3">
+      <span>.col-3</span>
+    </div>
+    <div class="col-3">
+      <span>.col-3</span>
+    </div>
+    <div class="col-3">
+      <span>.col-3</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-4">
+      <span>.col-4</span>
+    </div>
+    <div class="col-4">
+      <span>.col-4</span>
+    </div>
+    <div class="col-4">
+      <span>.col-4</span>
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -1,0 +1,47 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Grid / Responsive{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+<style>
+[class*='col-']::before {
+  content: attr(class);
+}
+</style>
+
+<div class="grid-demo">
+  <div class="row">
+    <div class="col-2 col-medium-1 col-small-1">
+    </div>
+    <div class="col-2 col-medium-1 col-small-1">
+    </div>
+    <div class="col-2 col-medium-1 col-small-2">
+    </div>
+    <div class="col-2 col-medium-1 col-small-2">
+    </div>
+    <div class="col-2 col-medium-1 col-small-1">
+    </div>
+    <div class="col-2 col-medium-1 col-small-1">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-3 col-medium-1 col-small-1">
+    </div>
+    <div class="col-3 col-medium-2 col-small-1">
+    </div>
+    <div class="col-3 col-medium-2 col-small-1">
+    </div>
+    <div class="col-3 col-medium-1 col-small-1">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-4 col-medium-2 col-small-4">
+    </div>
+    <div class="col-4 col-medium-2 col-small-2">
+    </div>
+    <div class="col-4 col-medium-2 col-small-2">
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Done

Adds basic fallback implementation of grid for IE11 using flexbox.

For large screens (12 column grid) simplified flexbox based grid should be applied in IE11.
For smaller screens columns just render one under another.

Fixes #2685 

## QA

You can use [ignore whitespace](https://github.com/canonical-web-and-design/vanilla-framework/pull/2943/files?w=1) mode on GitHub when reviewing the code to avoid confusing diff where stuff got nested into `@supports`.


- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2943.run.demo.haus/)
- Check grid examples:
  - [basic](https://vanilla-framework-canonical-web-and-design-pr-2943.run.demo.haus/docs/examples/patterns/grid/default)
  - [nested](https://vanilla-framework-canonical-web-and-design-pr-2943.run.demo.haus/docs/examples/patterns/grid/nested)
  - [responsive](https://vanilla-framework-canonical-web-and-design-pr-2943.run.demo.haus/docs/examples/patterns/grid/responsive)
- Make sure grid works as expected in modern browsers (Chrome, Firefox)
- Check grid examples also in IE11

<img width="784" alt="Screenshot 2020-03-24 at 10 22 57" src="https://user-images.githubusercontent.com/83575/77409397-7b1b8580-6db9-11ea-810b-db67c44c677b.png">
