### PR TITLE
Update listing of latest blog posts on home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -132,6 +132,10 @@
   </div>
   <div class="row">
     <div class="col-3">
+      <h4><a href="https://ubuntu.com/blog/automating-our-vanilla-releases-with-github-actions">Automating our Vanilla releases with GitHub actions</a></h4>
+      <p class="p-heading--6">31 March 2020</p>
+    </div>
+    <div class="col-3">
       <h4><a href="https://ubuntu.com/blog/the-lifecycle-of-components-in-your-design-system">The lifecycle of a component</a></h4>
       <p class="p-heading--6">21 November 2019</p>
     </div>
@@ -142,10 +146,6 @@
     <div class="col-3">
       <h4><a href="https://ubuntu.com/blog/new-release-vanilla-framework-2-0">New release: Vanilla framework 2.0</a></h4>
       <p class="p-heading--6">13 June 2019</p>
-    </div>
-    <div class="col-3">
-      <h4><a href="https://ubuntu.com/blog/a-fresh-look-for-releases-ubuntu-com">A fresh look for releases.ubuntu.com</a></h4>
-      <p class="p-heading--6">13 February 2019</p>
     </div>
   </div>
   <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>


### PR DESCRIPTION
## Done

Adds latest blog post to Vanilla home page

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/774

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- Go to home page and check if latest blog post is listed

## Screenshots

<img width="1109" alt="Screenshot 2020-03-31 at 13 24 31" src="https://user-images.githubusercontent.com/83575/78021128-fac5c900-7352-11ea-95ac-a5603b6d8535.png">

