### PR TITLE
Add redirect for legacy /docs/en/ URLs

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,5 +1,6 @@
 /en/?: /
 /en/(?P<path>.*): /{path}
+/docs/en/(?P<path>.*): /docs/{path}
 /(?P<path>.+)\.html: /{path}
 /build/(?P<path>.*): /static/build/{path}
 /css/(?P<path>.*): /static/css/{path}


### PR DESCRIPTION
## Done

Make sure old /docs/en/... links work.

Fixes #3056

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- [Add additional steps]



