### PR TITLE
Don't rely on icon from juju charms

### DIFF
--- a/templates/docs/examples/patterns/media-object/media-object-large.html
+++ b/templates/docs/examples/patterns/media-object/media-object-large.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-media-object--large">
-  <img src="https://api.jujucharms.com/charmstore/v5/mysql-58/icon.svg" class="p-media-object__image">
+  <img src="https://assets.ubuntu.com/v1/80cd67d3-mysql.svg" class="p-media-object__image">
   <div class="p-media-object__details">
     <h1 class="p-media-object__title">Mysql</h1>
     <p class="p-media-object__content">By mysql-charmers</p>


### PR DESCRIPTION
## Done

Don't rely on images from juju charms in examples, because screenshots will timeout when juju api is down

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-2997.run.demo.haus/)
- CI jobs should pass
- Go to [large media object example](https://vanilla-framework-canonical-web-and-design-pr-2997.run.demo.haus/docs/examples/patterns/media-object/media-object-large), it should render icon from assets server

## Screenshots

<img width="839" alt="Screenshot 2020-04-23 at 09 26 15" src="https://user-images.githubusercontent.com/83575/80071196-80006000-8544-11ea-8883-3092f704376e.png">

