### PR TITLE
Add documentation layout example

### DIFF
--- a/scss/_layouts_docs.scss
+++ b/scss/_layouts_docs.scss
@@ -1,25 +1,35 @@
 @mixin vf-l-docs {
+  .l-docs .l-content,
   .l-fixed-width--with-sidebar {
     @extend %vf-row;
   }
 
-  .l-sidebar,
-  .l-content {
+  .l-aside,
+  .l-main {
     @extend %span-full-grid-on-mobile;
     @extend %span-full-grid-on-tablet;
     @extend %display-block;
   }
 
   @media (min-width: $threshold-6-12-col) {
+    .l-docs .l-content,
     .l-fixed-width--with-sidebar {
+      // we use 12 column grid from %vf-row
       grid-template-areas: 'side side side main main main main main main main main main';
     }
 
-    .l-sidebar {
+    .l-docs .l-aside, // FIXME: fighting specificity
+    .l-aside {
       grid-area: side;
+
+      // content area takes 3 columns, so we reset nested rows to use 9 columns as well
+      & .row {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
     }
 
-    .l-content {
+    .l-docs .l-main, // FIXME: fighting specificity
+    .l-main {
       grid-area: main;
 
       // content area takes 9 columns, so we reset nested rows to use 9 columns as well

--- a/scss/_layouts_docs.scss
+++ b/scss/_layouts_docs.scss
@@ -1,0 +1,34 @@
+/// Animations
+@mixin vf-l-docs {
+  //.l-docs {}
+
+  .l-docs__wrapper {
+    @extend %fixed-width-container;
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      display: flex;
+      flex-wrap: wrap;
+    }
+  }
+
+  .l-docs__sidebar {
+    background: transparentize($color-positive, 0.9);
+
+    flex-basis: 16rem;
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin-right: map-get($grid-gutter-widths, large);
+  }
+
+  .l-docs__content {
+    background: transparentize($color-positive, 0.9);
+
+    flex-basis: 0;
+    flex-grow: 3;
+    flex-shrink: 1;
+
+    .row {
+      padding: 0;
+    }
+  }
+}

--- a/scss/_layouts_docs.scss
+++ b/scss/_layouts_docs.scss
@@ -1,34 +1,31 @@
-/// Animations
 @mixin vf-l-docs {
-  //.l-docs {}
+  .l-fixed-width--with-sidebar {
+    @extend %vf-row;
+  }
 
-  .l-docs__wrapper {
-    @extend %fixed-width-container;
+  .l-sidebar,
+  .l-content {
+    @extend %span-full-grid-on-mobile;
+    @extend %span-full-grid-on-tablet;
+    @extend %display-block;
+  }
 
-    @media (min-width: $breakpoint-navigation-threshold) {
-      display: flex;
-      flex-wrap: wrap;
+  @media (min-width: $threshold-6-12-col) {
+    .l-fixed-width--with-sidebar {
+      grid-template-areas: 'side side side main main main main main main main main main';
     }
-  }
 
-  .l-docs__sidebar {
-    background: transparentize($color-positive, 0.9);
+    .l-sidebar {
+      grid-area: side;
+    }
 
-    flex-basis: 16rem;
-    flex-grow: 0;
-    flex-shrink: 0;
-    margin-right: map-get($grid-gutter-widths, large);
-  }
+    .l-content {
+      grid-area: main;
 
-  .l-docs__content {
-    background: transparentize($color-positive, 0.9);
-
-    flex-basis: 0;
-    flex-grow: 3;
-    flex-shrink: 1;
-
-    .row {
-      padding: 0;
+      // content area takes 9 columns, so we reset nested rows to use 9 columns as well
+      & .row {
+        grid-template-columns: repeat(9, minmax(0, 1fr));
+      }
     }
   }
 }

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -66,6 +66,8 @@
 @import 'utilities_vertically-center';
 @import 'utilities_no-print';
 
+@import 'layouts_docs';
+
 // Include all the CSS
 @mixin vanilla {
   @include vf-base;
@@ -136,4 +138,6 @@
   @include vf-u-vertically-center;
   @include vf-u-visualise-baseline;
   @include vf-u-no-print;
+
+  @include vf-l-docs;
 }

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -1,12 +1,14 @@
 {% extends "_layouts/_root.html" %}
 
+{# TODO: move to layout #}
 {% block custom_head %}
-    <link rel="stylesheet" href="/static/build/css/docs/docs.css" />
+    <link rel="stylesheet" href="/static/build/css/docs/site.css" />
 {% endblock %}
 
 {% block body %}
+    {# TODO: move to layout #}
     <header id="navigation" class="p-navigation">
-      <div class="p-navigation__row--full-width">
+      <div class="p-navigation__row">
         <div class="p-navigation__banner">
           <div class="p-navigation__logo">
             <a class="p-navigation__item" href="/">
@@ -40,8 +42,10 @@
     </header>
 
     <hr class="u-no-margin u-hide--small">
-    <div class="docs-container">
-      <aside class="p-sidebar">
+
+    <div class="p-strip is-shallow is-bordered">
+    <div class="l-fixed-width--with-sidebar">
+      <aside class="l-aside">
         <nav class="p-side-navigation">
 
             <ul class="p-side-navigation__list">
@@ -149,19 +153,15 @@
 
       </aside>
 
-      <main class="p-content" id="main-content">
+      <main class="l-main" id="main-content">
         {% block banner %}{% endblock %}
-        <div class="p-strip is-shallow">
-          <div class="p-content__row">
-            {% block content %}{{ content | safe }}{% endblock content %}
-          </div>
-        </div>
 
-        <hr>
+        {% block content %}{{ content | safe }}{% endblock content %}
 
-        {% include "_layouts/_footer.html" %}
       </main>
 
+      {# TODO: remove or reimplement page TOC #}
+      <!--
       <aside id="side-content" class="u-hide--small p-aside js-contents" style="display: none">
         <div class="p-aside__section">
           <h4 class="p-aside__header">Contents</h4>
@@ -170,6 +170,7 @@
           </nav>
         </div>
       </aside>
+      -->
 
       <script>
         let aside = document.querySelector('.js-contents');
@@ -198,6 +199,9 @@
         }
       </script>
     </div>
+    </div>
+
+    {% include "_layouts/_footer.html" %}
     <script src="/static/js/scripts.js"></script>
     <script defer src="https://static.codepen.io/assets/embed/ei.js"></script>
     <script defer src="/static/js/example.js"></script>

--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -68,7 +68,7 @@
     </script>
   </head>
 
-  <body>
+  <body class="{% block body_class %}{% endblock %}">
     {% block content %}{% endblock %}
   </body>
 </html>

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -45,6 +45,16 @@
     </nav>
   </div>
   <div class="col-3">
+    <h3>Layouts</h3>
+    <nav>
+      <ul class="p-list">
+        {% for example in examples.layouts %}
+          <li class="p-list__item">
+            <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    </nav>
     <h3>Templates</h3>
     <nav>
       <ul class="p-list">

--- a/templates/docs/examples/layouts/documentation-layout-2.html
+++ b/templates/docs/examples/layouts/documentation-layout-2.html
@@ -1,7 +1,9 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Documentation - Layout{% endblock %}
+{% block title %}Documentation - Layout with regions{% endblock %}
 
 {% block content %}
+<div class="l-header">
+
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
@@ -29,6 +31,10 @@
   </div>
 </header>
 
+</div>
+
+<div class="l-hero">
+
 <section id="search-docs" class="p-strip--light is-shallow">
   <div class="row">
     <form class="p-search-box u-no-margin--bottom" action="#">
@@ -39,7 +45,10 @@
   </div>
 </section>
 
+</div>
 
+<div class="l-content">
+  <div class="p-strip is-bordered">
   <div class="l-fixed-width--with-sidebar">
     <aside class="l-aside">
       <nav class="p-side-navigation">
@@ -93,6 +102,9 @@
     </aside>
 
     <main class="l-main" id="main-content">
+      <h1>Documentation layout with regions</h1>
+      <p>In this example page is built of severaly regions (header, hero, content, footer). Each of the regions contains independent components. Content region additionally contains layout child elements to build sidebar / main content split.</p>
+
       <h1>Main documentation content</h1>
       <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
 
@@ -295,7 +307,10 @@
       </div>
     </main>
   </div>
+  </div>
+</div>
 
+<div class="l-footer">
 <div class="p-strip grid-demo">
   <div class="row">
     <div class="col-1">
@@ -370,6 +385,8 @@
     </div>
   </div>
 </div>
+
+
 <footer class="p-strip--light">
   <nav class="row">
     <div class="has-cookie">
@@ -386,6 +403,8 @@
     </div>
   </nav>
 </footer>
+
+</div>
 
 <script>
   {% include "docs/examples/patterns/side-navigation/_script.js" %}

--- a/templates/docs/examples/layouts/documentation-layout-3.html
+++ b/templates/docs/examples/layouts/documentation-layout-3.html
@@ -1,7 +1,10 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Documentation - Layout{% endblock %}
+{% block title %}Documentation - Layout with regions{% endblock %}
 
+{% block body_class %}l-docs{% endblock %}
 {% block content %}
+<div class="l-header">
+
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
@@ -29,6 +32,10 @@
   </div>
 </header>
 
+</div>
+
+<div class="l-hero">
+
 <section id="search-docs" class="p-strip--light is-shallow">
   <div class="row">
     <form class="p-search-box u-no-margin--bottom" action="#">
@@ -39,8 +46,11 @@
   </div>
 </section>
 
+</div>
 
-  <div class="l-fixed-width--with-sidebar">
+
+<div class="p-strip is-bordered">
+  <div class="l-content">
     <aside class="l-aside">
       <nav class="p-side-navigation">
         <ul class="p-side-navigation__list">
@@ -93,6 +103,11 @@
     </aside>
 
     <main class="l-main" id="main-content">
+      <h1>Documentation layout with regions and layout class on body</h1>
+
+      <p>In this example page is built of severaly regions (header, hero, content, footer). Each of the regions contains independent components.</p>
+      <p>Layout of content region depends on the class on body.</p>
+
       <h1>Main documentation content</h1>
       <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
 
@@ -295,7 +310,9 @@
       </div>
     </main>
   </div>
+</div>
 
+<div class="l-footer">
 <div class="p-strip grid-demo">
   <div class="row">
     <div class="col-1">
@@ -370,6 +387,8 @@
     </div>
   </div>
 </div>
+
+
 <footer class="p-strip--light">
   <nav class="row">
     <div class="has-cookie">
@@ -386,6 +405,8 @@
     </div>
   </nav>
 </footer>
+
+</div>
 
 <script>
   {% include "docs/examples/patterns/side-navigation/_script.js" %}

--- a/templates/docs/examples/layouts/documentation-layout.html
+++ b/templates/docs/examples/layouts/documentation-layout.html
@@ -2,12 +2,6 @@
 {% block title %}Documentation - Layout{% endblock %}
 
 {% block content %}
-<style>
-
-
-</style>
-<div class="l-docs">
-
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
@@ -46,8 +40,8 @@
 </section>
 
 
-  <div class="l-docs__wrapper">
-    <aside class="l-docs__sidebar">
+  <div class="l-fixed-width--with-sidebar">
+    <aside class="l-sidebar">
       <nav class="p-side-navigation">
         <ul class="p-side-navigation__list">
           <li class="p-side-navigation__item--title">
@@ -98,7 +92,7 @@
       </nav>
     </aside>
 
-    <main class="l-docs__content" id="main-content">
+    <main class="l-content" id="main-content">
       <h1>Main documentation content</h1>
       <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
 
@@ -264,23 +258,8 @@
         <div class="col-1">
           <span>.col-1</span>
         </div>
-        <div class="col-1">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1">
-          <span>.col-1</span>
-        </div>
       </div>
       <div class="row">
-        <div class="col-2">
-          <span>.col-2</span>
-        </div>
-        <div class="col-2">
-          <span>.col-2</span>
-        </div>
         <div class="col-2">
           <span>.col-2</span>
         </div>
@@ -304,8 +283,13 @@
         <div class="col-3">
           <span>.col-3</span>
         </div>
-        <div class="col-3">
-          <span>.col-3</span>
+      </div>
+      <div class="row">
+        <div class="col-4">
+          <span>.col-4</span>
+        </div>
+        <div class="col-4">
+          <span>.col-4</span>
         </div>
       </div>
       </div>
@@ -403,7 +387,6 @@
   </nav>
 </footer>
 
-</div>
 <script>
   {% include "docs/examples/patterns/side-navigation/_script.js" %}
 </script>

--- a/templates/docs/examples/layouts/documentation-layout.html
+++ b/templates/docs/examples/layouts/documentation-layout.html
@@ -1,7 +1,13 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Documentation - Vanilla Grid{% endblock %}
+{% block title %}Documentation - Layout{% endblock %}
 
 {% block content %}
+<style>
+
+
+</style>
+<div class="l-docs">
+
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
@@ -39,9 +45,9 @@
   </div>
 </section>
 
-<div class="p-strip">
-  <div class="row">
-    <aside class="col-3">
+
+  <div class="l-docs__wrapper">
+    <aside class="l-docs__sidebar">
       <nav class="p-side-navigation">
         <ul class="p-side-navigation__list">
           <li class="p-side-navigation__item--title">
@@ -92,7 +98,7 @@
       </nav>
     </aside>
 
-    <main class="col-9" id="main-content">
+    <main class="l-docs__content" id="main-content">
       <h1>Main documentation content</h1>
       <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
 
@@ -228,10 +234,158 @@
           </ul>
         </div>
       </div>
+
+      <div class="grid-demo">
+      <div class="row">
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1">
+          <span>.col-1</span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-2">
+          <span>.col-2</span>
+        </div>
+        <div class="col-2">
+          <span>.col-2</span>
+        </div>
+        <div class="col-2">
+          <span>.col-2</span>
+        </div>
+        <div class="col-2">
+          <span>.col-2</span>
+        </div>
+        <div class="col-2">
+          <span>.col-2</span>
+        </div>
+        <div class="col-2">
+          <span>.col-2</span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-3">
+          <span>.col-3</span>
+        </div>
+        <div class="col-3">
+          <span>.col-3</span>
+        </div>
+        <div class="col-3">
+          <span>.col-3</span>
+        </div>
+        <div class="col-3">
+          <span>.col-3</span>
+        </div>
+      </div>
+      </div>
     </main>
   </div>
-</div>
 
+<div class="p-strip grid-demo">
+  <div class="row">
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+    <div class="col-2">
+      <span>.col-2</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <span>.col-3</span>
+    </div>
+    <div class="col-3">
+      <span>.col-3</span>
+    </div>
+    <div class="col-3">
+      <span>.col-3</span>
+    </div>
+    <div class="col-3">
+      <span>.col-3</span>
+    </div>
+  </div>
+</div>
 <footer class="p-strip--light">
   <nav class="row">
     <div class="has-cookie">
@@ -249,6 +403,7 @@
   </nav>
 </footer>
 
+</div>
 <script>
   {% include "docs/examples/patterns/side-navigation/_script.js" %}
 </script>

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -1,0 +1,255 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Documentation{% endblock %}
+
+{% block content %}
+<header id="navigation" class="p-navigation is-dark">
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__item" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="" width="95" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__items" role="menu">
+        <li class="p-navigation__item is-selected" role="menuitem">
+          <a class="p-navigation__link" href="#">Docs</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a class="p-navigation__link" href="#">About</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<section id="search-docs" class="p-strip--light is-shallow">
+  <div class="row">
+    <form class="p-search-box u-no-margin--bottom" action="#">
+      <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" />
+      <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close">Close</i></button>
+      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
+    </form>
+  </div>
+</section>
+
+<div class="p-strip">
+  <div class="row">
+    <aside class="col-3">
+      <nav class="p-side-navigation">
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item--title">
+            <a class="p-side-navigation__link">Side navigation</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">First page</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Second page</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Third page</a>
+          </li>
+          <li class="p-side-navigation__item">
+            <span class="p-side-navigation__text is-selected">Sub section</span>
+            <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item">
+                <a class="p-side-navigation__link" href="#">Second level link</a>
+              </li>
+              <li class="p-side-navigation__item ">
+                <a class="p-side-navigation__link is-active" href="#">Current page</a>
+              </li>
+              <li class="p-side-navigation__item ">
+                <a class="p-side-navigation__link" href="#">Another second level link</a>
+              </li>
+            </ul>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Last page</a>
+          </li>
+        </ul>
+
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item--title">
+            <a class="p-side-navigation__link">Another group</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">First page</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Second page</a>
+          </li>
+          <li class="p-side-navigation__item ">
+            <a class="p-side-navigation__link" href="#">Third page</a>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+
+    <main class="col-9" id="main-content">
+      <h1>Main documentation content</h1>
+      <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
+
+      <h2>Examples</h2>
+
+      <p>Below you can find examples of components commonly used in documentation</p>
+
+      <h3>Code blocks</h3>
+      <pre><code>// Import Vanilla framework
+@import 'vanilla-framework/scss/vanilla';
+
+// Include base Vanilla styles
+@include vf-base;
+
+// Include the components you want
+@include vf-p-buttons;
+@include vf-p-forms;
+@include vf-p-links;
+</code></pre>
+
+      <h3>Lists</h3>
+
+      <ul>
+        <li><a href="#docs/what-is-maas">What is MAAS – and what does it really do for me?</a></li>
+        <li><a href="#docs/maas-example-config">Can you show me an example datacentre using MAAS?</a></li>
+        <li><a href="#docs/what-is-maas#heading--how-maas-works">How does MAAS work, in detail?</a></li>
+        <li><a href="#docs/concepts-and-terms">What concepts might I need to understand before starting?</a></li>
+        <li><a href="#docs/explore-maas">Can I just install it and try it for myself?</a></li>
+      </ul>
+
+      <h3>Tables</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Interface name</th>
+            <th>Description</th>
+            <th>Auto-connect</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="#docs/account-control-interface">account-control</a></td>
+            <td>add/remove user accounts or change passwords</td>
+            <td>no</td>
+          </tr>
+          <tr>
+            <td><a href="#docs/accounts-service-interface">accounts-service</a></td>
+            <td>allows communication with the accounts service</td>
+            <td>no</td>
+          </tr>
+          <tr>
+            <td><a href="#docs/adb-support-interface">adb-support</a></td>
+            <td>allows operating as Android Debug Bridge service</td>
+            <td>no</td>
+          </tr>
+          <tr>
+            <td><a href="#docs/alsa-interface">alsa</a></td>
+            <td>play or record sound</td>
+            <td>no</td>
+          </tr>
+          <tr>
+            <td><a href="#docs/appstream-metadata-interface">appstream-metadata</a></td>
+            <td>allows access to AppStream metadata</td>
+            <td>no</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Notifications</h3>
+
+      <div class="p-notification">
+        <p class="p-notification__response">In versions prior to <code>v.2.6.1</code> the <code>add-cloud</code> command only operates locally (there is no <code>--local</code> option).</p>
+      </div>
+
+      <div class="p-notification--caution">
+        <p class="p-notification__response">Multi-cloud functionality via <code>add-cloud</code> (not <code>add-k8s</code>) is available as “early access” and requires the use of a feature flag. Once the controller is created, you can enable it with: <code>juju controller-config features="[multi-cloud]"</code></p>
+      </div>
+
+      <div class="p-notification--information">
+        <p class="p-notification__response">
+          Last updated 29 days ago.
+          <a href="#clouds/1100">Help improve this document in the forum</a>.
+        </p>
+      </div>
+
+      <h3>Grid</h3>
+
+      <p>Main documentation content block is contained in grid <code>col-9</code>.</p>
+
+      <p>For two columns split use two <code>col-4</code> columns.</p>
+      <div class="row">
+        <div class="col-4">
+          <ul class="p-list">
+            <li class="p-list__item"><a href="#docs/whats-new-2-6">New features in 2.6&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/clouds">Clouds&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/vsphere-cloud">Using VMware vSphere with Juju&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/k8s-cloud">Using Kubernetes with Juju&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/k8s-charms-tutorial">Understanding Kubernetes charms&nbsp;›</a></li>
+          </ul>
+        </div>
+        <div class="col-4">
+          <ul class="p-list">
+            <li class="p-list__item"><a href="#docs/migrating-models">Migrating models&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/bundle-reference">Bundle reference&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/microk8s-cloud">Using Juju with MicroK8s&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/removing-things">Removing things&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/controller-logins">Controller logins&nbsp;›</a></li>
+          </ul>
+        </div>
+      </div>
+
+      <p>For three columns split use three <code>col-3</code> columns.</p>
+
+      <div class="row">
+        <div class="col-3">
+          <ul class="p-list--divided">
+            <li class="p-list__item"><a href="#docs/settings/animation-settings">Animation</a></li>
+            <li class="p-list__item"><a href="#docs/settings/assets-settings">Assets</a></li>
+            <li class="p-list__item"><a href="#docs/settings/breakpoint-settings">Breakpoint</a></li>
+          </ul>
+        </div>
+        <div class="col-3">
+          <ul class="p-list--divided">
+            <li class="p-list__item"><a href="#docs/settings/color-settings">Color</a></li>
+            <li class="p-list__item"><a href="#docs/settings/font-settings">Font</a></li>
+            <li class="p-list__item"><a href="#docs/settings/layout-settings">Layout</a></li>
+          </ul>
+        </div>
+        <div class="col-3">
+          <ul class="p-list--divided">
+            <li class="p-list__item"><a href="#docs/settings/placeholder-settings">Placeholder</a></li>
+            <li class="p-list__item"><a href="#docs/settings/spacing-settings">Spacing</a></li>
+          </ul>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<footer class="p-strip--light">
+  <nav class="row">
+    <div class="has-cookie">
+      <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item">
+          <a href="#"><small>Legal information</small></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="#"><small>Report a bug on this site</small></a>
+        </li>
+      </ul>
+      <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
+    </div>
+  </nav>
+</footer>
+
+<script>
+  {% include "docs/examples/patterns/side-navigation/_script.js" %}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Done

Adds documentation layout build with existing Vanilla grid and classes.

Fixes [list issues/bugs if needed]

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2968.run.demo.haus/docs/examples/)
- Go to [documentation layout example](https://vanilla-framework-canonical-web-and-design-pr-2968.run.demo.haus/docs/examples/layouts/documentation-layout)
  - check if it renders correctly

## Screenshots

<img width="1293" alt="Screenshot 2020-04-06 at 11 57 55" src="https://user-images.githubusercontent.com/83575/78546539-e45db880-77fd-11ea-8674-297d657319b9.png">
