### PR TITLE
Fix z-index issues between contextual menu and tabs

### DIFF
--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -24,7 +24,7 @@
     position: absolute;
     right: 0;
     width: fit-content;
-    z-index: 1;
+    z-index: 10;
 
     // When set to false will show the contextual menu
     &[aria-hidden='false'] {

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -1,0 +1,103 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Z-index{% endblock %}
+
+{% block content %}
+<p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="true" aria-haspopup="true">take action left</a>
+    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="false" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
+    <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu">
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
+    <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true" aria-label="submenu">
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Commission</a>
+          <a href="#" class="p-contextual-menu__link">Aquire</a>
+          <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+          <a href="#" class="p-contextual-menu__link">Test harware</a>
+          <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+          <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span> vel eu.</p>
+
+<nav class="p-tabs">
+  <ul class="p-tabs__list" role="tablist">
+    <li class="p-tabs__item" role="presentation">
+      <a href="#section1"
+        class="p-tabs__link"
+        tabindex="0"
+        role="tab"
+        aria-controls="section1"
+        aria-selected="true">Machine summary</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#section2"
+        class="p-tabs__link"
+        role="tab"
+        aria-controls="section2">Interfaces</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#section3"
+        class="p-tabs__link"
+        role="tab"
+        aria-controls="section3">Storage</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#section4"
+        class="p-tabs__link"
+        role="tab"
+        aria-controls="section4">Commissioning</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#section5"
+        class="p-tabs__link"
+        role="tab"
+        aria-controls="section5">Hardware tests</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#section6"
+        class="p-tabs__link"
+        role="tab"
+        aria-controls="section6">Logs</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#section7"
+        class="p-tabs__link"
+        role="tab"
+        aria-controls="section7">Event</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#section8"
+        class="p-tabs__link"
+        role="tab"
+        aria-controls="section8">Configuration</a>
+    </li>
+  </ul>
+</nav>
+{% endblock %}


### PR DESCRIPTION
## Done

Fixes a regression issue of z-index between tabs and contextual menu.
Adds an example to make sure we avoid this regression in future.

Fixes #3068

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3095.run.demo.haus/docs/examples/templates/z-index)
- Check [z-index example](https://vanilla-framework-canonical-web-and-design-pr-3095.run.demo.haus/docs/examples/templates/z-index), make sure contextual menu renders correctly, not overlapping with tabs borders


## Screenshots

<img width="404" alt="Screenshot 2020-05-26 at 11 14 24" src="https://user-images.githubusercontent.com/83575/82882950-14921f80-9f42-11ea-8e5e-bbef46332efe.png">

