### PR TITLE
add borders to detailed list

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -239,10 +239,22 @@ $spv-list-item--inner: null;
 
     .p-stepped-list__item {
       @extend %vf-row;
-      @extend %vf-pseudo-border--top;
       @include vf-b-row-reset;
 
-      padding-top: $sp-unit;
+      @media (min-width: $breakpoint-medium) {
+        padding-top: $sp-unit;
+        position: relative;
+
+        &::after {
+          background-color: $colors--light-theme--border-low-contrast;
+          content: '';
+          height: 1px;
+          left: 0;
+          position: absolute;
+          right: 0;
+          top: 0;
+        }
+      }
     }
   }
 }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -239,7 +239,10 @@ $spv-list-item--inner: null;
 
     .p-stepped-list__item {
       @extend %vf-row;
+      @extend %vf-pseudo-border--top;
       @include vf-b-row-reset;
+
+      padding-top: $sp-unit;
     }
   }
 }


### PR DESCRIPTION
## Done

Fix #1917 as agreed in https://app.zeplin.io/project/5edf6c235bee26b85b117af7/dashboard?seid=5edf6c93b4f7a9982d6866d9

## QA

- Pull code
- Run `dotrun`
- Open docs/examples/patterns/lists/lists-stepped-detailed

Verify the list has borders:

![image](https://user-images.githubusercontent.com/2741678/84264686-84df9a00-ab19-11ea-8341-e572d8c05435.png)

