### PR TITLE
Change default font-display value to fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.14.0",
+  "version": "2.14.1",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -3,7 +3,7 @@ $font-base-family: '"Ubuntu", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ca
 $font-monospace: '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
 $font-heading-family: $font-base-family !default;
 $font-use-subset-latin: false !default;
-$font-display-option: optional !default;
+$font-display-option: fallback !default;
 $font-allow-cyrillic-greek-latin: false !default;
 $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -220,7 +220,7 @@ The CSS [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-
 $font-display-option: <auto | block | swap | fallback | optional>;
 ```
 
-The default value of the `font-display` property on [all fonts used by Vanilla](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_base_fontfaces.scss) is set to `optional`.
+The default value of the `font-display` property on [all fonts used by Vanilla](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_base_fontfaces.scss) is set to `fallback`.
 
 ### Import
 


### PR DESCRIPTION
## Done

Because of the cases of Ubuntu font not rendering at all in some cases, even on fast connections, we change default value to 'fallback' - this makes sure the text is rendered immediately, but web font still has a small time window to load to be rendered.

Fixes #3157 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3164.demos.haus)
- Make sure text is rendered immediately with fallback font, but Ubuntu font is loaded on fast connection

