### PR TITLE
Fix class attribute selectors

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -144,7 +144,7 @@
 }
 
 @mixin vf-button-icon {
-  [class^='p-button'].has-icon {
+  [class*='p-button'].has-icon {
     width: auto;
 
     & [class*='p-icon'] {

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -79,7 +79,7 @@
   }
 
   [class*='p-card'] {
-    > p:not([class^='p-heading--']),
+    > p:not([class*='p-heading--']),
     > h5,
     > h6 {
       &:last-child {


### PR DESCRIPTION
## Done

Updates the use of `[class^=]` attribute selector to `[class*=]` to make sure class name doesn't need to start with given value.


## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2973.run.demo.haus/docs/examples/patterns/buttons/icon)
- Make sure there are no regressions (in Percy)
- Go to [button example with icon](https://vanilla-framework-canonical-web-and-design-pr-2973.run.demo.haus/docs/examples/patterns/buttons/icon). Change order or class names to "has-icon p-button", everything should look the same


<img width="605" alt="Screenshot 2020-04-08 at 11 08 40" src="https://user-images.githubusercontent.com/83575/78766283-5e6e7880-7989-11ea-8a5a-f994454670aa.png">
