### PR TITLE
Side nav mobile toggle

### DIFF
--- a/scss/_patterns_menu-toggle.scss
+++ b/scss/_patterns_menu-toggle.scss
@@ -1,0 +1,33 @@
+@mixin vf-p-menu-toggle {
+  .p-menu-toggle {
+    display: flex;
+  }
+
+  .p-menu-toggle__button {
+    // reset default button styling
+    background: none;
+    border: 0;
+    display: block;
+    line-height: inherit;
+    margin: 0;
+    margin-left: auto;
+    padding: 1rem;
+    width: auto;
+  }
+
+  .p-menu-toggle__button--hide {
+    display: none;
+
+    .p-menu-toggle__button[aria-expanded='true'] & {
+      display: block;
+    }
+  }
+
+  .p-menu-toggle__button--show {
+    display: block;
+
+    .p-menu-toggle__button[aria-expanded='true'] & {
+      display: none;
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -25,6 +25,7 @@
 @import 'patterns_lists';
 @import 'patterns_matrix';
 @import 'patterns_media-object';
+@import 'patterns_menu-toggle';
 @import 'patterns_modal';
 @import 'patterns_muted-heading';
 @import 'patterns_navigation';
@@ -97,6 +98,7 @@
   @include vf-p-lists;
   @include vf-p-matrix;
   @include vf-p-media-object;
+  @include vf-p-menu-toggle;
   @include vf-p-modal;
   @include vf-p-muted-heading;
   @include vf-p-navigation;

--- a/scss/standalone/patterns_side-navigation.scss
+++ b/scss/standalone/patterns_side-navigation.scss
@@ -12,5 +12,18 @@
 @import '../patterns_grid';
 @include vf-p-grid;
 
+// notification used in menu toggle example
+@import '../patterns_notifications';
+@include vf-p-notification;
+
+// show/hide utilities used in mobile toggle example
+@import '../utilities_hide';
+@include vf-u-hide;
+@import '../utilities_show';
+@include vf-u-show;
+
+@import '../patterns_menu-toggle';
+@include vf-p-menu-toggle;
+
 @import '../patterns_side-navigation';
 @include vf-p-side-navigation;

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation">
+<div class="p-side-navigation" id="side-navigation">
   <ul class="p-side-navigation__list">
     <li class="p-side-navigation__item--title">
       <a class="p-side-navigation__link" href="#">Title that is a link</a>

--- a/templates/docs/examples/patterns/side-navigation/toggle.html
+++ b/templates/docs/examples/patterns/side-navigation/toggle.html
@@ -1,0 +1,63 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Side navigation / Mobile toggle{% endblock %}
+
+{% block standalone_css %}patterns_side-navigation{% endblock %}
+
+{% block content %}
+<div class="p-menu-toggle u-show--small u-hide">
+  <button class="p-menu-toggle__button" aria-expanded="true" aria-controls="side-navigation" data-hide-class="u-hide--small">
+    <i class="p-icon--menu p-menu-toggle__button--show"></i>
+    <i class="p-icon--close p-menu-toggle__button--hide"></i>
+  </button>
+</div>
+{% include "docs/examples/patterns/side-navigation/_default.html" %}
+
+<script>
+  /**
+    Toggles the necessary aria- attributes' values on the menus
+    and handles to show or hide them.
+    @param {HTMLElement} element The menu link or button.
+    @param {Boolean} show Whether to show or hide the menu.
+    @param {Number} top Top offset in pixels where to show the menu.
+  */
+  function toggleMenu(element, show) {
+    var target = document.getElementById(element.getAttribute('aria-controls'));
+
+    if (target) {
+      element.setAttribute('aria-expanded', show);
+      target.setAttribute('aria-hidden', !show);
+      if (element.dataset.hideClass) {
+        target.classList.toggle(element.dataset.hideClass, !show)
+      }
+    }
+  }
+
+  /**
+    Attaches event listeners for the menu toggle open and close click events.
+    @param {HTMLElement} menuToggle The menu container element.
+  */
+  function setupMenuToggle(menuToggle) {
+    menuToggle.addEventListener('click', function(event) {
+      event.preventDefault();
+      var menuAlreadyOpen = menuToggle.getAttribute('aria-expanded') === 'true';
+
+      toggleMenu(menuToggle, !menuAlreadyOpen);
+    });
+  }
+
+  /**
+    Attaches event listeners for all the menu toggles in the document.
+    @param {String} menuToggleSelector The CSS selector matching menu toggle elements.
+  */
+  function setupAllMenuToggles(menuToggleSelector) {
+    // Setup all menu toggles on the page.
+    var toggles = document.querySelectorAll(menuToggleSelector);
+
+    for (var i = 0, l = toggles.length; i < l; i++) {
+      setupMenuToggle(toggles[i]);
+    }
+  }
+
+  setupAllMenuToggles('.p-menu-toggle__button');
+</script>
+{% endblock %}

--- a/templates/docs/examples/patterns/side-navigation/toggle.html
+++ b/templates/docs/examples/patterns/side-navigation/toggle.html
@@ -4,6 +4,10 @@
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
 {% block content %}
+<div class="p-notification--caution u-hide--small">
+  <p class="p-notification__response">Resize the example to show menu toggle for small screens</p>
+</div>
+
 <div class="p-menu-toggle u-show--small u-hide">
   <button class="p-menu-toggle__button" aria-expanded="true" aria-controls="side-navigation" data-hide-class="u-hide--small">
     <i class="p-icon--menu p-menu-toggle__button--show"></i>

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -89,6 +89,16 @@ To add icons on the left side of the items in side navigation use the `.p-side-n
 View example of the side navigation pattern with icons
 </a>
 
+#### Menu toggle
+
+Side navigation can be closed on small screens using menu toggle component.
+
+Use responsive show/hide utilities' classes to control when the side navigation should be visible or controlled by the menu toggle.
+
+<a href="/docs/examples/patterns/side-navigation/toggle" class="js-example">
+View example of the side navigation pattern with menu toggle
+</a>
+
 ### Import
 
 To import just navigation or sub-navigation component into your project, copy snippets below and include it in your main Sass file.


### PR DESCRIPTION
## Done

Adds menu toggle component to be used with side navigation.

Fixes #2937

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2944.run.demo.haus/docs/examples/patterns/side-navigation/toggle)
- Open [side navigation menu toggle example](https://vanilla-framework-canonical-web-and-design-pr-2944.run.demo.haus/docs/examples/patterns/side-navigation/toggle)
  - menu toggle should only be visible on small screens
  - make sure on small screens navigation can be expanded/collapsed


## Screenshots

<img width="293" alt="Screenshot 2020-03-25 at 08 37 13" src="https://user-images.githubusercontent.com/83575/77512778-f3468180-6e73-11ea-8126-988d3eecd9b3.png">

<img width="302" alt="Screenshot 2020-03-25 at 08 23 29" src="https://user-images.githubusercontent.com/83575/77512602-a4005100-6e73-11ea-913d-7dd60c597d51.png">

