### PR TITLE
Documentation layout documentation

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -100,6 +100,11 @@
             </ul>
 
             <ul class="p-side-navigation__list">
+              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
+              <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/layouts/documentation' %}is-active{% endif %}" href="/docs/layouts/documentation">Documentation</a></li>
+            </ul>
+
+            <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Settings</span></li>
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/animation-settings' %}is-active{% endif %}" href="/docs/settings/animation-settings">Animations</a></li>
               <li class="p-side-navigation__item"><a class="p-side-navigation__link {% if path == '/docs/settings/assets-settings' %}is-active{% endif %}" href="/docs/settings/assets-settings">Assets</a></li>

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -51,6 +51,16 @@
       </nav>
     </div>
     <div class="col-3">
+      <h3>Layouts</h3>
+      <nav>
+        <ul class="p-list">
+          {% for example in examples.layouts %}
+            <li class="p-list__item">
+              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
       <h3>Templates</h3>
       <nav>
         <ul class="p-list">

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -1,0 +1,278 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Documentation{% endblock %}
+
+{% block content %}
+<header id="navigation" class="p-navigation is-dark">
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__item" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="" width="95" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__items" role="menu">
+        <li class="p-navigation__item is-selected" role="menuitem">
+          <a class="p-navigation__link" href="#">Docs</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a class="p-navigation__link" href="#">About</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<section id="search-docs" class="p-strip--light is-shallow">
+  <div class="row">
+    <form class="p-search-box u-no-margin--bottom" action="#">
+      <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" />
+      <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close">Close</i></button>
+      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
+    </form>
+  </div>
+</section>
+
+<div class="p-strip is-shallow">
+  <div class="row">
+    <aside class="col-3">
+      <nav class="p-side-navigation" id="drawer">
+        <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+          Toggle side navigation
+        </button>
+
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+
+        <div class="p-side-navigation__drawer">
+          <div class="p-side-navigation__drawer-header">
+            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle side navigation
+            </button>
+          </div>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item--title">
+              <a class="p-side-navigation__link">Side navigation</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">First page</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Second page</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Third page</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <span class="p-side-navigation__text is-selected">Sub section</span>
+              <ul class="p-side-navigation__list">
+                <li class="p-side-navigation__item">
+                  <a class="p-side-navigation__link" href="#">Second level link</a>
+                </li>
+                <li class="p-side-navigation__item ">
+                  <a class="p-side-navigation__link is-active" href="#">Current page</a>
+                </li>
+                <li class="p-side-navigation__item ">
+                  <a class="p-side-navigation__link" href="#">Another second level link</a>
+                </li>
+              </ul>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Last page</a>
+            </li>
+          </ul>
+
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item--title">
+              <a class="p-side-navigation__link">Another group</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">First page</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Second page</a>
+            </li>
+            <li class="p-side-navigation__item ">
+              <a class="p-side-navigation__link" href="#">Third page</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </aside>
+
+    <main class="col-9" id="main-content">
+      <h1>Main documentation content</h1>
+      <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
+
+      <h2>Examples</h2>
+
+      <p>Below you can find examples of components commonly used in documentation</p>
+
+      <h3>Code blocks</h3>
+      <pre><code>// Import Vanilla framework
+@import 'vanilla-framework/scss/vanilla';
+
+// Include base Vanilla styles
+@include vf-base;
+
+// Include the components you want
+@include vf-p-buttons;
+@include vf-p-forms;
+@include vf-p-links;
+</code></pre>
+
+      <h3>Lists</h3>
+
+      <ul>
+        <li><a href="#docs/what-is-maas">What is MAAS – and what does it really do for me?</a></li>
+        <li><a href="#docs/maas-example-config">Can you show me an example datacentre using MAAS?</a></li>
+        <li><a href="#docs/what-is-maas#heading--how-maas-works">How does MAAS work, in detail?</a></li>
+        <li><a href="#docs/concepts-and-terms">What concepts might I need to understand before starting?</a></li>
+        <li><a href="#docs/explore-maas">Can I just install it and try it for myself?</a></li>
+      </ul>
+
+      <h3>Tables</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Interface name</th>
+            <th>Description</th>
+            <th>Auto-connect</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="#docs/account-control-interface">account-control</a></td>
+            <td>add/remove user accounts or change passwords</td>
+            <td>no</td>
+          </tr>
+          <tr>
+            <td><a href="#docs/accounts-service-interface">accounts-service</a></td>
+            <td>allows communication with the accounts service</td>
+            <td>no</td>
+          </tr>
+          <tr>
+            <td><a href="#docs/adb-support-interface">adb-support</a></td>
+            <td>allows operating as Android Debug Bridge service</td>
+            <td>no</td>
+          </tr>
+          <tr>
+            <td><a href="#docs/alsa-interface">alsa</a></td>
+            <td>play or record sound</td>
+            <td>no</td>
+          </tr>
+          <tr>
+            <td><a href="#docs/appstream-metadata-interface">appstream-metadata</a></td>
+            <td>allows access to AppStream metadata</td>
+            <td>no</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Notifications</h3>
+
+      <div class="p-notification">
+        <p class="p-notification__response">
+          In versions prior to <code>v.2.6.1</code> the <code>add-cloud</code> command only operates locally (there is no <code>--local</code> option).
+        </p>
+      </div>
+
+      <div class="p-notification--caution">
+        <p class="p-notification__response">
+          Multi-cloud functionality via <code>add-cloud</code> (not <code>add-k8s</code>) is available as “early access” and requires the use of a feature flag. Once the controller
+          is created, you can enable it with: <code>juju controller-config features="[multi-cloud]"</code>
+        </p>
+      </div>
+
+      <div class="p-notification--information">
+        <p class="p-notification__response">
+          Last updated 29 days ago.
+          <a href="#clouds/1100">Help improve this document in the forum</a>.
+        </p>
+      </div>
+
+      <h3>Grid</h3>
+
+      <p>Main documentation content block is contained in grid <code>col-9</code>.</p>
+
+      <p>For two columns split use two <code>col-4</code> columns.</p>
+      <div class="row">
+        <div class="col-4">
+          <ul class="p-list">
+            <li class="p-list__item"><a href="#docs/whats-new-2-6">New features in 2.6&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/clouds">Clouds&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/vsphere-cloud">Using VMware vSphere with Juju&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/k8s-cloud">Using Kubernetes with Juju&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/k8s-charms-tutorial">Understanding Kubernetes charms&nbsp;›</a></li>
+          </ul>
+        </div>
+        <div class="col-4">
+          <ul class="p-list">
+            <li class="p-list__item"><a href="#docs/migrating-models">Migrating models&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/bundle-reference">Bundle reference&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/microk8s-cloud">Using Juju with MicroK8s&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/removing-things">Removing things&nbsp;›</a></li>
+            <li class="p-list__item"><a href="#docs/controller-logins">Controller logins&nbsp;›</a></li>
+          </ul>
+        </div>
+      </div>
+
+      <p>For three columns split use three <code>col-3</code> columns.</p>
+
+      <div class="row">
+        <div class="col-3">
+          <ul class="p-list--divided">
+            <li class="p-list__item"><a href="#docs/settings/animation-settings">Animation</a></li>
+            <li class="p-list__item"><a href="#docs/settings/assets-settings">Assets</a></li>
+            <li class="p-list__item"><a href="#docs/settings/breakpoint-settings">Breakpoint</a></li>
+          </ul>
+        </div>
+        <div class="col-3">
+          <ul class="p-list--divided">
+            <li class="p-list__item"><a href="#docs/settings/color-settings">Color</a></li>
+            <li class="p-list__item"><a href="#docs/settings/font-settings">Font</a></li>
+            <li class="p-list__item"><a href="#docs/settings/layout-settings">Layout</a></li>
+          </ul>
+        </div>
+        <div class="col-3">
+          <ul class="p-list--divided">
+            <li class="p-list__item"><a href="#docs/settings/placeholder-settings">Placeholder</a></li>
+            <li class="p-list__item"><a href="#docs/settings/spacing-settings">Spacing</a></li>
+          </ul>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<footer class="p-strip--light">
+  <nav class="row">
+    <div class="has-cookie">
+      <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item">
+          <a href="#"><small>Legal information</small></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="#"><small>Report a bug on this site</small></a>
+        </li>
+      </ul>
+      <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
+    </div>
+  </nav>
+</footer>
+
+<script>
+  {% include "docs/examples/patterns/side-navigation/_example_script.js" %}
+  {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
+</script>
+
+<style>
+  body { margin: 0; }
+</style>
+{% endblock %}

--- a/templates/docs/layouts/documentation.md
+++ b/templates/docs/layouts/documentation.md
@@ -1,0 +1,82 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Documentation | Layouts
+---
+
+## Documentation layout
+
+<hr>
+
+Documentation page layout can be build using Vanilla grid and common components. It consists of header with main navigation, optional hero strip (that may contain search field), grid based content area and a footer.
+
+### Structure
+
+#### Heading
+
+Heading with the main navigation is build with [navigation component](/docs/patterns/navigation#global-navigation).
+
+Style and contents of documentation main navigation should be consistent with rest of the site.
+
+Documentation pages may have an optional search box in the main navigation.
+
+#### Hero
+
+Documentation pages can have a hero area above main content area. This part of the page will usually contain a search field.
+
+Hero area is build with strip component with grid row inside. Usually it would be shallow light strip (`.p-strip--light is-shallow`), but the specific styling can be customised to match the site branding or other design requirements.
+
+#### Content area
+
+Content area is placed inside a regular strip (`.p-strip`) and a grid row (`.row`). Within standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) reserved for main documentation content.
+
+Sidebar should contain only the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items in side navigation component should be used to build the logical structure of documentation navigation. Side navigation component has built-in responsive functionality which makes the sidebar expandable on small screens.
+
+Main navigation area is placed in `col-9` grid container. Within this area 9 grid columns are available. For most of documentation content standard flow of the document should be enough in the main content. Default base styling of Vanilla will provide proper spacing for the documentation content.
+
+In cases when grid is used in documentation content for some specific layout, the maximum of 9 columns should be used.
+
+<div class="grid-demo">
+  <div class="row">
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+  </div>
+</div>
+
+To create 3 part split of the page use `col-3`:
+
+<div class="grid-demo">
+  <div class="row">
+    <div class="col-3">.col-3</div>
+    <div class="col-3">.col-3</div>
+    <div class="col-3">.col-3</div>
+  </div>
+</div>
+
+To create 2 part split of the page use `col-4`:
+
+<div class="grid-demo">
+  <div class="row">
+    <div class="col-4">.col-4</div>
+    <div class="col-4">.col-4</div>
+  </div>
+</div>
+
+#### Footer
+
+Footer is build with a [strip component](/docs/patterns/strip). Footer documentation pages should be consistent with the rest of the site.
+
+### Example
+
+<div class="embedded-example"><a href="/docs/examples/layouts/documentation/" class="js-example" data-height="600">
+View example of the documentation layout
+</a></div>
+
+[View full screen example of the documentation layout](/docs/examples/layouts/documentation/).

--- a/templates/docs/layouts/documentation.md
+++ b/templates/docs/layouts/documentation.md
@@ -12,7 +12,7 @@ context:
 
 The documentation layout is built using Vanilla grid classes and common components. It consists of 3 horizontal areas that span the entire fixed width of the grid: header, content, footer.
 
-![Documentation layout structure](https://assets.ubuntu.com/v1/cdf09557-Documentation+layout%401x.svg)
+![Documentation layout structure](https://assets.ubuntu.com/v1/2725610a-Documentation+layout+text+to+curves.svg)
 
 At the large breakpoint, the content area is further divided into an aside (3 columns) and a main content area (9 columns).
 

--- a/templates/docs/layouts/documentation.md
+++ b/templates/docs/layouts/documentation.md
@@ -8,31 +8,31 @@ context:
 
 <hr>
 
-Documentation page layout can be build using Vanilla grid and common components. It consists of header with main navigation, optional hero strip (that may contain search field), grid based content area and a footer.
+Documentation page layout can be built using the Vanilla frameworks grid and common components. It consists of a header containing main navigation, optional hero strip (that may contain search field), grid-based content area and a footer.
 
 ### Structure
 
 #### Heading
 
-Heading with the main navigation is build with [navigation component](/docs/patterns/navigation#global-navigation).
+The heading with the main navigation, built with the [navigation component](/docs/patterns/navigation#global-navigation).
 
-Style and contents of documentation main navigation should be consistent with rest of the site.
+Style and contents of the documentation main navigation should be consistent with rest of the site.
 
 Documentation pages may have an optional search box in the main navigation.
 
 #### Hero
 
-Documentation pages can have a hero area above main content area. This part of the page will usually contain a search field.
+Documentation pages can have a hero area above the main content area. This part of the page will usually contain a search field.
 
-Hero area is build with strip component with grid row inside. Usually it would be shallow light strip (`.p-strip--light is-shallow`), but the specific styling can be customised to match the site branding or other design requirements.
+The hero area is built with the [Strip component](/docs/patterns/strip) with grid row inside. Usually, it would be shallow light strip (`.p-strip--light is-shallow`), but the specific styling can be customised to match the site branding or other design requirements.
 
 #### Content area
 
-Content area is placed inside a regular strip (`.p-strip`) and a grid row (`.row`). Within standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) reserved for main documentation content.
+The content area is placed inside a regular strip (`.p-strip`) and a grid row (`.row`). Within the standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) is deadicated to the main documentation content.
 
 Sidebar should contain only the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items in side navigation component should be used to build the logical structure of documentation navigation. Side navigation component has built-in responsive functionality which makes the sidebar expandable on small screens.
 
-Main navigation area is placed in `col-9` grid container. Within this area 9 grid columns are available. For most of documentation content standard flow of the document should be enough in the main content. Default base styling of Vanilla will provide proper spacing for the documentation content.
+The main content area is placed in `col-9` grid container. Within this area 9 grid columns are available. For most of the documentation content standard flow of the document should be enough in the main content. Default base styling of Vanilla will provide proper spacing for the documentation content.
 
 In cases when grid is used in documentation content for some specific layout, the maximum of 9 columns should be used.
 

--- a/templates/docs/layouts/documentation.md
+++ b/templates/docs/layouts/documentation.md
@@ -8,29 +8,33 @@ context:
 
 <hr>
 
-Documentation page layout can be built using the Vanilla frameworks grid and common components. It consists of a header containing main navigation, optional hero strip (that may contain search field), grid-based content area and a footer.
-
 ### Structure
 
-#### Heading
+The documentation page layout can be built using the Vanilla grid classes and common components. It consists of 3 horizontal areas that span the entire fixed width of the grid: header, content, footer.
 
-The heading with the main navigation, built with the [navigation component](/docs/patterns/navigation#global-navigation).
+![Documentation layout structure](https://assets.ubuntu.com/v1/cdf09557-Documentation+layout%401x.svg)
+
+At the large breakpoint, the content area is further divided into an aside (3 columns) and a main content area (9 columns).
+
+At smaller breakpoints, the aside is moved offscreen and shown / hidden using a toggle.
+
+#### Header
+
+The header with the main navigation, built with the [navigation component](/docs/patterns/navigation#global-navigation).
 
 Style and contents of the documentation main navigation should be consistent with rest of the site.
 
+##### Search
+
 Documentation pages may have an optional search box in the main navigation.
 
-#### Hero
-
-Documentation pages can have a hero area above the main content area. This part of the page will usually contain a search field.
-
-The hero area is built with the [Strip component](/docs/patterns/strip) with grid row inside. Usually, it would be shallow light strip (`.p-strip--light is-shallow`), but the specific styling can be customised to match the site branding or other design requirements.
+Alternatively search can be added in a full-width area under the top navigation, but above the aside and main content in a [strip component](/docs/patterns/strip) with grid row inside. Usually, it would be shallow light strip (`.p-strip--light is-shallow`), but the specific styling can be customised to match the site branding or other design requirements.
 
 #### Content area
 
-The content area is placed inside a regular strip (`.p-strip`) and a grid row (`.row`). Within the standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) is deadicated to the main documentation content.
+The content area is implemented as a regular strip (`.p-strip`) with a grid row (`.row`) inside. Within the standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) is deadicated to the main documentation content.
 
-Sidebar should contain only the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items in side navigation component should be used to build the logical structure of documentation navigation. Side navigation component has built-in responsive functionality which makes the sidebar expandable on small screens.
+Sidebar should contain only the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items should be used to build the logical structure of documentation navigation. Side navigation component has built-in responsive functionality which makes the sidebar expandable on small screens.
 
 The main content area is placed in `col-9` grid container. Within this area 9 grid columns are available. For most of the documentation content standard flow of the document should be enough in the main content. Default base styling of Vanilla will provide proper spacing for the documentation content.
 

--- a/templates/docs/layouts/documentation.md
+++ b/templates/docs/layouts/documentation.md
@@ -10,7 +10,7 @@ context:
 
 ### Structure
 
-The documentation page layout can be built using the Vanilla grid classes and common components. It consists of 3 horizontal areas that span the entire fixed width of the grid: header, content, footer.
+The documentation layout is built using Vanilla grid classes and common components. It consists of 3 horizontal areas that span the entire fixed width of the grid: header, content, footer.
 
 ![Documentation layout structure](https://assets.ubuntu.com/v1/cdf09557-Documentation+layout%401x.svg)
 
@@ -20,7 +20,7 @@ At smaller breakpoints, the aside is moved offscreen and shown / hidden using a 
 
 #### Header
 
-The header with the main navigation, built with the [navigation component](/docs/patterns/navigation#global-navigation).
+Place the [navigation component](/docs/patterns/navigation#global-navigation) and any other full width elements in the header. This could include a strip with a search, a hero element, etc.
 
 Style and contents of the documentation main navigation should be consistent with rest of the site.
 
@@ -28,17 +28,17 @@ Style and contents of the documentation main navigation should be consistent wit
 
 Documentation pages may have an optional search box in the main navigation.
 
-Alternatively search can be added in a full-width area under the top navigation, but above the aside and main content in a [strip component](/docs/patterns/strip) with grid row inside. Usually, it would be shallow light strip (`.p-strip--light is-shallow`), but the specific styling can be customised to match the site branding or other design requirements.
+Alternatively, a search can be added in a full-width area under the top navigation, but above the aside and main content in a [strip component](/docs/patterns/strip) with grid row inside. The specific styling of the strip can be customised to match the site branding or other design requirements.
 
 #### Content area
 
 The content area is implemented as a regular strip (`.p-strip`) with a grid row (`.row`) inside. Within the standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) is deadicated to the main documentation content.
 
-Sidebar should contain only the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items should be used to build the logical structure of documentation navigation. Side navigation component has built-in responsive functionality which makes the sidebar expandable on small screens.
+The aside area should contain the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items should be used to build the logical structure of the documentation navigation. The side navigation component has built-in responsive functionality which makes it appear / go offscreen using a toggle.
 
-The main content area is placed in `col-9` grid container. Within this area 9 grid columns are available. For most of the documentation content standard flow of the document should be enough in the main content. Default base styling of Vanilla will provide proper spacing for the documentation content.
+The main content area is placed in a `col-9` grid container. Note that the number of columns available to use by content inside this container is equal to the number of columns the container spans. For the main content this means 9 available columns.
 
-In cases when grid is used in documentation content for some specific layout, the maximum of 9 columns should be used.
+A visualisation of the grid, and how to nest different layouts inside the main content container:
 
 <div class="grid-demo">
   <div class="row">
@@ -54,7 +54,7 @@ In cases when grid is used in documentation content for some specific layout, th
   </div>
 </div>
 
-To create 3 part split of the page use `col-3`:
+To split the main content area into 3 parts, use `col-3`:
 
 <div class="grid-demo">
   <div class="row">
@@ -64,7 +64,7 @@ To create 3 part split of the page use `col-3`:
   </div>
 </div>
 
-To create 2 part split of the page use `col-4`:
+To split the main content into 2 parts, use `col-4`:
 
 <div class="grid-demo">
   <div class="row">
@@ -75,12 +75,12 @@ To create 2 part split of the page use `col-4`:
 
 #### Footer
 
-Footer is build with a [strip component](/docs/patterns/strip). Footer documentation pages should be consistent with the rest of the site.
+The footer is built using a [strip component](/docs/patterns/strip).
 
 ### Example
 
 <div class="embedded-example"><a href="/docs/examples/layouts/documentation/" class="js-example" data-height="600">
-View example of the documentation layout
+View an example of the documentation layout
 </a></div>
 
 [View full screen example of the documentation layout](/docs/examples/layouts/documentation/).


### PR DESCRIPTION
## Done

Needs #2988 

Adds documentation layout example and documentation page about documentation layout structure.

![3xnur2](https://user-images.githubusercontent.com/83575/80217649-54fb3680-8640-11ea-82e5-5c44987c9842.jpg)


Fixes #2953

## QA

DEMO: https://vanilla-framework-canonical-web-and-design-pr-2996.run.demo.haus/docs/layouts/documentation

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2996.run.demo.haus/docs/layouts/documentation)
- Go to [documentation layout page](https://vanilla-framework-canonical-web-and-design-pr-2996.run.demo.haus/docs/layouts/documentation), check if it has enough information
- Check [documentation layout example](https://vanilla-framework-canonical-web-and-design-pr-2996.run.demo.haus/docs/examples/layouts/documentation) if it has good structure to be used as a base for documentation sites to copy from


<img width="1148" alt="Screenshot 2020-04-24 at 15 31 21" src="https://user-images.githubusercontent.com/83575/80217861-adcacf00-8640-11ea-83c3-b482626e33ce.png">

