### PR TITLE
Removed confusing sentence about margin in notification.

### DIFF
--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -54,7 +54,7 @@ View example of the information notification pattern
 
 ### Actions
 
-Notifications have the ability to add an action link to them. These should appear inline with the notification response and will add a margin between the link and content.
+Notifications have the ability to add an action link to them. These will appear inline with the notification response.
 
 <div class="p-notification--information">
   <p class="p-notification__response">


### PR DESCRIPTION
## Done

Removed confusing sentence about margin in notification.

Fixes #2986

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- Go to notification with action docs. Make sure margin is not mentioned.


## Screenshots

[if relevant, include a screenshot]
