### PR TITLE
Use font-display optional by default

### DIFF
--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -3,7 +3,7 @@ $font-base-family: '"Ubuntu", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ca
 $font-monospace: '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
 $font-heading-family: $font-base-family !default;
 $font-use-subset-latin: false !default;
-$font-display-option: auto !default; // options - auto | block | swap | fallback | optional
+$font-display-option: optional !default;
 $font-allow-cyrillic-greek-latin: false !default;
 $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -220,7 +220,7 @@ The CSS [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-
 $font-display-option: <auto | block | swap | fallback | optional>;
 ```
 
-The `font-display` descriptor's default setting is `auto`.
+For the web fonts loaded by Vanilla we set `font-display` to `optional` by default.
 
 ### Import
 

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -220,7 +220,7 @@ The CSS [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-
 $font-display-option: <auto | block | swap | fallback | optional>;
 ```
 
-For the web fonts loaded by Vanilla we set `font-display` to `optional` by default.
+The default value of the `font-display` property on [all fonts used by Vanilla](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_base_fontfaces.scss) is set to `optional`.
 
 ### Import
 


### PR DESCRIPTION
## Done

Uses `font-display: optional` by default to improve perceived loading performance.

Fixes #2569 #2701 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- You should see fallback font on first page load (until it is cached)


## Screenshots

[if relevant, include a screenshot]
