### PR TITLE
Add list inline stretch variant

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -32,10 +32,11 @@ $spv-list-item--inner: null;
 @mixin vf-inline-list-item {
   display: inline;
   list-style: none;
+  margin-right: $sph-outer;
 
-  &:not(:last-of-type),
-  &:not(.last-item) {
-    margin-right: $sph-outer;
+  &.last-item,
+  &:last-of-type {
+    margin-right: 0;
   }
 }
 
@@ -131,6 +132,20 @@ $spv-list-item--inner: null;
           content: '';
         }
       }
+    }
+  }
+}
+
+@mixin vf-p-inline-list-stretch {
+  .p-inline-list--stretch {
+    display: flex;
+    flex-wrap: wrap;
+    margin-left: 0;
+    padding-left: 0;
+
+    .p-inline-list__item {
+      flex: 1 auto;
+      list-style: none;
     }
   }
 }
@@ -338,6 +353,7 @@ $spv-list-item--inner: null;
   @include vf-p-list-item-state;
   @include vf-p-inline-list;
   @include vf-p-inline-list-middot;
+  @include vf-p-inline-list-stretch;
   @include vf-p-stepped-list;
   @include vf-p-stepped-list-detailed;
   @include vf-p-list-split;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -56,7 +56,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
-              {{ side_nav_item("/docs/patterns/accordion", "Accordion", "updated") }}
+              {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
               {{ side_nav_item("/docs/patterns/article-pagination", "Article pagination") }}
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
               {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
@@ -70,7 +70,7 @@
               {{ side_nav_item("/docs/patterns/labels", "Labels") }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
+              {{ side_nav_item("/docs/patterns/lists", "Lists", "new") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -27,7 +27,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <th><a href="/docs/patterns/lists#inline-stretched">List inline stretched</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.14.0</td>
-      <td>We added new <code>.p-inline-list--stretch</code> list variant that can be used to lay out list items across whole width of their container.</td>
+      <td>We added the new <code>.p-inline-list--stretch</code> list variant that arranges items so they span the full width of the parent container.</td>
     </tr>
   </tbody>
 </table>
@@ -49,7 +49,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <th><a href="/docs/patterns/accordion#headings">Accordion</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.13.0</td>
-      <td>We updated accordion component with a new <code>.p-accordion__tab--with-title</code> variant that allows using headings in accordion buttons.</td>
+      <td>We updated the accordion component with a new <code>.p-accordion__tab--with-title</code> variant that allows using headings in accordion buttons.</td>
     </tr>
     <!-- 2.12 -->
     <tr>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -10,7 +10,7 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### What's new in Vanilla 2.13
+### What's new in Vanilla 2.14
 
 <table>
   <thead>
@@ -22,12 +22,12 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-    <!-- 2.13 -->
+    <!-- 2.14 -->
     <tr>
-      <th><a href="/docs/patterns/accordion#headings">Accordion</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
-      <td>2.13.0</td>
-      <td>We updated accordion component with a new `.p-accordion__tab--with-title` variant that allows using headings in accordion buttons.</td>
+      <th><a href="/docs/patterns/lists#inline-stretched">List inline stretched</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.14.0</td>
+      <td>We added new <code>.p-inline-list--stretch</code> list variant that can be used to lay out list items across whole width of their container.</td>
     </tr>
   </tbody>
 </table>
@@ -44,6 +44,13 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.13 -->
+    <tr>
+      <th><a href="/docs/patterns/accordion#headings">Accordion</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.13.0</td>
+      <td>We updated accordion component with a new <code>.p-accordion__tab--with-title</code> variant that allows using headings in accordion buttons.</td>
+    </tr>
     <!-- 2.12 -->
     <tr>
       <th><a href="/docs/base/typography#muted-text">Muted text</a></th>

--- a/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
+++ b/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
@@ -1,0 +1,11 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Lists / Stretched with alignment{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<ul class="p-inline-list--stretch">
+  <li class="p-inline-list__item"><h3>Documentation</h3></li>
+  <li class="p-inline-list__item u-vertiacally-center u-align--right"><span class="p-label--new">New</span></li>
+</ul>
+{% endblock %}

--- a/templates/docs/examples/patterns/lists/lists-inline-stretch.html
+++ b/templates/docs/examples/patterns/lists/lists-inline-stretch.html
@@ -1,0 +1,12 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Lists / Stretched{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<ul class="p-inline-list--stretch">
+  <li class="p-inline-list__item">Community</li>
+  <li class="p-inline-list__item">Careers</li>
+  <li class="p-inline-list__item">Press centre</li>
+</ul>
+{% endblock %}

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -80,13 +80,13 @@ View example of the middot list pattern
 
 <span class="p-label--new">New</span>
 
-Apply the class `.p-inline-list--stretch` to stretch the list items along the whole width of the container.
+Apply the class `.p-inline-list--stretch` to stretch the list items to fill the full width of the parent container.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-inline-stretch/" class="js-example">
 View example of the stretched list pattern
 </a></div>
 
-You can use align utilities to align content of the individual items.
+You can use the align utilities to align the content of individual items.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-inline-stretch-align/" class="js-example">
 View example of the stretched list pattern with alignment

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -76,6 +76,22 @@ inline list items.
 View example of the middot list pattern
 </a></div>
 
+### Inline stretched
+
+<span class="p-label--new">New</span>
+
+Apply the class `.p-inline-list--stretch` to stretch the list items along the whole width of the container.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-inline-stretch/" class="js-example">
+View example of the stretched list pattern
+</a></div>
+
+You can use align utilities to align content of the individual items.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-inline-stretch-align/" class="js-example">
+View example of the stretched list pattern with alignment
+</a></div>
+
 ### Vertical stepped
 
 If you want to display a list of items that form a set of steps — like a


### PR DESCRIPTION
## Done

Adds new list variant to cover cases where flexbox utils on custom styles were used to lay out elements.

Fixes #2923
Fixes #2451 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3139.k8s.demo.haus/docs/examples/patterns/lists/lists-inline-stretch)
- Check the stretch list example: https://vanilla-framework-3139.k8s.demo.haus/docs/examples/patterns/lists/lists-inline-stretch
- Check the stretch example with align utils: https://vanilla-framework-3139.k8s.demo.haus/docs/examples/patterns/lists/lists-inline-stretch-align
- Check the updated lists documentation page: https://vanilla-framework-3139.k8s.demo.haus/docs/patterns/lists#inline- stretched
  - note that CodePen will show unstyled examples (as it uses published version of Vanilla that doesn't have the new styles yet)


## Screenshots

<img width="934" alt="Screenshot 2020-07-01 at 16 04 08" src="https://user-images.githubusercontent.com/83575/86253305-a978e000-bbb4-11ea-8ce5-4955935c5b1d.png">
<img width="939" alt="Screenshot 2020-07-01 at 16 03 57" src="https://user-images.githubusercontent.com/83575/86253310-aaaa0d00-bbb4-11ea-8973-bfbbcb203ef8.png">

