### PR TITLE
Update renovate.json based on maas-ui

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,13 @@
 {
-  "extends": ["config:base", "schedule:monthly", "group:all"],
+  "extends": ["config:base"],
+  "labels": ["Maintenance 🔨"],
   "packageRules": [
     {
-      "depTypeList": ["devDependencies"],
-      "extends": [":automergeMinor"]
-    },
-    {
-      "packageNames": ["vanilla-framework"],
+      "packagePatterns": ["*"],
+      "extends": ["schedule:weekly"],
       "minor": {
-        "automerge": false
-      },
-      "patch": {
-        "automerge": false
+        "groupName": "all non-major dependencies",
+        "groupSlug": "all-minor-patch"
       }
     }
   ]


### PR DESCRIPTION
## Done

Updates `renovate.json` to use similar grouping config as maas-ui.



## QA

- Compare with https://github.com/canonical-web-and-design/maas-ui/blob/master/renovate.json
