### PR TITLE
Clarify side navigation color theming documentation

### DIFF
--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -94,6 +94,15 @@ View example of the side navigation pattern with icons
 On small screens side navigation is rendered off-screen as a drawer. To open the side navigation drawer, add `is-expanded` class to
 main `.p-side-navigation` element. To close the drawer (with the animation) remove `is-expanded` class and replace it with `is-collapsed` class.
 
+#### Theming
+
+Light and dark color themes are available for side navigation and all colors used by side navigation are defined by the theme settings.
+Individual colors of particular elements of side navigation should not be redefined or overridden directly outside of the theme, as they are designed to provide accessible and consistent appearance.
+
+Light theme is used by default. It can be changed in theme settings or by using `is-dark` class name on side navigation element. For more details about themes in Vanilla check [Color theming](/docs/settings/color-settings#color-theming) section of color settings documentation.
+
+[See example of side navigation with dark theme](/docs/examples/patterns/side-navigation/dark).
+
 ### Import
 
 To import just navigation or sub-navigation component into your project, copy snippets below and include it in your main Sass file.

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -96,10 +96,14 @@ main `.p-side-navigation` element. To close the drawer (with the animation) remo
 
 #### Theming
 
-Light and dark color themes are available for side navigation and all colors used by side navigation are defined by the theme settings.
-Individual colors of particular elements of side navigation should not be redefined or overridden directly outside of the theme, as they are designed to provide accessible and consistent appearance.
+The side navigation is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical-web-and-design/vanilla-framework/blob/7550549d1576046041db7e9594bd5675de0f448b/scss/_settings_colors.scss#L58).
+Overriding the colours of individual elements of the side navigation is discouraged, as this may lead to accessibility issues, or inconsistencies with other components that use the same theme.
 
-Light theme is used by default. It can be changed in theme settings or by using `is-dark` class name on side navigation element. For more details about themes in Vanilla check [Color theming](/docs/settings/color-settings#color-theming) section of color settings documentation.
+By default, the side navigation uses the light theme. To change the global default, set [`$theme-default-p-side-navigation`](https://github.com/canonical-web-and-design/vanilla-framework/blob/7550549d1576046041db7e9594bd5675de0f448b/scss/_settings_themes.scss#L4) to `dark`.
+
+To change the appearance of an individual instance of the sidenav, you can use the `is-dark` class.
+
+For more details about themes in Vanilla refer to the [Color theming](/docs/settings/color-settings#color-theming) section of the documentation.
 
 [See example of side navigation with dark theme](/docs/examples/patterns/side-navigation/dark).
 

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -96,10 +96,10 @@ main `.p-side-navigation` element. To close the drawer (with the animation) remo
 
 #### Theming
 
-The side navigation is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical-web-and-design/vanilla-framework/blob/7550549d1576046041db7e9594bd5675de0f448b/scss/_settings_colors.scss#L58).
+The side navigation is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_settings_colors.scss).
 Overriding the colours of individual elements of the side navigation is discouraged, as this may lead to accessibility issues, or inconsistencies with other components that use the same theme.
 
-By default, the side navigation uses the light theme. To change the global default, set [`$theme-default-p-side-navigation`](https://github.com/canonical-web-and-design/vanilla-framework/blob/7550549d1576046041db7e9594bd5675de0f448b/scss/_settings_themes.scss#L4) to `dark`.
+By default, the side navigation uses the light theme. To change the global default, set `$theme-default-p-side-navigation` to `dark`.
 
 To change the appearance of an individual instance of the sidenav, you can use the `is-dark` class.
 

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -127,14 +127,14 @@ It’s important for us to meet all web accessibility standards. Vanilla encoura
 
 <div class="p-strip is-shallow">
   <div class="row">
-     <div class="col-6">
+     <div class="col-4">
        <div class="p-notification--positive">
         <p class="p-notification__response"><span class="p-notification__status">Do:</span>Use a minimum contrast ratio of 4.5 for normal text and UI components</p>
        </div>
        <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/e1183cd5-basics-text-color-do.png" alt="text-color-do">
        <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/92607803-basics-button-color-do.png" alt="button-color-do">
      </div>
-    <div class="col-6">
+    <div class="col-4">
       <div class="p-notification--negative">
         <p class="p-notification__response"><span class="p-notification__status">Don't:</span>Use low-contrast text and background combinations.</p>
       </div>
@@ -148,19 +148,22 @@ It’s important for us to meet all web accessibility standards. Vanilla encoura
 
 Starting with the [2.3.0](https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0) release, Vanilla framework introduces a theming mechanism. The current default for all components is referred to as the light theme. A subset of elements and components now offer a dark theme:
 
-- `checkbox`
-- `hr`
-- `radio`
-- <a href="/docs/patterns/navigation">navigation</a>
-- search box
+- [Checkbox](/docs/base/forms#checkbox) and [radio](/docs/base/forms#radio-button) form inputs
+- Horizontal rule element `<hr />`
+- [Contextual menu](/docs/patterns/contextual-menu)
+- [Navigation](/docs/patterns/navigation)
+- [Side navigation](/docs/patterns/navigation#side-navigation)
+- [Search box](/docs/patterns/search-box)
 
-| Element / Component | Variable                      | Default value |
-| ------------------- | ----------------------------- | ------------- |
-| checkbox            | `$theme-default-forms`        | `light`       |
-| radio               | `$theme-default-forms`        | `light`       |
-| hr                  | `$theme-default-hr`           | `light`       |
-| Navigation          | `$theme-default-nav`          | `light`       |
-| Search box          | `$theme-default-p-search-box` | `light`       |
+| Element / Component | Variable                           | Default value |
+| ------------------- | ---------------------------------- | ------------- |
+| checkbox            | `$theme-default-forms`             | `light`       |
+| radio               | `$theme-default-forms`             | `light`       |
+| hr                  | `$theme-default-hr`                | `light`       |
+| Contextual menu     | `$theme-default-p-contextual-menu` | `light`       |
+| Navigation          | `$theme-default-nav`               | `light`       |
+| Side navigation     | `$theme-default-p-side-navigation` | `light`       |
+| Search box          | `$theme-default-p-search-box`      | `light`       |
 
 Future releases will expand this list to include all elements and components.
 


### PR DESCRIPTION
## Done

Fixes #2966 

Clarifies documentation about colors used by side navigation component

## QA

- Check [Side navigation documentation about color theming](https://vanilla-framework-canonical-web-and-design-pr-3051.run.demo.haus/docs/patterns/navigation#side-navigation)
- Check [Color theming](https://vanilla-framework-canonical-web-and-design-pr-3051.run.demo.haus/docs/settings/color-settings#color-theming) documentation, verify it's updated

