### PR TITLE
Update Vanilla docs to use fixed width layout with side navigation

### DIFF
--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -1,4 +1,4 @@
-<footer class="p-strip is-shallow" role="contentinfo">
+<footer class="p-strip--light" role="contentinfo">
   <div class="row p-content__row">
     <div class="col-12">
       &copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -1,9 +1,9 @@
 <footer class="p-strip--light" role="contentinfo">
   <div class="row p-content__row">
     <div class="col-12">
-      &copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
+      <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
       <nav>
-        <ul class="p-inline-list--middot">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
           <li class="p-inline-list__item">
             <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
           </li>

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="/">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/94d962aa-vanilla_white-orange_hex.svg" alt="Vanilla framework logo">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/94d962aa-vanilla_white-orange_hex.svg" style="height:1.5rem" alt="Vanilla framework logo">
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -1,0 +1,35 @@
+<header id="navigation" class="p-navigation is-dark">
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__item" href="/">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/94d962aa-vanilla_white-orange_hex.svg" alt="Vanilla framework logo">
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__items">
+        <li class="p-navigation__item u-hide--small {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
+        <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
+        <li class="p-navigation__link{% if path == '/accessibility' %} is-selected{% endif %}"><a href="/accessibility">Accessibility</a></li>
+        <li class="p-navigation__link{% if path == '/browser-support' %} is-selected{% endif %}"><a href="/browser-support">Browser support</a></li>
+        <li class="p-navigation__link{% if path == '/contribute' %} is-selected{% endif %}"><a href="/contribute">Contribute</a></li>
+        {% if not path.startswith('/docs') %}
+        <li class="p-navigation__link{% if path == '/showcase' %} is-selected{% endif %}"><a href="/showcase">Showcase</a></li>
+        {% endif %}
+      </ul>
+      {% if path.startswith('/docs') %}
+      <form class="p-search-box" action="/docs/search">
+        <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation" required />
+        <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" alt="reset"><i class="p-icon--close"></i></button>
+        <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+      </form>
+      {% endif %}
+    </nav>
+  </div>
+</header>

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -14,7 +14,7 @@
         <a href="#main-content">Jump to main content</a>
       </span>
       <ul class="p-navigation__items">
-        <li class="p-navigation__item u-hide--small {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
+        <li class="p-navigation__item {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
         <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
         <li class="p-navigation__link{% if path == '/accessibility' %} is-selected{% endif %}"><a href="/accessibility">Accessibility</a></li>
         <li class="p-navigation__link{% if path == '/browser-support' %} is-selected{% endif %}"><a href="/browser-support">Browser support</a></li>

--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -49,7 +49,10 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K7ZB6FL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+
+    {% include "_layouts/_header.html" %}
     {% block body %}{% endblock %}
+    {% include "_layouts/_footer.html" %}
 
     <!-- begin usabilla live embed code -->
     <script type="text/javascript">/*{literal}<![CDATA[*/window.lightningjs||function(c){function g(b,d){d&&(d+=(/\?/.test(d)?"&":"?")+"lv=1");c[b]||function(){var i=window,h=document,j=b,g=h.location.protocol,l="load",k=0;(function(){function b(){a.P(l);a.w=1;c[j]("_load")}c[j]=function(){function m(){m.id=e;return c[j].apply(m,arguments)}var b,e=++k;b=this&&this!=i?this.id||0:0;(a.s=a.s||[]).push([e,b,arguments]);m.then=function(b,c,h){var d=a.fh[e]=a.fh[e]||[],j=a.eh[e]=a.eh[e]||[],f=a.ph[e]=a.ph[e]||[];b&&d.push(b);c&&j.push(c);h&&f.push(h);return m};return m};var a=c[j]._={};a.fh={};a.eh={};a.ph={};a.l=d?d.replace(/^\/\//,(g=="https:"?g:"http:")+"///"):d;a.p={0:+new Date};a.P=function(b){a.p[b]=new Date-a.p[0]};a.w&&b();i.addEventListener?i.addEventListener(l,b,!1):i.attachEvent("on"+l,b);var q=function(){function b(){return["<head></head><",c,' onload="var d=',n,";d.getElementsByTagName('head')[0].",d,"(d.",g,"('script')).",i,"='",a.l,"'\"></",c,">"].join("")}var c="body",e=h[c];if(!e)return setTimeout(q,100);a.P(1);var d="appendChild",g="createElement",i="src",k=h[g]("div"),l=k[d](h[g]("div")),f=h[g]("iframe"),n="document",p;k.style.display="none";e.insertBefore(k,e.firstChild).id=o+"-"+j;f.frameBorder="0";f.id=o+"-frame-"+j;/MSIE[ ]+6/.test(navigator.userAgent)&&(f[i]="javascript:false");f.allowTransparency="true";l[d](f);try{f.contentWindow[n].open()}catch(s){a.domain=h.domain,p="javascript:var d="+n+".open();d.domain='"+h.domain+"';",f[i]=p+"void(0);"}try{var r=f.contentWindow[n];r.write(b());r.close()}catch(t){f[i]=p+'d.write("'+b().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}a.P(2)};a.l&&setTimeout(q,0)})()}();c[b].lv="1";return c[b]}var o="lightningjs",k=window[o]=g(o);k.require=g;k.modules=c}({});

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -135,7 +135,7 @@
     <script defer src="https://static.codepen.io/assets/embed/ei.js"></script>
     <script defer src="/static/js/example.js"></script>
 
-    <!-- include properly as external JS -->
+    <!-- TODO: include properly as external JS -->
     <script>
       {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
     </script>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -134,9 +134,4 @@
     <script src="/static/js/scripts.js"></script>
     <script defer src="https://static.codepen.io/assets/embed/ei.js"></script>
     <script defer src="/static/js/example.js"></script>
-
-    <!-- TODO: include properly as external JS -->
-    <script>
-      {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
-    </script>
 {% endblock %}

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -5,40 +5,7 @@
 {% endblock %}
 
 {% block body %}
-    <header id="navigation" class="p-navigation">
-      <div class="p-navigation__row">
-        <div class="p-navigation__banner">
-          <div class="p-navigation__logo">
-            <a class="p-navigation__item" href="/">
-              <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="Vanilla framework logo">
-            </a>
-          </div>
-          <div class="p-navigation__toggles u-hide--large u-hide--medium">
-            <a href="#navigation" class="p-navigation__toggle--open" title="about menu">About</a>
-            <a href="#navigation-closed" class="p-navigation__toggle--close" title="close about menu">About</a>
-          </div>
-        </div>
-        <nav class="p-navigation__nav">
-          <span class="u-off-screen">
-            <a href="#main-content">Jump to main content</a>
-          </span>
-          <ul class="p-navigation__items">
-            <li class="p-navigation__item u-hide--small {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
-            <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
-            <li class="p-navigation__item"><a class="p-navigation__link" href="/accessibility">Accessibility</a></li>
-            <li class="p-navigation__item"><a class="p-navigation__link" href="/browser-support">Browser support</a></li>
-            <li class="p-navigation__item"><a class="p-navigation__link" href="/contribute">Contribute</a></li>
-          </ul>
-          <form class="p-search-box" action="/docs/search">
-            <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation" required />
-            <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" alt="reset"><i class="p-icon--close"></i></button>
-            <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
-          </form>
-        </nav>
-      </div>
-    </header>
 
-    <hr class="u-no-margin u-hide--small">
 
     {% block banner %}{% endblock %}
 
@@ -163,8 +130,6 @@
 
     </div>
     </div>
-
-    {% include "_layouts/_footer.html" %}
 
     <script src="/static/js/scripts.js"></script>
     <script defer src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -9,7 +9,7 @@
 
     {% block banner %}{% endblock %}
 
-    <div class="p-strip is-shallow">
+    <div class="p-strip">
     <div class="row">
       <aside class="col-3">
         <nav class="p-side-navigation" id="side-navigation">

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -1,12 +1,12 @@
 {% extends "_layouts/_root.html" %}
 
 {% block custom_head %}
-    <link rel="stylesheet" href="/static/build/css/docs/docs.css" />
+    <link rel="stylesheet" href="/static/build/css/build.css" />
 {% endblock %}
 
 {% block body %}
     <header id="navigation" class="p-navigation">
-      <div class="p-navigation__row--full-width">
+      <div class="p-navigation__row">
         <div class="p-navigation__banner">
           <div class="p-navigation__logo">
             <a class="p-navigation__item" href="/">
@@ -16,7 +16,6 @@
           <div class="p-navigation__toggles u-hide--large u-hide--medium">
             <a href="#navigation" class="p-navigation__toggle--open" title="about menu">About</a>
             <a href="#navigation-closed" class="p-navigation__toggle--close" title="close about menu">About</a>
-            <a class="p-sidebar__toggle u-hide--medium u-hide--large" href="#">Docs</a>
           </div>
         </div>
         <nav class="p-navigation__nav">
@@ -40,9 +39,25 @@
     </header>
 
     <hr class="u-no-margin u-hide--small">
-    <div class="docs-container">
-      <aside class="p-sidebar">
-        <nav class="p-side-navigation">
+
+    {% block banner %}{% endblock %}
+
+    <div class="p-strip is-shallow is-bordered">
+    <div class="row">
+      <aside class="col-3">
+        <nav class="p-side-navigation" id="side-navigation">
+          <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation">
+            Toggle side navigation
+          </button>
+
+          <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation"></div>
+
+          <div class="p-side-navigation__drawer">
+            <div class="p-side-navigation__drawer-header">
+              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation">
+                Toggle side navigation
+              </button>
+            </div>
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Welcome</span></li>
@@ -51,8 +66,6 @@
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/customising-vanilla' %}is-active{% endif %}" href="/docs/customising-vanilla">Customising Vanilla</a></li>
               <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">What’s new in {{ version }}</a></li>
             </ul>
-
-
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
@@ -97,8 +110,6 @@
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/patterns/tooltips' %}is-active{% endif %}" href="/docs/patterns/tooltips">Tooltips</a></li>
             </ul>
 
-
-
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Utilities</span></li>
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/align' %}is-active{% endif %}" href="/docs/utilities/align">Alignment</a></li>
@@ -121,8 +132,6 @@
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/utilities/vertically-center' %}is-active{% endif %}" href="/docs/utilities/vertically-center">Vertically center</a></li>
             </ul>
 
-
-
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Settings</span></li>
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/animation-settings' %}is-active{% endif %}" href="/docs/settings/animation-settings">Animations</a></li>
@@ -136,69 +145,33 @@
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/table-layout' %}is-active{% endif %}" href="/docs/settings/table-layout">Table layout</a></li>
             </ul>
 
-
-
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Resources</span></li>
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/examples' %}is-active{% endif %}" href="/docs/examples">Component examples</a></li>
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/component-status' %}is-active{% endif %}" href="/docs/component-status">Component status</a></li>
-              <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download Sketch UI Kit</a></li>
             </ul>
 
+          </div>
         </nav>
 
       </aside>
 
-      <main class="p-content" id="main-content">
-        {% block banner %}{% endblock %}
-        <div class="p-strip is-shallow">
-          <div class="p-content__row">
-            {% block content %}{{ content | safe }}{% endblock content %}
-          </div>
-        </div>
-
-        <hr>
-
-        {% include "_layouts/_footer.html" %}
+      <main class="col-9" id="main-content">
+        {% block content %}{{ content | safe }}{% endblock content %}
       </main>
 
-      <aside id="side-content" class="u-hide--small p-aside js-contents" style="display: none">
-        <div class="p-aside__section">
-          <h4 class="p-aside__header">Contents</h4>
-          <nav class="p-aside__nav">
-            <ul class="p-list js-contents-list"></ul>
-          </nav>
-        </div>
-      </aside>
-
-      <script>
-        let aside = document.querySelector('.js-contents');
-        let list = aside.querySelector('.js-contents-list');
-
-        let item = document.createElement('li');
-        let anchor = document.createElement('a');
-        anchor.classList.add('p-toc__link');
-        item.classList.add('p-toc__item');
-
-        // Add all H3s with IDs to the "Contents" list
-        [].slice.call(document.querySelectorAll('main h3[id]')).forEach(
-          function(heading) {
-            let thisItem = item.cloneNode();
-            let thisAnchor = anchor.cloneNode();
-            thisAnchor.setAttribute('href', '#' + heading.id);
-            thisAnchor.textContent = heading.textContent;
-            thisItem.appendChild(thisAnchor);
-            list.appendChild(thisItem);
-          }
-        )
-
-        // Display the "Contents" list, if there are items
-        if (list.querySelectorAll('li').length > 0) {
-          aside.style.display = 'block';
-        }
-      </script>
     </div>
+    </div>
+
+    {% include "_layouts/_footer.html" %}
+
     <script src="/static/js/scripts.js"></script>
     <script defer src="https://static.codepen.io/assets/embed/ei.js"></script>
     <script defer src="/static/js/example.js"></script>
+
+    <!-- include properly as external JS -->
+    <script>
+      {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
+    </script>
 {% endblock %}

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -9,7 +9,7 @@
 
     {% block banner %}{% endblock %}
 
-    <div class="p-strip is-shallow is-bordered">
+    <div class="p-strip is-shallow">
     <div class="row">
       <aside class="col-3">
         <nav class="p-side-navigation" id="side-navigation">

--- a/templates/_layouts/site.html
+++ b/templates/_layouts/site.html
@@ -11,7 +11,4 @@
 
 {% block body %}
     {% block content %}{{ content | safe }}{% endblock content %}
-
-    {# TODO: this makes border above the footer, should be moved out of here #}
-    <hr>
 {% endblock %}

--- a/templates/_layouts/site.html
+++ b/templates/_layouts/site.html
@@ -10,36 +10,8 @@
 {% endblock %}
 
 {% block body %}
-    <header id="navigation" class="p-navigation">
-      <div class="p-navigation__row">
-        <div class="p-navigation__banner">
-          <div class="p-navigation__logo" style="margin-bottom: 0">
-            <a class="p-navigation__link" href="/">
-              <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="Vanilla">
-            </a>
-          </div>
-          <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-          <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
-        </div>
-        <nav class="p-navigation__nav">
-          <span class="u-off-screen">
-            <a href="#main-content">Jump to main content</a>
-          </span>
-          <ul class="p-navigation__links">
-            <li class="p-navigation__link"><a href="/docs">Docs</a></li>
-            <li class="p-navigation__link"><a href="/docs/examples">Examples</a></li>
-            <li class="p-navigation__link{% if path == '/accessibility' %} is-selected{% endif %}"><a href="/accessibility">Accessibility</a></li>
-            <li class="p-navigation__link{% if path == '/browser-support' %} is-selected{% endif %}"><a href="/browser-support">Browser support</a></li>
-            <li class="p-navigation__link{% if path == '/contribute' %} is-selected{% endif %}"><a href="/contribute">Contribute</a></li>
-            <li class="p-navigation__link{% if path == '/showcase' %} is-selected{% endif %}"><a href="/showcase">Showcase</a></li>
-          </ul>
-        </nav>
-      </div>
-    </header>
-
     {% block content %}{{ content | safe }}{% endblock content %}
 
+    {# TODO: this makes border above the footer, should be moved out of here #}
     <hr>
-
-    {% include "_layouts/_footer.html" %}
 {% endblock %}

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -28,14 +28,14 @@ This component should be used when displaying a single line of code, accompanied
 
 <div class="p-strip is-shallow">
   <div class="row">
-     <div class="col-6">
+     <div class="col-4">
        <div class="p-notification--positive">
         <p class="p-notification__response"><span class="p-notification__status">Do:</span>Use for single line terminal commands, functions or instructions.</p>
        </div>
      </div>
-    <div class="col-6">
+    <div class="col-4">
       <div class="p-notification--negative">
-        <p class="p-notification__response"><span class="p-notification__status">Don't:</span>Use more than two lines of code, if required, it's recommended you use code <a href="#block" class="p-notification__action">block</a>.</p>
+        <p class="p-notification__response"><span class="p-notification__status">Don't:</span>Use for multiline code. If needed, code <a href="#block" class="p-notification__action">block</a> should be used.</p>
       </div>
     </div>
   </div>

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -18,9 +18,9 @@ When you refer to code inline with other text, use the <code>&lt;code></code> ta
 
 If you want to refer to a larger piece of code, use <code>&lt;pre></code> together with the <code>&lt;code></code> tag.
 
-<a href="/docs/examples/base/code/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/code/" class="js-example">
 View example of the base code block
-</a>
+</a></div>
 
 ### Copyable
 
@@ -41,9 +41,9 @@ This component should be used when displaying a single line of code, accompanied
   </div>
 </div>
 
-<a href="/docs/examples/patterns/code-copyable/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/code-copyable/" class="js-example">
 View example of the code copyable pattern
-</a>
+</a></div>
 
 ### Functionality
 
@@ -53,9 +53,9 @@ Please copy the entire JS in the example, for copy to clipboard functionality.
 
 The code numbered pattern can be used when displaying large blocks of code to enable users to quickly reference a specific line.
 
-<a href="/docs/examples/patterns/code-numbered/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/code-numbered/" class="js-example">
 View example of the code numbered pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -10,17 +10,17 @@ context:
 
 Form controls have global styling defined at the HTML element level. Labels and most input types are 100% width of the `<form>` parent element.
 
-<a href="/docs/examples/base/forms/form/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/form/" class="js-example">
 View example of a base form
-</a>
+</a></div>
 
 ### Input
 
 An input field where the user can enter data, which can vary in many ways, depending on the type attribute.
 
-<a href="/docs/examples/base/forms/input/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/input/" class="js-example">
 View example of an input element
-</a>
+</a></div>
 
 ### HTML5
 
@@ -30,9 +30,9 @@ We support all HTML5 input types: `text`, `password`, `datetime`, `datetime-loca
 
 The `<textarea>` tag defines a multi-line text input control.
 
-<a href="/docs/examples/base/forms/textarea/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/textarea/" class="js-example">
 View example of an input element
-</a>
+</a></div>
 
 Note: The attribute `readonly` disables the input but it still retains a default cursor.
 
@@ -40,49 +40,49 @@ Note: The attribute `readonly` disables the input but it still retains a default
 
 Use checkboxes to select one or more options, default checkboxes can appear in three states: selected, unselected and disabled.
 
-<a href="/docs/examples/base/forms/checkboxes/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/checkboxes/" class="js-example">
 View example of the base checkboxes
-</a>
+</a></div>
 
 <span class="p-label--updated">Updated</span>
 
 By default, checkboxes are vertically aligned to the baseline of text wrapped in a `label`, `h5`, `h6`, or `p` tag. If you need to align them to other elements, use one of the following classes:
 `is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
 
-<a href="/docs/examples/base/forms/aligned-checkboxes/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/aligned-checkboxes/" class="js-example">
 View example of checkboxes aligned to different headings
-</a>
+</a></div>
 
 ### Radio button
 
 Use radio buttons to select one or more options, our radio buttons can appear in four states: both selected, unselected and disabled.
 
-<a href="/docs/examples/base/forms/radio-buttons/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/radio-buttons/" class="js-example">
 View example of the base radio buttons
-</a>
+</a></div>
 
 <span class="p-label--updated">Updated</span>
 
 By default, radio buttons are vertically aligned to the baseline of text wrapped in a `label`, `h5`, `h6`, or `p` tag. If you need to align them to other elements, use one of the following classes:
 `is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
 
-<a href="/docs/examples/base/forms/aligned-radio/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/aligned-radio/" class="js-example">
 View example of the aligned radio buttons
-</a>
+</a></div>
 
 ### Select
 
 Use the `<select>` element to create a drop-down list.
 
-<a href="/docs/examples/base/forms/selects/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/selects/" class="js-example">
 View example of the base selects
-</a>
+</a></div>
 
 Use the `multiple` attribute to create a multiple select control.
 
-<a href="/docs/examples/base/forms/select-multiple/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/select-multiple/" class="js-example">
 View example of the base multiple selects
-</a>
+</a></div>
 
 ### Range
 
@@ -90,33 +90,33 @@ View example of the base multiple selects
 
 The `<input type="range">` allows a user to select from a specified range of values, where the precise value is not considered important.
 
-<a href="/docs/examples/base/forms/range/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/range/" class="js-example">
 View example of the slider pattern
-</a>
+</a></div>
 
 ### Fieldset
 
 You can use the `<fieldset>` element to divide the form into different logical sections.
 
-<a href="/docs/examples/base/forms/fieldset/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/fieldset/" class="js-example">
 View example of the base form fieldset
-</a>
+</a></div>
 
 ### Inline
 
 By applying the class `.p-form--inline` and wrapping any form control in `.p-form__group` you can change the layout style of any form to be inline.
 
-<a href="/docs/examples/patterns/forms/form-inline/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/form-inline/" class="js-example">
 View examples of form inline patterns
-</a>
+</a></div>
 
 ### Stacked
 
 By applying the class `.p-form--stacked` and wrapping any form control in `.p-form__group` you can change the layout style of any form to be stacked.
 
-<a href="/docs/examples/patterns/forms/form-stacked/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/form-stacked/" class="js-example">
 View examples of form stacked patterns
-</a>
+</a></div>
 
 ### Disabled
 
@@ -128,9 +128,9 @@ Adding the `disabled` attribute to an input will prevent user interaction.
   </p>
 </div>
 
-<a href="/docs/examples/base/forms/disabled-input/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/forms/disabled-input/" class="js-example">
 View example of a disabled input
-</a>
+</a></div>
 
 ### Validation
 
@@ -140,25 +140,25 @@ If your form uses select elements then you will additionally need to wrap only t
 
 Descriptive text relating to the element's validation status should use the class `p-form-validation__message`.
 
-<a href="/docs/examples/patterns/forms/form-validation/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/form-validation/" class="js-example">
 View example of form validation patterns
-</a>
+</a></div>
 
 ### Required
 
 By applying the class `.is-required` the attribute specifies that an input field must be filled out before submitting the form.
 
-<a href="/docs/examples/patterns/forms/forms-required/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/forms-required/" class="js-example">
 View example of an input required element
-</a>
+</a></div>
 
 ### Dense form elements
 
 In contexts where vertical space is limited, e.g. inside a table row, you might prefer form elements with reduced vertical padding. Add class `.is-dense` to achieve that:
 
-<a href="/docs/examples/patterns/forms/dense/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/dense/" class="js-example">
 View example of the dense form elements
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -15,17 +15,17 @@ to the right by adding the class `.u-align--right` to each individual cell,
 as in the example that follows. This is considered good practice when formatting
 data tables as it makes it easier to scan and compare the values quickly.
 
-<a href="/docs/examples/base/table/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/table/" class="js-example">
 View example of the base table
-</a>
+</a></div>
 
 ### Sortable
 
 Using the class `p-table--sortable` and assigning `role="columnheader"` and `aria-sort` to each `<th>` element will show each table column to be sortable. With javascript toggling between `ascending` and `descending` for the `aria-sort` attribute it will change the chevron icon in that direction.
 
-<a href="/docs/examples/patterns/tables/table-sortable/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/tables/table-sortable/" class="js-example">
 View example of the table sortable pattern
-</a>
+</a></div>
 
 ### Expanding
 
@@ -35,9 +35,9 @@ This pattern should be used when a table requires configuration fields (add, edi
 
 Using `p-table-expanding__panel` it can be hidden using the `aria-hidden` attribute. The table must contain all table cells required.
 
-<a href="/docs/examples/patterns/tables/table-expanding/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/tables/table-expanding/" class="js-example">
 View example of the expanding table pattern
-</a>
+</a></div>
 
 ### Responsive
 
@@ -46,9 +46,9 @@ an `[aria-label]` to describe the cell on a mobile screen. We use the content to
 
 The `<thead>` element is completely hidden from view on a smaller screen and if the table holds a `.p-contextual-menu` pattern all the children elements will be visible and be interactive.
 
-<a href="/docs/examples/patterns/tables/table-mobile-card/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/tables/table-mobile-card/" class="js-example">
 View example of the patterns table mobile card
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -75,9 +75,9 @@ heading order and semantics.
 In the following example, each heading is actually a `<p>` element that has been
 modified to look like a particular heading size.
 
-<a href="/docs/examples/patterns/headings/default/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/headings/default/" class="js-example">
 View example of the heading pattern
-</a>
+</a></div>
 
 <span class="p-label--deprecated">Deprecated</span> Heading classes with numbers as words (`p-heading--one`, `--two`, ...) are deprecated and will be removed in future release v3.0. Please use class names with numbers (`p-heading--1`, `--2`, ...) instead.
 
@@ -85,18 +85,18 @@ View example of the heading pattern
 
 Sub-headings visually convey importance beneath a heading, or a line of text that expands on the meaning of the heading immediately before it.
 
-<a href="/docs/examples/base/sub-headings/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/sub-headings/" class="js-example">
 View example of the heading pattern
-</a>
+</a></div>
 
 ### Mixed heading classes
 
 It is also possible to apply heading classes directly to heading elements if that
 better suits your document style and tree.
 
-<a href="/docs/examples/patterns/headings/mixed/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/headings/mixed/" class="js-example">
 View example of the mixed headings pattern
-</a>
+</a></div>
 
 ### Line length
 
@@ -105,9 +105,10 @@ Line length, measured in number of characters per line (CPL), has been shown to 
 The max-width of text elements in Vanilla Framework is limited using the `$max-width--default` variable, currently set to `40em`, or around 90 characters.
 
 Vanilla also includes a utility to unset the max-width where necessary &ndash; `u-no-max-width`:
-<a href="/docs/examples/utilities/max-width-unset/" class="js-example">
+
+<div class="embedded-example"><a href="/docs/examples/utilities/max-width-unset/" class="js-example">
 View example of how to unset max-width
-</a>
+</a></div>
 
 Overriding or unsetting the `max-width` is reasonable in certain cases:
 
@@ -118,70 +119,70 @@ Overriding or unsetting the `max-width` is reasonable in certain cases:
 
 Use an ordered list when the order of the items is important.
 
-<a href="/docs/examples/base/lists/ordered-list/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/lists/ordered-list/" class="js-example">
 View example of the base ordered list
-</a>
+</a></div>
 
 ### Unordered list
 
 Use an unordered list when the order of the items isn't important.
 
-<a href="/docs/examples/base/lists/unordered-list/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/lists/unordered-list/" class="js-example">
 View example of the base unordered list
-</a>
+</a></div>
 
 ### Definition list
 
 Use a definition list when you want to list a group of one or more terms and
 descriptions.
 
-<a href="/docs/examples/base/lists/definition-list/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/lists/definition-list/" class="js-example">
 View example of the base definition list
-</a>
+</a></div>
 
 ### Blockquotes and citations
 
-<a href="/docs/examples/base/blockquotes/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/blockquotes/" class="js-example">
 View example of the base blockquotes
-</a>
+</a></div>
 
 ### Small text
 
-<a href="/docs/examples/base/small/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/small/" class="js-example">
 View example of the small text
-</a>
+</a></div>
 
 ### Strong text
 
-<a href="/docs/examples/base/strong/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/strong/" class="js-example">
 View example of the strong text
-</a>
+</a></div>
 
 ### Superscripted text
 
-<a href="/docs/examples/base/sup/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/sup/" class="js-example">
 View example of the superscripted pattern
-</a>
+</a></div>
 
 ### Subscripted text
 
-<a href="/docs/examples/base/sub/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/sub/" class="js-example">
 View example of the subscripted pattern
-</a>
+</a></div>
 
 ### Abbreviation
 
-<a href="/docs/examples/base/abbr/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/abbr/" class="js-example">
 View example of the abbreviation pattern
-</a>
+</a></div>
 
 ### Font weights
 
 If you are using the Ubuntu font, it comes in five weights; thin, light, regular, medium, and bold.
 
-<a href="/docs/examples/base/font-weights/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/font-weights/" class="js-example">
 View example of the Ubuntu font weights.
-</a>
+</a></div>
 
 ### Using a smaller set of Latin font faces
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -151,31 +151,31 @@ When we add, make significant updates, or deprecate a component we update their 
 ### Status key
 
 <div class="row">
-  <div class="col-4 u-equal-height">
+  <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
       <div class="p-label--new">New</div>
       <p class="p-card__content">Newly released components, utilities or settings that are safe to use in projects.</p>
     </div>
   </div>
-  <div class="col-4 u-equal-height">
+  <div class="col-3 u-equal-height">
   <div class="p-card--highlighted">
       <div class="p-label--deprecated">Deprecated</div>
       <p class="p-card__content">These components, utilities or settings are in the process of being removed and should no longer be used in projects.</p>
     </div>
   </div>
-  <div class="col-4 u-equal-height">
+  <div class="col-3 u-equal-height">
   <div class="p-card--highlighted">
       <div class="p-label--in-progress">In progress</div>
       <p class="p-card__content">Design spec and code implementation are not yet finished.</p>
     </div>
   </div>
-  <div class="col-4 u-equal-height">
+  <div class="col-3 u-equal-height">
   <div class="p-card--highlighted">
       <div class="p-label--updated">Updated</div>
       <p class="p-card__content">These are existing components, utilities or settings that have been updated either through design or code.</p>
     </div>
   </div>
-  <div class="col-4 u-equal-height">
+  <div class="col-3 u-equal-height">
   <div class="p-card--highlighted">
       <div class="p-label--validated">Validated</div>
       <p class="p-card__content">Proposal approved in our bi-weekly meeting . A design spec is created and development starts ready for code review.</p>

--- a/templates/docs/customising-vanilla.md
+++ b/templates/docs/customising-vanilla.md
@@ -51,21 +51,21 @@ Your project may not warrant including all of Vanilla, in which case you can inc
 ### Related settings
 
 <div class="row">
-  <div class="col-4">
+  <div class="col-3">
   <ul class="p-list--divided">
   <li class="p-list__item"><a href="/docs/settings/animation-settings">Animation</a></li>
   <li class="p-list__item"><a href="/docs/settings/assets-settings">Assets</a></li>
   <li class="p-list__item"><a href="/docs/settings/breakpoint-settings">Breakpoint</a></li>
   </ul>
   </div>
-  <div class="col-4">
+  <div class="col-3">
   <ul class="p-list--divided">
   <li class="p-list__item"><a href="/docs/settings/color-settings">Color</a></li>
   <li class="p-list__item"><a href="/docs/settings/font-settings">Font</a></li>
   <li class="p-list__item"><a href="/docs/settings/layout-settings">Layout</a></li>
   </ul>
   </div>
-  <div class="col-4">
+  <div class="col-3">
   <ul class="p-list--divided">
   <li class="p-list__item"><a href="/docs/settings/placeholder-settings">Placeholder</a></li>
   <li class="p-list__item"><a href="/docs/settings/spacing-settings">Spacing</a></li>

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -1,62 +1,71 @@
-{% extends "_layouts/docs.html" %}
+{% extends "_layouts/_root.html" %}
+
+{% block custom_head %}
+    <link rel="stylesheet" href="/static/build/css/build.css" />
+{% endblock %}
 
 {% block title %}Component examples{% endblock %}
 
-{% block content %}
-<h2>Component examples</h2>
+{% block body %}
+<div class="p-strip is-bordered">
+  <div class="u-fixed-width">
+    <h2>Component examples</h2>
+    <hr>
+  </div>
 
-<hr>
+  <div class="row">
+    <div class="col-3">
+      <h3>Base elements</h3>
+      <nav>
+        <ul class="p-list">
+          {% for example in examples.base %}
+            <li class="p-list__item">
+              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </div>
+    <div class="col-3">
+      <h3>Components</h3>
+      <nav>
+        <ul class="p-list">
+          {% for example in examples.patterns %}
+            <li class="p-list__item">
+              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </div>
+    <div class="col-3">
+      <h3>Utilities</h3>
+      <nav>
+        <ul class="p-list">
+          {% for example in examples.utilities %}
+            <li class="p-list__item">
+              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </div>
+    <div class="col-3">
+      <h3>Templates</h3>
+      <nav>
+        <ul class="p-list">
+          {% for example in examples.templates %}
+            <li class="p-list__item">
+              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </div>
+  </div>
 
-<div class="row">
-  <div class="col-3">
-    <h3>Base elements</h3>
-    <nav>
-      <ul class="p-list">
-        {% for example in examples.base %}
-          <li class="p-list__item">
-            <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  </div>
-  <div class="col-3">
-    <h3>Components</h3>
-    <nav>
-      <ul class="p-list">
-        {% for example in examples.patterns %}
-          <li class="p-list__item">
-            <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  </div>
-  <div class="col-3">
-    <h3>Utilities</h3>
-    <nav>
-      <ul class="p-list">
-        {% for example in examples.utilities %}
-          <li class="p-list__item">
-            <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  </div>
-  <div class="col-3">
-    <h3>Templates</h3>
-    <nav>
-      <ul class="p-list">
-        {% for example in examples.templates %}
-          <li class="p-list__item">
-            <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
+  <div class="u-fixed-width">
+    <p><a href="/docs/examples/standalone">Examples using standalone component CSS for testing/debugging</a></p>
   </div>
 </div>
-
-<p><a href="/docs/examples/standalone">Examples using standalone component CSS for testing/debugging</a></p>
 {% endblock %}

--- a/templates/docs/examples/patterns/side-navigation/_toggle_script.js
+++ b/templates/docs/examples/patterns/side-navigation/_toggle_script.js
@@ -46,4 +46,4 @@ function setupSideNavigations(sideNavigationSelector) {
   sideNavigations.forEach(setupSideNavigation);
 }
 
-setupSideNavigations('[class*="p-side-navigation"]');
+setupSideNavigations('.p-side-navigation, .p-side-navigation--icons');

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -1,41 +1,45 @@
-{% extends "_layouts/docs.html" %}
+{% extends "_layouts/_root.html" %}
+
+{% block custom_head %}
+    <link rel="stylesheet" href="/static/build/css/build.css" />
+{% endblock %}
 
 {% block title %}Standalone component examples{% endblock %}
 
-{% block content %}
-<h2>Standalone component examples</h2>
-
-<hr>
-
-<div class="row">
-  <div class="col-8">
-    <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
+{% block body %}
+<div class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Standalone component examples</h2>
+      <hr>
+      <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
+    </div>
   </div>
-</div>
-<div class="row">
-  <div class="col-3">
-    <h3>Base elements</h3>
-    <nav>
-      <ul class="p-list">
-        {% for example in examples.base %}
-          <li class="p-list__item">
-            <a href="/docs/examples/standalone/{{ example.path }}" class="p-link">{{ example.title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  </div>
-  <div class="col-3">
-    <h3>Components</h3>
-    <nav>
-      <ul class="p-list">
-        {% for example in examples.patterns %}
-          <li class="p-list__item">
-            <a href="/docs/examples/standalone/{{ example.path }}" class="p-link">{{ example.title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
+  <div class="row">
+    <div class="col-3">
+      <h3>Base elements</h3>
+      <nav>
+        <ul class="p-list">
+          {% for example in examples.base %}
+            <li class="p-list__item">
+              <a href="/docs/examples/standalone/{{ example.path }}" class="p-link">{{ example.title }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </div>
+    <div class="col-3">
+      <h3>Components</h3>
+      <nav>
+        <ul class="p-list">
+          {% for example in examples.patterns %}
+            <li class="p-list__item">
+              <a href="/docs/examples/standalone/{{ example.path }}" class="p-link">{{ example.title }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -3,7 +3,7 @@
 
 {% block banner %}
 <div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png'); background-position: 75% 50%;">
-  <div class="p-content__row">
+  <div class="row">
     <h1>Vanilla documentation</h1>
     <p class="p-heading--four">Everything you need to get your project started with Vanilla.</p>
   </div>

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -1,4 +1,5 @@
 {% extends "_layouts/docs.html" %}
+
 {% block title %}Get started{% endblock %}
 
 {% block content %}

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -1,15 +1,6 @@
 {% extends "_layouts/docs.html" %}
 {% block title %}Get started{% endblock %}
 
-{% block banner %}
-<div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png'); background-position: 75% 50%;">
-  <div class="row">
-    <h1>Vanilla documentation</h1>
-    <p class="p-heading--four">Everything you need to get your project started with Vanilla.</p>
-  </div>
-</div>
-{% endblock %}
-
 {% block content %}
 <h2>Get started</h2>
 

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -9,25 +9,21 @@
 <p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
 
 <h3>Install</h3>
-<div class="row">
-  <div class="col-6">
-    <p>The recommended way to get Vanilla is with <a href="https://www.yarnpkg.com/" class="p-link--external">yarn</a>:</p>
-    <pre><code>yarn add vanilla-framework</code></pre>
-    <p>Or <a href="https://www.npmjs.com/" class="p-link--external">npm</a>:</p>
-    <pre><code>npm install vanilla-framework</code></pre>
-    <p>This will pull down the latest version into your local <code>node_modules</code> folder and save it into your project's dependencies in <code>package.json</code>.</p>
-  </div>
-  <div class="col-6">
-    <p>You can now reference Vanilla from your main Sass file - note that the path to <code>node_modules</code> might be different for your project:</p>
-    <pre><code>// Import the framework
+
+<p>The recommended way to get Vanilla is with <a href="https://www.yarnpkg.com/" class="p-link--external">yarn</a>:</p>
+<pre><code>yarn add vanilla-framework</code></pre>
+<p>Or <a href="https://www.npmjs.com/" class="p-link--external">npm</a>:</p>
+<pre><code>npm install vanilla-framework</code></pre>
+<p>This will pull down the latest version into your local <code>node_modules</code> folder and save it into your project's dependencies in <code>package.json</code>.</p>
+
+<p>You can now reference Vanilla from your main Sass file - note that the path to <code>node_modules</code> might be different for your project:</p>
+<pre><code>// Import the framework
 @import 'node_modules/vanilla-framework/scss/vanilla';
 
 // Include all of Vanilla Framework
 @include vanilla;</code></pre>
 
-    <p><em>For information on overriding settings and importing only parts of Vanilla, see <a href="/docs/customising-vanilla">Customising Vanilla</a>.</em></p>
-  </div>
-</div>
+<p><em>For information on overriding settings and importing only parts of Vanilla, see <a href="/docs/customising-vanilla">Customising Vanilla</a>.</em></p>
 
 <h3>Hotlink</h3>
 <p>You can add Vanilla directly to your markup:</p>

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -20,9 +20,9 @@ Each tab styling can be changed to open or collapse using `aria-expanded`, set `
   </p>
 </div>
 
-<a href="/docs/examples/patterns/accordion/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/accordion/" class="js-example">
 View example of the accordion pattern
-</a>
+</a></div>
 
 ### Functionality
 

--- a/templates/docs/patterns/article-pagination.md
+++ b/templates/docs/patterns/article-pagination.md
@@ -10,9 +10,9 @@ context:
 
 The article pagination component should be used to navigate from one article to the next, or previous, in chronological order.
 
-<a href="/docs/examples/patterns/article-pagination" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/article-pagination" class="js-example">
 View example of the pagination pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/breadcrumbs.md
+++ b/templates/docs/patterns/breadcrumbs.md
@@ -12,9 +12,9 @@ You can use the breadcrumbs pattern to indicate where the current page sits in
 the site's navigation. The separators between each item are added via CSS, so
 you don't have to include them manually.
 
-<a href="/docs/examples/patterns/breadcrumbs/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/breadcrumbs/" class="js-example">
 View example of the breadcrumbs pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -20,65 +20,65 @@ Buttons are clickable elements used to perform an action, you can apply `button`
 
 A base button is usually used alongside a neutral button.
 
-<a href="/docs/examples/patterns/buttons/base/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/base/" class="js-example">
 View example of the base button pattern
-</a>
+</a></div>
 
 ### Neutral
 
 A neutral button can be used to indicate a positive action that isn't necessarily the main call-to-action.
 
-<a href="/docs/examples/patterns/buttons/neutral/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/neutral/" class="js-example">
 View example of the neutral button pattern
-</a>
+</a></div>
 
 ### Positive
 
 A positive button can be used to indicate a positive action that is the main call-to-action.
 
-<a href="/docs/examples/patterns/buttons/positive/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/positive/" class="js-example">
 View example of the positive button pattern
-</a>
+</a></div>
 
 ### Negative
 
 A negative button can be used to indicate a negative action that is destructive or permanent.
 
-<a href="/docs/examples/patterns/buttons/negative/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/negative/" class="js-example">
 View example of the negative button pattern
-</a>
+</a></div>
 
 ### Brand
 
 You can use the brand button with the main color of your brand.
 
-<a href="/docs/examples/patterns/buttons/brand/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/brand/" class="js-example">
 View example of the brand button pattern
-</a>
+</a></div>
 
 ### Inline
 
 Should you wish to place a button after a line of inline text, as a CTA for example, you can do so by adding the state class `is-inline` to the button element.
 
-<a href="/docs/examples/patterns/buttons/inline/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/inline/" class="js-example">
 View example of the inline button pattern
-</a>
+</a></div>
 
 ### Dense
 
 In contexts where vertical space is limited, you might want a button with reduced vertical padding. Add class `.is-dense` to achieve that:
 
-<a href="/docs/examples/patterns/buttons/dense/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/dense/" class="js-example">
 View example of the dense button pattern
-</a>
+</a></div>
 
 ### Icon
 
 Should you wish to place an icon in a button. You will not want to button to become full width on small screens. Therefore, you can add the state class `has-icon` to the button. If the contrast between the icon chosen and the button background is not sufficient then the `is-dark` or `is-light` classes can be added to the icon where appropriate.
 
-<a href="/docs/examples/patterns/buttons/icon/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/icon/" class="js-example">
 View example of the icon button pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/card.md
+++ b/templates/docs/patterns/card.md
@@ -14,33 +14,33 @@ There are four card styles available to use in Vanilla: default, header, highlig
 
 The purpose of the default card is to display information, without user interaction.
 
-<a href="/docs/examples/patterns/card/default/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/card/default/" class="js-example">
 View example of the default card pattern
-</a>
+</a></div>
 
 ### Header
 
 The purpose of the header card is to display information, grouped under a heading.
 
-<a href="/docs/examples/patterns/card/header/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/card/header/" class="js-example">
 View example of the header card pattern
-</a>
+</a></div>
 
 ### Highlighted
 
 The purpose of the highlighted card should be used when you can interact with the content.
 
-<a href="/docs/examples/patterns/card/highlighted/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/card/highlighted/" class="js-example">
 View example of the highlighted card pattern
-</a>
+</a></div>
 
 ### Overlay
 
 The purpose of the overlay card is to make the text visible in conjunction with a strip image.
 
-<a href="/docs/examples/patterns/card/overlay/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/card/overlay/" class="js-example">
 View example of the patterns card overlay
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -29,9 +29,9 @@ Using direction modifiers will change the placement of the drop-down menu. By de
   </div>
 </div>
 
-<a href="/docs/examples/patterns/contextual-menu/default" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/contextual-menu/default" class="js-example">
 View example of the contextual menu pattern
-</a>
+</a></div>
 
 ### Indicator
 
@@ -43,9 +43,9 @@ If you require a drop-down button with a state indicator then the `p-contextual-
   </p>
 </div>
 
-<a href="/docs/examples/patterns/contextual-menu/with-indicator" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/contextual-menu/with-indicator" class="js-example">
 View example of the contextual menu pattern
-</a>
+</a></div>
 
 ### Functionality
 
@@ -60,9 +60,9 @@ The contextual menu uses Vanilla's light theme by default. There are two ways to
 - Change the default: go to `_settings_themes.scss` and set `$theme-default-p-contextual-menu` to `dark`
 - Override the default by adding a state to `p-contextual-menu`: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark:
 
-<a href="/docs/examples/patterns/contextual-menu/dark" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/contextual-menu/dark" class="js-example">
 View example of the contextual menu with an is-dark class
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -18,13 +18,13 @@ The target element will be hidden or shown with `aria-hidden="true"` or `false`.
 Using direction modifiers will change the placement of the drop-down menu. By default alignment is to the right of the parent pattern.
 
 <div class="row">
-  <div class="col-4">
+  <div class="col-3">
   <pre><code>.p-contextual-menu</code></pre>
   </div>
-  <div class="col-4">
+  <div class="col-3">
   <pre><code>.p-contextual-menu--left</code></pre>
   </div>
-  <div class="col-4">
+  <div class="col-3">
   <pre><code>.p-contextual-menu--center</code></pre>
   </div>
 </div>

--- a/templates/docs/patterns/grid.md
+++ b/templates/docs/patterns/grid.md
@@ -26,17 +26,17 @@ Layouts can be created combining rows with different number of columns to an ide
 
 Read also: [Breakpoints](/docs/settings/breakpoint-settings)
 
-<a href="/docs/examples/patterns/grid/default/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/default/" class="js-example">
     View example of the default grid
-</a>
+</a></div>
 
 ### Fixed width containers
 
 If you only want to constrain content so it matches the grid's fixed width, you can use the utility `.u-fixed-width`. It behaves as a grid `.row` with a single 12 column container inside:
 
-<a href="/docs/examples/utilities/fixed-width-container/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/fixed-width-container/" class="js-example">
     View example of a fixed width container
-</a>
+</a></div>
 
 ### Nested columns
 
@@ -44,9 +44,9 @@ Columns can be nested infinitely by adding `.row` classes within columns. When n
 • keep track of the context (available columns), which is equal to the number of columns spanned by the parent element.
 • Ensure `.col-*` classes are direct descendants of `.row` classes. Failing to do so will result in a broken layout.
 
-<a href="/docs/examples/patterns/grid/nested/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/nested/" class="js-example">
     View example of the nested columns within the grid
-</a>
+</a></div>
 
 ### Empty columns
 
@@ -56,15 +56,15 @@ To leave gap columns, use `col-start-{breakpoint}{index}`, e.g.: `col-start-larg
 
 `{index}` options: an integer between 1 and the available columns.
 
-<a href="/docs/examples/patterns/grid/empty-columns/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/empty-columns/" class="js-example">
     View example of the empty columns within the grid
-</a>
+</a></div>
 
 Please note, specifying a value that exceeds the available number of columns will result in incorrect offsets. This happens because the grid implicitly creates additional columns to accommodate the grid-column-start property. You should always keep track of how many available columns you have, especially when nesting. In the example below, we are indicating we want a `div` to span 3 columns, and start at position 7. This requires 10 total columns inside a `div` spanning only 4.
 
-<a href="/docs/examples/patterns/grid/incorrect-empty-columns/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/incorrect-empty-columns/" class="js-example">
 View example of the incorrect column offset within a nested grid
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/heading-icon.md
+++ b/templates/docs/patterns/heading-icon.md
@@ -11,25 +11,25 @@ context:
 
 A header can be emphasised by adding an icon alongside the text.
 
-<a href="/docs/examples/patterns/heading-icon/heading-icon/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/heading-icon/heading-icon/" class="js-example">
 View example of the pattern heading icons
-</a>
+</a></div>
 
 ### Stacked
 
 This variant positions the icon vertically with the text content for an alternate layout.
 
-<a href="/docs/examples/patterns/heading-icon/heading-icon-stacked/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/heading-icon/heading-icon-stacked/" class="js-example">
 View example of the pattern heading icon stacked
-</a>
+</a></div>
 
 ### Small
 
 The icon for this component is also available at a smaller size of 32 x 32 pixels rather than our default size of 60 x 60 pixels.
 
-<a href="/docs/examples/patterns/heading-icon/heading-icon-small/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/heading-icon/heading-icon-small/" class="js-example">
 View example of the pattern heading icon small
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -23,85 +23,85 @@ Our icons have two predefined color styles: light and dark. The light variant is
 <section>
   <div class="p-strip is-shallow u-no-padding--top">
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--plus" style="margin-right: 1rem;"></i>p-icon--plus</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--minus" style="margin-right: 1rem;"></i>p-icon--minus</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--expand" style="margin-right: 1rem;"></i>p-icon--expand</p>
       </div>
     </div>
 
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--collapse" style="margin-right: 1rem;"></i>p-icon--collapse</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--spinner" style="margin-right: 1rem;"></i>p-icon--spinner</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--drag" style="margin-right: 1rem;"></i>p-icon--drag</p>
       </div>
     </div>
 
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--close" style="margin-right: 1rem;"></i>p-icon--close</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--help" style="margin-right: 1rem;"></i>p-icon--help</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--information" style="margin-right: 1rem;"></i>p-icon--information</p>
       </div>
       </div>
 
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--delete" style="margin-right: 1rem;"></i>p-icon--delete</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--external-link" style="margin-right: 1rem;"></i>p-icon--external-link</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--contextual-menu" style="margin-right: 1rem;"></i>p-icon--contextual-menu</p>
       </div>
     </div>
 
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--menu" style="margin-right: 1rem;"></i>p-icon--menu</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--code" style="margin-right: 1rem;"></i>p-icon--code</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--copy" style="margin-right: 1rem;"></i>p-icon--copy</p>
       </div>
     </div>
 
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--search" style="margin-right: 1rem;"></i>p-icon--search</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--share" style="margin-right: 1rem;"></i>p-icon--share</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--user" style="margin-right: 1rem;"></i>p-icon--user</p>
       </div>
     </div>
 
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
       <i class="p-icon--share" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--share
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--anchor" style="margin-right: 1rem;"></i>p-icon--anchor</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--question" style="margin-right: 1rem;"></i>p-icon--question</p>
       </div>
     </div>
@@ -118,13 +118,13 @@ Alternatively to use light version of icons outside of the dark strip, add `is-l
 <section>
 <div class="p-strip--dark is-shallow u-no-padding--top" style="background-color: transparent;">
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+      <div class="p-card col-3 u-vertically-center" style="background-color:#111;">
         <p style="color: #fff;"><i class="p-icon--plus" style="margin-right: 1rem;"></i>p-icon--plus</p>
       </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+      <div class="p-card col-3 u-vertically-center" style="background-color:#111;">
         <p style="color: #fff;"><i class="p-icon--external-link" style="margin-right: 1rem;"></i>p-icon--external-link</p>
       </div>
-      <div class="p-card col-4 u-vertically-center" style="background-color:#111;">
+      <div class="p-card col-3 u-vertically-center" style="background-color:#111;">
         <p style="color: #fff;"><i class="p-icon--search" style="margin-right: 1rem;"></i>p-icon--search</p>
       </div>
     </div>
@@ -138,13 +138,13 @@ Our alert icons are used to indicate the status of a message in a notification.
 <section>
   <div class="p-strip is-shallow u-no-padding--top">
     <div class="row u-equal-height">
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--error" style="margin-right: 1rem;"></i>p-icon--error</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--warning" style="margin-right: 1rem;"></i>p-icon--warning</p>
       </div>
-      <div class="p-card col-4 u-vertically-center">
+      <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--success" style="margin-right: 1rem;"></i>p-icon--success</p>
       </div>
     </div>
@@ -158,39 +158,39 @@ Our social icons are used to drive users to social content.
 <section>
   <div class="p-strip is-shallow u-no-padding--top">
     <div class="row">
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--facebook" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--facebook
       </div>
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--instagram" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--instagram
       </div>
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--twitter" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--twitter
+      </div>
     </div>
 
     <div class="row">
-    <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-      <i class="p-icon--linkedin" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--linkedin
-    </div>
-    <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-      <i class="p-icon--youtube" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--youtube
-    </div>
-    <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
-      <i class="p-icon--rss" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--rss
-    </div>
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--linkedin" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--linkedin
+      </div>
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--youtube" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--youtube
+      </div>
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--rss" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--rss
+      </div>
     </div>
 
     <div class="row">
-      <div class="p-card col-4 u-vertically-center" style="display:flex; align-items:center;">
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--email" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--email
       </div>
     </div>
-    </div>
-
-<span class="p-label--deprecated">Deprecated</span> We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from our social icon set, they will no longer be available from our future release v3.0.
 
   </div>
 </section>
+
+<span class="p-label--deprecated">Deprecated</span> We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from our social icon set, they will no longer be available from our future release v3.0.
 
 ### Share
 

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -14,17 +14,17 @@ Enhance images by adding a variant style with a border or drop shadow.
 
 A simple key-line around your image.
 
-<a href="/docs/examples/patterns/image/bordered/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/image/bordered/" class="js-example">
 View example of image with border
-</a>
+</a></div>
 
 ### Image with drop shadow
 
 Add depth using our drop shadow around your image.
 
-<a href="/docs/examples/patterns/image/shadowed/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/image/shadowed/" class="js-example">
 View example of image with shadow
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/inline-images.md
+++ b/templates/docs/patterns/inline-images.md
@@ -10,9 +10,9 @@ context:
 
 The Inline images pattern can be used to showcase a group of related images, such as a group of customer or partner logos.
 
-<a href="/docs/examples/patterns/inline-images/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/inline-images/" class="js-example">
 View example of the inline images pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/labels.md
+++ b/templates/docs/patterns/labels.md
@@ -20,41 +20,41 @@ Labels are static elements which you can apply to signify status, tags or any ot
 
 Label to be used on newly released components, utilities or settings that are safe to use in projects.
 
-<a href="/docs/examples/patterns/labels/new/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/labels/new/" class="js-example">
 View example of the new label pattern
-</a>
+</a></div>
 
 ### Deprecated
 
 Label to be used on components, utilities or settings are in the process of being removed and should no longer be used in projects.
 
-<a href="/docs/examples/patterns/labels/deprecated/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/labels/deprecated/" class="js-example">
 View example of the deprecated label pattern
-</a>
+</a></div>
 
 ### In progress
 
 Label to be used when a design spec and code implementation are not yet finished.
 
-<a href="/docs/examples/patterns/labels/in-progress/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/labels/in-progress/" class="js-example">
 View example of the in progress label pattern
-</a>
+</a></div>
 
 ### Updated
 
 Label to be used on existing components, utilities or settings that have been updated either through design or code.
 
-<a href="/docs/examples/patterns/labels/updated/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/labels/updated/" class="js-example">
 View example of the updated label pattern
-</a>
+</a></div>
 
 ### Validated
 
 Label to be used on a proposal approved in our bi-weekly meeting. A design spec is created and development starts ready for code review.
 
-<a href="/docs/examples/patterns/labels/validated/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/labels/validated/" class="js-example">
 View example of the validated label pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/links.md
+++ b/templates/docs/patterns/links.md
@@ -14,9 +14,9 @@ Links are used to embed actions or pathways to more information, allowing users 
 
 Default links are a color defined by `$color-link` and are 10% darker when already visited.
 
-<a href="/docs/examples/base/links/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/base/links/" class="js-example">
 View example of the default link pattern
-</a>
+</a></div>
 
 ### External
 
@@ -30,33 +30,33 @@ The `.p-link--external` class should be used on hyperlinks that go to a differen
   </p>
 </div>
 
-<a href="/docs/examples/patterns/links/links-external/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/links/links-external/" class="js-example">
 View example of the external link pattern
-</a>
+</a></div>
 
 ### Soft
 
 The `.p-link--soft` class should be used on hyperlinks where many links are grouped together, such as a link cloud.
 
-<a href="/docs/examples/patterns/links/links-soft/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/links/links-soft/" class="js-example">
 View example of the soft link pattern
-</a>
+</a></div>
 
 ### Inverted
 
 The `.p-link--inverted` class should be used where links are placed on a dark background.
 
-<a href="/docs/examples/patterns/links/links-inverted/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/links/links-inverted/" class="js-example">
 View example of the inverted link pattern
-</a>
+</a></div>
 
 ### Back to top
 
 The `.p-top` link can be used to make it easier to go back to the top on long pages. If the page is divided into different sections, you can use more than one per page.
 
-<a href="/docs/examples/patterns/links/links-back-to-top/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/links/links-back-to-top/" class="js-example">
 View example of the back to top pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/list-tree.md
+++ b/templates/docs/patterns/list-tree.md
@@ -12,9 +12,9 @@ The list tree pattern can be used to show a directory style listing, such as a l
 
 Each directory can be opened or collapse using `aria-hidden`, set `true` for open and `false` to close on the nested list. Using JS this can be changed and should also update the `aria-expanded` attribute on the folder element.
 
-<a href="/docs/examples/patterns/list-tree/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/list-tree/" class="js-example">
 View example of the list tree pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -16,9 +16,9 @@ standard `<ol>` and `<ul>`, we have 7 list styles at your disposal.
 Use the class `.p-list` for a list without bullets and more spacing between
 items than the basic lists.
 
-<a href="/docs/examples/patterns/lists/list/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/list/" class="js-example">
 View example of the list pattern
-</a>
+</a></div>
 
 ### Ticked
 
@@ -30,60 +30,60 @@ Add the class `.is-ticked` to each list item to display tick icons.
   </p>
 </div>
 
-<a href="/docs/examples/patterns/lists/lists-ticked/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-ticked/" class="js-example">
 View example of the ticked list pattern
-</a>
+</a></div>
 
 ### Horizontal divider
 
 Use the class `.p-list--divided` to add horizontal lines between the items.
 
-<a href="/docs/examples/patterns/lists/lists-dividers/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-dividers/" class="js-example">
 View example of the divided list pattern
-</a>
+</a></div>
 
 ### Ticked with horizontal divider
 
 You can combine both `.is-ticked` and `.p-list--divided` to style a
 list with horizontal dividers and tick icons.
 
-<a href="/docs/examples/patterns/lists/lists-dividers-ticked/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-dividers-ticked/" class="js-example">
 View example of the ticked divided list pattern
-</a>
+</a></div>
 
 ### Responsive divider
 
 A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-medium`), the divider lines appear horizontally. On screens bigger than \$breakpoint-medium, the divider lines appear vertically, centered in the column gutters.
 
-<a href="/docs/examples/patterns/lists/divider/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/divider/" class="js-example">
 View example of lists with a responsive divider
-</a>
+</a></div>
 
 ### Inline
 
 Apply the class `.p-inline-list` to display all the list items in one line.
 
-<a href="/docs/examples/patterns/lists/lists-inline/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-inline/" class="js-example">
 View example of the inline list pattern
-</a>
+</a></div>
 
 ### Middot
 
 Apply the class `.p-inline-list--middot` to add a middot character between
 inline list items.
 
-<a href="/docs/examples/patterns/lists/lists-mid-dot/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-mid-dot/" class="js-example">
 View example of the middot list pattern
-</a>
+</a></div>
 
 ### Vertical stepped
 
 If you want to display a list of items that form a set of steps — like a
 tutorial or instructions — you can use the class `.p-stepped-list`.
 
-<a href="/docs/examples/patterns/lists/lists-stepped/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-stepped/" class="js-example">
 View example of the stepped list pattern
-</a>
+</a></div>
 
 ### Horizontal stepped
 
@@ -91,17 +91,17 @@ The stepped list should be used for step by step instructions. This pattern is b
 used on a `.p-strip--light` as the description sections are displayed in a white
 box.
 
-<a href="/docs/examples/patterns/lists/lists-stepped-detailed/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-stepped-detailed/" class="js-example">
 View example of the pattern stepped list detailed
-</a>
+</a></div>
 
 ### Split
 
 If you wish to split the items in a list into two columns above `$breakpoint-medium`, you can do so by adding the class `is-split` to the list element.
 
-<a href="/docs/examples/patterns/lists/lists-split/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-split/" class="js-example">
 View example of the patterns list split
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/matrix.md
+++ b/templates/docs/patterns/matrix.md
@@ -18,9 +18,9 @@ Items will display in one column on small screens. At resolutions above `$breakp
   </p>
 </div>
 
-<a href="/docs/examples/patterns/matrix/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/matrix/" class="js-example">
 View example of the matrix pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/media-object.md
+++ b/templates/docs/patterns/media-object.md
@@ -11,25 +11,25 @@ context:
 
 A media object should be used to display events or articles.
 
-<a href="/docs/examples/patterns/media-object/media-object/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/media-object/media-object/" class="js-example">
 View example of the pattern media object
-</a>
+</a></div>
 
 ### Circular
 
 You can add an `is-round` state to the `.p-media-object__image` element to create a circular image style, which we recommend to be used for head shots of people. In order for this variant to work, the original image must be square.
 
-<a href="/docs/examples/patterns/media-object/media-object-circ-img/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/media-object/media-object-circ-img/" class="js-example">
 View example of the pattern media object
-</a>
+</a></div>
 
 ### Large
 
 Use a large variant of the component to display details of a single object on a page.
 
-<a href="/docs/examples/patterns/media-object/media-object-large/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/media-object/media-object-large/" class="js-example">
 View example of the pattern media object large
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -12,9 +12,9 @@ The modal component can be used to overlay an area of the screen which can conta
 
 On `p-modal` set display to `display:flex` or `display:none` to toggle the visibility of the modal.
 
-<a href="/docs/examples/patterns/modal/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/modal/" class="js-example">
 View example of the modal pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/muted-heading.md
+++ b/templates/docs/patterns/muted-heading.md
@@ -11,9 +11,9 @@ context:
 
 A muted heading can be used to subtly provide context to content without the heading itself being too prominent.
 
-<a href="/docs/examples/patterns/headings/muted/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/headings/muted/" class="js-example">
 View example of the pattern muted heading
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -32,9 +32,9 @@ You can also manually override the background color of the navigation using the 
 You can change the breakpoint at which the menu changes to a small screen menu
 by adjusting the `$breakpoint-navigation-threshold` in `_settings_breakpoints.scss`.
 
-<a href="/docs/examples/patterns/navigation/default/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/navigation/default/" class="js-example">
 View example of the navigation pattern
-</a>
+</a></div>
 
 <span class="p-label--deprecated">Deprecated</span>
 
@@ -57,9 +57,9 @@ To open the subnav-menu you need to set the `is-active` class on `p-subnav` elem
 
 By default the sub-navigation menus are left-aligned with their parent, if you'd prefer the menu to be positioned from the right, use the `p-subnav__items--right` modifier. This can be seen in the "My account" menu in the example.
 
-<a href="/docs/examples/patterns/navigation/subnav" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/navigation/subnav" class="js-example">
 View example of the sub-navigation pattern
-</a>
+</a></div>
 
 ### Side navigation
 
@@ -73,9 +73,9 @@ Current page in the side navigation should be highlighted by adding `is-active` 
 
 Use `p-side-navigation__status` inside `p-side-navigation__link` elements to add status labels or icons on right side of navigation items.
 
-<a href="/docs/examples/patterns/side-navigation/docs" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/docs" class="js-example">
 View example of the side navigation pattern
-</a>
+</a></div>
 
 To add icons on the left side of the items in side navigation use the `.p-side-navigation--items` class.
 
@@ -85,9 +85,9 @@ To add icons on the left side of the items in side navigation use the `.p-side-n
   </p>
 </div>
 
-<a href="/docs/examples/patterns/side-navigation/icons" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/icons" class="js-example">
 View example of the side navigation pattern with icons
-</a>
+</a></div>
 
 #### JavaScript functionality
 

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -16,41 +16,41 @@ You can also include a close button using the `p-icon--close` pattern, although 
 
 The default variant should be used to display global messages.
 
-<a href="/docs/examples/patterns/notifications/notifications/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/notifications/" class="js-example">
 View example of the default notification pattern
-</a>
+</a></div>
 
 ### Caution
 
 The caution variant should be used to convey information that is not critical but the user should be aware of.
 
-<a href="/docs/examples/patterns/notifications/caution/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/caution/" class="js-example">
 View example of the caution notification pattern
-</a>
+</a></div>
 
 ### Negative
 
 The negative variant should be used to convey information that is critical and the user should take action.
 
-<a href="/docs/examples/patterns/notifications/negative/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/negative/" class="js-example">
 View example of the negative notification pattern
-</a>
+</a></div>
 
 ### Positive
 
 The positive variant should be used to convey success or completion.
 
-<a href="/docs/examples/patterns/notifications/positive/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/positive/" class="js-example">
 View example of the positive notification pattern
-</a>
+</a></div>
 
 ### Information
 
 The information variant should be used to convey an information message.
 
-<a href="/docs/examples/patterns/notifications/information/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/information/" class="js-example">
 View example of the information notification pattern
-</a>
+</a></div>
 
 ### Actions
 
@@ -62,9 +62,9 @@ Notifications have the ability to add an action link to them. These should appea
   </p>
 </div>
 
-<a href="/docs/examples/patterns/notifications/action/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/action/" class="js-example">
 View example of the caution notification pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/pagination.md
+++ b/templates/docs/patterns/pagination.md
@@ -10,25 +10,25 @@ context:
 
 The pagination component should be used to navigate between pages of content. Depending on the length provided, the pagination component will automatically scale.
 
-<a href="/docs/examples/patterns/pagination/pagination" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/pagination/pagination" class="js-example">
 View example of the pagination pattern
-</a>
+</a></div>
 
 ### Truncated
 
 When it is not possible to fit all pages into the component, a truncated option should be used to give the first, last and as many siblings of the current page as possible.
 
-<a href="/docs/examples/patterns/pagination/pagination-truncated" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/pagination/pagination-truncated" class="js-example">
 View example of the pagination pattern
-</a>
+</a></div>
 
 ### Disabled controls
 
 When a user is at the first or last item then the previous or next button, respectively, should be disabled.
 
-<a href="/docs/examples/patterns/pagination/pagination-disabled" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/pagination/pagination-disabled" class="js-example">
 View example of the pagination pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/pull-quote.md
+++ b/templates/docs/patterns/pull-quote.md
@@ -11,33 +11,33 @@ context:
 Use the pull quote pattern to highlight content from different sources in a
 visually prominent way.
 
-<a href="/docs/examples/patterns/pull-quotes/default/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/pull-quotes/default/" class="js-example">
 View example of the pull quote pattern
-</a>
+</a></div>
 
 ### Small
 
 A small variant is available which displays the quote text at the same size as normal paragraph text.
 
-<a href="/docs/examples/patterns/pull-quotes/small/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/pull-quotes/small/" class="js-example">
 View example of the small pull quote pattern
-</a>
+</a></div>
 
 ### Large
 
 To give more prominence to a quote, there is also a large variant.
 
-<a href="/docs/examples/patterns/pull-quotes/large/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/pull-quotes/large/" class="js-example">
 View example of the small pull quote pattern
-</a>
+</a></div>
 
 ### Image
 
 To add an image to any size of pull-quote, add the class `has-image` and use the following markup for the image.
 
-<a href="/docs/examples/patterns/pull-quotes/default-image/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/pull-quotes/default-image/" class="js-example">
 View example of the small pull quote pattern with an image
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/search-box.md
+++ b/templates/docs/patterns/search-box.md
@@ -14,17 +14,17 @@ Search boxes enable search functionality on a page and are typically used in a n
 
 The component expands to the full width of its container by default.
 
-<a href="/docs/examples/patterns/search-box/default/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/search-box/default/" class="js-example">
 View examples of search box patterns
-</a>
+</a></div>
 
 ### Navigation
 
 This component integrates with `.p-navigation__nav` for both small and large screens.
 
-<a href="/docs/examples/patterns/search-box/navigation/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/search-box/navigation/" class="js-example">
 View examples of search box navigation patterns
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/slider.md
+++ b/templates/docs/patterns/slider.md
@@ -11,9 +11,9 @@ context:
 The `p-slider__wrapper` and `p-slider__input` classes should be used with `<input type="range">` elements
 when you want to provide a numeric representation of the slider value, as well as allow the user to specify a value.
 
-<a href="/docs/examples/patterns/slider/slider-input/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/slider/slider-input/" class="js-example">
 View example of the slider pattern
-</a>
+</a></div>
 
 <span class="p-label--updated">Updated</span> In version 2.6.0 Vanilla framework added slider styling as default for
 all range inputs, so adding `p-slider` class just to style `<input type="range">` is not necessary any more.

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -12,22 +12,22 @@ The strip pattern provides a full width strip container in which to wrap a row. 
 
 A `.p-strip` container should always be the parent of a `.row` (from the [Grid pattern](/docs/patterns/grid/)) and never the other way around.
 
-<a href="/docs/examples/patterns/strips/strips-light/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/strips-light/" class="js-example">
 View example of the strip light pattern
-</a>
+</a></div>
 
-<a href="/docs/examples/patterns/strips/strips-dark/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/strips-dark/" class="js-example">
 View example of the strip dark pattern
-</a>
+</a></div>
 
 ### Accent strip
 
 The purpose of the strip accent pattern is to display content with a
 highlighted strip using the accent colour.
 
-<a href="/docs/examples/patterns/strips/accent/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/accent/" class="js-example">
 View example of the pattern strip accent
-</a>
+</a></div>
 
 ### Image strip
 
@@ -42,9 +42,9 @@ This pattern allows for an image background to be appear as a background on a st
 You can also add the classes '.is-light' and '.is-dark' to the strips to describe the background image.
 These classes will then override the text color to ensure it remains visible.
 
-<a href="/docs/examples/patterns/strips/image/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/image/" class="js-example">
 View example of the pattern strip image
-</a>
+</a></div>
 
 ### Bordered strip
 
@@ -56,25 +56,25 @@ This pattern is used to add a dividing border at the bottom of the strip.
   </p>
 </div>
 
-<a href="/docs/examples/patterns/strips/is-bordered/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/is-bordered/" class="js-example">
 View example of the pattern strip is-bordered
-</a>
+</a></div>
 
 ### Deep strip
 
 This state gives the strip larger vertical padding.
 
-<a href="/docs/examples/patterns/strips/deep/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/deep/" class="js-example">
 View example of the pattern strip is-deep
-</a>
+</a></div>
 
 ### Shallow strip
 
 This state gives the strip smaller vertical padding.
 
-<a href="/docs/examples/patterns/strips/shallow/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/shallow/" class="js-example">
 View example of the pattern strip is-shallow
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/switch.md
+++ b/templates/docs/patterns/switch.md
@@ -10,9 +10,9 @@ context:
 
 You can use this switch component to display on and off content, such as for settings or simple controls. By changing the `aria-checked` attribute from true or false will animate the switch on/off.
 
-<a href="/docs/examples/patterns/switch/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/switch/" class="js-example">
 View example of the switch pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/table-of-contents.md
+++ b/templates/docs/patterns/table-of-contents.md
@@ -10,9 +10,9 @@ context:
 
 A table of contents can be used to display supplementary links to a page.
 
-<a href="/docs/examples/patterns/table-of-contents/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/table-of-contents/" class="js-example">
 View example of the table of contents pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/patterns/tabs.md
+++ b/templates/docs/patterns/tabs.md
@@ -21,13 +21,13 @@ View example of the tabs pattern
 <div class="p-strip is-shallow">
   <h3>Usage</h3>
   <div class="row">
-    <div class="col-6">
+    <div class="col-4">
       <div class="p-notification--positive">
         <p class="p-notification__response"><span class="p-notification__status">Do:</span>Use when there are multiple categories, views or panes of content.</p>
       </div>
       <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/252d5420-navigation-tabs-color-do.png" alt="Tabs do">
     </div>
-    <div class="col-6">
+    <div class="col-4">
       <div class="p-notification--negative">
         <p class="p-notification__response"><span class="p-notification__status">Don't:</span>Mix tabs that contain only text, with tabs that contain icons.</p>
       </div>

--- a/templates/docs/patterns/tabs.md
+++ b/templates/docs/patterns/tabs.md
@@ -14,9 +14,9 @@ To select the active tab add the attribute `aria-selected="true"` and that list 
 
 To horizontally align the tab list with other content, the whole tab set can be contained within a `.row` element to provide correct gutters.
 
-<a href="/docs/examples/patterns/tabs/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/tabs/" class="js-example">
 View example of the tabs pattern
-</a>
+</a></div>
 
 <div class="p-strip is-shallow">
   <h3>Usage</h3>

--- a/templates/docs/patterns/tooltips.md
+++ b/templates/docs/patterns/tooltips.md
@@ -19,9 +19,9 @@ Tooltips are text labels that appear when the user hovers over, focuses on, or t
   </p>
 </div>
 
-<a href="/docs/examples/patterns/tooltips/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/tooltips/" class="js-example">
 View example of the tooltips pattern
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -3,7 +3,6 @@
 {% block title %}Search results{% if query %} for "{{query}}"{% endif %}{% endblock %}
 
 {% block content %}
-<div class="u-fixed-width">
   {% if results and results.entries %}
     <h1 class="p-heading--two">We've found these results for your search <strong>"{{ query }}"</strong></h1>
   {% else %}
@@ -41,5 +40,4 @@
   </div>
 
   {% endif %}
-</div>
 {% endblock %}

--- a/templates/docs/settings/animation-settings.md
+++ b/templates/docs/settings/animation-settings.md
@@ -43,9 +43,9 @@ Recommended durations for easing can be `easeInCubic` or `easeOutCubic`.
 
 Add a spin animation to an element with the following utility class.
 
-<a href="/docs/examples/utilities/animations/spin/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/animations/spin/" class="js-example">
 View example of the spin animation utility
-</a>
+</a></div>
 
 ### Reduced motion
 

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -12,25 +12,25 @@ These guidelines are the framework upon which we have built our system for how c
 
 <div class="p-strip is-shallow">
   <div class="row">
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #fff"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-x-light<br><span class="p-muted-heading">#fff</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #f7f7f7"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-light<br><span class="p-muted-heading">#f7f7f7</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #e5e5e5"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-mid-x-light<br><span class="p-muted-heading">#e5e5e5</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #cdcdcd"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-mid-light<br><span class="p-muted-heading">#cdcdcd</span>
@@ -38,25 +38,25 @@ These guidelines are the framework upon which we have built our system for how c
     </div>
   </div>
   <div class="row">
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #666"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-mid-dark<br><span class="p-muted-heading">#666</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #111"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-dark<br><span class="p-muted-heading">#111</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #000"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-x-dark<br><span class="p-muted-heading">#000</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #333"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-brand<br><span class="p-muted-heading">#333</span>
@@ -64,25 +64,25 @@ These guidelines are the framework upon which we have built our system for how c
     </div>
   </div>
   <div class="row">
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #c7162b"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-negative<br><span class="p-muted-heading">#c7162b</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #f99b11"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-caution<br><span class="p-muted-heading">#f99b11</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #0e8420"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-positive<br><span class="p-muted-heading">#0e8420</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #335280"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-information<br><span class="p-muted-heading">#335280</span>
@@ -90,25 +90,25 @@ These guidelines are the framework upon which we have built our system for how c
     </div>
   </div>
   <div class="row">
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #007aa6"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-link<br><span class="p-muted-heading">#007aa6</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #333"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-accent<br><span class="p-muted-heading">#333</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #333"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-accent-background<br><span class="p-muted-heading">#333</span>
       </p>
     </div>
-    <div class="col-3 p-card u-no-padding">
+    <div class="col-2 p-card u-no-padding">
       <div class="p-strip is-shallow is-bordered" style="background-color: #fff"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
         $color-navigation-background<br><span class="p-muted-heading">#fff</span>

--- a/templates/docs/settings/spacing-settings.md
+++ b/templates/docs/settings/spacing-settings.md
@@ -14,9 +14,9 @@ Vanilla uses numerous spacing variables across the codebase in order to ensure c
 
 Vanilla uses a default spacing unit of `.5rem` (`8px`) as a basis to calculate spacing inside and between components, as well as the line-heights of the different type sizes.
 
-<a href="/docs/examples/utilities/baseline-grid/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/baseline-grid/" class="js-example">
 View example of the baseline grid utility
-</a>
+</a></div>
 
 The example above shows headings sitting on the baseline grid, where the space between each red line is one `$sp-unit`.
 

--- a/templates/docs/utilities/align.md
+++ b/templates/docs/utilities/align.md
@@ -10,9 +10,9 @@ context:
 
 You can use these utilities to force the content inside an element to align center, left or right.
 
-<a href="/docs/examples/utilities/align/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/align/" class="js-example">
 View example of the content align utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/baseline-grid.md
+++ b/templates/docs/utilities/baseline-grid.md
@@ -10,9 +10,9 @@ context:
 
 You can apply this utility to an element (such as `<body>`) to visualise the `.5rem` baseline grid to which text elements adhere.
 
-<a href="/docs/examples/utilities/baseline-grid/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/baseline-grid/" class="js-example">
 View example of the baseline grid utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/clearfix.md
+++ b/templates/docs/utilities/clearfix.md
@@ -14,9 +14,9 @@ The clearfix is a way to combat the zero-height container problem for floated el
 
 In the example below, the parent wrapping container does not collapse even though it's only two children are floated.
 
-<a href="/docs/examples/utilities/clearfix/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/clearfix/" class="js-example">
 View example of the clearfix utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/embedded-media.md
+++ b/templates/docs/utilities/embedded-media.md
@@ -10,9 +10,9 @@ context:
 
 Embed media objects such as videos, maps and calendars.
 
-<a href="/docs/examples/utilities/embedded-media/" class="js-example" data-height="600">
+<div class="embedded-example"><a href="/docs/examples/utilities/embedded-media/" class="js-example" data-height="600">
 View example of the embedded media utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/equal-height.md
+++ b/templates/docs/utilities/equal-height.md
@@ -10,9 +10,9 @@ context:
 
 To ensure two or more elements have an equal height regardless of their content, add the class `.u-equal-height` to their wrapping parent element.
 
-<a href="/docs/examples/utilities/equal-height/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/equal-height/" class="js-example">
 View example of the equal height utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/floats.md
+++ b/templates/docs/utilities/floats.md
@@ -15,33 +15,33 @@ The float utilities allow you to float an element left or right.
 You can use the following to float an element on left or right on all screen
 sizes.
 
-<a href="/docs/examples/utilities/floats/default/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/floats/default/" class="js-example">
 View example of the all screen floats utility
-</a>
+</a></div>
 
 ### Only large screens
 
 You can limit floats to only large screen sizes using the following example.
 
-<a href="/docs/examples/utilities/floats/large-screens/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/floats/large-screens/" class="js-example">
 View example of the large screen floats utility
-</a>
+</a></div>
 
 ### Only medium screens
 
 You can limit floats to only medium screen sizes using the following example.
 
-<a href="/docs/examples/utilities/floats/medium-screens/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/floats/medium-screens/" class="js-example">
 View example of the medium screen floats utility
-</a>
+</a></div>
 
 ### Only small screens
 
 You can limit floats to only small screen sizes using the following example.
 
-<a href="/docs/examples/utilities/floats/small-screens/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/floats/small-screens/" class="js-example">
 View example of the small screen floats utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/font-metrics.md
+++ b/templates/docs/utilities/font-metrics.md
@@ -12,9 +12,9 @@ Being able to visualise the <a target="_blank" href="https://en.wikipedia.org/wi
 
 These properties are not directly accessible via css, but can be obtained from font-editing software like <a target="_blank" href="https://fontforge.github.io/">FontForge</a>. The values are stored in `_settings_font.scss` (the defaults apply to the Ubuntu font family). If you want to use this utility with another font, you will need to change the default values to match your font.
 
-<a href="/docs/examples/utilities/font-metrics/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/font-metrics/" class="js-example">
 View an example of the font metrics utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/hide.md
+++ b/templates/docs/utilities/hide.md
@@ -14,9 +14,9 @@ To hide an element from the user, use the class `u-hide`.
 
 To hide only at a specific viewport, add `--small`, `--medium` or `--large` modifiers to the `u-hide` class.
 
-<a href="/docs/examples/utilities/hide/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/hide/" class="js-example">
 View example of the Hide utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/image-position.md
+++ b/templates/docs/utilities/image-position.md
@@ -20,51 +20,51 @@ most cases it would be a strip.
 
 ### Bottom
 
-<a href="/docs/examples/utilities/image-position/bottom/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/image-position/bottom/" class="js-example">
 View example of the utilities image position bottom
-</a>
+</a></div>
 
 ### Top
 
-<a href="/docs/examples/utilities/image-position/top/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/image-position/top/" class="js-example">
 View example of the utilities image position top
-</a>
+</a></div>
 
 ### Left
 
-<a href="/docs/examples/utilities/image-position/left/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/image-position/left/" class="js-example">
 View example of the utilities image position top
-</a>
+</a></div>
 
 ### Right
 
-<a href="/docs/examples/utilities/image-position/right/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/image-position/right/" class="js-example">
 View example of the utilities image position top
-</a>
+</a></div>
 
 ### Top right
 
-<a href="/docs/examples/utilities/image-position/top-right/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/image-position/top-right/" class="js-example">
 View example of the utilities image position top right
-</a>
+</a></div>
 
 ### Top left
 
-<a href="/docs/examples/utilities/image-position/top-left/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/image-position/top-left/" class="js-example">
 View example of the utilities image position top left
-</a>
+</a></div>
 
 ### Bottom right
 
-<a href="/docs/examples/utilities/image-position/bottom-right/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/image-position/bottom-right/" class="js-example">
 View example of the utilities image position bottom right
-</a>
+</a></div>
 
 ### Bottom left
 
-<a href="/docs/examples/utilities/image-position/bottom-left/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/image-position/bottom-left/" class="js-example">
 View example of the utilities image position bottom left
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/margin-collapse.md
+++ b/templates/docs/utilities/margin-collapse.md
@@ -10,9 +10,9 @@ context:
 
 Remove one or more margins of an element.
 
-<a href="/docs/examples/utilities/margin-collapse/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/margin-collapse/" class="js-example">
 View example of the margin collapse utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/no-print.md
+++ b/templates/docs/utilities/no-print.md
@@ -13,9 +13,9 @@ Add the class `u-no-print` to elements you want to hide when the page is printed
 
 Use your browser's print preview to see the following example working.
 
-<a href="/docs/examples/utilities/no-print" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/no-print" class="js-example">
 View example of the no-print utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/off-screen.md
+++ b/templates/docs/utilities/off-screen.md
@@ -10,9 +10,9 @@ context:
 
 The `.u-off-screen` class will position an element out of the page flow and off-screen, while still making it available to screen readers.
 
-<a href="/docs/examples/utilities/off-screen/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/off-screen/" class="js-example">
 View example of the off-screen utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/padding-collapse.md
+++ b/templates/docs/utilities/padding-collapse.md
@@ -10,9 +10,9 @@ context:
 
 Remove one or more paddings on an element.
 
-<a href="/docs/examples/utilities/padding-collapse/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/padding-collapse/" class="js-example">
 View example of the padding collapse utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/show.md
+++ b/templates/docs/utilities/show.md
@@ -10,9 +10,9 @@ context:
 
 Show an element within a certain breakpoint.
 
-<a href="/docs/examples/utilities/show/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/show/" class="js-example">
 View example of the Show utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/docs/utilities/table-cell-padding-overlap.md
+++ b/templates/docs/utilities/table-cell-padding-overlap.md
@@ -12,6 +12,6 @@ Vanilla applies padding-top and padding bottom to table cells. This is done to p
 
 In some cases it can be helpful to override this behaviour for specific children of the table cell, e.g. a `button`:
 
-<a href="/docs/examples/utilities/table-cell-padding-overlap/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/table-cell-padding-overlap/" class="js-example">
 View example of the table padding overlap
-</a>
+</a></div>

--- a/templates/docs/utilities/truncate.md
+++ b/templates/docs/utilities/truncate.md
@@ -13,9 +13,9 @@ To truncate text, use the class `u-truncate`.
 When applied to a parent container, it will truncate any elements placed inside, so long as the parent's width is set.
 When applied to individual elements within a parent, e.g. a table cell, only those elements will be truncated.
 
-<a href="/docs/examples/utilities/truncate/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/truncate/" class="js-example">
 View example of the truncate utility
-</a>
+</a></div>
 
 Note: `u-truncate` will affect any tooltips placed inside.
 

--- a/templates/docs/utilities/vertically-center.md
+++ b/templates/docs/utilities/vertically-center.md
@@ -12,9 +12,9 @@ The `.u-vertically-center` class will vertically center the direct child of the 
 
 Note: only affects medium and large screens.
 
-<a href="/docs/examples/utilities/vertically-center/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/vertically-center/" class="js-example">
 View example of the vertically center utility
-</a>
+</a></div>
 
 ### Import
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -151,7 +151,7 @@
   <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>
 </div>
 
-<div class="p-strip">
+<div class="p-strip is-bordered">
   <div class="row">
     <h2 class="p-muted-heading u-align-text--center">Who&rsquo;s using Vanilla</h2>
   </div>
@@ -180,7 +180,7 @@
   </div>
 </div>
 
-<div class="p-strip--light">
+<div class="p-strip">
   <div class="row">
     <div class="col-3">
       <h2 class="p-heading--3">Contribute</h2>

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -1,43 +1,59 @@
-// Toggle mobile sidebar nav
-var sidebarToggle = document.querySelector('.p-sidebar__toggle');
-var sidebarContent = document.querySelector('.p-sidebar');
-var openMainNav = document.querySelector('.p-navigation__toggle--open');
+// Add table of contents to side navigation on documentation pages
 
-// if (sidebarToggle) {
-//   sidebarToggle.addEventListener('click', function(e) {
-//     sidebarToggle.classList.toggle('is-active');
-//     sidebarContent.classList.toggle('is-active');
-//   });
-// }
+// get all headings from page and add it to current highligted item in side navigation
+(function() {
+  let list = document.createElement('ul');
+  list.classList.add('p-side-navigation__list');
 
-if (openMainNav) {
-  openMainNav.addEventListener('click', function(e) {
-    //sidebarToggle.classList.remove('is-active');
-    sidebarContent.classList.remove('is-active');
+  let item = document.createElement('li');
+  item.classList.add('p-side-navigation__item');
+
+  let anchor = document.createElement('a');
+  anchor.classList.add('p-side-navigation__link');
+
+  // Add all H3s with IDs to the table of contents list
+  [].slice.call(document.querySelectorAll('main h3[id]')).forEach(function(heading) {
+    let thisItem = item.cloneNode();
+    let thisAnchor = anchor.cloneNode();
+    thisAnchor.setAttribute('href', '#' + heading.id);
+    thisAnchor.textContent = heading.textContent;
+    thisItem.appendChild(thisAnchor);
+    list.appendChild(thisItem);
   });
-}
 
-// Add classes to links
-var links = document.querySelectorAll('a');
-links.forEach(function(link) {
-  var parentClass = link.parentNode.classList;
-  var ignoreNav = !(parentClass.contains('p-navigation__logo') || parentClass.contains('p-navigation__link'));
+  // Add table of contents as nested list to side navigation
+  if (list.querySelectorAll('li').length > 0) {
+    let parent = document.querySelector('.p-side-navigation__link.is-active').parentNode;
 
-  var isInternal = link.href.indexOf('https://vanillaframework.io') === 0;
-
-  if (!isInternal && link.hostname && link.hostname != location.hostname && ignoreNav) {
-    link.className += ' p-link--external';
+    parent.appendChild(list);
   }
-});
+})();
+
+// Add class to exteral links
+(function() {
+  var links = document.querySelectorAll('a');
+  links.forEach(function(link) {
+    var parentClass = link.parentNode.classList;
+    var ignoreNav = !(parentClass.contains('p-navigation__logo') || parentClass.contains('p-navigation__link'));
+
+    var isInternal = link.href.indexOf('https://vanillaframework.io') === 0;
+
+    if (!isInternal && link.hostname && link.hostname != location.hostname && ignoreNav) {
+      link.className += ' p-link--external';
+    }
+  });
+})();
 
 // Docs search functions
-var searchDocsReset = document.getElementById('search-docs-reset');
-var searchBox = document.getElementById('search-docs');
+(function() {
+  var searchDocsReset = document.getElementById('search-docs-reset');
+  var searchBox = document.getElementById('search-docs');
 
-if (searchDocsReset) {
-  searchDocsReset.addEventListener('click', function(e) {
-    searchBox.value = '';
-    searchBox.focus();
-    e.preventDefault();
-  });
-}
+  if (searchDocsReset) {
+    searchDocsReset.addEventListener('click', function(e) {
+      searchBox.value = '';
+      searchBox.focus();
+      e.preventDefault();
+    });
+  }
+})();

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -29,6 +29,23 @@
   }
 })();
 
+// scroll active side navigation item into view (without scrolling whole page)
+(function() {
+  let sideNav = document.querySelector('.p-side-navigation');
+  let currentItem = document.querySelector('.p-side-navigation__link.is-active');
+
+  // calculate scroll by comparing top of side nav and top of active item
+  let currentItemOffset = currentItem.getBoundingClientRect().top;
+  let offset = currentItemOffset - sideNav.getBoundingClientRect().top;
+
+  // only scroll if active link is off screen or close to bottom of the window
+  if (currentItemOffset > window.innerHeight * 0.7) {
+    setTimeout(function() {
+      sideNav.scrollTop = offset;
+    }, 0);
+  }
+})();
+
 // Add class to exteral links
 (function() {
   var links = document.querySelectorAll('a');

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -3,16 +3,16 @@ var sidebarToggle = document.querySelector('.p-sidebar__toggle');
 var sidebarContent = document.querySelector('.p-sidebar');
 var openMainNav = document.querySelector('.p-navigation__toggle--open');
 
-if (sidebarToggle) {
-  sidebarToggle.addEventListener('click', function(e) {
-    sidebarToggle.classList.toggle('is-active');
-    sidebarContent.classList.toggle('is-active');
-  });
-}
+// if (sidebarToggle) {
+//   sidebarToggle.addEventListener('click', function(e) {
+//     sidebarToggle.classList.toggle('is-active');
+//     sidebarContent.classList.toggle('is-active');
+//   });
+// }
 
 if (openMainNav) {
   openMainNav.addEventListener('click', function(e) {
-    sidebarToggle.classList.remove('is-active');
+    //sidebarToggle.classList.remove('is-active');
     sidebarContent.classList.remove('is-active');
   });
 }

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -1,20 +1,100 @@
-// Add table of contents to side navigation on documentation pages
-
-// get all headings from page and add it to current highligted item in side navigation
+// Setup toggling of side navigation drawer
 (function() {
-  let list = document.createElement('ul');
+  // throttling function calls, by Remy Sharp
+  // http://remysharp.com/2010/07/21/throttling-function-calls/
+  var throttle = function(fn, delay) {
+    var timer = null;
+    return function() {
+      var context = this,
+        args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function() {
+        fn.apply(context, args);
+      }, delay);
+    };
+  };
+
+  /**
+    Toggles the expanded/collapsed classed on side navigation element.
+
+    @param {HTMLElement} sideNavigation The side navigation element.
+    @param {Boolean} show Whether to show or hide the drawer.
+  */
+  function toggleDrawer(sideNavigation, show) {
+    if (sideNavigation) {
+      if (show) {
+        sideNavigation.classList.remove('is-collapsed');
+        sideNavigation.classList.add('is-expanded');
+
+        // disable scroll on body when drawer is open
+        document.body.style.overflow = 'hidden';
+      } else {
+        sideNavigation.classList.remove('is-expanded');
+        sideNavigation.classList.add('is-collapsed');
+
+        // enable scroll on body when drawer is open
+        document.body.style.overflow = null;
+      }
+    }
+  }
+
+  /**
+    Attaches event listeners for the side navigation toggles
+    @param {HTMLElement} sideNavigation The side navigation element.
+  */
+  function setupSideNavigation(sideNavigation) {
+    var toggles = [].slice.call(sideNavigation.querySelectorAll('.js-drawer-toggle'));
+
+    toggles.forEach(function(toggle) {
+      toggle.addEventListener('click', function(event) {
+        event.preventDefault();
+        var sideNav = document.getElementById(toggle.getAttribute('aria-controls'));
+
+        if (sideNav) {
+          toggleDrawer(sideNav, !sideNav.classList.contains('is-expanded'));
+        }
+      });
+    });
+
+    // improvements for side nav when resizing the window
+    var sideNav = document.querySelector('.p-side-navigation');
+    var drawerEl = document.querySelector('.p-side-navigation__drawer');
+
+    window.addEventListener(
+      'resize',
+      throttle(function() {
+        var drawerPosition = window.getComputedStyle(drawerEl).position;
+
+        // when screen size changes from mobile (fixed drawer) to large screen
+        // enable scroll on body and reset any styles added by opening the drawer
+        if (drawerPosition !== 'fixed') {
+          sideNav.classList.remove('is-expanded');
+          sideNav.classList.remove('is-collapsed');
+          document.body.style.overflow = null;
+        }
+      }, 200)
+    );
+  }
+
+  setupSideNavigation(document.querySelector('.p-side-navigation'));
+})();
+
+// Add table of contents to side navigation on documentation pages
+(function() {
+  // get all headings from page and add it to current highligted item in side navigation
+  var list = document.createElement('ul');
   list.classList.add('p-side-navigation__list');
 
-  let item = document.createElement('li');
+  var item = document.createElement('li');
   item.classList.add('p-side-navigation__item');
 
-  let anchor = document.createElement('a');
+  var anchor = document.createElement('a');
   anchor.classList.add('p-side-navigation__link');
 
   // Add all H3s with IDs to the table of contents list
   [].slice.call(document.querySelectorAll('main h3[id]')).forEach(function(heading) {
-    let thisItem = item.cloneNode();
-    let thisAnchor = anchor.cloneNode();
+    var thisItem = item.cloneNode();
+    var thisAnchor = anchor.cloneNode();
     thisAnchor.setAttribute('href', '#' + heading.id);
     thisAnchor.textContent = heading.textContent;
     thisItem.appendChild(thisAnchor);
@@ -23,7 +103,7 @@
 
   // Add table of contents as nested list to side navigation
   if (list.querySelectorAll('li').length > 0) {
-    let parent = document.querySelector('.p-side-navigation__link.is-active').parentNode;
+    var parent = document.querySelector('.p-side-navigation__link.is-active').parentNode;
 
     parent.appendChild(list);
   }
@@ -31,12 +111,12 @@
 
 // scroll active side navigation item into view (without scrolling whole page)
 (function() {
-  let sideNav = document.querySelector('.p-side-navigation');
-  let currentItem = document.querySelector('.p-side-navigation__link.is-active');
+  var sideNav = document.querySelector('.p-side-navigation');
+  var currentItem = document.querySelector('.p-side-navigation__link.is-active');
 
   // calculate scroll by comparing top of side nav and top of active item
-  let currentItemOffset = currentItem.getBoundingClientRect().top;
-  let offset = currentItemOffset - sideNav.getBoundingClientRect().top;
+  var currentItemOffset = currentItem.getBoundingClientRect().top;
+  var offset = currentItemOffset - sideNav.getBoundingClientRect().top;
 
   // only scroll if active link is off screen or close to bottom of the window
   if (currentItemOffset > window.innerHeight * 0.7) {


### PR DESCRIPTION
## Done

Updated Vanilla navigation to use recommended documentation layout:

- responsive side navigation
- dark header
- updated existing content to fit new layout
- added some custom JS to scroll side navigation active item into view and to prevent scrolling document when mobile side navigation drawer is open

Fixes #2974 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2988.run.demo.haus/docs/)
- [Browse new docs](https://vanilla-framework-canonical-web-and-design-pr-2988.run.demo.haus/docs/), check if everything looks OK
  - try different docs pages ([code](https://vanilla-framework-canonical-web-and-design-pr-2988.run.demo.haus/docs/base/code), etc)
  - some use grid: ([icons](https://vanilla-framework-canonical-web-and-design-pr-2988.run.demo.haus/docs/patterns/icons), [component status](https://vanilla-framework-canonical-web-and-design-pr-2988.run.demo.haus/docs/component-status)
  - check updated [examples listing](https://vanilla-framework-canonical-web-and-design-pr-2988.run.demo.haus/docs/examples)
  - try search
  - check home page and other pages

Make sure to try on different screen sizes (with side navigation visible, and with a toggle on small screens). 

- open side navigation drawer on small screen
  - verify that side nav can be scrolled, but document body doesn't scroll
  - resize screen back to desktop size, make sure scroll works as expected


## Screenshots

<img width="1152" alt="Screenshot 2020-04-20 at 13 55 19" src="https://user-images.githubusercontent.com/83575/79749000-ab9a0500-830e-11ea-9b7d-ea84d5740199.png">

## Tasks

- [x] what to do with hero on docs home page? - removed
- [x] use dark navigation
- [x] codepens are even smaller that previously
- [x] update pages that use grid in content
- [x] what to do with table of contents (currently removed)
  - experiment with adding to side navigation
  - DONE, but it seems quite useless for pages very low in side navigation, because you need to scroll to table of contents anyway
- [x] sticky side navigation
- [x] make active side nav element scroll into view
- [x] disable scroll on body when mobile side navigation is open (via JS)