### PR TITLE
Add yarn.lock to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 FROM node:12-slim AS yarn-dependencies
 WORKDIR /srv
 ADD package.json package.json
+ADD yarn.lock yarn.lock
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 
 


### PR DESCRIPTION
## Done

Makes sure building docker image uses yarn.lock

## QA

Docker image should build correctly, demo should work as expected

Demo: https://vanilla-framework-3182.demos.haus/

