### PR TITLE
Close side navigation drawer on anchor click

### DIFF
--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -20,7 +20,12 @@
 
   document.addEventListener('DOMContentLoaded', function () {
     var examples = document.querySelectorAll('.js-example');
-    examples.forEach(renderExample);
+
+    // IE11 doesn't support forEach on NodeList, CodePen doesn't support IE as well
+    // so we don't want to load CodePen when forEach is not supported
+    if (examples.forEach) {
+      examples.forEach(renderExample);
+    }
   });
 
   function renderExample(exampleElement) {

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -56,6 +56,17 @@
       });
     });
 
+    // close side navigation drawer when any link (anchor) inside it is clicked
+    sideNavigation.addEventListener('click', function (event) {
+      var target = event.target;
+      if (
+        sideNavigation.classList.contains('is-expanded') &&
+        (target.classList.contains('p-side-navigation__link') || (target.closest && target.closest('.p-side-navigation__link')))
+      ) {
+        toggleDrawer(sideNavigation, false);
+      }
+    });
+
     // improvements for side nav when resizing the window
     var sideNav = document.querySelector('.p-side-navigation');
     var drawerEl = document.querySelector('.p-side-navigation__drawer');

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -33,7 +33,7 @@
         sideNavigation.classList.add('is-collapsed');
 
         // enable scroll on body when drawer is open
-        document.body.style.overflow = null;
+        document.body.style.overflow = '';
       }
     }
   }
@@ -81,7 +81,7 @@
         if (drawerPosition !== 'fixed') {
           sideNav.classList.remove('is-expanded');
           sideNav.classList.remove('is-collapsed');
-          document.body.style.overflow = null;
+          document.body.style.overflow = '';
         }
       }, 200)
     );
@@ -139,7 +139,7 @@
 
 // Add class to exteral links
 (function () {
-  var links = document.querySelectorAll('a');
+  var links = [].slice.call(document.querySelectorAll('a'));
   links.forEach(function (link) {
     var parentClass = link.parentNode.classList;
     var ignoreNav = !(parentClass.contains('p-navigation__logo') || parentClass.contains('p-navigation__link'));


### PR DESCRIPTION
## Done

Makes sure side navigation drawer closes when clicking on in-page anchors
Fixes some small JS issues in IE11.

Fixes #3025

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3028.run.demo.haus/)
- On small screen (mobile)
- Go to documentation page with sections like [Code](https://vanilla-framework-canonical-web-and-design-pr-3028.run.demo.haus/docs/base/code)
- Open side navigation drawer
- Click on any page subsection (like Copyable)
- Side navigation drawer should close, page should scroll to chosen section




## Screenshots

<img width="466" alt="Screenshot 2020-04-30 at 07 23 48" src="https://user-images.githubusercontent.com/83575/80674956-8eee9180-8ab3-11ea-9c0a-0ea81cf76e23.png">
