### PR TITLE
WIP: Row with aside

### DIFF
--- a/scss/_patterns_row-with-aside.scss
+++ b/scss/_patterns_row-with-aside.scss
@@ -1,6 +1,7 @@
 @mixin vf-p-row-with-aside {
   .p-row-with-aside {
     @extend %vf-row;
+    position: relative;
   }
 
   .p-row-with-aside__aside,
@@ -8,6 +9,38 @@
     @extend %span-full-grid-on-mobile;
     @extend %span-full-grid-on-tablet;
     @extend %display-block;
+  }
+
+  @media (max-width: $breakpoint-medium - 1px) {
+    .p-row-with-aside__mobile-open,
+    .p-row-with-aside__mobile-close {
+      border-bottom: 1px solid $color-mid-light;
+      margin-bottom: $spv-outer--small;
+      padding: $spv-inner--small 0;
+    }
+
+    .p-row-with-aside__aside-content {
+      background: $color-x-light;
+      left: 0;
+      padding-left: map-get($grid-margin-widths, small);
+      padding-right: map-get($grid-margin-widths, small);
+      position: absolute;
+      top: 0;
+      transform: translateX(-100%);
+      transition: transform 200ms;
+      width: 100%;
+
+      &.is-expanded {
+        transform: translateX(0);
+      }
+    }
+  }
+
+  @media (min-width: $breakpoint-medium) {
+    .p-row-with-aside__mobile-open,
+    .p-row-with-aside__mobile-close {
+      display: none;
+    }
   }
 
   @media (min-width: $threshold-6-12-col) {

--- a/scss/_patterns_row-with-aside.scss
+++ b/scss/_patterns_row-with-aside.scss
@@ -1,0 +1,37 @@
+@mixin vf-p-row-with-aside {
+  .p-row-with-aside {
+    @extend %vf-row;
+  }
+
+  .p-row-with-aside__aside,
+  .p-row-with-aside__main {
+    @extend %span-full-grid-on-mobile;
+    @extend %span-full-grid-on-tablet;
+    @extend %display-block;
+  }
+
+  @media (min-width: $threshold-6-12-col) {
+    .p-row-with-aside {
+      // we use 12 column grid from %vf-row
+      grid-template-areas: 'side side side main main main main main main main main main';
+    }
+
+    .p-row-with-aside__aside {
+      grid-area: side;
+
+      // content area takes 3 columns, so we reset nested rows to use 9 columns as well
+      & .row {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    .p-row-with-aside__main {
+      grid-area: main;
+
+      // content area takes 9 columns, so we reset nested rows to use 9 columns as well
+      & .row {
+        grid-template-columns: repeat(9, minmax(0, 1fr));
+      }
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -32,6 +32,7 @@
 @import 'patterns_notifications';
 @import 'patterns_pagination';
 @import 'patterns_pull-quotes';
+@import 'patterns_row-with-aside';
 @import 'patterns_search-box';
 @import 'patterns_side-navigation';
 @import 'patterns_slider';
@@ -104,6 +105,7 @@
   @include vf-p-notification;
   @include vf-p-pagination;
   @include vf-p-pull-quotes;
+  @include vf-p-row-with-aside;
   @include vf-p-search-box;
   @include vf-p-side-navigation;
   @include vf-p-slider;

--- a/templates/docs/examples/patterns/row-with-aside/default.html
+++ b/templates/docs/examples/patterns/row-with-aside/default.html
@@ -1,0 +1,34 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Row with aside{% endblock %}
+
+{% block content %}
+<div class="p-row-with-aside">
+  <aside class="p-row-with-aside__aside">
+    <p>This is content of the sidebar. This is content of the sidebar.</p>
+  </aside>
+  <div class="p-row-with-aside__main">
+    <p>This is the main content area. This is the main content area. This is the main content area. This is the main content area. This is the main content area.</p>
+
+    <h5>Nested grid</h5>
+    <p>There are 9 grid columns available in main content area</p>
+    <div class="grid-demo row">
+      <div class="col-9">.col-9</div>
+    </div>
+    <div class="grid-demo row">
+      <div class="col-3">.col-3</div>
+      <div class="col-3">.col-3</div>
+      <div class="col-3">.col-3</div>
+    </div>
+    <div class="grid-demo row">
+      <div class="col-4">.col-4</div>
+      <div class="col-4">.col-4</div>
+    </div>
+    <div class="grid-demo row">
+      <div class="col-2">.col-2</div>
+      <div class="col-2">.col-2</div>
+      <div class="col-2">.col-2</div>
+      <div class="col-2">.col-2</div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/row-with-aside/side-navigation-mobile-toggle.html
+++ b/templates/docs/examples/patterns/row-with-aside/side-navigation-mobile-toggle.html
@@ -1,0 +1,51 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Row with aside / Mobile toggle{% endblock %}
+
+{% block content %}
+<div class="p-strip--light is-shallow">
+  <div class="u-fixed-width">
+    <h1> Some content above side navigation </h1>
+    <p>This is some content that may be above side navigation</p>
+  </div>
+</div>
+<div class="p-row-with-aside">
+  <aside class="p-row-with-aside__aside">
+    <div class="p-row-with-aside__mobile-open u-hide u-show--small">
+      <button class="p-button--base has-icon js-toggle u-no-margin "><i class="p-icon--menu"></i><span>Show side navigation</span></button>
+    </div>
+    <div class="p-row-with-aside__aside-content">
+      <div class="p-row-with-aside__mobile-close u-hide u-show--small">
+        <button class="p-button--base has-icon js-toggle u-no-margin "><i class="p-icon--close"></i><span>Hide side navigation</span></button>
+      </div>
+      <nav class="p-side-navigation">
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Welcome</span></li>
+          <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#docs">Get started</a></li>
+          <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#docs/building-vanilla">Building with Vanilla</a></li>
+          <li class="p-side-navigation__item"><a class="p-side-navigation__link " href="#docs/customising-vanilla">Customising Vanilla</a></li>
+        </ul>
+      </nav>
+    </div>
+  </aside>
+  <div class="p-row-with-aside__main">
+    <h2>Get started</h2>
+    <p>You can use Vanilla in your projects in a few different ways. See Building with Vanilla and Customising Vanilla for more in-depth setup instructions.</p>
+    <p>You can use Vanilla in your projects in a few different ways. See Building with Vanilla and Customising Vanilla for more in-depth setup instructions.</p>
+    <p>You can use Vanilla in your projects in a few different ways. See Building with Vanilla and Customising Vanilla for more in-depth setup instructions.</p>
+    <p>You can use Vanilla in your projects in a few different ways. See Building with Vanilla and Customising Vanilla for more in-depth setup instructions.</p>
+    <p>You can use Vanilla in your projects in a few different ways. See Building with Vanilla and Customising Vanilla for more in-depth setup instructions.</p>
+    <p>You can use Vanilla in your projects in a few different ways. See Building with Vanilla and Customising Vanilla for more in-depth setup instructions.</p>
+  </div>
+</div>
+<script>
+  document.querySelectorAll(".js-toggle").forEach((button) => {
+    button.addEventListener("click", () => {
+      console.log("click");
+      document.querySelector(".p-row-with-aside__aside-content").classList.toggle("is-expanded")
+    })
+  });
+</script>
+<style>
+  body { margin: 0 }
+</style>
+{% endblock %}

--- a/templates/docs/examples/patterns/row-with-aside/side-navigation.html
+++ b/templates/docs/examples/patterns/row-with-aside/side-navigation.html
@@ -1,0 +1,21 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Row with aside / Side navigation{% endblock %}
+
+{% block content %}
+<div class="p-row-with-aside">
+  <aside class="p-row-with-aside__aside">
+    <nav class="p-side-navigation">
+      <ul class="p-side-navigation__list">
+        <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Welcome</span></li>
+        <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#docs">Get started</a></li>
+        <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#docs/building-vanilla">Building with Vanilla</a></li>
+        <li class="p-side-navigation__item"><a class="p-side-navigation__link " href="#docs/customising-vanilla">Customising Vanilla</a></li>
+      </ul>
+    </nav>
+  </aside>
+  <div class="p-row-with-aside__main">
+    <h2>Get started</h2>
+    <p>You can use Vanilla in your projects in a few different ways. See Building with Vanilla and Customising Vanilla for more in-depth setup instructions.</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Work in progress.

Pattern in place of descoped 'documentation layout'.

## Done

[List of work items including drive-bys]

Fixes [list issues/bugs if needed]

## QA

- Open demo
- [Row with aside](https://vanilla-framework-canonical-web-and-design-pr-2972.run.demo.haus/docs/examples/patterns/row-with-aside/default)
- [Row with aside with mobile toggle (on small screens)](https://vanilla-framework-canonical-web-and-design-pr-2972.run.demo.haus/docs/examples/patterns/row-with-aside/side-navigation-mobile-toggle)
## Screenshots

<img width="1272" alt="Screenshot 2020-04-08 at 12 03 30" src="https://user-images.githubusercontent.com/83575/78771947-41d63e80-7991-11ea-8bd1-7722cf7aaff1.png">


<img width="423" alt="Screenshot 2020-04-08 at 12 04 08" src="https://user-images.githubusercontent.com/83575/78771941-3f73e480-7991-11ea-90ba-cdf3cfa0af8f.png">

