### PR TITLE
Adjust border color of interactive elements to meet AA 

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -82,9 +82,9 @@
   $button-disabled-background-color: $color-transparent,
   $button-disabled-border-color: $colors--light-theme--border-high-contrast,
   $button-border-color: $colors--light-theme--border-high-contrast,
-  $button-hover-background-color: darken($color-x-light, $hover-darken-percentage),
+  $button-hover-background-color: darken($color-x-light, $hover-background-darken-percentage),
   $button-hover-border-color: $colors--light-theme--border-high-contrast,
-  $button-active-background-color: darken($color-x-light, $active-darken-percentage),
+  $button-active-background-color: darken($color-x-light, $active-background-darken-percentage),
   $button-active-border-color: $colors--light-theme--border-high-contrast
 ) {
   background-color: $button-background-color;

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -34,7 +34,7 @@
     &:disabled,
     &.is-disabled {
       cursor: not-allowed;
-      opacity: 0.5;
+      opacity: $disabled-element-opacity;
     }
 
     @media only screen and (max-width: $breakpoint-x-small) {
@@ -80,12 +80,12 @@
   $button-background-color: $color-x-light,
   $button-text-color: $color-x-dark,
   $button-disabled-background-color: $color-transparent,
-  $button-disabled-border-color: $color-mid,
-  $button-border-color: $color-mid,
-  $button-hover-background-color: darken($color-x-light, 10%),
-  $button-hover-border-color: $color-mid,
-  $button-active-background-color: darken($color-x-light, 15%),
-  $button-active-border-color: $color-mid
+  $button-disabled-border-color: $colors--light-theme--border-high-contrast,
+  $button-border-color: $colors--light-theme--border-high-contrast,
+  $button-hover-background-color: darken($color-x-light, $hover-darken-percentage),
+  $button-hover-border-color: $colors--light-theme--border-high-contrast,
+  $button-active-background-color: darken($color-x-light, $active-darken-percentage),
+  $button-active-border-color: $colors--light-theme--border-high-contrast
 ) {
   background-color: $button-background-color;
   border-color: $button-border-color;
@@ -95,16 +95,15 @@
     color: $button-text-color;
   }
 
-  &:active,
-  &:active:hover {
-    background-color: $button-active-background-color;
-    border-color: $button-active-border-color;
-    transition-duration: 0s;
-  }
-
   &:hover {
     background-color: $button-hover-background-color;
     border-color: $button-hover-border-color;
+  }
+
+  &:active {
+    background-color: $button-active-background-color;
+    border-color: $button-active-border-color;
+    transition-duration: 0s;
   }
 
   &:disabled,

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -4,7 +4,7 @@
   $thumb-radius: $bar-thickness;
   $track-height: 5px;
   $track-border-size: 1px;
-  $track-border: $track-border-size solid $color-mid-light;
+  $track-border: $track-border-size solid $colors--light-theme--border-high-contrast;
   $track-radius: $bar-thickness;
 
   // stylelint-disable-next-line selector-no-qualifying-type

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -484,7 +484,7 @@ $box-offsets-top: (
   // color of the tick element background
     $color-tick-background,
   // color of the tick element border
-    $color-tick-border
+    $color-tick-border: $colors--light-theme--border-high-contrast
 ) {
   & + label {
     color: $color-tick-text;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -25,7 +25,7 @@
     // stylelint-enable property-no-vendor-prefix
 
     background-color: $color-x-light;
-    border: 1px solid $color-mid;
+    border: 1px solid $colors--light-theme--border-high-contrast;
     border-radius: 0;
     box-shadow: inset 0 1px 1px $color-input-shadow;
     color: $color-dark;
@@ -46,22 +46,12 @@
       padding-top: calc(#{$spv-nudge - $spv-inner--x-small} - 1px);
     }
 
-    &:active {
-      border-color: $color-mid-dark;
-      color: $color-dark;
-      outline: none;
-    }
-
     &::-webkit-placeholder,
     &::-ms-placeholder,
     &:-ms-placeholder,
     &::placeholder {
       color: $color-mid-dark;
       opacity: 1;
-    }
-
-    &:focus {
-      border-color: $color-mid-dark;
     }
 
     &[disabled],
@@ -84,7 +74,7 @@
   // Disabled form elements
   %vf-disabled-element {
     cursor: not-allowed;
-    opacity: 0.5;
+    opacity: $disabled-element-opacity;
   }
 
   // Readonly form elements
@@ -221,7 +211,7 @@
   // Fieldset styles
   fieldset {
     background-color: $color-light;
-    border: 1px solid $color-mid-light;
+    border: 1px solid $colors--light-theme--border-high-contrast;
     border-radius: $border-radius;
     color: $color-dark;
     margin-bottom: $spv-outer--scaleable;

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -19,7 +19,7 @@
     @include vf-button-pattern(
       $button-disabled-background-color: $color-x-light,
       $button-disabled-border-color: $color-x-light,
-      $button-active-background-color: darken($color-light, $active-darken-percentage),
+      $button-active-background-color: darken($color-light, $active-background-darken-percentage),
       $button-active-border-color: $color-x-light
     );
   }
@@ -49,12 +49,12 @@
       $button-background-color: $color-brand,
       $button-border-color: $color-brand,
       $button-text-color: vf-contrast-text-color($color-brand),
-      $button-hover-background-color: darken($color-brand, $hover-darken-percentage),
-      $button-hover-border-color: darken($color-brand, $hover-darken-percentage),
+      $button-hover-background-color: darken($color-brand, $hover-background-darken-percentage),
+      $button-hover-border-color: darken($color-brand, $hover-background-darken-percentage),
       $button-disabled-background-color: $color-brand,
       $button-disabled-border-color: $color-brand,
-      $button-active-background-color: darken($color-brand, $active-darken-percentage),
-      $button-active-border-color: darken($color-brand, $active-darken-percentage)
+      $button-active-background-color: darken($color-brand, $active-background-darken-percentage),
+      $button-active-border-color: darken($color-brand, $active-background-darken-percentage)
     );
   }
 
@@ -71,12 +71,12 @@
       $button-background-color: $color-positive,
       $button-border-color: $color-positive,
       $button-text-color: $color-x-light,
-      $button-hover-background-color: darken($color-positive, $hover-darken-percentage),
-      $button-hover-border-color: darken($color-positive, $hover-darken-percentage),
+      $button-hover-background-color: darken($color-positive, $hover-background-darken-percentage),
+      $button-hover-border-color: darken($color-positive, $hover-background-darken-percentage),
       $button-disabled-background-color: $color-positive,
       $button-disabled-border-color: $color-positive,
-      $button-active-background-color: darken($color-positive, $active-darken-percentage),
-      $button-active-border-color: darken($color-positive, $active-darken-percentage)
+      $button-active-background-color: darken($color-positive, $active-background-darken-percentage),
+      $button-active-border-color: darken($color-positive, $active-background-darken-percentage)
     );
 
     @include vf-focus($color-focus-positive);
@@ -95,12 +95,12 @@
       $button-background-color: $color-negative,
       $button-border-color: $color-negative,
       $button-text-color: $color-x-light,
-      $button-hover-background-color: darken($color-negative, $hover-darken-percentage),
-      $button-hover-border-color: darken($color-negative, $hover-darken-percentage),
+      $button-hover-background-color: darken($color-negative, $hover-background-darken-percentage),
+      $button-hover-border-color: darken($color-negative, $hover-background-darken-percentage),
       $button-disabled-background-color: $color-negative,
       $button-disabled-border-color: $color-negative,
-      $button-active-background-color: darken($color-negative, $active-darken-percentage),
-      $button-active-border-color: darken($color-negative, $active-darken-percentage)
+      $button-active-background-color: darken($color-negative, $active-background-darken-percentage),
+      $button-active-border-color: darken($color-negative, $active-background-darken-percentage)
     );
 
     @include vf-focus($color-focus-negative);
@@ -119,9 +119,9 @@
       $button-background-color: $color-transparent,
       $button-border-color: $color-transparent,
       $button-text-color: $color-x-dark,
-      $button-hover-background-color: darken($color-x-light, $hover-darken-percentage),
+      $button-hover-background-color: darken($color-x-light, $hover-background-darken-percentage),
       $button-hover-border-color: $color-transparent,
-      $button-active-background-color: darken($color-light, $active-darken-percentage),
+      $button-active-background-color: darken($color-light, $active-background-darken-percentage),
       $button-active-border-color: $color-transparent
     );
   }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -19,7 +19,7 @@
     @include vf-button-pattern(
       $button-disabled-background-color: $color-x-light,
       $button-disabled-border-color: $color-x-light,
-      $button-active-background-color: darken($color-light, 15%),
+      $button-active-background-color: darken($color-light, $active-darken-percentage),
       $button-active-border-color: $color-x-light
     );
   }
@@ -33,14 +33,7 @@
   %p-button--neutral {
     @extend %vf-button-base;
 
-    @include vf-button-pattern(
-      $button-disabled-border-color: $color-mid,
-      $button-border-color: $color-mid,
-      $button-hover-background-color: darken($color-x-light, 10%),
-      $button-hover-border-color: $color-mid,
-      $button-active-background-color: darken($color-x-light, 15%),
-      $button-active-border-color: $color-mid
-    );
+    @include vf-button-pattern;
   }
 
   .p-button--neutral {
@@ -56,12 +49,12 @@
       $button-background-color: $color-brand,
       $button-border-color: $color-brand,
       $button-text-color: vf-contrast-text-color($color-brand),
-      $button-hover-background-color: darken($color-brand, 10%),
-      $button-hover-border-color: darken($color-brand, 10%),
+      $button-hover-background-color: darken($color-brand, $hover-darken-percentage),
+      $button-hover-border-color: darken($color-brand, $hover-darken-percentage),
       $button-disabled-background-color: $color-brand,
       $button-disabled-border-color: $color-brand,
-      $button-active-background-color: darken($color-brand, 15%),
-      $button-active-border-color: darken($color-brand, 15%)
+      $button-active-background-color: darken($color-brand, $active-darken-percentage),
+      $button-active-border-color: darken($color-brand, $active-darken-percentage)
     );
   }
 
@@ -78,12 +71,12 @@
       $button-background-color: $color-positive,
       $button-border-color: $color-positive,
       $button-text-color: $color-x-light,
-      $button-hover-background-color: darken($color-positive, 10%),
-      $button-hover-border-color: darken($color-positive, 10%),
+      $button-hover-background-color: darken($color-positive, $hover-darken-percentage),
+      $button-hover-border-color: darken($color-positive, $hover-darken-percentage),
       $button-disabled-background-color: $color-positive,
       $button-disabled-border-color: $color-positive,
-      $button-active-background-color: darken($color-positive, 15%),
-      $button-active-border-color: darken($color-positive, 15%)
+      $button-active-background-color: darken($color-positive, $active-darken-percentage),
+      $button-active-border-color: darken($color-positive, $active-darken-percentage)
     );
 
     @include vf-focus($color-focus-positive);
@@ -102,12 +95,12 @@
       $button-background-color: $color-negative,
       $button-border-color: $color-negative,
       $button-text-color: $color-x-light,
-      $button-hover-background-color: darken($color-negative, 10%),
-      $button-hover-border-color: darken($color-negative, 10%),
+      $button-hover-background-color: darken($color-negative, $hover-darken-percentage),
+      $button-hover-border-color: darken($color-negative, $hover-darken-percentage),
       $button-disabled-background-color: $color-negative,
       $button-disabled-border-color: $color-negative,
-      $button-active-background-color: darken($color-negative, 15%),
-      $button-active-border-color: darken($color-negative, 15%)
+      $button-active-background-color: darken($color-negative, $active-darken-percentage),
+      $button-active-border-color: darken($color-negative, $active-darken-percentage)
     );
 
     @include vf-focus($color-focus-negative);
@@ -126,9 +119,9 @@
       $button-background-color: $color-transparent,
       $button-border-color: $color-transparent,
       $button-text-color: $color-x-dark,
-      $button-hover-background-color: darken($color-x-light, 10%),
+      $button-hover-background-color: darken($color-x-light, $hover-darken-percentage),
       $button-hover-border-color: $color-transparent,
-      $button-active-background-color: darken($color-light, 15%),
+      $button-active-background-color: darken($color-light, $active-darken-percentage),
       $button-active-border-color: $color-transparent
     );
   }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -26,6 +26,10 @@ $color-caution: #f99b11 !default;
 $color-positive: #0e8620 !default;
 $color-information: #24598f !default;
 
+$hover-darken-percentage: 10%;
+$active-darken-percentage: 15%;
+$disabled-element-opacity: 0.33;
+
 $color-label-validated: #006b75;
 
 $states: (
@@ -67,7 +71,7 @@ $colors--light-theme--background-highlight: #f7f7f7 !default;
 $colors--light-theme--background-overlay: transparentize($color-dark, 0.15) !default;
 
 $colors--light-theme--border-default: #cdcdcd !default;
-$colors--light-theme--border-high-contrast: #999 !default;
+$colors--light-theme--border-high-contrast: #717171 !default;
 $colors--light-theme--border-low-contrast: #e5e5e5 !default;
 
 // Dark theme

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -1,10 +1,7 @@
 // Global color settings
 $color-transparent: transparent !default;
 
-$color-brand: #333 !default;
-$color-accent: $color-brand !default;
-$color-accent-background: $color-accent !default;
-
+// Generic gray values (used in elements that have not been themed yet)
 $color-x-light: #fff !default;
 $color-light: #f7f7f7 !default;
 $color-mid-x-light: #e5e5e5 !default;
@@ -15,22 +12,36 @@ $color-dark: #111 !default;
 $color-x-dark: #000 !default;
 $color-input-shadow: rgba($color-x-dark, 0.12) !default;
 
-$color-link: #06c !default;
-$color-link-visited: #7d42b8 !default;
-$color-focus: #2e96ff !default;
-$color-focus-positive: #003008 !default;
-$color-focus-negative: #3b0006 !default;
-
+// SEMANTIC COLOURS
 $color-negative: #c7162b !default;
 $color-caution: #f99b11 !default;
 $color-positive: #0e8620 !default;
 $color-information: #24598f !default;
 
-$hover-darken-percentage: 10%;
-$active-darken-percentage: 15%;
+// STATE VARIABLES
 $disabled-element-opacity: 0.33;
 
+// Link colors
+$color-link: #06c !default;
+$color-link-visited: #7d42b8 !default;
+$color-focus: #2e96ff !default;
+
+// Focus modifications to meet AA 3:1 contrast ratio against
+// button background for positive/negative buttons
+$color-focus-positive: #003008 !default;
+$color-focus-negative: #3b0006 !default;
+
+// Button background color changes
+$hover-background-darken-percentage: 10%;
+$active-background-darken-percentage: 15%;
+
+// NON-SEMANTIC COLOURS
 $color-label-validated: #006b75;
+
+// Branding colors
+$color-brand: #333 !default;
+$color-accent: $color-brand !default;
+$color-accent-background: $color-accent !default;
 
 $states: (
   error: $color-negative,

--- a/templates/docs/examples/templates/tick-element-comparison.html
+++ b/templates/docs/examples/templates/tick-element-comparison.html
@@ -2,66 +2,137 @@
 {% block title %}Forms / Tick elements{% endblock %}
 
 {% block content %}
-<div class="p-strip is-shallow u-no-padding--top">
-  <div class="row">
-  </div>
-  <div class="row">
-    <div class="col-3">
-      <form action="">
+<!-- <div class="p-strip--dark">
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row">
+    </div>
+    <div class="row">
+      <div class="col-3">
+        <form action="">
+          <input type="checkbox" id="checkExample2">
+          <label for="checkExample2">Checkbox option 2</label>
+          <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+          <label for="Radio1">Radio option 1</label>
+        </form>
+      </div>
+      <div class="col-3">
+        <form action="">
+          <input type="text">
+          <button>Button</button>
+          <button>Button</button>
+          <button>Button</button>
+          <button disabled>Button</button>
+        </form>
+      </div>
+      <div class="col-3">
+        <form action="">
+          <input type="text">
+          <input type="checkbox" id="checkExample1" checked>
+          <label for="checkExample1">Checkbox option 1</label>
+        </form>
+      </div>
+      <div class="col-3">
+        <form action="">
+          <input type="text">
+          <select name="" id=""></select>
+        </form>
+      </div>
+      <div class="col-3">
         <input type="checkbox" id="checkExample2">
         <label for="checkExample2">Checkbox option 2</label>
         <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
         <label for="Radio1">Radio option 1</label>
-      </form>
+        <input type="radio" name="RadioOptions" id="Radio2" value="option2">
+        <label for="Radio2">Radio option 2</label>
+      </div>
+      <div class="col-3">
+        <input type="radio" name="RadioOptions" id="Radio3" value="option3" >
+        <label for="Radio3">Radio option 3</label>
+        <input type="radio" name="RadioOptions" id="Radio4" value="option4">
+        <label for="Radio4">Radio option 4</label>
+        <input type="checkbox" id="checkExample3" checked>
+        <label for="checkExample3">Checkbox option 3</label>
+        <input type="checkbox" id="checkExample4">
+        <label for="checkExample4">Checkbox option 4</label>
+      </div>
     </div>
-    <div class="col-3">
-      <form action="">
-        <input type="text">
-        <button>Button</button>
-        <button>Button</button>
-        <button>Button</button>
-        <button>Button</button>
-      </form>
+  </div>
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row">
+      <hr>
+      <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use class "is-inline-label" on the label to achieve that.</p>
     </div>
-    <div class="col-3">
-      <form action="">
-        <input type="text">
-        <input type="checkbox" id="checkExample1" checked>
-        <label for="checkExample1">Checkbox option 1</label>
-      </form>
+  </div>
+
+</div> -->
+
+<div class="p-strip">
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row">
     </div>
-    <div class="col-3">
-      <form action="">
-        <input type="text">
-        <select name="" id=""></select>
-      </form>
+    <div class="row">
+      <div class="col-3">
+        <form action="">
+          <input type="checkbox" id="checkExample2">
+          <label for="checkExample2">Checkbox option 2</label>
+          <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+          <label for="Radio1">Radio option 1</label>
+        </form>
+      </div>
+      <div class="col-3">
+        <form action="">
+          <input type="text">
+          <button>Button</button>
+          <button class="p-button--neutral">Button</button>
+          <button class="p-button--negative">Button</button>
+          <a class="p-button--negative">Button</a>
+          <button class="p-button--positive">Button</button>
+          <button class="p-button--positive" disabled>Button</button>
+          <button>Button</button>
+          <button disabled>Button</button>
+        </form>
+      </div>
+      <div class="col-3">
+        <form action="">
+          <input type="text">
+          <input type="checkbox" id="checkExample1" checked>
+          <label for="checkExample1">Checkbox option 1</label>
+        </form>
+      </div>
+      <div class="col-3">
+        <form action="">
+          <input type="text" placeholder="Enter email">
+          <select name="" id=""></select>
+        </form>
+      </div>
+      <div class="col-3">
+        <input type="checkbox" id="checkExample2">
+        <label for="checkExample2">Checkbox option 2</label>
+        <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+        <label for="Radio1">Radio option 1</label>
+        <input type="radio" name="RadioOptions" id="Radio2" value="option2">
+        <label for="Radio2">Radio option 2</label>
+      </div>
+      <div class="col-3">
+        <input type="radio" name="RadioOptions" id="Radio3" value="option3" >
+        <label for="Radio3">Radio option 3</label>
+        <input type="radio" name="RadioOptions" id="Radio4" value="option4">
+        <label for="Radio4">Radio option 4</label>
+        <input type="checkbox" id="checkExample3" checked>
+        <label for="checkExample3">Checkbox option 3</label>
+        <input type="checkbox" id="checkExample4">
+        <label for="checkExample4">Checkbox option 4</label>
+      </div>
     </div>
-    <div class="col-3">
-      <input type="checkbox" id="checkExample2">
-      <label for="checkExample2">Checkbox option 2</label>
-      <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
-      <label for="Radio1">Radio option 1</label>
-      <input type="radio" name="RadioOptions" id="Radio2" value="option2">
-      <label for="Radio2">Radio option 2</label>
-    </div>
-    <div class="col-3">
-      <input type="radio" name="RadioOptions" id="Radio3" value="option3" >
-      <label for="Radio3">Radio option 3</label>
-      <input type="radio" name="RadioOptions" id="Radio4" value="option4">
-      <label for="Radio4">Radio option 4</label>
-      <input type="checkbox" id="checkExample3" checked>
-      <label for="checkExample3">Checkbox option 3</label>
-      <input type="checkbox" id="checkExample4">
-      <label for="checkExample4">Checkbox option 4</label>
+  </div>
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row">
+      <hr>
+      <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use class "is-inline-label" on the label to achieve that.</p>
     </div>
   </div>
 </div>
-<div class="p-strip is-shallow u-no-padding--top">
-  <div class="row">
-    <hr>
-    <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use class "is-inline-label" on the label to achieve that.</p>
-  </div>
-</div>
+
 <div class="p-strip is-shallow u-no-padding--top">
   <div class="u-fixed-width">
     <table class="p-table--mobile-card">

--- a/templates/docs/examples/templates/tick-element-comparison.html
+++ b/templates/docs/examples/templates/tick-element-comparison.html
@@ -2,69 +2,6 @@
 {% block title %}Forms / Tick elements{% endblock %}
 
 {% block content %}
-<!-- <div class="p-strip--dark">
-  <div class="p-strip is-shallow u-no-padding--top">
-    <div class="row">
-    </div>
-    <div class="row">
-      <div class="col-3">
-        <form action="">
-          <input type="checkbox" id="checkExample2">
-          <label for="checkExample2">Checkbox option 2</label>
-          <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
-          <label for="Radio1">Radio option 1</label>
-        </form>
-      </div>
-      <div class="col-3">
-        <form action="">
-          <input type="text">
-          <button>Button</button>
-          <button>Button</button>
-          <button>Button</button>
-          <button disabled>Button</button>
-        </form>
-      </div>
-      <div class="col-3">
-        <form action="">
-          <input type="text">
-          <input type="checkbox" id="checkExample1" checked>
-          <label for="checkExample1">Checkbox option 1</label>
-        </form>
-      </div>
-      <div class="col-3">
-        <form action="">
-          <input type="text">
-          <select name="" id=""></select>
-        </form>
-      </div>
-      <div class="col-3">
-        <input type="checkbox" id="checkExample2">
-        <label for="checkExample2">Checkbox option 2</label>
-        <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
-        <label for="Radio1">Radio option 1</label>
-        <input type="radio" name="RadioOptions" id="Radio2" value="option2">
-        <label for="Radio2">Radio option 2</label>
-      </div>
-      <div class="col-3">
-        <input type="radio" name="RadioOptions" id="Radio3" value="option3" >
-        <label for="Radio3">Radio option 3</label>
-        <input type="radio" name="RadioOptions" id="Radio4" value="option4">
-        <label for="Radio4">Radio option 4</label>
-        <input type="checkbox" id="checkExample3" checked>
-        <label for="checkExample3">Checkbox option 3</label>
-        <input type="checkbox" id="checkExample4">
-        <label for="checkExample4">Checkbox option 4</label>
-      </div>
-    </div>
-  </div>
-  <div class="p-strip is-shallow u-no-padding--top">
-    <div class="row">
-      <hr>
-      <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use class "is-inline-label" on the label to achieve that.</p>
-    </div>
-  </div>
-
-</div> -->
 
 <div class="p-strip">
   <div class="p-strip is-shallow u-no-padding--top">


### PR DESCRIPTION
## Done

- adjust border color of interactive elements to meet AA on #f7f7f7 and lighter backgrounds; 
- small color refactor linking variables that should change in sync with each other
- update tick element template example to include more components in different states

Fixes #3057 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- QA forms examples, as many as possible; bare minimum: http://192.168.64.2:8101/docs/examples/templates/tick-element-comparison - border should be #717171 in all states

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/81948489-b5571580-95f9-11ea-98c4-36fc68871c38.png)
