### PR TITLE
Make sure side navigation id doesn't collide with side navigation docs

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -12,16 +12,16 @@
     <div class="p-strip">
     <div class="row">
       <aside class="col-3">
-        <nav class="p-side-navigation" id="side-navigation">
-          <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation">
+        <nav class="p-side-navigation" id="side-navigation-drawer">
+          <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation-drawer">
             Toggle side navigation
           </button>
 
-          <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation"></div>
+          <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation-drawer"></div>
 
           <div class="p-side-navigation__drawer">
             <div class="p-side-navigation__drawer-header">
-              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation">
+              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
                 Toggle side navigation
               </button>
             </div>


### PR DESCRIPTION
## Done

Follow up on #3023 and #3015 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3024.run.demo.haus/docs/patterns/navigation)
- Make sure Vanilla documentation side navigation toggle works on mobile
- Make sure link to ["Side navigation"](https://vanilla-framework-canonical-web-and-design-pr-3024.run.demo.haus/docs/patterns/navigation#side-navigation) part of ["Navigation"](https://vanilla-framework-canonical-web-and-design-pr-3024.run.demo.haus/docs/patterns/navigation) page works


