### PR TITLE
Fix focus outline in tab strip

### DIFF
--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -76,6 +76,16 @@
         z-index: 1;
       }
 
+      // make sure tab strip border doesn't overlap focus outline
+      &:focus {
+        z-index: 1;
+
+        &::before,
+        &::after {
+          content: none;
+        }
+      }
+
       &:hover,
       &[aria-selected='true'] {
         @include vf-highlight-bar($color-tabs-active-bar, bottom, false);


### PR DESCRIPTION
## Done

Fixes tab strip border overflowing focus outline

Fixes #3073

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-canonical-web-and-design-pr-3128.run.demo.haus/docs/examples/patterns/tabs)
- Go to [tabs example](https://vanilla-framework-canonical-web-and-design-pr-3128.run.demo.haus/docs/examples/patterns/tabs), check if focus outline looks fine and is not covered by border


## Screenshots

<img width="767" alt="Screenshot 2020-06-17 at 11 25 41" src="https://user-images.githubusercontent.com/83575/84880791-4d2ea000-b08d-11ea-809f-aafafc159762.png">

