### PR TITLE
Fix selector to match all buttons with modifiers

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -135,7 +135,7 @@
 }
 
 @mixin vf-button-inline {
-  [class~='p-button'].is-inline {
+  [class*='p-button'].is-inline {
     @media (min-width: $breakpoint-medium) {
       margin-left: $sph-outer;
       width: auto;


### PR DESCRIPTION
## Done

Fixes selector to match all buttons with modifiers

Fixes #2938

## QA

- Run `./run or [demo](https://vanilla-framework-canonical-web-and-design-pr-2962.run.demo.haus/docs/examples/patterns/buttons/inline)
- Go to [inline button example](https://vanilla-framework-canonical-web-and-design-pr-2962.run.demo.haus/docs/examples/patterns/buttons/inline) - make sure button has margin on left side

<img width="681" alt="Screenshot 2020-03-31 at 09 15 38" src="https://user-images.githubusercontent.com/83575/77997737-34d1a380-7330-11ea-95af-38bf061209e9.png">

