### PR TITLE
Fix the small screen side navigation

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -12,7 +12,7 @@
     <div class="p-strip">
     <div class="row">
       <aside class="col-3">
-        <nav class="p-side-navigation">
+        <nav class="p-side-navigation" id="side-navigation">
           <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation">
             Toggle side navigation
           </button>


### PR DESCRIPTION
## Done
Added the missing `id` to the navigation element.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3022

## QA
- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs
- Shrink your screen to mobile size
- Click the navigation toggle and check it works.

