### PR TITLE
Bump version of Vanilla to 2.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.13.0",
+  "version": "2.14.0",
   "files": [
     "/scss",
     "!/scss/docs"


### PR DESCRIPTION
## Done

Bump version of Vanilla for next release

## QA

- Check if [version is correct](https://vanilla-framework-3156.k8s.demo.haus/docs/)
- Check [component status page](https://vanilla-framework-3156.k8s.demo.haus/docs/component-status)
