### PR TITLE
Fix z-index collisiton and bottom border in tabs on small screens

### DIFF
--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -10,7 +10,7 @@
     padding: 0;
     position: relative;
 
-    &::before {
+    &::after {
       background: linear-gradient(to right, $color-transparent 0%, $color-x-light 45%, $color-x-light 100%);
       color: $color-mid-dark;
       content: '\203A';
@@ -25,7 +25,6 @@
       text-align: right;
       top: 0;
       width: 1rem;
-      z-index: 10;
 
       @media screen and (min-width: $breakpoint-medium) {
         display: none;
@@ -46,6 +45,8 @@
     }
 
     &__item {
+      @extend %vf-pseudo-border--bottom;
+
       display: inline-block;
       float: none;
       font-size: 1rem;


### PR DESCRIPTION
## Done

Fixes issue with tabs chevron appearing above other elements because of z-index.
Fixes issue that bottom border of tabs on small screens was scrolling off screen when tabs were scrolled.

Fixes #3027 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3029.run.demo.haus/)
- Go to [tabs](https://vanilla-framework-canonical-web-and-design-pr-3029.run.demo.haus/docs/examples/patterns/tabs), make sure they work as expected
- Go to CodePen https://codepen.io/bartoszopka/pen/JjYyaQE
- Resize the screen to make it smaller so that contextual menu appears above tabs chevron.
- Contextual menu should over the chevron.

## Screenshots




### Before
https://cdpn.io/bartoszopka/debug/ExVveBy/VGkWNxzxLexA

<img width="578" alt="Screenshot 2020-04-30 at 08 39 40" src="https://user-images.githubusercontent.com/83575/80679932-26f17880-8abe-11ea-9dac-fe53c0f10438.png">




#### After
https://cdpn.io/bartoszopka/debug/JjYyaQE/dXAqBNoNLPek
<img width="580" alt="Screenshot 2020-04-30 at 08 37 14" src="https://user-images.githubusercontent.com/83575/80679888-10e3b800-8abe-11ea-823a-c6c47679556a.png">
