### PR TITLE
Add no-JS fallback to side navigation component

### DIFF
--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -33,6 +33,8 @@
     width: 100%;
     z-index: 12;
 
+    .p-side-navigation:target &,
+    [class*='p-side-navigation--']:target &,
     .p-side-navigation.is-expanded &,
     [class*='p-side-navigation--'].is-expanded & {
       @extend %vf-has-box-shadow;
@@ -63,6 +65,8 @@
     top: 0;
     z-index: 11;
 
+    .p-side-navigation:target &,
+    [class*='p-side-navigation--']:target &,
     .p-side-navigation.is-expanded &,
     [class*='p-side-navigation--'].is-expanded & {
       opacity: 1;
@@ -83,6 +87,8 @@
 
   .p-side-navigation__toggle,
   .p-side-navigation__toggle--in-drawer {
+    @extend %vf-button-base;
+
     // override base button styles that extend button to full width on mobile
     width: auto;
 
@@ -127,6 +133,8 @@
 
     .p-side-navigation__drawer,
     // fight specificity of expanded version
+    .p-side-navigation:target .p-side-navigation__drawer,
+    [class*='p-side-navigation--']:target .p-side-navigation__drawer,
     .p-side-navigation.is-expanded .p-side-navigation__drawer,
     [class*='p-side-navigation--'].is-expanded .p-side-navigation__drawer {
       box-shadow: none;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -13,17 +13,17 @@
     <div class="row">
       <aside class="col-3">
         <nav class="p-side-navigation" id="side-navigation-drawer">
-          <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation-drawer">
+          <a href="#side-navigation-drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation-drawer">
             Toggle side navigation
-          </button>
+          </a>
 
           <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation-drawer"></div>
 
           <div class="p-side-navigation__drawer">
             <div class="p-side-navigation__drawer-header">
-              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
+              <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
                 Toggle side navigation
-              </button>
+              </a>
             </div>
 
             <ul class="p-side-navigation__list">

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -23,6 +23,12 @@ When we add, make significant updates, or deprecate a component we update their 
   </thead>
   <tbody>
     <tr>
+      <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.11.0</td>
+      <td>A no-JS fallback was added for the side navigation toggle functionality on small screens.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/navigation#raw-html">Side navigation</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.11.0</td>

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -43,17 +43,17 @@
   <div class="row">
     <aside class="col-3">
       <nav class="p-side-navigation--raw-html" id="drawer">
-        <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
-        </button>
+        </a>
 
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
         <div class="p-side-navigation__drawer">
           <div class="p-side-navigation__drawer-header">
-            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
               Toggle side navigation
-            </button>
+            </a>
           </div>
           <h3>Side navigation</h3>
           <ul>

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -1,16 +1,16 @@
 <div class="p-side-navigation {% if is_dark %}is-dark{% endif %}" id="drawer">
 
-  <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+  <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
     Toggle side navigation
-  </button>
+  </a>
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
   <div class="p-side-navigation__drawer">
     <div class="p-side-navigation__drawer-header">
-      <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+      <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
         Toggle side navigation
-      </button>
+      </a>
     </div>
 
     <ul class="p-side-navigation__list">

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -1,7 +1,7 @@
 <div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
-  <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer-icons">
+  <a href="#drawer-icons" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer-icons">
     Toggle side navigation
-  </button>
+  </a>
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer-icons"></div>
 
@@ -10,9 +10,9 @@
   {% endif %}
   <div class="p-side-navigation__drawer" {% if is_dark %}style="background: #003b4e"{% endif %}>
     <div class="p-side-navigation__drawer-header" {% if is_dark %}style="background: #003b4e"{% endif %}>
-      <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer-icons">
+      <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer-icons">
         Toggle side navigation
-      </button>
+      </a>
     </div>
 
     <ul class="p-side-navigation__list">

--- a/templates/docs/examples/patterns/side-navigation/_toggle_script.js
+++ b/templates/docs/examples/patterns/side-navigation/_toggle_script.js
@@ -46,4 +46,4 @@ function setupSideNavigations(sideNavigationSelector) {
   sideNavigations.forEach(setupSideNavigation);
 }
 
-setupSideNavigations('.p-side-navigation, .p-side-navigation--icons');
+setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');

--- a/templates/docs/examples/patterns/side-navigation/docs.html
+++ b/templates/docs/examples/patterns/side-navigation/docs.html
@@ -5,17 +5,17 @@
 
 {% block content %}
 <div class="p-side-navigation" id="drawer">
-  <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+  <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
     Toggle side navigation
-  </button>
+  </a>
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
   <div class="p-side-navigation__drawer">
     <div class="p-side-navigation__drawer-header">
-      <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+      <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
         Toggle side navigation
-      </button>
+      </a>
     </div>
 
     <ul class="p-side-navigation__list">

--- a/templates/docs/examples/patterns/side-navigation/icons.html
+++ b/templates/docs/examples/patterns/side-navigation/icons.html
@@ -5,17 +5,17 @@
 
 {% block content %}
 <div class="p-side-navigation--icons" id="drawer">
-  <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+  <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
     Toggle side navigation
-  </button>
+  </a>
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
   <div class="p-side-navigation__drawer">
     <div class="p-side-navigation__drawer-header">
-      <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+      <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
         Toggle side navigation
-      </button>
+      </a>
     </div>
 
     <ul class="p-side-navigation__list">

--- a/templates/docs/examples/patterns/side-navigation/raw-html.html
+++ b/templates/docs/examples/patterns/side-navigation/raw-html.html
@@ -8,17 +8,17 @@
   <div class="col-3">
     <div class="p-side-navigation--raw-html" id="drawer">
 
-      <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+      <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
         Toggle side navigation
-      </button>
+      </a>
 
       <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
       <div class="p-side-navigation__drawer">
         <div class="p-side-navigation__drawer-header">
-          <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+          <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
             Toggle side navigation
-          </button>
+          </a>
         </div>
 
         <h3>Title</h3>

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -132,6 +132,8 @@ View example of the side navigation pattern for raw HTML
 On small screens side navigation is rendered off-screen as a drawer. To open the side navigation drawer, add `is-expanded` class to
 main `.p-side-navigation` element. To close the drawer (with the animation) remove `is-expanded` class and replace it with `is-collapsed` class.
 
+To make sure side navigation toggle works without JavaScript the toggle button for opening the side navigation drawer should be an anchor with href linking to the id attribute of the side navigation element (for example: `<a href="#drawer" class="p-side-navigation__toggle">`).
+
 #### Theming
 
 The side navigation is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_settings_colors.scss).


### PR DESCRIPTION
## Done

Adds no-JS fallback to the side navigation component

Fixes #3026 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3065.run.demo.haus/docs/)
- Disable JS in browser
- Check [Vanilla docs](https://vanilla-framework-canonical-web-and-design-pr-3065.run.demo.haus/docs/) on small screen, make sure side navigation can be toggled on/off
- Check all [Side navigation examples](https://vanilla-framework-canonical-web-and-design-pr-3065.run.demo.haus/docs/examples), make sure toggle works without JS
- Enable JS in browser
- Check [Side navigation examples](https://vanilla-framework-canonical-web-and-design-pr-3065.run.demo.haus/docs/examples) again, make sure clicking on toggle with JS enabled doesn't change the URL





