### PR TITLE
Encode CodePen prefill data

### DIFF
--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -83,7 +83,7 @@
       config.title = title;
     }
 
-    container.setAttribute('data-prefill', JSON.stringify(config));
+    container.setAttribute('data-prefill', encodeURI(JSON.stringify(config)));
     container.setAttribute('data-height', height);
     // For more options see CodePen docs
     // https://blog.codepen.io/documentation/prefill-embeds/


### PR DESCRIPTION
## Done

CodePen seems to be using `decodeURI` when reading data from `data-prefill` attribute.
So we need to use `encodeURI` when setting the attribute to make sure it's correctly encoded if it contains any special characters.

Fixes #3093

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3094.run.demo.haus/docs/layouts/documentation)
- Go to [/docs/layouts/documentation](https://vanilla-framework-canonical-web-and-design-pr-3094.run.demo.haus/docs/layouts/documentation), there should be no errors in console, CodePen should be rendered
- Make sure codepen renders on other pages as well


