### PR TITLE
Update grid.md

### DIFF
--- a/templates/docs/patterns/grid.md
+++ b/templates/docs/patterns/grid.md
@@ -12,7 +12,7 @@ Vanilla has a responsive grid with the following columns and gutters:
 
 | Screen size (px)                       | Columns | Grid gap (gutters) | Outer margins |
 | -------------------------------------- | ------- | ------------------ | ------------- |
-| 0 - $breakpoint-small                  | 4       | 1.5rem             | 1.0rem        |
+| Less than $breakpoint-small            | 4       | 1.5rem             | 1.0rem        |
 | $breakpoint-small - $breakpoint-medium | 6       | 2.0rem             | 1.5rem        |
 | above $breakpoint-medium               | 12      | 2.0rem             | 1.5rem        |
 

--- a/templates/docs/patterns/grid.md
+++ b/templates/docs/patterns/grid.md
@@ -10,11 +10,11 @@ context:
 
 Vanilla has a responsive grid with the following columns and gutters:
 
-| Screen size (px)                       | Columns | Grid gap (gutters) | Outer margins |
-| -------------------------------------- | ------- | ------------------ | ------------- |
-| Less than $breakpoint-small            | 4       | 1.5rem             | 1.0rem        |
-| $breakpoint-small - $breakpoint-medium | 6       | 2.0rem             | 1.5rem        |
-| Greater than $breakpoint-medium        | 12      | 2.0rem             | 1.5rem        |
+| Screen size (px)                           | Columns | Grid gap (gutters) | Outer margins |
+| ------------------------------------------ | ------- | ------------------ | ------------- |
+| Less than `$breakpoint-small`              | 4       | 1.5rem             | 1.0rem        |
+| `$breakpoint-small` - `$breakpoint-medium` | 6       | 2.0rem             | 1.5rem        |
+| Greater than `$breakpoint-medium`          | 12      | 2.0rem             | 1.5rem        |
 
 <br>
 

--- a/templates/docs/patterns/grid.md
+++ b/templates/docs/patterns/grid.md
@@ -12,9 +12,9 @@ Vanilla has a responsive grid with the following columns and gutters:
 
 | Screen size (px)                       | Columns | Grid gap (gutters) | Outer margins |
 | -------------------------------------- | ------- | ------------------ | ------------- |
-| 0 - \$breakpoint-small                 | 4       | 1.5rem             | 1.0rem        |
+| 0 - $breakpoint-small                  | 4       | 1.5rem             | 1.0rem        |
 | $breakpoint-small - $breakpoint-medium | 6       | 2.0rem             | 1.5rem        |
-| above \$breakpoint-medium              | 12      | 2.0rem             | 1.5rem        |
+| above $breakpoint-medium               | 12      | 2.0rem             | 1.5rem        |
 
 <br>
 

--- a/templates/docs/patterns/grid.md
+++ b/templates/docs/patterns/grid.md
@@ -14,7 +14,7 @@ Vanilla has a responsive grid with the following columns and gutters:
 | -------------------------------------- | ------- | ------------------ | ------------- |
 | Less than $breakpoint-small            | 4       | 1.5rem             | 1.0rem        |
 | $breakpoint-small - $breakpoint-medium | 6       | 2.0rem             | 1.5rem        |
-| above $breakpoint-medium               | 12      | 2.0rem             | 1.5rem        |
+| Greater than $breakpoint-medium        | 12      | 2.0rem             | 1.5rem        |
 
 <br>
 

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -53,7 +53,7 @@ View example of the ticked divided list pattern
 
 ### Responsive divider
 
-A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-medium`), the divider lines appear horizontally. On screens bigger than \$breakpoint-medium, the divider lines appear vertically, centered in the column gutters.
+A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-medium`), the divider lines appear horizontally. On screens bigger than `$breakpoint-medium`, the divider lines appear vertically, centered in the column gutters.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/lists/divider/" class="js-example">
 View example of lists with a responsive divider

--- a/templates/docs/settings/table-layout.md
+++ b/templates/docs/settings/table-layout.md
@@ -10,9 +10,9 @@ context:
 
 By default, tables in Vanilla use `table-layout: fixed`.
 
-There are cases where you might want to use `table-layout: auto` - e.g. in automatically generated tables. To do this, you need to set the \$table-layout-fixed variable to `true`.
+There are cases where you might want to use `table-layout: auto` - e.g. in automatically generated tables. To do this, you need to set the `$table-layout-fixed` variable to `true`.
 
-Depending on the value of \$table-layout-fixed, a utility class is generated to allow overriding if necessary:
+Depending on the value of `$table-layout-fixed`, a utility class is generated to allow overriding if necessary:
 
-- If \$table-layout-fixed is set to `true` (the default), you can use `u-table-layout--auto` to override it.
-- if \$table-layout-fixed is set to `auto` it adds a utility called `u-table-layout--fixed`.
+- If `$table-layout-fixed` is set to `true` (the default), you can use `u-table-layout--auto` to override it.
+- if `$table-layout-fixed` is set to `auto` it adds a utility called `u-table-layout--fixed`.


### PR DESCRIPTION
## Done

Remove `\` which are displaying on the page

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/patterns/grid
- See that the first table doesn't have the visible slashes as shown in the screenshot below

## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/118614/81669102-990e7980-943d-11ea-84bb-1bb7ef3828e3.png)

