### PR TITLE
Fix focus outline in navigation and tabs

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -17,6 +17,7 @@ $lightness-threshold: 70;
   %navigation-link {
     $properties: #{background-color, color, opacity};
     @include vf-animation($properties);
+    @include vf-focus;
 
     display: block;
     line-height: map-get($line-heights, default-text);

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -73,6 +73,8 @@ $lightness-threshold: 70;
   }
 
   %navigation-item-in-logo {
+    @include vf-focus;
+
     display: flex;
   }
 
@@ -212,6 +214,8 @@ $lightness-threshold: 70;
 
       &--open,
       &--close {
+        @include vf-focus;
+
         margin: 0 0 auto $sph-inner;
         padding: $spv-inner--medium 0;
 

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -32,6 +32,8 @@
     }
 
     &__list {
+      @extend %vf-pseudo-border--bottom;
+
       display: flex;
       margin: 0 auto $spv-outer--scaleable;
       overflow-x: auto;
@@ -71,6 +73,7 @@
         @extend %vf-pseudo-border;
 
         bottom: 0;
+        z-index: 1;
       }
 
       &:hover,

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -32,8 +32,6 @@
     }
 
     &__list {
-      @extend %vf-pseudo-border--bottom;
-
       display: flex;
       font-size: 0;
       margin: 0 auto $spv-outer--scaleable;
@@ -45,9 +43,6 @@
     }
 
     &__item {
-      @extend %vf-pseudo-border--bottom;
-
-      display: inline-block;
       float: none;
       font-size: 1rem;
       margin: 0;
@@ -60,8 +55,11 @@
     }
 
     &__link {
+      @include vf-focus;
+      @extend %vf-pseudo-border--bottom;
+
       color: $color-x-dark;
-      display: inline-block;
+      display: block;
       line-height: map-get($line-heights, default-text);
       padding: $spv-inner--medium $sph-inner;
 
@@ -75,6 +73,11 @@
       &:hover,
       &[aria-selected='true'] {
         @include vf-highlight-bar($color-tabs-active-bar, bottom, true);
+
+        &:focus::before,
+        &:focus::after {
+          content: none;
+        }
       }
     }
   }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -33,7 +33,7 @@
 
     &__list {
       display: flex;
-      margin: 0 auto $spv-outer--scaleable;
+      margin: 0 auto calc($spv-outer--scaleable);
       overflow-x: auto;
       padding: 0;
       position: relative;
@@ -52,13 +52,13 @@
     }
 
     &__link {
-      @extend %vf-pseudo-border--bottom;
       @include vf-focus;
 
       color: $color-x-dark;
       display: block;
       line-height: map-get($line-heights, default-text);
       padding: $spv-inner--medium $sph-inner;
+      position: relative;
 
       &:active,
       &:hover,
@@ -67,9 +67,15 @@
         text-decoration: none;
       }
 
+      &::before {
+        @extend %vf-pseudo-border;
+
+        bottom: 0;
+      }
+
       &:hover,
       &[aria-selected='true'] {
-        @include vf-highlight-bar($color-tabs-active-bar, bottom, true);
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
 
         &:focus::before,
         &:focus::after {

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -52,17 +52,17 @@
     }
 
     &__link {
-      @include vf-focus;
       @extend %vf-pseudo-border--bottom;
+      @include vf-focus;
 
       color: $color-x-dark;
       display: block;
       line-height: map-get($line-heights, default-text);
       padding: $spv-inner--medium $sph-inner;
 
-      &:visited,
       &:active,
-      &:hover {
+      &:hover,
+      &:visited {
         color: $color-x-dark;
         text-decoration: none;
       }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -33,7 +33,7 @@
 
     &__list {
       display: flex;
-      margin: 0 auto calc($spv-outer--scaleable);
+      margin: 0 auto $spv-outer--scaleable;
       overflow-x: auto;
       padding: 0;
       position: relative;

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -33,7 +33,6 @@
 
     &__list {
       display: flex;
-      font-size: 0;
       margin: 0 auto $spv-outer--scaleable;
       overflow-x: auto;
       padding: 0;
@@ -43,8 +42,6 @@
     }
 
     &__item {
-      float: none;
-      font-size: 1rem;
       margin: 0;
       padding: 0;
       width: auto;

--- a/templates/docs/examples/patterns/tabs.html
+++ b/templates/docs/examples/patterns/tabs.html
@@ -17,49 +17,42 @@
     <li class="p-tabs__item" role="presentation">
       <a href="#section2"
         class="p-tabs__link"
-        tabindex="-1"
         role="tab"
         aria-controls="section2">Interfaces</a>
     </li>
     <li class="p-tabs__item" role="presentation">
       <a href="#section3"
         class="p-tabs__link"
-        tabindex="-1"
         role="tab"
         aria-controls="section3">Storage</a>
     </li>
     <li class="p-tabs__item" role="presentation">
       <a href="#section4"
         class="p-tabs__link"
-        tabindex="-1"
         role="tab"
         aria-controls="section4">Commissioning</a>
     </li>
     <li class="p-tabs__item" role="presentation">
       <a href="#section5"
         class="p-tabs__link"
-        tabindex="-1"
         role="tab"
         aria-controls="section5">Hardware tests</a>
     </li>
     <li class="p-tabs__item" role="presentation">
       <a href="#section6"
         class="p-tabs__link"
-        tabindex="-1"
         role="tab"
         aria-controls="section6">Logs</a>
     </li>
     <li class="p-tabs__item" role="presentation">
       <a href="#section7"
         class="p-tabs__link"
-        tabindex="-1"
         role="tab"
         aria-controls="section7">Event</a>
     </li>
     <li class="p-tabs__item" role="presentation">
       <a href="#section8"
         class="p-tabs__link"
-        tabindex="-1"
         role="tab"
         aria-controls="section8">Configuration</a>
     </li>


### PR DESCRIPTION
## Done

Fix a focus states in the tabstrip and nav. partial fix for https://github.com/canonical-web-and-design/vanilla-framework/issues/3073

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/navigation/default-dark and /docs/examples/patterns/tabs
- Verify the focus outline appears within the elements, rather than outside them



## Screenshots

Tabs: 

![image](https://user-images.githubusercontent.com/2741678/82333558-cb404e00-99de-11ea-8542-db4107ca83ee.png)

Nav:

![image](https://user-images.githubusercontent.com/2741678/82333954-430e7880-99df-11ea-81d7-3b11e62f8912.png)

Fixes #3073

