### PR TITLE
Ensure <pre> elements use ubuntu mono instead of browser default

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -19,8 +19,8 @@
     font-weight: bold;
   }
 
-  pre,
-  code {
+  code,
+  pre {
     direction: ltr;
     // stylelint-disable property-no-vendor-prefix
     -webkit-hyphens: none;
@@ -50,6 +50,7 @@
     border-radius: $border-radius;
     color: $color-dark;
     display: block;
+    font-family: unquote($font-monospace);
     margin-bottom: $spv-outer--scaleable;
     margin-top: 0;
     overflow: auto;

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -3,20 +3,26 @@
 // Base code styles
 @mixin vf-b-code {
   code,
-  samp,
-  kbd {
-    background-color: $color-mid-x-light;
-    box-shadow: 0 0 0 0.25rem $color-mid-x-light;
+  kbd,
+  pre,
+  samp {
     font-family: unquote($font-monospace);
     font-weight: $font-weight-regular-text;
-    margin-left: 0.25rem;
-    margin-right: 0.25rem;
     text-align: left;
+
+    b,
+    strong {
+      font-weight: bold;
+    }
   }
 
-  code b,
-  code strong {
-    font-weight: bold;
+  code,
+  kbd,
+  samp {
+    background-color: $color-mid-x-light;
+    box-shadow: 0 0 0 0.25rem $color-mid-x-light;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
   }
 
   code,
@@ -50,11 +56,10 @@
     border-radius: $border-radius;
     color: $color-dark;
     display: block;
-    font-family: unquote($font-monospace);
     margin-bottom: $spv-outer--scaleable;
     margin-top: 0;
     overflow: auto;
-    padding: calc(#{map-get($nudges, nudge--p-ubuntumono)} - 1px) $sph-inner calc(#{map-get($nudges, nudge--p-ubuntumono)} - 1px);
+    padding: map-get($nudges, nudge--p-ubuntumono) $sph-inner;
     text-align: left;
     text-shadow: none;
     white-space: pre;

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -136,6 +136,7 @@
   }
 
   // misc
+  b,
   strong {
     @extend %bold;
   }

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -14,11 +14,23 @@ Vanilla gives you multiple ways to display code using the standard HTML elements
 
 When you refer to code inline with other text, use the <code>&lt;code></code> tag.
 
+<div class="embedded-example"><a href="/docs/examples/base/code-inline/" class="js-example">
+View example of inline code
+</a></div>
+
 ### Block
 
-If you want to refer to a larger piece of code, use <code>&lt;pre></code> together with the <code>&lt;code></code> tag.
+To create a preformatted block, use either `<pre>` (where preserving white space is important, but the text is not necesserily code) or `<pre><code>` (to indicate the contents are a piece of code):
 
-<div class="embedded-example"><a href="/docs/examples/base/code/" class="js-example">
+**Preformatted block:**
+
+<div class="embedded-example"><a href="/docs/examples/base/pre/" class="js-example">
+View example of the base pre block
+</a></div>
+
+**Preformatted code block:**
+
+<div class="embedded-example"><a href="/docs/examples/base/code-block/" class="js-example">
 View example of the base code block
 </a></div>
 

--- a/templates/docs/examples/base/code-block.html
+++ b/templates/docs/examples/base/code-block.html
@@ -1,14 +1,12 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Code - inline{% endblock %}
+{% block title %}Code block{% endblock %}
 
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-  <pre>
-  <code>bolla.internal
-  - lldp:descr:
-    label: SysDescr
-    Ubuntu 18.04.4 LTS Linux 4.15.0-106-generic #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 x86_64
-  </code></pre>
+<pre>
+<code>function() {
+  alert("Hello world");
+}</code></pre>
 
   {% endblock %}

--- a/templates/docs/examples/base/code-block.html
+++ b/templates/docs/examples/base/code-block.html
@@ -1,0 +1,14 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Code - inline{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block content %}
+  <pre>
+  <code>bolla.internal
+  - lldp:descr:
+    label: SysDescr
+    Ubuntu 18.04.4 LTS Linux 4.15.0-106-generic #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 x86_64
+  </code></pre>
+
+  {% endblock %}

--- a/templates/docs/examples/base/code-inline.html
+++ b/templates/docs/examples/base/code-inline.html
@@ -1,14 +1,8 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Code{% endblock %}
+{% block title %}Code - inline{% endblock %}
 
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-<pre>
-<code>Mode: all
-<b>Settings</b>:
-maas_url=http://192.168.122.1:5240/MAAS</code>
-</pre>
-
 <p>The quick brown <code>fox&nbsp;jumps</code> over the lazy dog</p>
 {% endblock %}

--- a/templates/docs/examples/base/pre.html
+++ b/templates/docs/examples/base/pre.html
@@ -1,0 +1,12 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Pre{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block content %}
+<pre>bolla.internal
+  - lldp:descr:
+    label: SysDescr
+    Ubuntu 18.04.4 LTS Linux 4.15.0-106-generic #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 x86_64
+  </pre>
+{% endblock %}


### PR DESCRIPTION
## Done

Fix #2037

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- paste this anywhere, ensure the font-family is ubuntu mono: `<pre>Test</pre>`
