### PR TITLE
Remove vertical offsets from divider lines

### DIFF
--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -26,7 +26,7 @@
     }
 
     @media (min-width: $threshold-6-12-col) {
-      &:not(:nth-child(1))::before {
+      &:not(:first-child)::before {
         background-color: $color-mid-light;
         bottom: 0;
         content: '';

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -28,11 +28,11 @@
     @media (min-width: $threshold-6-12-col) {
       &:not(:nth-child(1))::before {
         background-color: $color-mid-light;
-        bottom: $sp-unit; // compensate for bottom margin on children
+        bottom: 0;
         content: '';
         left: map-get($grid-gutter-widths, large) * -0.5; // "large" here is not a typo. The grid switches to 12 columns at breakpoint medium. Hence the use of large-screen gutter
         position: absolute;
-        top: $sp-unit;
+        top: 0;
         width: 1px;
       }
     }


### PR DESCRIPTION
## Done

Remove vertical offsets from divider lines

Fixes #3086

## QA

- Pull code
- Run `./run`
- Open docs/examples/patterns/lists/divider
- Verify divider lines span the full height of the component.

![image](https://user-images.githubusercontent.com/2741678/82662654-26b04d00-9c26-11ea-8abb-55da01f0d78e.png)
