### PR TITLE
Bump Vanilla version to 2.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.10.1",
+  "version": "2.11.0",
   "files": [
     "/scss",
     "!/scss/docs"


### PR DESCRIPTION
## Done

Just a version bump for next release.


## QA

- './run' or [demo](https://vanilla-framework-canonical-web-and-design-pr-3070.run.demo.haus/docs)
- Check the [docs](https://vanilla-framework-canonical-web-and-design-pr-3070.run.demo.haus/docs) if latest version is 2.11

