### PR TITLE
Support rgba colors in `vf-url-friendly-color` function

### DIFF
--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -1,13 +1,31 @@
 // Functions used across multiple patterns or utils
 
-// This is to get the variable inserted in an inline svg, we have to strip the #
-// and replace with %23
+/// Replace `$search` with `$replace` in `$string`
+/// see: https://css-tricks.com/snippets/sass/str-replace-function/
+/// @author Hugo Giraudel
+/// @param {String} $string - Initial string
+/// @param {String} $search - Substring to replace
+/// @param {String} $replace ('') - New value
+/// @return {String} - Updated string
+@function str-replace($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+
+  @return $string;
+}
+
+// This is to get the color variable inserted in an inline svg,
+// we have to strip the `#` and replace with %23 for #HEX notation, or
+// remove spaces and replace `,` with %2C for rgba() notation.
 @function vf-url-friendly-color($color) {
   @if type-of($color) != 'color' {
     @warn '#{$color} is not a color.';
     @return $color;
   } @else {
-    @return '%23' + str-slice('#{$color}', 2, -1);
+    @return str-replace(str-replace(str-replace('#{$color}', '#', '%23'), ',', '%2C'), ' ');
   }
 }
 


### PR DESCRIPTION
## Done

Fixes #2955 

## QA

- Pull code
- in `_pattern_icons.scss` replace color in any icon mixin `@include vf-icon-anchor($color-mid-dark);` with rgba value (like `@include vf-icon-anchor(rgba(255,255,255,0.5))`;
- rebuild vanilla (there should be no errors)
- check icons example locally, see if transparent color was correctly applied to the icon changed

