### PR TITLE
Bump version to 2.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.12.0",
+  "version": "2.12.1",
   "files": [
     "/scss",
     "!/scss/docs"


### PR DESCRIPTION
## Done

Bumps version of Vanilla to 2.12.1 for the release

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3108.run.demo.haus/)
- Make sure demo shows correct version 
