### PR TITLE
Remove duplicated side-navigation id from the template

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -12,7 +12,7 @@
     <div class="p-strip">
     <div class="row">
       <aside class="col-3">
-        <nav class="p-side-navigation" id="side-navigation">
+        <nav class="p-side-navigation">
           <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation">
             Toggle side navigation
           </button>


### PR DESCRIPTION
## Done

Remove duplicated side-navigation id from the template to make sure automatic scrolling to #side-navigation works properly

## QA

- Pull code
- Run `./run` or [demo](https://vanilla-framework-canonical-web-and-design-pr-3015.run.demo.haus/docs/patterns/navigation)
- Go to [Navigation page](https://vanilla-framework-canonical-web-and-design-pr-3015.run.demo.haus/docs/patterns/navigation)
- Click on [Side navigation](https://vanilla-framework-canonical-web-and-design-pr-3015.run.demo.haus/docs/patterns/navigation#side-navigation) sub item in side navigation
- Make sure the page scroll to side navigation part of documentation
- Go directly to [Side navigation](https://vanilla-framework-canonical-web-and-design-pr-3015.run.demo.haus/docs/patterns/navigation#side-navigation)
- Make sure page loads with Sub navigation part visible on top of screen


## Screenshots

<img width="1267" alt="Screenshot 2020-04-28 at 08 01 08" src="https://user-images.githubusercontent.com/83575/80452535-c4b23f80-8926-11ea-8b19-6a9fd7c31702.png">

