### PR TITLE
Fix scrolling with modal

### DIFF
--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -24,6 +24,7 @@
 
     bottom: $spv-inner--large;
     left: $sph-inner--large;
+    margin-bottom: 0;
     max-height: calc(100% - #{2 * $spv-inner--large});
     max-width: $grid-max-width;
     overflow: scroll;
@@ -68,9 +69,12 @@
     border: 0;
     box-sizing: content-box;
     height: $icon-size;
-    margin: -#{$icon-size} -#{$icon-size} 0 0;
-    padding: $icon-size;
+    margin: 0;
+    padding: $spv-inner--small $sph-inner--small;
+    position: absolute;
+    right: 0;
     text-indent: -999em;
+    top: 0;
     width: $icon-size;
 
     &:focus {

--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -4,15 +4,15 @@
   .p-modal {
     align-items: center;
     background: transparentize($color-dark, 0.15);
-    content: '';
+    bottom: 0;
     display: flex;
     height: 100vh;
     justify-content: center;
     left: 0;
     margin: 0;
-    overflow: scroll;
-    padding: $sp-large;
-    position: absolute;
+    padding: $spv-inner--large;
+    position: fixed;
+    right: 0;
     top: 0;
     width: 100%;
   }
@@ -22,19 +22,19 @@
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
 
-    bottom: $sp-large;
-    left: $sp-large;
+    bottom: $spv-inner--large;
+    left: $sph-inner--large;
+    max-height: calc(100% - #{2 * $spv-inner--large});
     max-width: $grid-max-width;
     overflow: scroll;
     position: absolute;
-    right: $sp-large;
-    top: $sp-large;
+    right: $sph-inner--large;
+    top: $spv-inner--large;
     width: auto;
 
     @media screen and (min-width: $breakpoint-medium) {
       bottom: initial;
       left: initial;
-      overflow: visible;
       position: relative;
       right: initial;
       top: initial;
@@ -42,8 +42,11 @@
   }
 
   .p-modal__header {
+    @extend %vf-pseudo-border--bottom;
+
     display: flex;
     justify-content: space-between;
+    margin-bottom: $spv-inner--small;
   }
 
   .p-modal__title {
@@ -53,20 +56,22 @@
   }
 
   .p-modal__close {
+    $icon-size: map-get($icon-sizes, default);
+
     background: {
       image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='90' width='90'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h90v90H0z'/%3E%3Cpath d='M14.52 6L6 14.52 36.48 45 6 75.49 14.52 84 45 53.52 75.48 84 84 75.49 53.52 45 84 14.52 75.48 6 45 36.49z' fill='%23888'/%3E%3C/g%3E%3C/svg%3E");
       position: center;
       repeat: no-repeat;
-      size: $sp-medium;
+      size: $icon-size;
     }
 
     border: 0;
     box-sizing: content-box;
-    height: $sp-medium;
-    margin: -#{$sp-medium} -#{$sp-medium} 0 0;
-    padding: $sp-medium;
+    height: $icon-size;
+    margin: -#{$icon-size} -#{$icon-size} 0 0;
+    padding: $icon-size;
     text-indent: -999em;
-    width: $sp-medium;
+    width: $icon-size;
 
     &:focus {
       outline: 2px solid $color-focus;

--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -1,0 +1,21 @@
+/**
+  Toggles visibility of modal dialog.
+  @param {HTMLElement} modal Modal dialog to show or hide.
+*/
+function toggleModal(modal) {
+  if (modal && modal.classList.contains('p-modal')) {
+    if (modal.style.display === 'none') {
+      modal.style.display = 'flex';
+    } else {
+      modal.style.display = 'none';
+    }
+  }
+}
+
+// Add click handler for clicks on elements with aria-controls
+document.addEventListener('click', function (event) {
+  var targetControls = event.target.getAttribute('aria-controls');
+  if (targetControls) {
+    toggleModal(document.getElementById(targetControls));
+  }
+});

--- a/templates/docs/examples/patterns/modal/default.html
+++ b/templates/docs/examples/patterns/modal/default.html
@@ -27,26 +27,6 @@
 </div>
 
 <script>
-/**
-  Toggles visibility of modal dialog.
-  @param {HTMLElement} modal Modal dialog to show or hide.
-*/
-function toggleModal(modal) {
-  if (modal && modal.classList.contains('p-modal')) {
-    if (modal.style.display === 'none') {
-      modal.style.display = 'flex';
-    } else {
-      modal.style.display = 'none';
-    }
-  }
-}
-
-// Add click handler for clicks on elements with aria-controls
-document.addEventListener('click', function(event) {
-  var targetControls = event.target.getAttribute('aria-controls');
-  if (targetControls) {
-    toggleModal(document.getElementById(targetControls));
-  }
-});
+  {% include 'docs/examples/patterns/modal/_script.js' %}
 </script>
 {% endblock %}

--- a/templates/docs/examples/patterns/modal/default.html
+++ b/templates/docs/examples/patterns/modal/default.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Modal{% endblock %}
+{% block title %}Modal / Default{% endblock %}
 
 {% block standalone_css %}patterns_modal{% endblock %}
 

--- a/templates/docs/examples/patterns/modal/modal-scroll.html
+++ b/templates/docs/examples/patterns/modal/modal-scroll.html
@@ -90,26 +90,6 @@
 </div>
 
 <script>
-/**
-  Toggles visibility of modal dialog.
-  @param {HTMLElement} modal Modal dialog to show or hide.
-*/
-function toggleModal(modal) {
-  if (modal && modal.classList.contains('p-modal')) {
-    if (modal.style.display === 'none') {
-      modal.style.display = 'flex';
-    } else {
-      modal.style.display = 'none';
-    }
-  }
-}
-
-// Add click handler for clicks on elements with aria-controls
-document.addEventListener('click', function(event) {
-  var targetControls = event.target.getAttribute('aria-controls');
-  if (targetControls) {
-    toggleModal(document.getElementById(targetControls));
-  }
-});
+  {% include 'docs/examples/patterns/modal/_script.js' %}
 </script>
 {% endblock %}

--- a/templates/docs/examples/patterns/modal/modal-scroll.html
+++ b/templates/docs/examples/patterns/modal/modal-scroll.html
@@ -1,0 +1,115 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Modal / Scrollable{% endblock %}
+
+{% block standalone_css %}patterns_modal{% endblock %}
+
+{% block content %}
+<button id="showModal" aria-controls="modal">Show modal</button>
+
+<p>An <em>application</em> is typically a long-running service that is accessible over the network. Applications are the centre of a Juju deployment. Everything within the Juju ecosystem exists to facilitate them.</p>
+<p>It’s easiest to think of the term “application” in Juju in the same way you would think of using it day-to-day. Middleware such as database servers (PostgreSQL, MySQL, Percona Cluster, etcd, …), message queues (RabbitMQ) and other utilities (Nagios, Prometheus, …) are all applications. The term has a specialist meaning within the Juju community, however. It is broader than the ordinary use of the term in computing.</p>
+<h3>A Juju application is more than a software application</h3>
+<p>Juju takes care of ensuring that the compute node that they’re being deployed to satisfies the size constraints that you specify, installing them, increasing their scale, setting up their networking and storage capacity rules. This, and other functionality, is provided within software packages called charms.</p>
+<p>Alongside your application, Juju executes charm code when triggered.  Triggers are typically requests from the administrator, such as:</p>
+<ul>
+<li>
+<p>“The configuration needs to change” via <code>juju config</code>. The <a href="#jaas.ai/spark">spark charm</a> provides the ability to dynamically change the memory available to the driver and executors:  <code>juju config spark executor_memory=2g</code></p>
+</li>
+<li>
+<p>“Please scale-up this application” via <code>juju add-unit</code>. The <a href="#jaas.ai/postgresql">postgresql charm</a> can detect when its scale is more than 1 and automatically switches itself into a high-availability cluster: <code>juju add -unit --num-units 2 postgresql</code></p>
+</li>
+<li>
+<p>“Allocate a 20GB storage volume to the application unit 0” via <code>juju add-storage</code>. The <a href="#jaas.ai/etcd">etcd charm</a> can provide an SSD-backed volume on AWS to the etcd application with:  <code>juju add-storage etcd/0 data=ebs-ssd,20G</code></p>
+</li>
+</ul>
+<div class="p-notification">
+<p class="p-notification__response">The Juju project uses an active agent architecture. Juju software agents are running alongside your applications. They periodically execute commands that are provided in software packages called charms. </p>
+</div>
+<h3>Differences between a stock software application and a Juju application</h3>
+<h4>Applications are scale-independent</h4>
+<p>An application in the Juju ecosystem can span multiple operating system processes. An HTTP API would probably be considered a Juju application, but that might bundle together several other components.</p>
+<p>Some examples:</p>
+<ul>
+<li>A Ruby on Rails web application might be deployed behind Apache2 and Phusion Passenger.</li>
+<li>All workers within a Hadoop cluster are considered a single application, although each worker its own <em>unit</em>
+</li>
+</ul>
+<p>A Juju application can also span multiple compute nodes and/or containers.  Within the Juju community, we use the term <em>machine</em> to cover physical hardware, virtual machines and containers.</p>
+<p>To make this clearer, consider an analogy from the desktop. An Electron app is composed of an Internet browser, a node.js runtime and application code. Each of those components is distinct, but they exist as a single unit.  That unit is an application.</p>
+<p>A final iteration of scale-independence is that Juju will maintain a record for applications that have a scale of 0. Perhaps earlier in the application’s lifecycle it was wound down, but the business required that the storage volumes were to be retained.</p>
+<h4>Applications are active</h4>
+<p>Applications automatically negotiate their own configuration depending on their situation. Through the business logic encoded within charms,  two applications can create user accounts and passwords between themselves without leaking secrets.</p>
+<h4>Applications are responsive</h4>
+<p>Juju applications can indicate their status, run actions and provide metrics. An action is typically a script that is useful for running a management task.</p>
+
+
+
+<div class="p-modal" id="modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="modal-title">Help</h2>
+      <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
+    </header>
+    <p id="modal-description">Learn how to operate production-ready clusters.</p>
+    <p>An <em>application</em> is typically a long-running service that is accessible over the network. Applications are the centre of a Juju deployment. Everything within the Juju ecosystem exists to facilitate them.</p>
+    <p>It’s easiest to think of the term “application” in Juju in the same way you would think of using it day-to-day. Middleware such as database servers (PostgreSQL, MySQL, Percona Cluster, etcd, …), message queues (RabbitMQ) and other utilities (Nagios, Prometheus, …) are all applications. The term has a specialist meaning within the Juju community, however. It is broader than the ordinary use of the term in computing.</p>
+    <h3>A Juju application is more than a software application</h3>
+    <p>Juju takes care of ensuring that the compute node that they’re being deployed to satisfies the size constraints that you specify, installing them, increasing their scale, setting up their networking and storage capacity rules. This, and other functionality, is provided within software packages called charms.</p>
+    <p>Alongside your application, Juju executes charm code when triggered.  Triggers are typically requests from the administrator, such as:</p>
+    <ul>
+    <li>
+    <p>“The configuration needs to change” via <code>juju config</code>. The <a href="#jaas.ai/spark">spark charm</a> provides the ability to dynamically change the memory available to the driver and executors:  <code>juju config spark executor_memory=2g</code></p>
+    </li>
+    <li>
+    <p>“Please scale-up this application” via <code>juju add-unit</code>. The <a href="#jaas.ai/postgresql">postgresql charm</a> can detect when its scale is more than 1 and automatically switches itself into a high-availability cluster: <code>juju add -unit --num-units 2 postgresql</code></p>
+    </li>
+    <li>
+    <p>“Allocate a 20GB storage volume to the application unit 0” via <code>juju add-storage</code>. The <a href="#jaas.ai/etcd">etcd charm</a> can provide an SSD-backed volume on AWS to the etcd application with:  <code>juju add-storage etcd/0 data=ebs-ssd,20G</code></p>
+    </li>
+    </ul>
+    <div class="p-notification">
+    <p class="p-notification__response">The Juju project uses an active agent architecture. </p>
+    </div>
+    <h3>Differences between a stock software application and a Juju application</h3>
+    <h4>Applications are scale-independent</h4>
+    <p>An application in the Juju ecosystem can span multiple operating system processes. An HTTP API would probably be considered a Juju application, but that might bundle together several other components.</p>
+    <p>Some examples:</p>
+    <ul>
+    <li>A Ruby on Rails web application might be deployed behind Apache2 and Phusion Passenger.</li>
+    <li>All workers within a Hadoop cluster are considered a single application, although each worker its own <em>unit</em>
+    </li>
+    </ul>
+    <p>A Juju application can also span multiple compute nodes and/or containers.  Within the Juju community, we use the term <em>machine</em> to cover physical hardware, virtual machines and containers.</p>
+    <p>To make this clearer, consider an analogy from the desktop. An Electron app is composed of an Internet browser, a node.js runtime and application code. Each of those components is distinct, but they exist as a single unit.  That unit is an application.</p>
+    <p>A final iteration of scale-independence is that Juju will maintain a record for applications that have a scale of 0. Perhaps earlier in the application’s lifecycle it was wound down, but the business required that the storage volumes were to be retained.</p>
+    <h4>Applications are active</h4>
+    <p>Applications automatically negotiate their own configuration depending on their situation. Through the business logic encoded within charms,  two applications can create user accounts and passwords between themselves without leaking secrets.</p>
+    <h4>Applications are responsive</h4>
+    <p>Juju applications can indicate their status, run actions and provide metrics. An action is typically a script that is useful for running a management task.</p>
+  </div>
+</div>
+
+<script>
+/**
+  Toggles visibility of modal dialog.
+  @param {HTMLElement} modal Modal dialog to show or hide.
+*/
+function toggleModal(modal) {
+  if (modal && modal.classList.contains('p-modal')) {
+    if (modal.style.display === 'none') {
+      modal.style.display = 'flex';
+    } else {
+      modal.style.display = 'none';
+    }
+  }
+}
+
+// Add click handler for clicks on elements with aria-controls
+document.addEventListener('click', function(event) {
+  var targetControls = event.target.getAttribute('aria-controls');
+  if (targetControls) {
+    toggleModal(document.getElementById(targetControls));
+  }
+});
+</script>
+{% endblock %}

--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -12,7 +12,7 @@ The modal component can be used to overlay an area of the screen which can conta
 
 On `p-modal` set display to `display:flex` or `display:none` to toggle the visibility of the modal.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/modal/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/modal/default/" class="js-example">
 View example of the modal pattern
 </a></div>
 


### PR DESCRIPTION
## Done

- Makes modal fixed to the window, so it's not affected by body scroll.
- Updates the styling to make modal dialog itself scrollable if it has more content than fits on the screen.
- Adds the border under modal header as per new design #2801

Fixes #2970
Fixes #2801

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3018.run.demo.haus/docs/examples/patterns/modal/modal-scroll)
- Open [scrollable modal example](https://vanilla-framework-canonical-web-and-design-pr-3018.run.demo.haus/docs/examples/patterns/modal/modal-scroll)
  - make sure large modal works on different screen sizes
- Open existing [modal example](https://vanilla-framework-canonical-web-and-design-pr-3018.run.demo.haus/docs/examples/patterns/modal/default)
  - make sure it works as expected


## Screenshots

<img width="1200" alt="Screenshot 2020-04-28 at 12 18 41" src="https://user-images.githubusercontent.com/83575/80476264-6e56f800-894a-11ea-8ede-6d189894280e.png">
