### PR TITLE
Update positioning of accordion icon and support headings in accordion

### DIFF
--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -16,18 +16,9 @@
   }
 
   .p-accordion__tab,
-  [class*='p-accordion__tab--'] {
+  .p-accordion__tab--with-title {
     @extend %single-border-text-vpadding--scaling;
     @include vf-focus;
-
-    // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
-    // and offset to align it with baseline of accordion tab text element
-    $icon-top-position: calc(#{$table-cell-vertical-padding} - 1px + 0.25rem);
-
-    background: {
-      position: top $icon-top-position left $sph-inner;
-      repeat: no-repeat;
-    }
 
     background-color: inherit;
     border: 0;
@@ -40,6 +31,17 @@
     transition-duration: 0s;
     width: 100%;
     z-index: 2;
+  }
+
+  .p-accordion__tab {
+    // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
+    // and offset to align it with baseline of accordion tab text element
+    $icon-top-position: calc(#{$table-cell-vertical-padding} - 1px + 0.25rem);
+
+    background: {
+      position: top $icon-top-position left $sph-inner;
+      repeat: no-repeat;
+    }
 
     // aria-selected controls the open and closed state for the accordion tab
     &[aria-expanded='true'] {
@@ -55,20 +57,44 @@
     }
   }
 
-  .p-accordion__tab--h3 {
-    // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
-    // and offset to align it with baseline of accordion tab h3 element
-    $icon-top-position: calc(#{$table-cell-vertical-padding} - 1px + 0.8rem);
+  .p-accordion__title {
+    margin-bottom: 0;
+    padding-top: 0;
+    position: relative;
 
-    background-position: top $icon-top-position left $sph-inner;
+    &::before {
+      // attempt to align icon on the baseline
+      $icon-top-position: calc(#{$baseline-position} - #{$icon-size} + 0.25rem);
+
+      background-size: $icon-size;
+      content: '';
+      display: block;
+      height: $icon-size;
+      left: -$icon-size - $sph-inner;
+      position: absolute;
+      top: $icon-top-position;
+      width: $icon-size;
+    }
   }
 
-  .p-accordion__tab--h4 {
-    // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
-    // and offset to align it with baseline of accordion tab h4 element
-    $icon-top-position: calc(#{$table-cell-vertical-padding} - 1px + 0.5rem);
+  // stylelint-disable-next-line selector-no-qualifying-type
+  h2.p-accordion__title::before {
+    $icon-size-h2: $x-height;
+    // attempt to align icon on the baseline
+    $icon-top-position: calc(#{$baseline-position} - #{$icon-size-h2} + 0.25rem);
 
-    background-position: top $icon-top-position left $sph-inner;
+    background-size: $icon-size-h2;
+    height: $icon-size-h2;
+    top: $icon-top-position;
+    width: $icon-size-h2;
+  }
+
+  .p-accordion__tab--with-title[aria-expanded='true'] .p-accordion__title::before {
+    @include vf-icon-minus($color-mid-dark);
+  }
+
+  .p-accordion__tab--with-title[aria-expanded='false'] .p-accordion__title::before {
+    @include vf-icon-plus($color-mid-dark);
   }
 
   .p-accordion__panel {

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -61,33 +61,36 @@
     margin-bottom: 0;
     padding-top: 0;
     position: relative;
+    text-indent: -$sph-inner - $icon-size;
 
     &::before {
-      // attempt to align icon on the baseline
-      $icon-top-position: calc(#{$baseline-position} - #{$icon-size} + 0.25rem);
-
       background-size: $icon-size;
       content: '';
-      display: block;
+      display: inline-block;
       height: $icon-size;
-      left: -$icon-size - $sph-inner;
-      position: absolute;
-      top: $icon-top-position;
+      margin-right: $sph-inner;
       width: $icon-size;
     }
   }
 
-  // stylelint-disable-next-line selector-no-qualifying-type
+  // stylelint-disable selector-no-qualifying-type
   h2.p-accordion__title::before {
+    // make icon bigger for h2 (same as p-icon)
     $icon-size-h2: $x-height;
-    // attempt to align icon on the baseline
-    $icon-top-position: calc(#{$baseline-position} - #{$icon-size-h2} + 0.25rem);
 
     background-size: $icon-size-h2;
     height: $icon-size-h2;
-    top: $icon-top-position;
     width: $icon-size-h2;
   }
+
+  h5.p-accordion__title::before,
+  h6.p-accordion__title::before {
+    // align icon within font metrics same as p-icon pattern
+    $vertical-offset: 0.5px;
+
+    vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $icon-size});
+  }
+  // stylelint-enable selector-no-qualifying-type
 
   .p-accordion__tab--with-title[aria-expanded='true'] .p-accordion__title::before {
     @include vf-icon-minus($color-mid-dark);

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -1,7 +1,7 @@
 @import 'settings';
 
 @mixin vf-p-accordion {
-  $icon-size: map-get($icon-sizes, accordion);
+  $icon-size: map-get($icon-sizes, default);
 
   .p-accordion__list {
     list-style-type: none;
@@ -15,13 +15,17 @@
     }
   }
 
-  .p-accordion__tab {
+  .p-accordion__tab,
+  [class*='p-accordion__tab--'] {
     @extend %single-border-text-vpadding--scaling;
     @include vf-focus;
 
-    $calculated-height: $multi * $spv-inner--x-small * 2 + map-get($line-heights, default-text);
+    // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
+    // and offset to align it with baseline of accordion tab text element
+    $icon-top-position: calc(#{$table-cell-vertical-padding} - 1px + 0.25rem);
+
     background: {
-      position: top 50% left $sph-inner;
+      position: top $icon-top-position left $sph-inner;
       repeat: no-repeat;
     }
 
@@ -49,6 +53,22 @@
 
       background-size: $icon-size;
     }
+  }
+
+  .p-accordion__tab--h3 {
+    // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
+    // and offset to align it with baseline of accordion tab h3 element
+    $icon-top-position: calc(#{$table-cell-vertical-padding} - 1px + 0.8rem);
+
+    background-position: top $icon-top-position left $sph-inner;
+  }
+
+  .p-accordion__tab--h4 {
+    // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
+    // and offset to align it with baseline of accordion tab h4 element
+    $icon-top-position: calc(#{$table-cell-vertical-padding} - 1px + 0.5rem);
+
+    background-position: top $icon-top-position left $sph-inner;
   }
 
   .p-accordion__panel {

--- a/templates/docs/examples/patterns/accordion/_script.js
+++ b/templates/docs/examples/patterns/accordion/_script.js
@@ -1,0 +1,63 @@
+/**
+  Toggles the necessary aria- attributes' values on the accordion panels
+  and handles to show or hide them.
+  @param {HTMLElement} element The tab that acts as the handles.
+  @param {Boolean} show Whether to show or hide the accordion panel.
+*/
+function toggleExpanded(element, show) {
+  var target = document.getElementById(element.getAttribute('aria-controls'));
+
+  if (target) {
+    element.setAttribute('aria-expanded', show);
+    target.setAttribute('aria-hidden', !show);
+  }
+}
+
+/**
+  Attaches event listeners for the accordion open and close click events.
+  @param {HTMLElement} accordionContainer The accordion container element.
+*/
+function setupAccordion(accordionContainer) {
+  // Finds any open panels within the container and closes them.
+  function closeAllPanels() {
+    var openPanels = accordionContainer.querySelectorAll('[aria-expanded=true]');
+
+    for (var i = 0, l = openPanels.length; i < l; i++) {
+      toggleExpanded(openPanels[i], false);
+    }
+  }
+
+  // Set up an event listener on the container so that panels can be added
+  // and removed and events do not need to be managed separately.
+  accordionContainer.addEventListener('click', function (event) {
+    var target = event.target;
+
+    if (target.closest) {
+      target = target.closest('[class*="p-accordion__tab"]');
+    } else if (target.msMatchesSelector) {
+      // IE friendly `Element.closest` equivalent
+      // as in https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+      do {
+        if (target.msMatchesSelector('[class*="p-accordion__tab"]')) {
+          break;
+        }
+        target = target.parentElement || target.parentNode;
+      } while (target !== null && target.nodeType === 1);
+    }
+
+    if (target) {
+      var isTargetOpen = target.getAttribute('aria-expanded') === 'true';
+      closeAllPanels();
+
+      // Toggle visibility of the target panel.
+      toggleExpanded(target, !isTargetOpen);
+    }
+  });
+}
+
+// Setup all accordions on the page.
+var accordions = document.querySelectorAll('.p-accordion');
+
+for (var i = 0, l = accordions.length; i < l; i++) {
+  setupAccordion(accordions[i]);
+}

--- a/templates/docs/examples/patterns/accordion/default.html
+++ b/templates/docs/examples/patterns/accordion/default.html
@@ -39,55 +39,6 @@
 </aside>
 
 <script>
-/**
-  Toggles the necessary aria- attributes' values on the accordion panels
-  and handles to show or hide them.
-  @param {HTMLElement} element The tab that acts as the handles.
-  @param {Boolean} show Whether to show or hide the accordion panel.
-*/
-function toggleExpanded(element, show) {
-  var target = document.getElementById(element.getAttribute('aria-controls'));
-
-  if (target) {
-    element.setAttribute('aria-expanded', show);
-    target.setAttribute('aria-hidden', !show);
-  }
-}
-
-/**
-  Attaches event listeners for the accordion open and close click events.
-  @param {HTMLElement} accordionContainer The accordion container element.
-*/
-function setupAccordion(accordionContainer) {
-  // Finds any open panels within the container and closes them.
-  function closeAllPanels() {
-    var openPanels = accordionContainer.querySelectorAll('[aria-expanded=true]');
-
-    for (var i = 0, l = openPanels.length; i < l; i++) {
-      toggleExpanded(openPanels[i], false);
-    }
-  }
-
-  // Set up an event listener on the container so that panels can be added
-  // and removed and events do not need to be managed separately.
-  accordionContainer.addEventListener('click', function(event) {
-    var target = event.target;
-    var isTargetOpen = target.getAttribute('aria-expanded') === 'true';
-
-    if (target.classList.contains('p-accordion__tab')) {
-      closeAllPanels();
-
-      // Toggle visibility of the target panel.
-      toggleExpanded(target, !isTargetOpen);
-    }
-  });
-}
-
-// Setup all accordions on the page.
-var accordions = document.querySelectorAll('.p-accordion');
-
-for (var i = 0, l = accordions.length; i < l; i++) {
-  setupAccordion(accordions[i]);
-}
+  {% include 'docs/examples/patterns/accordion/_script.js' %}
 </script>
 {% endblock %}

--- a/templates/docs/examples/patterns/accordion/headings.html
+++ b/templates/docs/examples/patterns/accordion/headings.html
@@ -7,7 +7,24 @@
 <aside class="p-accordion" role="tablist" aria-multiselect="true">
   <ul class="p-accordion__list">
     <li class="p-accordion__group">
-      <button type="button" class="p-accordion__tab--h3" id="tab1" role="tab" aria-controls="tab1-section" aria-expanded="true"><h3 class="u-no-margin--bottom u-no-padding--top">Advanced topics</h3></button>
+      <button type="button" class="p-accordion__tab--with-title" id="tab1" role="tab" aria-controls="tab0-section" aria-expanded="true">
+        <h2 class="p-accordion__title"><span class="u-visualise-font-metrics">Advanced topics</span></h2>
+      </button>
+      <section class="p-accordion__panel" id="tab0-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab0-section">
+        <p>Charm bundles</p>
+        <p>Machine authentication</p>
+        <p>Migrating models</p>
+        <p>Using storage</p>
+        <p>Working with actions</p>
+        <p>Working with resources</p>
+        <p>Cloud image metadata</p>
+        <p>Tools</p>
+      </section>
+    </li>
+    <li class="p-accordion__group">
+      <button type="button" class="p-accordion__tab--with-title" id="tab1" role="tab" aria-controls="tab1-section" aria-expanded="true">
+        <h3 class="p-accordion__title"><span class="u-visualise-font-metrics">Advanced topics</span></h3>
+      </button>
       <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab1-section">
         <p>Charm bundles</p>
         <p>Machine authentication</p>
@@ -20,7 +37,9 @@
       </section>
     </li>
     <li class="p-accordion__group">
-      <button type="button" class="p-accordion__tab--h4" id="tab2" role="tab" aria-controls="tab2-section" aria-expanded="false"><h4 class="u-no-margin--bottom u-no-padding--top">Networking</h4></button>
+      <button type="button" class="p-accordion__tab--with-title" id="tab2" role="tab" aria-controls="tab2-section" aria-expanded="false">
+        <h4 class="p-accordion__title">Networking</h4>
+      </button>
       <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
         <p>Working offline</p>
         <p>Fan container networking</p>
@@ -28,7 +47,9 @@
       </section>
     </li>
     <li class="p-accordion__group">
-      <button type="button" class="p-accordion__tab--h5" id="tab3" role="tab" aria-controls="tab3-section" aria-expanded="false"><h5 class="u-no-margin--bottom u-no-padding--top">Miscellaneous</h5></button>
+      <button type="button" class="p-accordion__tab--with-title" id="tab3" role="tab" aria-controls="tab3-section" aria-expanded="false">
+        <h5 class="p-accordion__title">Miscellaneous</h5>
+      </button>
       <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
         <p>Juju GUI</p>
         <p>CentOS support</p>

--- a/templates/docs/examples/patterns/accordion/headings.html
+++ b/templates/docs/examples/patterns/accordion/headings.html
@@ -38,7 +38,7 @@
     </li>
     <li class="p-accordion__group">
       <button type="button" class="p-accordion__tab--with-title" id="tab2" role="tab" aria-controls="tab2-section" aria-expanded="false">
-        <h4 class="p-accordion__title">Networking</h4>
+        <h4 class="p-accordion__title"><span class="u-visualise-font-metrics">Networking</span></h4>
       </button>
       <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
         <p>Working offline</p>
@@ -48,7 +48,7 @@
     </li>
     <li class="p-accordion__group">
       <button type="button" class="p-accordion__tab--with-title" id="tab3" role="tab" aria-controls="tab3-section" aria-expanded="false">
-        <h5 class="p-accordion__title">Miscellaneous</h5>
+        <h5 class="p-accordion__title"><span class="u-visualise-font-metrics">Miscellaneous</span></h5>
       </button>
       <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
         <p>Juju GUI</p>

--- a/templates/docs/examples/patterns/accordion/headings.html
+++ b/templates/docs/examples/patterns/accordion/headings.html
@@ -1,0 +1,44 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Accordion / Headings{% endblock %}
+
+{% block standalone_css %}patterns_accordion{% endblock %}
+
+{% block content %}
+<aside class="p-accordion" role="tablist" aria-multiselect="true">
+  <ul class="p-accordion__list">
+    <li class="p-accordion__group">
+      <button type="button" class="p-accordion__tab--h3" id="tab1" role="tab" aria-controls="tab1-section" aria-expanded="true"><h3 class="u-no-margin--bottom u-no-padding--top">Advanced topics</h3></button>
+      <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab1-section">
+        <p>Charm bundles</p>
+        <p>Machine authentication</p>
+        <p>Migrating models</p>
+        <p>Using storage</p>
+        <p>Working with actions</p>
+        <p>Working with resources</p>
+        <p>Cloud image metadata</p>
+        <p>Tools</p>
+      </section>
+    </li>
+    <li class="p-accordion__group">
+      <button type="button" class="p-accordion__tab--h4" id="tab2" role="tab" aria-controls="tab2-section" aria-expanded="false"><h4 class="u-no-margin--bottom u-no-padding--top">Networking</h4></button>
+      <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
+        <p>Working offline</p>
+        <p>Fan container networking</p>
+        <p>Network spaces</p>
+      </section>
+    </li>
+    <li class="p-accordion__group">
+      <button type="button" class="p-accordion__tab--h5" id="tab3" role="tab" aria-controls="tab3-section" aria-expanded="false"><h5 class="u-no-margin--bottom u-no-padding--top">Miscellaneous</h5></button>
+      <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
+        <p>Juju GUI</p>
+        <p>CentOS support</p>
+        <p>Collecting Juju metrics</p>
+      </section>
+    </li>
+  </ul>
+</aside>
+
+<script>
+  {% include 'docs/examples/patterns/accordion/_script.js' %}
+</script>
+{% endblock %}

--- a/templates/docs/examples/patterns/accordion/headings.html
+++ b/templates/docs/examples/patterns/accordion/headings.html
@@ -8,7 +8,7 @@
   <ul class="p-accordion__list">
     <li class="p-accordion__group">
       <button type="button" class="p-accordion__tab--with-title" id="tab1" role="tab" aria-controls="tab0-section" aria-expanded="true">
-        <h2 class="p-accordion__title"><span class="u-visualise-font-metrics">Advanced topics</span></h2>
+        <h2 class="p-accordion__title">Basic topics</h2>
       </button>
       <section class="p-accordion__panel" id="tab0-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab0-section">
         <p>Charm bundles</p>
@@ -22,10 +22,10 @@
       </section>
     </li>
     <li class="p-accordion__group">
-      <button type="button" class="p-accordion__tab--with-title" id="tab1" role="tab" aria-controls="tab1-section" aria-expanded="true">
-        <h3 class="p-accordion__title"><span class="u-visualise-font-metrics">Advanced topics</span></h3>
+      <button type="button" class="p-accordion__tab--with-title" id="tab1" role="tab" aria-controls="tab1-section" aria-expanded="false">
+        <h3 class="p-accordion__title">Advanced topics</h3>
       </button>
-      <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false" aria-labelledby="tab1-section">
+      <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab1-section">
         <p>Charm bundles</p>
         <p>Machine authentication</p>
         <p>Migrating models</p>
@@ -38,7 +38,7 @@
     </li>
     <li class="p-accordion__group">
       <button type="button" class="p-accordion__tab--with-title" id="tab2" role="tab" aria-controls="tab2-section" aria-expanded="false">
-        <h4 class="p-accordion__title"><span class="u-visualise-font-metrics">Networking</span></h4>
+        <h4 class="p-accordion__title">Networking</h4>
       </button>
       <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab2-section">
         <p>Working offline</p>
@@ -48,7 +48,7 @@
     </li>
     <li class="p-accordion__group">
       <button type="button" class="p-accordion__tab--with-title" id="tab3" role="tab" aria-controls="tab3-section" aria-expanded="false">
-        <h5 class="p-accordion__title"><span class="u-visualise-font-metrics">Miscellaneous</span></h5>
+        <h5 class="p-accordion__title">Miscellaneous</h5>
       </button>
       <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab3-section">
         <p>Juju GUI</p>

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -20,7 +20,7 @@ Each tab styling can be changed to open or collapse using `aria-expanded`, set `
   </p>
 </div>
 
-<div class="embedded-example"><a href="/docs/examples/patterns/accordion/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/accordion/default/" class="js-example">
 View example of the accordion pattern
 </a></div>
 

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -24,6 +24,16 @@ Each tab styling can be changed to open or collapse using `aria-expanded`, set `
 View example of the accordion pattern
 </a></div>
 
+### Headings
+
+To use headings in the accordion buttons use `.p-accordion__tab--with-title` class on the button and `.p-accordion__title` on the heading element inside it.
+
+Heading levels from `h2` up to `h6` are supported in the accordion pattern. Heading `h1` should not be used in the accordion, as it's reserved for the top-level title of the page. Also, make sure to use the same level of heading in all accordion buttons to ensure the same level in the document hierarchy.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/accordion/headings/" class="js-example">
+View example of the accordion pattern with headings
+</a></div>
+
 ### Functionality
 
 Please ensure the `aria-control` attribute matches an ID of an element. If `aria-expanded` is true, then the accordion will be open by default. When clicking on the `accordion__tab`, you must toggle the `aria-expanded` attribute on the toggle and the `aria-hidden` attribute on the panel.


### PR DESCRIPTION
## Done

Updates accordion to fix the bug with misaligned icon when text wraps.
Adds a variant to support headings in accordion buttons.

Fixes #2926 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3107.run.demo.haus/docs/examples/patterns/accordion/headings)
- Check accordion with headings example: https://vanilla-framework-canonical-web-and-design-pr-3107.run.demo.haus/docs/examples/patterns/accordion/headings
- Make sure documentation is fine (Codepen will show unstyled version until released): https://vanilla-framework-canonical-web-and-design-pr-3107.run.demo.haus/docs/patterns/accordion#headings


## Screenshots

<img width="504" alt="Screenshot 2020-05-29 at 15 59 27" src="https://user-images.githubusercontent.com/83575/83268286-b07f8d80-a1c5-11ea-8a91-9120860d70ce.png">
<img width="491" alt="Screenshot 2020-06-08 at 15 58 47" src="https://user-images.githubusercontent.com/83575/84039042-f6480d00-a9a0-11ea-9f92-52dd04083bfc.png">


