### PR TITLE
Update light theme border and highlight colors to be transparent

### DIFF
--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -141,7 +141,7 @@
     $color-contextual-menu-background: $colors--light-theme--background-default,
     $color-contextual-menu-border: $colors--light-theme--border-default,
     $color-contextual-menu-text: $colors--light-theme--text-default,
-    $color-contextual-menu-hover-background: $colors--light-theme--background-alt
+    $color-contextual-menu-hover-background: $colors--light-theme--background-highlight
   );
 }
 
@@ -150,6 +150,6 @@
     $color-contextual-menu-background: $colors--dark-theme--background-default,
     $color-contextual-menu-border: $colors--dark-theme--border-default,
     $color-contextual-menu-text: $colors--dark-theme--text-default,
-    $color-contextual-menu-hover-background: $colors--dark-theme--background-alt
+    $color-contextual-menu-hover-background: $colors--dark-theme--background-highlight
   );
 }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -78,12 +78,12 @@ $colors--light-theme--text-muted: #666 !default;
 
 $colors--light-theme--background-default: #fff !default;
 $colors--light-theme--background-alt: #f7f7f7 !default;
-$colors--light-theme--background-highlight: #f7f7f7 !default;
+$colors--light-theme--background-highlight: rgba($color-x-dark, 0.03) !default;
 $colors--light-theme--background-overlay: transparentize($color-dark, 0.15) !default;
 
-$colors--light-theme--border-default: #cdcdcd !default;
-$colors--light-theme--border-high-contrast: #717171 !default;
-$colors--light-theme--border-low-contrast: #e5e5e5 !default;
+$colors--light-theme--border-default: rgba($color-x-dark, 0.2) !default;
+$colors--light-theme--border-high-contrast: rgba($color-x-dark, 0.56) !default;
+$colors--light-theme--border-low-contrast: rgba($color-x-dark, 0.1) !default;
 
 // Dark theme
 $colors--dark-theme--text-default: hsl(0, 0%, 100%) !default;

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -8,8 +8,8 @@
   {% if is_dark %}
   <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
   {% endif %}
-  <div class="p-side-navigation__drawer" {% if is_dark %}style="background: #003b4e"{% endif %}>
-    <div class="p-side-navigation__drawer-header" {% if is_dark %}style="background: #003b4e"{% endif %}>
+  <div class="p-side-navigation__drawer" style="background: {% if is_dark %}#003b4e{% else %}#f7f7f7{% endif %}">
+    <div class="p-side-navigation__drawer-header" style="background: {% if is_dark %}#003b4e{% else %}#f7f7f7{% endif %}">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer-icons">
         Toggle side navigation
       </a>


### PR DESCRIPTION
## Done

Update light theme border and highlight colors to be transparent to fix hover issue in side navigation on gray (`#f7f7f7`) background.

Fixes usage of proper `--highlight` color on hover in contextual menu light theme.

Fixes #3105 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3106.run.demo.haus/docs/examples/patterns/side-navigation/default)
- Go to [side navigation light examples](https://vanilla-framework-canonical-web-and-design-pr-3106.run.demo.haus/docs/examples/patterns/side-navigation/default), make sure they look of both on white and light grey backgrounds
- Go to [contextual menu example](https://vanilla-framework-canonical-web-and-design-pr-3106.run.demo.haus/docs/examples/patterns/contextual-menu/default), make sure hover on items looks ok



## Screenshots

<img width="744" alt="Screenshot 2020-05-29 at 15 13 23" src="https://user-images.githubusercontent.com/83575/83263492-f8e77d00-a1be-11ea-9807-f3d9e8753db1.png">

