### PR TITLE
Changes notification example to not use “Information:”

### DIFF
--- a/templates/docs/examples/patterns/notifications/information.html
+++ b/templates/docs/examples/patterns/notifications/information.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="p-notification--information">
   <p class="p-notification__response">
-    <span class="p-notification__status">Information:</span>Anyone with access can view your invited users.
+    <span class="p-notification__status">Permissions changed:</span>Anyone with access can view your invited users.
   </p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Done

Removes “Information:” from the Information notification example, to avoid people thinking that it’s boilerplate they’re supposed to include.

[Inspired by [ubuntu.com#6695](https://github.com/canonical-web-and-design/ubuntu.com/pull/6695).]