### PR TITLE
Add muted text and small refactor

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -78,7 +78,7 @@
 /// override colors as desired
 @mixin vf-button-pattern(
   $button-background-color: $color-x-light,
-  $button-text-color: $color-x-dark,
+  $button-text-color: $color-dark,
   $button-disabled-background-color: $color-transparent,
   $button-disabled-border-color: $colors--light-theme--border-high-contrast,
   $button-border-color: $colors--light-theme--border-high-contrast,

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -218,17 +218,21 @@
     }
   }
 
+  %muted-text {
+    color: $colors--light-theme--text-muted;
+  }
+
   %table-header-label {
+    @extend %muted-text;
     @extend %x-small-text;
 
-    color: $color-mid-dark;
-    font-weight: 400;
+    font-weight: $font-weight-bold;
   }
 
   %muted-heading {
     @extend %small-text;
+    @extend %muted-text;
 
-    color: $color-mid-dark;
     margin-bottom: map-get($sp-after, small) - map-get($nudges, nudge--small);
     margin-top: 0;
     padding-top: map-get($nudges, nudge--small);

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -32,7 +32,7 @@
 // Test value of bg $color and return light or dark text color accordingly
 @function vf-contrast-text-color($color) {
   @if (lightness($color) > 55) {
-    @return $color-x-dark; // Lighter background, return dark color
+    @return $color-dark; // Lighter background, return dark color
   } @else {
     @return $color-x-light; // Darker background, return light color
   }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -118,7 +118,7 @@
     @include vf-button-pattern(
       $button-background-color: $color-transparent,
       $button-border-color: $color-transparent,
-      $button-text-color: $color-x-dark,
+      $button-text-color: $color-dark,
       $button-hover-background-color: darken($color-x-light, $hover-background-darken-percentage),
       $button-hover-border-color: $color-transparent,
       $button-active-background-color: darken($color-light, $active-background-darken-percentage),

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -8,7 +8,7 @@
     border-radius: $border-radius;
     border-style: solid;
     border-width: 1px;
-    color: $color-x-dark;
+    color: $color-dark;
     display: block;
     padding: calc(#{$spv-nudge} - 1px) $sph-inner;
     text-decoration: none;
@@ -27,7 +27,7 @@
     &.is-active {
       background-color: darken($color-x-light, 10%);
       border-color: $color-mid;
-      color: $color-x-dark;
+      color: $color-dark;
       text-decoration: none;
     }
 

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -88,7 +88,7 @@
     background-size: cover;
 
     &.is-light {
-      color: $color-x-dark;
+      color: $color-dark;
     }
 
     &.is-dark {

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -56,7 +56,7 @@
     &__link {
       @include vf-focus;
 
-      color: $color-x-dark;
+      color: $color-dark;
       display: block;
       line-height: map-get($line-heights, default-text);
       padding: $spv-inner--medium $sph-inner;
@@ -65,7 +65,7 @@
       &:active,
       &:hover,
       &:visited {
-        color: $color-x-dark;
+        color: $color-dark;
         text-decoration: none;
       }
 

--- a/scss/_utilities_muted-text.scss
+++ b/scss/_utilities_muted-text.scss
@@ -1,0 +1,5 @@
+@mixin vf-u-text-muted {
+  .u-text--muted {
+    @extend %muted-text;
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -1,6 +1,7 @@
 @import 'settings';
 @import 'base';
 // Patterns
+
 @import 'patterns_accordion';
 @import 'patterns_article-pagination';
 @import 'patterns_breadcrumbs';
@@ -58,6 +59,7 @@
 @import 'utilities_layout';
 @import 'utilities_margin-collapse';
 @import 'utilities_max-width';
+@import 'utilities_muted-text';
 @import 'utilities_off-screen';
 @import 'utilities_padding-collapse';
 @import 'utilities_show';
@@ -88,6 +90,7 @@
   @include vf-p-grid;
   @include vf-p-heading-icon;
   @include vf-p-headings;
+
   @include vf-p-icons;
   @include vf-p-image;
   @include vf-p-inline-images;
@@ -132,6 +135,8 @@
   @include vf-u-padding-collapse;
   @include vf-u-show;
   @include vf-u-truncate;
+  @include vf-u-text-muted;
+
   @include vf-u-vertical-spacing;
   @include vf-u-vertically-center;
   @include vf-u-visualise-baseline;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -51,7 +51,7 @@
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/tables", "Tables") }}
-              {{ side_nav_item("/docs/base/typography", "Typography") }}
+              {{ side_nav_item("/docs/base/typography", "Typography", "new") }}
             </ul>
 
             <ul class="p-side-navigation__list">

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -186,6 +186,8 @@ View example of the Ubuntu font weights.
 
 ### Muted text
 
+<span class="p-label--new">New</span>
+
 To reduce the prominence of text, use class `u-text--muted`.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/muted-text/" class="js-example">

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -184,6 +184,14 @@ If you are using the Ubuntu font, it comes in five weights; thin, light, regular
 View example of the Ubuntu font weights.
 </a></div>
 
+### Muted text
+
+To reduce the prominence of text, use class `u-text--muted`.
+
+<div class="embedded-example"><a href="/docs/examples/utilities/muted-text/" class="js-example">
+View example of the muted-text
+</a></div>
+
 ### Using a smaller set of Latin font faces
 
 The default Ubuntu fonts are fairly large as they contain glyphs for many languages. If you are building sites in; Afrikaans, Albanian, Catalan, Danish, Dutch, English, German, Icelandic, Italian, Norwegian, Portuguese, Spanish, Swedish or Zulu, you could use the subset of Latin fonts by setting the following variable to true:

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -10,7 +10,7 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### What's new in Vanilla 2.11
+### What's new in Vanilla 2.12
 
 <table>
   <thead>
@@ -23,28 +23,22 @@ When we add, make significant updates, or deprecate a component we update their 
   </thead>
   <tbody>
     <tr>
+      <th><a href="/docs/base/typography#muted-text">Muted text</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.12.0</td>
+      <td>New <code>u-text--muted</code> utility class has been added.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/icons">Icons</a></th>
       <td><div class="p-label--updated">Updated</div></td>
-      <td>2.11.1</td>
+      <td>2.12.0</td>
       <td>The icons have been updated to new style.</td>
     </tr>
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Question</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
-      <td>2.11.1</td>
-      <td>The <code>.p-icon--question</code> has been deprecated will be removed in future release v3.0. Please use existing `.p-icon--help` icon instead.</td>
-    </tr>
-    <tr>
-      <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
-      <td>2.11.0</td>
-      <td>A no-JS fallback was added for the side navigation toggle functionality on small screens.</td>
-    </tr>
-    <tr>
-      <th><a href="/docs/patterns/navigation#raw-html">Side navigation</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
-      <td>2.11.0</td>
-      <td>A new raw HTML variant of the side navigation component.</td>
+      <td>2.12.0</td>
+      <td>The <code>p-icon--question</code> has been deprecated will be removed in future release v3.0. Please use existing `.p-icon--help` icon instead.</td>
     </tr>
   </tbody>
 </table>
@@ -61,6 +55,19 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.11.0 -->
+    <tr>
+      <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.11.0</td>
+      <td>A no-JS fallback was added for the side navigation toggle functionality on small screens.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/navigation#raw-html">Side navigation</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.11.0</td>
+      <td>A new raw HTML variant of the side navigation component.</td>
+    </tr>
     <!-- 2.10.0 -->
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>

--- a/templates/docs/examples/utilities/muted-text.html
+++ b/templates/docs/examples/utilities/muted-text.html
@@ -1,0 +1,6 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Muted text{% endblock %}
+
+{% block content %}
+<p class="u-text--muted">Influential contributors of openstack</p>
+{% endblock %}


### PR DESCRIPTION
## Done

Fixes  #3063 - Add .p-muted-text class that turns text #666
Drive-by: Fixes #3062 -  change the few instances of text color that are not #111, but #000, to #111.

## QA

- Pull code
- Run `./run`
- Open http://192.168.64.2:8101/docs/base/typography, check doc is ok (at bottom)
- Open http://192.168.64.2:8101/docs/examples/patterns/muted-text, make sure text is `#666`

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/82676978-2e302000-9c3f-11ea-81a6-83690a8cbcb4.png)
