### PR TITLE
Fix typo in class name in list example

### DIFF
--- a/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
+++ b/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
@@ -6,6 +6,6 @@
 {% block content %}
 <ul class="p-inline-list--stretch">
   <li class="p-inline-list__item"><h3>Documentation</h3></li>
-  <li class="p-inline-list__item u-vertiacally-center u-align--right"><span class="p-label--new">New</span></li>
+  <li class="p-inline-list__item u-vertically-center u-align--right"><span class="p-label--new">New</span></li>
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Done

Fixes a typo in class name

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3146.k8s.demo.haus)
- Check [list stretched aligned example](https://vanilla-framework-3146.k8s.demo.haus/docs/examples/patterns/lists/lists-inline-stretch-align), label should be vertically centered



## Screenshots

<img width="593" alt="Screenshot 2020-07-03 at 13 41 51" src="https://user-images.githubusercontent.com/83575/86466034-2c27a980-bd33-11ea-9afd-13ebf093f188.png">

