### PR TITLE
Properly use margin bottom on tables

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -4,9 +4,9 @@
 @mixin vf-b-tables {
   table {
     border: 0;
-    border-bottom: $spv-outer--scaleable solid transparent;
     border-collapse: collapse;
     line-height: map-get($line-heights, default-text);
+    margin-bottom: $spv-outer--scaleable;
     overflow-x: auto;
     width: 100%;
 

--- a/templates/docs/examples/patterns/tables/table-colored-rows.html
+++ b/templates/docs/examples/patterns/tables/table-colored-rows.html
@@ -1,0 +1,35 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Table / With colored rows{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block content %}
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Foundation Cloud</th>
+      <th>Foundation Cloud Plus</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr style="background: #f99b11;">
+      <th>Expert delivery of an Ubuntu OpenStack cloud</th>
+      <td>Reference architecture</td>
+      <td>Custom architecture</td>
+    </tr>
+    <tr>
+      <th>Workshop and training</th>
+      <td>2-days</td>
+      <td>4-days</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr style="background: #f7f7f7;">
+      <th>One-time price</th>
+      <td>$75,000</td>
+      <td>$150,000</td>
+    </tr>
+  </tfoot>
+</table>
+{% endblock %}

--- a/templates/docs/examples/templates/firefox-grid-table-bug.html
+++ b/templates/docs/examples/templates/firefox-grid-table-bug.html
@@ -1,69 +1,15 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Forms / Tick elements{% endblock %}
+{% block title %}Firefox grid table bug{% endblock %}
 
 {% block content %}
+
 <div class="p-strip is-shallow u-no-padding--top">
   <div class="row">
-  </div>
-  <div class="row">
-    <div class="col-3">
-      <form action="">
-        <input type="checkbox" id="checkExample2">
-        <label for="checkExample2">Checkbox option 2</label>
-        <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
-        <label for="Radio1">Radio option 1</label>
-      </form>
-    </div>
-    <div class="col-3">
-      <form action="">
-        <input type="text">
-        <button>Button</button>
-        <button>Button</button>
-        <button>Button</button>
-        <button>Button</button>
-      </form>
-    </div>
-    <div class="col-3">
-      <form action="">
-        <input type="text">
-        <input type="checkbox" id="checkExample1" checked>
-        <label for="checkExample1">Checkbox option 1</label>
-      </form>
-    </div>
-    <div class="col-3">
-      <form action="">
-        <input type="text">
-        <select name="" id=""></select>
-      </form>
-    </div>
-    <div class="col-3">
-      <input type="checkbox" id="checkExample2">
-      <label for="checkExample2">Checkbox option 2</label>
-      <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
-      <label for="Radio1">Radio option 1</label>
-      <input type="radio" name="RadioOptions" id="Radio2" value="option2">
-      <label for="Radio2">Radio option 2</label>
-    </div>
-    <div class="col-3">
-      <input type="radio" name="RadioOptions" id="Radio3" value="option3" >
-      <label for="Radio3">Radio option 3</label>
-      <input type="radio" name="RadioOptions" id="Radio4" value="option4">
-      <label for="Radio4">Radio option 4</label>
-      <input type="checkbox" id="checkExample3" checked>
-      <label for="checkExample3">Checkbox option 3</label>
-      <input type="checkbox" id="checkExample4">
-      <label for="checkExample4">Checkbox option 4</label>
-    </div>
+    <p><a class="p-link--external" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1492315">Firefox bug</a> causes table rows to grow if table is inside CSS grid container. We use this example to have a table that is affected by this bug. Bug was fixed in Firefox 75.</p>
   </div>
 </div>
 <div class="p-strip is-shallow u-no-padding--top">
   <div class="row">
-    <hr>
-    <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use class "is-inline-label" on the label to achieve that.</p>
-  </div>
-</div>
-<div class="p-strip is-shallow u-no-padding--top">
-  <div class="u-fixed-width">
     <table class="p-table--mobile-card">
       <thead>
         <tr>


### PR DESCRIPTION
## Done

- Use proper margins at the bottom of the tables instead of transparent borders (to fix the issue with height of last row #2971)
- Add new example with coloured rows (so Percy can keep track of it)
- Add separate example to cover Firefox (pre 75) [issue with growing table margins](https://bugzilla.mozilla.org/show_bug.cgi?id=1492315)

Fixes #2971

## QA

- Run `./run` or [demo](https://vanilla-framework-canonical-web-and-design-pr-3019.run.demo.haus/)
- Go to tables examples, make sure they work as expected:
  - [base table](https://vanilla-framework-canonical-web-and-design-pr-3019.run.demo.haus/docs/examples/base/table)
  - [colored table](https://vanilla-framework-canonical-web-and-design-pr-3019.run.demo.haus/docs/examples/patterns/tables/table-colored-rows)
  - [expanding table](https://vanilla-framework-canonical-web-and-design-pr-3019.run.demo.haus/docs/examples/patterns/tables/table-expanding)
  - [mobile card table](https://vanilla-framework-canonical-web-and-design-pr-3019.run.demo.haus/docs/examples/patterns/tables/table-mobile-card)
  - [sortable table](https://vanilla-framework-canonical-web-and-design-pr-3019.run.demo.haus/docs/examples/patterns/tables/table-sortable)
  - [Firefox grid issue with table](https://vanilla-framework-canonical-web-and-design-pr-3019.run.demo.haus/docs/examples/templates/firefox-grid-table-bug) - on Firefox prior to version 75 this demo will have unnecessary bigger spacing that will grow on window resize


## Screenshots

<img width="1335" alt="Screenshot 2020-04-29 at 15 26 53" src="https://user-images.githubusercontent.com/83575/80601270-e0543d80-8a2d-11ea-8b9c-a96b4ce6ff92.png">

