### PR TITLE
Make sure Circle CI fails if server doesn't run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ jobs:
           name: Wait for development server
           command: sleep 5
       - run:
+          name: Check server status
+          command: curl localhost:${PORT}/_status/check -I
+      - run:
           name: Snapshot screenshots
           command: yarn percy
 workflows:


### PR DESCRIPTION
## Done

Update Circle CI config to fail early when server doesn't run.

## QA

When running server fails, Circle CI job should fail before attempting to run screenshots for Percy:
https://app.circleci.com/pipelines/github/canonical-web-and-design/vanilla-framework/170/workflows/573e06ae-dbf1-42d3-9f82-aa80da350560/jobs/195

When server runs correctly, Circle CI should pass and send screenshots to Percy:
https://app.circleci.com/pipelines/github/canonical-web-and-design/vanilla-framework/171/workflows/d867e64a-e990-4d77-a1c8-9df1c4e2c0c3/jobs/196
