### PR TITLE
Update blue link colours

### DIFF
--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -1,11 +1,11 @@
 @mixin vf-b-range {
-  $thumb-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.2);
+  $thumb-shadow: 0 0 $bar-thickness 1px rgba(0, 0, 0, 0.2);
   $thumb-size: 24px;
-  $thumb-radius: 2px;
+  $thumb-radius: $bar-thickness;
   $track-height: 5px;
   $track-border-size: 1px;
   $track-border: $track-border-size solid $color-mid-light;
-  $track-radius: 2px;
+  $track-radius: $bar-thickness;
 
   // stylelint-disable-next-line selector-no-qualifying-type
   input[type='range'] {
@@ -104,7 +104,7 @@
       border-radius: $thumb-radius;
       box-shadow: $thumb-shadow;
       height: $thumb-size;
-      margin: 0 2px;
+      margin: 0 $bar-thickness;
       width: $thumb-size;
 
       &:hover {
@@ -120,15 +120,15 @@
       outline: none;
 
       &::-webkit-slider-thumb {
-        outline: 2px solid $color-focus;
+        outline: $bar-thickness solid $color-focus;
       }
 
       &::-moz-range-thumb {
-        outline: 2px solid $color-focus;
+        outline: $bar-thickness solid $color-focus;
       }
 
       &::-ms-thumb {
-        outline: 2px solid $color-focus;
+        outline: $bar-thickness solid $color-focus;
       }
     }
 

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -191,7 +191,7 @@ $box-offsets-top: (
     }
 
     &:focus + label::before {
-      outline: 2px solid $color-focus;
+      outline: $bar-thickness solid $color-focus;
     }
 
     &[disabled],
@@ -436,8 +436,8 @@ $box-offsets-top: (
 
   %checked {
     & + label::before {
-      background-color: $color-information;
-      border-color: $color-information;
+      background-color: $color-link;
+      border-color: $color-link;
     }
   }
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -26,7 +26,6 @@
 
     background-color: $color-x-light;
     border: 1px solid $color-mid;
-    border-radius: 0;
     box-shadow: inset 0 1px 1px $color-input-shadow;
     color: $color-dark;
     font-family: unquote($font-base-family);

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -26,6 +26,7 @@
 
     background-color: $color-x-light;
     border: 1px solid $color-mid;
+    border-radius: 0;
     box-shadow: inset 0 1px 1px $color-input-shadow;
     color: $color-dark;
     font-family: unquote($font-base-family);

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -26,7 +26,7 @@
 
     background-color: $color-x-light;
     border: 1px solid $color-mid;
-    border-radius: $border-radius;
+    border-radius: 0;
     box-shadow: inset 0 1px 1px $color-input-shadow;
     color: $color-dark;
     font-family: unquote($font-base-family);

--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -7,7 +7,7 @@
     text-decoration: none;
 
     &:focus {
-      outline: thin dotted $color-mid-light;
+      outline: thin dotted $color-focus;
     }
 
     &:hover {
@@ -16,7 +16,7 @@
     }
 
     &:visited {
-      color: darken($color-link, 10%);
+      color: $color-link-visited;
     }
   }
 }

--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -3,11 +3,13 @@
 // Base styling for links
 @mixin vf-b-links {
   a {
+    @include vf-focus;
+
     color: $color-link;
     text-decoration: none;
 
     &:focus {
-      outline: thin dotted $color-focus;
+      outline-offset: 0;
     }
 
     &:hover {

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -85,6 +85,8 @@
       $button-active-background-color: darken($color-positive, 15%),
       $button-active-border-color: darken($color-positive, 15%)
     );
+
+    @include vf-focus($color-focus-positive);
   }
 
   .p-button--positive {
@@ -107,6 +109,8 @@
       $button-active-background-color: darken($color-negative, 15%),
       $button-active-border-color: darken($color-negative, 15%)
     );
+
+    @include vf-focus($color-focus-negative);
   }
 
   .p-button--negative {

--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -78,7 +78,7 @@
     width: $icon-size;
 
     &:focus {
-      outline: 2px solid $color-focus;
+      outline: $bar-thickness solid $color-focus;
     }
   }
 }

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -23,9 +23,11 @@
 
     &:hover,
     &:focus,
+    &:visited,
     &.is-active {
       background-color: darken($color-x-light, 10%);
       border-color: $color-mid;
+      color: $color-x-dark;
       text-decoration: none;
     }
 

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -21,7 +21,7 @@ $knob-size: $sp-unit * 3;
       outline: none;
 
       + .p-switch__slider {
-        outline: 2px solid $color-focus;
+        outline: $bar-thickness solid $color-focus;
       }
     }
   }
@@ -29,7 +29,7 @@ $knob-size: $sp-unit * 3;
   .p-switch__slider {
     @extend %vf-has-round-corners;
 
-    background: linear-gradient(to right, $color-information 50%, $color-mid-light 50%);
+    background: linear-gradient(to right, $color-link 50%, $color-mid-light 50%);
     box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
     height: $knob-size;
     margin: $spv-nudge-compensation 0 $spv-outer--small-scaleable 0;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -19,9 +19,9 @@ $color-label-validated: #006b75;
 
 $color-negative: #c7162b !default;
 $color-caution: #f99b11 !default;
-$color-positive: hsl(129, 81%, 29%) !default;
+$color-positive: #0e8620 !default;
 
-$color-link: #06c !default;
+$color-link: #0066cc !default;
 $color-link-visited: #7d42b8 !default;
 $color-focus: #2e96ff !default;
 $color-focus-positive: #003008 !default;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -15,18 +15,18 @@ $color-dark: #111 !default;
 $color-x-dark: #000 !default;
 $color-input-shadow: rgba($color-x-dark, 0.12) !default;
 
-$color-label-validated: #006b75;
-
-$color-negative: #c7162b !default;
-$color-caution: #f99b11 !default;
-$color-positive: #0e8620 !default;
-
 $color-link: #06c !default;
 $color-link-visited: #7d42b8 !default;
 $color-focus: #2e96ff !default;
 $color-focus-positive: #003008 !default;
 $color-focus-negative: #3b0006 !default;
+
+$color-negative: #c7162b !default;
+$color-caution: #f99b11 !default;
+$color-positive: #0e8620 !default;
 $color-information: #24598f !default;
+
+$color-label-validated: #006b75;
 
 $states: (
   error: $color-negative,

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -21,7 +21,7 @@ $color-negative: #c7162b !default;
 $color-caution: #f99b11 !default;
 $color-positive: #0e8620 !default;
 
-$color-link: #0066cc !default;
+$color-link: #06c !default;
 $color-link-visited: #7d42b8 !default;
 $color-focus: #2e96ff !default;
 $color-focus-positive: #003008 !default;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -2,7 +2,8 @@
 $color-transparent: transparent !default;
 
 $color-brand: #333 !default;
-$color-link: #007aa6 !default;
+$color-accent: $color-brand !default;
+$color-accent-background: $color-accent !default;
 
 $color-x-light: #fff !default;
 $color-light: #f7f7f7 !default;
@@ -12,21 +13,20 @@ $color-mid: #999 !default;
 $color-mid-dark: #666 !default;
 $color-dark: #111 !default;
 $color-x-dark: #000 !default;
-
-$color-negative: #c7162b !default;
-$color-caution: #f99b11 !default;
-$color-positive: #0e8420 !default;
-$color-information: #335280 !default;
+$color-input-shadow: rgba($color-x-dark, 0.12) !default;
 
 $color-label-validated: #006b75;
 
-$color-input-shadow: rgba($color-x-dark, 0.12) !default;
+$color-negative: #c7162b !default;
+$color-caution: #f99b11 !default;
+$color-positive: hsl(129, 81%, 29%) !default;
 
-$color-accent: $color-brand !default;
-$color-accent-background: $color-accent !default;
-
-// for visual outline on :active / :focus elements
-$color-focus: #19b6ee !default;
+$color-link: #06c !default;
+$color-link-visited: #7d42b8 !default;
+$color-focus: #2e96ff !default;
+$color-focus-positive: #003008 !default;
+$color-focus-negative: #3b0006 !default;
+$color-information: #24598f !default;
 
 $states: (
   error: $color-negative,

--- a/templates/docs/examples/base/forms/range.html
+++ b/templates/docs/examples/base/forms/range.html
@@ -10,7 +10,7 @@
 <script>
 var isWebkit =
   /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
-var PROGRESS_COLOUR = '#335280';
+var PROGRESS_COLOUR = '#06c';
 var EMPTY_COLOUR = '#fff';
 
 /**

--- a/templates/docs/examples/patterns/slider/slider-input.html
+++ b/templates/docs/examples/patterns/slider/slider-input.html
@@ -18,7 +18,7 @@ var isWebkit =
   /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
 var isIE = /NET/i.test(navigator.userAgent);
 
-var PROGRESS_COLOUR = '#335280';
+var PROGRESS_COLOUR = '#06c';
 var EMPTY_COLOUR = '#fff';
 
 /**

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -91,9 +91,9 @@ These guidelines are the framework upon which we have built our system for how c
   </div>
   <div class="row">
     <div class="col-2 p-card u-no-padding">
-      <div class="p-strip is-shallow is-bordered" style="background-color: #007aa6"></div>
+      <div class="p-strip is-shallow is-bordered" style="background-color: #06c"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
-        $color-link<br><span class="p-muted-heading">#007aa6</span>
+        $color-link<br><span class="p-muted-heading">#06c</span>
       </p>
     </div>
     <div class="col-2 p-card u-no-padding">

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -83,9 +83,9 @@ These guidelines are the framework upon which we have built our system for how c
       </p>
     </div>
     <div class="col-2 p-card u-no-padding">
-      <div class="p-strip is-shallow is-bordered" style="background-color: #335280"></div>
+      <div class="p-strip is-shallow is-bordered" style="background-color: #06c"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
-        $color-information<br><span class="p-muted-heading">#335280</span>
+        $color-information<br><span class="p-muted-heading">#06c</span>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Update link blues for all states
- Make checkboxes, switch, radios etc use the link blue

Drive-by's:
- remove border radius from inputs, something we had agreed a long time ago but never implemented
- Update focus state bar thickness for some components which had it hardcoded to 2px. The correct variable is $bar-thickness, which is 3px.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3042

## QA

- Pull code
- Run `./run`
- Open as many examples as possible, QA link colour and focus states. E.g.:
docs/examples/patterns/buttons/icon
docs/examples/patterns/forms/form-inline
docs/examples/patterns/forms/form-stacked
docs/examples/patterns/forms/form-validation

Open the pagination specifically, verify visited (or other link colours) do not show when the buttons are in various states:
docs/examples/patterns/pagination/pagination-truncated

## Screenshots

various form elements:

![image](https://user-images.githubusercontent.com/2741678/81578503-cd812780-93a2-11ea-819d-5929728e0a13.png)

green button with outline/background contrast ratio above 3:1:
![image](https://user-images.githubusercontent.com/2741678/81578634-fef9f300-93a2-11ea-943f-c4294b432f46.png)

Negative button with outline/background contrast ratio above 3:1:
![image](https://user-images.githubusercontent.com/2741678/81578689-0e793c00-93a3-11ea-8cd6-2f4579b8c6f3.png)


