### PR TITLE
Add suru strips to Vanilla

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -119,6 +119,11 @@
 @mixin vf-p-strip-suru {
   .p-strip--suru {
     @extend %vf-strip;
+    $brand-color: #333333;
+    $color-suru-start: lighten($brand-color, 10%);
+    $color-suru-middle: $brand-color;
+    $color-suru-end: darken($brand-color, 10%);
+
     background-blend-mode: multiply, multiply, normal, normal, normal;
     background-image:
       linear-gradient(
@@ -148,9 +153,9 @@
       ),
       linear-gradient(
         111deg,
-        #4e4e4e 10%,
-        #333333 37%,
-        #111111 100%
+        $color-suru-start 10%,
+        $color-suru-middle 37%,
+        $color-suru-end 100%
       );
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom,
     0% 0%;

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -233,7 +233,7 @@ $color-suru-end: darken($color-brand, 10%) !default;
     }
 
     &.is-shallow {
-      padding: 2rem 0rem 6rem 0rem;     
+      padding: 1.5rem 0rem 6rem 0rem;     
     }
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -106,7 +106,8 @@
 }
 
 @mixin vf-p-strip-shallow {
-  [class*='p-strip']:not([class*='suru']).is-shallow {
+  [class*='p-strip']:not([class*='-suru']).is-shallow {
+    // Suru strips were not designed to be shallow, so they are excluded
     @extend %section-padding--shallow;
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -49,6 +49,7 @@
   @include vf-p-strip-shallow;
   @include vf-p-strip-deep;
   @include vf-p-strip-suru;
+  @include vf-p-strip-suru-topped;
 }
 
 @mixin vf-p-strip-default {
@@ -116,14 +117,14 @@
   }
 }
 
+$brand-color: #333333;
+$color-suru-start: lighten($brand-color, 10%);
+$color-suru-middle: $brand-color;
+$color-suru-end: darken($brand-color, 10%);
+
 @mixin vf-p-strip-suru {
   .p-strip--suru {
     @extend %vf-strip;
-    $brand-color: #333333;
-    $color-suru-start: lighten($brand-color, 10%);
-    $color-suru-middle: $brand-color;
-    $color-suru-end: darken($brand-color, 10%);
-
     background-blend-mode: multiply, multiply, normal, normal, normal;
     background-image:
       linear-gradient(
@@ -230,5 +231,45 @@
         padding-bottom: ($padding * 3) !important;
       }
     }
+  }
+}
+
+@mixin vf-p-strip-suru-topped {
+  .p-strip--suru-topped {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal;
+    background-image:
+      linear-gradient(
+        to bottom left,
+        rgba(229, 229, 229, 0.5) 0%,
+        rgba(229, 229, 229, 0.5) 49%,
+        transparent 50%,
+        transparent 100%
+      ),
+      linear-gradient(
+        to bottom left,
+        rgba(205, 205, 205, 0.16) 0%,
+        rgba(205, 205, 205, 0.16) 49%,
+        transparent 50%,
+        transparent 100%
+      ),
+      linear-gradient(
+        to bottom right,
+        transparent 0%,
+        transparent 49%,
+        rgba(255, 255, 255, 1) 50%,
+        rgba(255, 255, 255, 1) 100%
+      ),
+      linear-gradient(
+        -75deg,
+        $color-suru-start 2%,
+        $color-suru-middle 28%,
+        $color-suru-end 89%
+    );
+    background-position: top right, top right, top left, top left;
+    background-repeat: no-repeat;
+    background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;
+    padding-bottom: 4rem;
+    padding-top: 6rem;
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -106,7 +106,7 @@
 }
 
 @mixin vf-p-strip-shallow {
-  [class*='p-strip'].is-shallow {
+  [class*='p-strip']:not([class*="suru"]).is-shallow {
     @extend %section-padding--shallow;
   }
 }
@@ -141,18 +141,11 @@ $color-suru-end: darken($color-brand, 10%) !default;
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;
     background-repeat: no-repeat;
     background-size: 100% calc(100% - 4rem), 50% 100%, 100% 4rem, 100% 4rem, auto;
+    color: $color-x-light;
     margin-bottom: -4rem;
     overflow: hidden;
     padding-bottom: 12rem;
     position: relative;
-
-    &.is-light {
-      color: $color-x-dark;
-    }
-
-    &.is-dark {
-      color: $color-x-light;
-    }
 
     &.is-deep {
       $padding: 3rem;
@@ -170,10 +163,6 @@ $color-suru-end: darken($color-brand, 10%) !default;
         margin-bottom: -$padding;
         padding-bottom: ($padding * 3) !important;
       }
-    }
-
-    &.is-shallow {
-      padding: 1.5rem 0 6rem 0;
     }
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -126,78 +126,20 @@ $color-suru-end: darken($color-brand, 10%) !default;
     @extend %vf-strip;
 
     background-blend-mode: multiply, multiply, normal, normal, normal;
-    background-image:
-      linear-gradient(
-        to bottom right,
-        rgba(205, 205, 205, 0.55) 0%,
-        rgba(205, 205, 205, 0.55) 49.8%,
-        transparent 50.0%,
-        transparent 100%
-      ),
-      linear-gradient(
-        to bottom left,
-        rgba(205, 205, 205, 0.55) 0%,
-        rgba(205, 205, 205, 0.55) 49.8%,
-        transparent 50.0%,
-        transparent 100%
-      ),
-      linear-gradient(
-        to top right,
-        #ffffff 0%,
-        #ffffff 49%,
-        transparent 50%,
-        transparent 100%
-      ),
-      linear-gradient(
-        #ffffff 0%,
-        #ffffff 100%
-      ),
-      linear-gradient(
-        111deg,
-        $color-suru-start 10%,
-        $color-suru-middle 37%,
-        $color-suru-end 100%
-      );
+    background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),
+      linear-gradient(to bottom left, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),
+      linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(#fff 0%, #fff 100%),
+      linear-gradient(111deg, $color-suru-start 10%, $color-suru-middle 37%, $color-suru-end 100%);
     @supports not (background-blend-mode: multiply) {
-      background-image:
-        linear-gradient(
-          to bottom right,
-          rgba(205, 205, 205, 0.14) 0%,
-          rgba(205, 205, 205, 0.14) 49.8%,
-          transparent 50%,
-          transparent 100%
-        ),
-        linear-gradient(
-          to bottom left,
-          rgba(205, 205, 205, 0.14) 0%,
-          rgba(205, 205, 205, 0.14) 49.8%,
-          transparent 50%,
-          transparent 100%
-        ),
-        linear-gradient(
-          to top right,
-          #ffffff 0%,
-          #ffffff 49%,
-          rgba(255, 255, 255, 0) 50%,
-          rgba(255, 255, 255, 0) 100%
-        ),
-        linear-gradient(
-          to top right,
-          #ffffff 0%,
-          #ffffff 100%
-        ),
-        linear-gradient(
-          111deg,
-          $color-suru-start 10%,
-          $color-suru-middle 37%,
-          $color-suru-end 100%
-        );
-      }
-    background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom,
-    0% 0%;
+      background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
+        linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
+        linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(to top right, #fff 0%, #fff 100%),
+        linear-gradient(111deg, $color-suru-start 10%, $color-suru-middle 37%, $color-suru-end 100%);
+    }
+
+    background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;
     background-repeat: no-repeat;
-    background-size: 100% calc(100% - 4rem), 50% 100%, 100% 4rem, 100% 4rem,
-    auto;
+    background-size: 100% calc(100% - 4rem), 50% 100%, 100% 4rem, 100% 4rem, auto;
     margin-bottom: -4rem;
     overflow: hidden;
     padding-bottom: 12rem;
@@ -214,27 +156,23 @@ $color-suru-end: darken($color-brand, 10%) !default;
     &.is-deep {
       $padding: 3rem;
 
-      background-position: 0% 0%, top right, right 0 bottom $padding,
-        right bottom, 0% 0%;
-      background-size: 100% calc(100% - #{$padding}), 100% 100%, 100% $padding,
-        100% $padding, auto;
+      background-position: 0% 0%, top right, right 0 bottom $padding, right bottom, 0% 0%;
+      background-size: 100% calc(100% - #{$padding}), 100% 100%, 100% $padding, 100% $padding, auto;
       margin-bottom: -$padding;
       padding-bottom: ($padding * 3) !important;
 
       @media (min-width: $breakpoint-medium) {
         $padding: 6rem;
 
-        background-position: 0% 0%, top right, right 0 bottom $padding,
-          right bottom, 0% 0%;
-        background-size: 100% calc(100% - #{$padding}), 50% 100%, 100% $padding,
-          100% $padding, auto;
+        background-position: 0% 0%, top right, right 0 bottom $padding, right bottom, 0% 0%;
+        background-size: 100% calc(100% - #{$padding}), 50% 100%, 100% $padding, 100% $padding, auto;
         margin-bottom: -$padding;
         padding-bottom: ($padding * 3) !important;
       }
     }
 
     &.is-shallow {
-      padding: 1.5rem 0rem 6rem 0rem;     
+      padding: 1.5rem 0 6rem 0;
     }
   }
 }
@@ -242,66 +180,20 @@ $color-suru-end: darken($color-brand, 10%) !default;
 @mixin vf-p-strip-suru-topped {
   .p-strip--suru-topped {
     @extend %vf-strip;
-    
+
     background-blend-mode: multiply, multiply, normal, normal;
-    background-image:
-      linear-gradient(
-        to bottom left,
-        rgba(229, 229, 229, 0.5) 0%,
-        rgba(229, 229, 229, 0.5) 49%,
-        transparent 50%,
-        transparent 100%
-      ),
-      linear-gradient(
-        to bottom left,
-        rgba(205, 205, 205, 0.16) 0%,
-        rgba(205, 205, 205, 0.16) 49%,
-        transparent 50%,
-        transparent 100%
-      ),
-      linear-gradient(
-        to bottom right,
-        transparent 0%,
-        transparent 49%,
-        rgba(255, 255, 255, 1) 50%,
-        rgba(255, 255, 255, 1) 100%
-      ),
-      linear-gradient(
-        -75deg,
-        $color-suru-start 2%,
-        $color-suru-middle 28%,
-        $color-suru-end 89%
-    );
+    background-image: linear-gradient(to bottom left, rgba(229, 229, 229, 0.5) 0%, rgba(229, 229, 229, 0.5) 49%, transparent 50%, transparent 100%),
+      linear-gradient(to bottom left, rgba(205, 205, 205, 0.16) 0%, rgba(205, 205, 205, 0.16) 49%, transparent 50%, transparent 100%),
+      linear-gradient(to bottom right, transparent 0%, transparent 49%, #fff 50%, #fff 100%),
+      linear-gradient(-75deg, $color-suru-start 2%, $color-suru-middle 28%, $color-suru-end 89%);
+
     @supports not (background-blend-mode: multiply) {
-      background-image:
-        linear-gradient(
-          to bottom left,
-          rgba(229, 229, 229, 0.14) 0%,
-          rgba(229, 229, 229, 0.14) 49%,
-          transparent 50%,
-          transparent 100%
-        ),
-        linear-gradient(
-          to bottom left,
-          rgba(205, 205, 205, 0.14) 0%,
-          rgba(205, 205, 205, 0.14) 49%,
-          transparent 50%,
-          transparent 100%
-        ),
-        linear-gradient(
-          to bottom right,
-          transparent 0%,
-          transparent 49%,
-          rgba(255, 255, 255, 1) 50%,
-          rgba(255, 255, 255, 1) 100%
-        ),
-        linear-gradient(
-          -75deg,
-          $color-suru-start 2%,
-          $color-suru-middle 28%,
-          $color-suru-end 89%
-        );
+      background-image: linear-gradient(to bottom left, rgba(229, 229, 229, 0.14) 0%, rgba(229, 229, 229, 0.14) 49%, transparent 50%, transparent 100%),
+        linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49%, transparent 50%, transparent 100%),
+        linear-gradient(to bottom right, transparent 0%, transparent 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
+        linear-gradient(-75deg, $color-suru-start 2%, $color-suru-middle 28%, $color-suru-end 89%);
     }
+
     background-position: top right, top right, top left, top left;
     background-repeat: no-repeat;
     background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -48,6 +48,7 @@
   @include vf-p-strip-bordered;
   @include vf-p-strip-shallow;
   @include vf-p-strip-deep;
+  @include vf-p-strip-suru;
 }
 
 @mixin vf-p-strip-default {
@@ -112,5 +113,83 @@
 @mixin vf-p-strip-deep {
   [class*='p-strip'].is-deep {
     @extend %section-padding--deep;
+  }
+}
+
+@mixin vf-p-strip-suru {
+  .p-strip--suru {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal, normal;
+    background-image:
+      linear-gradient(
+        to bottom right,
+        rgba(205, 205, 205, 0.55) 0%,
+        rgba(205, 205, 205, 0.55) 49.8%,
+        transparent 50.0%,
+        transparent 100%
+      ),
+      linear-gradient(
+        to bottom left,
+        rgba(205, 205, 205, 0.55) 0%,
+        rgba(205, 205, 205, 0.55) 49.8%,
+        transparent 50.0%,
+        transparent 100%
+      ),
+      linear-gradient(
+        to top right,
+        #ffffff 0%,
+        #ffffff 49%,
+        transparent 50%,
+        transparent 100%
+      ),
+      linear-gradient(
+        #ffffff 0%,
+        #ffffff 100%
+      ),
+      linear-gradient(
+        111deg,
+        #4e4e4e 10%,
+        #333333 37%,
+        #111111 100%
+      );
+    background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom,
+    0% 0%;
+    background-repeat: no-repeat;
+    background-size: 100% calc(100% - 4rem), 50% 100%, 100% 4rem, 100% 4rem,
+    auto;
+    margin-bottom: -4rem;
+    overflow: hidden;
+    padding-bottom: 12rem !important;
+    position: relative;
+
+    &.is-light {
+      color: $color-x-dark;
+    }
+
+    &.is-dark {
+      color: $color-x-light;
+    }
+
+    &.is-deep {
+      $padding: 3rem;
+
+      background-position: 0% 0%, top right, right 0 bottom $padding,
+        right bottom, 0% 0%;
+      background-size: 100% calc(100% - #{$padding}), 100% 100%, 100% $padding,
+        100% $padding, auto;
+      margin-bottom: -$padding;
+      padding-bottom: ($padding * 3) !important;
+
+      @media (min-width: $breakpoint-medium) {
+        $padding: 6rem;
+
+        background-position: 0% 0%, top right, right 0 bottom $padding,
+          right bottom, 0% 0%;
+        background-size: 100% calc(100% - #{$padding}), 50% 100%, 100% $padding,
+          100% $padding, auto;
+        margin-bottom: -$padding;
+        padding-bottom: ($padding * 3) !important;
+      }
+    }
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -129,7 +129,7 @@ $color-suru-end: darken($color-brand, 10%) !default;
       linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
       linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(to top right, #fff 0%, #fff 100%),
       linear-gradient(111deg, $color-suru-start 10%, $color-suru-middle 37%, $color-suru-end 100%);
-    
+
     @supports (background-blend-mode: multiply) {
       background-blend-mode: multiply, multiply, normal, normal, normal;
       background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -117,10 +117,10 @@
   }
 }
 
-$brand-color: #333333;
-$color-suru-start: lighten($brand-color, 10%);
-$color-suru-middle: $brand-color;
-$color-suru-end: darken($brand-color, 10%);
+$brand-color: #333333 !default;
+$color-suru-start: lighten($brand-color, 10%) !default;
+$color-suru-middle: $brand-color !default;
+$color-suru-end: darken($brand-color, 10%) !default;
 
 @mixin vf-p-strip-suru {
   .p-strip--suru {

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -125,15 +125,16 @@ $color-suru-end: darken($color-brand, 10%) !default;
   .p-strip--suru {
     @extend %vf-strip;
 
-    background-blend-mode: multiply, multiply, normal, normal, normal;
-    background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),
-      linear-gradient(to bottom left, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),
-      linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(#fff 0%, #fff 100%),
+    background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
+      linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
+      linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(to top right, #fff 0%, #fff 100%),
       linear-gradient(111deg, $color-suru-start 10%, $color-suru-middle 37%, $color-suru-end 100%);
-    @supports not (background-blend-mode: multiply) {
-      background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
-        linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
-        linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(to top right, #fff 0%, #fff 100%),
+    
+    @supports (background-blend-mode: multiply) {
+      background-blend-mode: multiply, multiply, normal, normal, normal;
+      background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),
+        linear-gradient(to bottom left, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),
+        linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(#fff 0%, #fff 100%),
         linear-gradient(111deg, $color-suru-start 10%, $color-suru-middle 37%, $color-suru-end 100%);
     }
 
@@ -181,16 +182,16 @@ $color-suru-end: darken($color-brand, 10%) !default;
   .p-strip--suru-topped {
     @extend %vf-strip;
 
-    background-blend-mode: multiply, multiply, normal, normal;
-    background-image: linear-gradient(to bottom left, rgba(229, 229, 229, 0.5) 0%, rgba(229, 229, 229, 0.5) 49%, transparent 50%, transparent 100%),
-      linear-gradient(to bottom left, rgba(205, 205, 205, 0.16) 0%, rgba(205, 205, 205, 0.16) 49%, transparent 50%, transparent 100%),
-      linear-gradient(to bottom right, transparent 0%, transparent 49%, #fff 50%, #fff 100%),
+    background-image: linear-gradient(to bottom left, rgba(229, 229, 229, 0.14) 0%, rgba(229, 229, 229, 0.14) 49%, transparent 50%, transparent 100%),
+      linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49%, transparent 50%, transparent 100%),
+      linear-gradient(to bottom right, transparent 0%, transparent 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
       linear-gradient(-75deg, $color-suru-start 2%, $color-suru-middle 28%, $color-suru-end 89%);
 
-    @supports not (background-blend-mode: multiply) {
-      background-image: linear-gradient(to bottom left, rgba(229, 229, 229, 0.14) 0%, rgba(229, 229, 229, 0.14) 49%, transparent 50%, transparent 100%),
-        linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49%, transparent 50%, transparent 100%),
-        linear-gradient(to bottom right, transparent 0%, transparent 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
+    @supports (background-blend-mode: multiply) {
+      background-blend-mode: multiply, multiply, normal, normal;
+      background-image: linear-gradient(to bottom left, rgba(229, 229, 229, 0.5) 0%, rgba(229, 229, 229, 0.5) 49%, transparent 50%, transparent 100%),
+        linear-gradient(to bottom left, rgba(205, 205, 205, 0.16) 0%, rgba(205, 205, 205, 0.16) 49%, transparent 50%, transparent 100%),
+        linear-gradient(to bottom right, transparent 0%, transparent 49%, #fff 50%, #fff 100%),
         linear-gradient(-75deg, $color-suru-start 2%, $color-suru-middle 28%, $color-suru-end 89%);
     }
 

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -158,39 +158,40 @@ $color-suru-end: darken($brand-color, 10%);
         $color-suru-middle 37%,
         $color-suru-end 100%
       );
-      @supports not (background-blend-mode: multiply) {
-        background-image: linear-gradient(
-            to bottom right,
-            rgba(205, 205, 205, 0.14) 0%,
-            rgba(205, 205, 205, 0.14) 49.8%,
-            transparent 50%,
-            transparent 100%
-          ),
-          linear-gradient(
-            to bottom left,
-            rgba(205, 205, 205, 0.14) 0%,
-            rgba(205, 205, 205, 0.14) 49.8%,
-            transparent 50%,
-            transparent 100%
-          ),
-          linear-gradient(
-            to top right,
-            #ffffff 0%,
-            #ffffff 49%,
-            rgba(255, 255, 255, 0) 50%,
-            rgba(255, 255, 255, 0) 100%
-          ),
-          linear-gradient(
-            to top right,
-            #ffffff 0%,
-            #ffffff 100%
-          ),
-          linear-gradient(
-            111deg,
-            $color-suru-start 10%,
-            $color-suru-middle 37%,
-            $color-suru-end 100%
-          );
+    @supports not (background-blend-mode: multiply) {
+      background-image:
+        linear-gradient(
+          to bottom right,
+          rgba(205, 205, 205, 0.14) 0%,
+          rgba(205, 205, 205, 0.14) 49.8%,
+          transparent 50%,
+          transparent 100%
+        ),
+        linear-gradient(
+          to bottom left,
+          rgba(205, 205, 205, 0.14) 0%,
+          rgba(205, 205, 205, 0.14) 49.8%,
+          transparent 50%,
+          transparent 100%
+        ),
+        linear-gradient(
+          to top right,
+          #ffffff 0%,
+          #ffffff 49%,
+          rgba(255, 255, 255, 0) 50%,
+          rgba(255, 255, 255, 0) 100%
+        ),
+        linear-gradient(
+          to top right,
+          #ffffff 0%,
+          #ffffff 100%
+        ),
+        linear-gradient(
+          111deg,
+          $color-suru-start 10%,
+          $color-suru-middle 37%,
+          $color-suru-end 100%
+        );
       }
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom,
     0% 0%;
@@ -266,6 +267,36 @@ $color-suru-end: darken($brand-color, 10%);
         $color-suru-middle 28%,
         $color-suru-end 89%
     );
+    @supports not (background-blend-mode: multiply) {
+      background-image:
+        linear-gradient(
+          to bottom left,
+          rgba(229, 229, 229, 0.14) 0%,
+          rgba(229, 229, 229, 0.14) 49%,
+          transparent 50%,
+          transparent 100%
+        ),
+        linear-gradient(
+          to bottom left,
+          rgba(205, 205, 205, 0.14) 0%,
+          rgba(205, 205, 205, 0.14) 49%,
+          transparent 50%,
+          transparent 100%
+        ),
+        linear-gradient(
+          to bottom right,
+          transparent 0%,
+          transparent 49%,
+          rgba(255, 255, 255, 1) 50%,
+          rgba(255, 255, 255, 1) 100%
+        ),
+        linear-gradient(
+          -75deg,
+          $color-suru-start 2%,
+          $color-suru-middle 28%,
+          $color-suru-end 89%
+        );
+    }
     background-position: top right, top right, top left, top left;
     background-repeat: no-repeat;
     background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -106,7 +106,7 @@
 }
 
 @mixin vf-p-strip-shallow {
-  [class*='p-strip']:not([class*="suru"]).is-shallow {
+  [class*='p-strip']:not([class*='suru']).is-shallow {
     @extend %section-padding--shallow;
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -124,6 +124,7 @@ $color-suru-end: darken($color-brand, 10%) !default;
 @mixin vf-p-strip-suru {
   .p-strip--suru {
     @extend %vf-strip;
+
     background-blend-mode: multiply, multiply, normal, normal, normal;
     background-image:
       linear-gradient(
@@ -241,6 +242,7 @@ $color-suru-end: darken($color-brand, 10%) !default;
 @mixin vf-p-strip-suru-topped {
   .p-strip--suru-topped {
     @extend %vf-strip;
+    
     background-blend-mode: multiply, multiply, normal, normal;
     background-image:
       linear-gradient(

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -157,6 +157,40 @@
         $color-suru-middle 37%,
         $color-suru-end 100%
       );
+      @supports not (background-blend-mode: multiply) {
+        background-image: linear-gradient(
+            to bottom right,
+            rgba(205, 205, 205, 0.14) 0%,
+            rgba(205, 205, 205, 0.14) 49.8%,
+            transparent 50%,
+            transparent 100%
+          ),
+          linear-gradient(
+            to bottom left,
+            rgba(205, 205, 205, 0.14) 0%,
+            rgba(205, 205, 205, 0.14) 49.8%,
+            transparent 50%,
+            transparent 100%
+          ),
+          linear-gradient(
+            to top right,
+            #ffffff 0%,
+            #ffffff 49%,
+            rgba(255, 255, 255, 0) 50%,
+            rgba(255, 255, 255, 0) 100%
+          ),
+          linear-gradient(
+            to top right,
+            #ffffff 0%,
+            #ffffff 100%
+          ),
+          linear-gradient(
+            111deg,
+            $color-suru-start 10%,
+            $color-suru-middle 37%,
+            $color-suru-end 100%
+          );
+      }
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom,
     0% 0%;
     background-repeat: no-repeat;

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -200,7 +200,7 @@ $color-suru-end: darken($brand-color, 10%) !default;
     auto;
     margin-bottom: -4rem;
     overflow: hidden;
-    padding-bottom: 12rem !important;
+    padding-bottom: 12rem;
     position: relative;
 
     &.is-light {
@@ -231,6 +231,10 @@ $color-suru-end: darken($brand-color, 10%) !default;
         margin-bottom: -$padding;
         padding-bottom: ($padding * 3) !important;
       }
+    }
+
+    &.is-shallow {
+      padding: 2rem 0rem 6rem 0rem;     
     }
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -106,8 +106,7 @@
 }
 
 @mixin vf-p-strip-shallow {
-  [class*='p-strip']:not([class*='-suru']).is-shallow {
-    // Suru strips were not designed to be shallow, so they are excluded
+  [class*='p-strip'].is-shallow {
     @extend %section-padding--shallow;
   }
 }
@@ -165,6 +164,11 @@ $color-suru-end: darken($color-brand, 10%) !default;
         padding-bottom: ($padding * 3) !important;
       }
     }
+
+    &.is-shallow {
+      // Override is-shallow class with default padding, as Suru strips were not designed to be shallow
+      padding: 4rem 0 12rem 0;
+    }
   }
 }
 
@@ -190,5 +194,10 @@ $color-suru-end: darken($color-brand, 10%) !default;
     background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;
     padding-bottom: 4rem;
     padding-top: 6rem;
+
+    &.is-shallow {
+      // Override is-shallow class with default padding, as Suru strips were not designed to be shallow
+      padding: 6rem 0 4rem 0;
+    }
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -117,10 +117,9 @@
   }
 }
 
-$brand-color: #333333 !default;
-$color-suru-start: lighten($brand-color, 10%) !default;
-$color-suru-middle: $brand-color !default;
-$color-suru-end: darken($brand-color, 10%) !default;
+$color-suru-start: lighten($color-brand, 10%) !default;
+$color-suru-middle: $color-brand !default;
+$color-suru-end: darken($color-brand, 10%) !default;
 
 @mixin vf-p-strip-suru {
   .p-strip--suru {

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -80,7 +80,7 @@
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
               {{ side_nav_item("/docs/patterns/slider", "Slider") }}
-              {{ side_nav_item("/docs/patterns/strip", "Strip") }}
+              {{ side_nav_item("/docs/patterns/strip", "Strip", "new") }}
               {{ side_nav_item("/docs/patterns/switch", "Switch") }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
               {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}

--- a/templates/docs/examples/patterns/strips/suru-topped.html
+++ b/templates/docs/examples/patterns/strips/suru-topped.html
@@ -1,0 +1,21 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Strips / Suru-topped{% endblock %}
+
+{% block standalone_css %}patterns_strip{% endblock %}
+
+{% block content %}
+<section class="p-strip--suru-topped">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <h1>Accessibility guidelines</h1>
+    </div>
+  </div>
+</section>
+<div class="row">
+	<div class="col-8">
+		<h4>Vanilla aims to be as inclusive as possible.</h4>
+		<p>While traditionally accessibility focuses on making the web more accessible for users with permanent disabilities, a focus on accessibility can deliver an improved user experience for everyone, including those with a temporary or circumstantial disability.</p>
+		<p>Accessibility should permeate the entire design and development process, rather than being something that you only think about after everything else has been defined and implemented. You should focus on accessibility when you are:</p>
+	</div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/strips/suru.html
+++ b/templates/docs/examples/patterns/strips/suru.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_strip{% endblock %}
 
 {% block content %}
-<section class="p-strip--suru is-dark">
+<section class="p-strip--suru">
   <div class="row u-vertically-center">
     <div class="col-8">
       <h1>A simple extensible CSS framework</h1>

--- a/templates/docs/examples/patterns/strips/suru.html
+++ b/templates/docs/examples/patterns/strips/suru.html
@@ -9,7 +9,7 @@
     <div class="col-8">
       <h1>A simple extensible CSS framework</h1>
       <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>
-      <a class="p-button--positive">Get started</a>
+      <button>Get started</button>
     </div>
   </div>
 </section>

--- a/templates/docs/examples/patterns/strips/suru.html
+++ b/templates/docs/examples/patterns/strips/suru.html
@@ -1,0 +1,16 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Strips / Suru{% endblock %}
+
+{% block standalone_css %}patterns_strip{% endblock %}
+
+{% block content %}
+<section class="p-strip--suru is-dark">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <h1>A simple extensible CSS framework</h1>
+      <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>
+      <a class="p-button--positive">Get started</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -76,6 +76,29 @@ This state gives the strip smaller vertical padding.
 View example of the pattern strip is-shallow
 </a></div>
 
+### Suru strip
+
+This is a patterned strip that is ideal for overview/main pages and can be used with images.
+
+You can change the base color of the gradient by overriding the `$brand-color` variable, or customise the gradient colors by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
+
+You can also add classes '.is-light' and '.is-dark' to describe the background color - these will override the text color to ensure it remains visible.
+The '.is-deep' class is also supported, which will increase the vertical padding.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">
+View example of the pattern strip suru
+</a></div>
+
+### Topped Suru strip
+
+This is a patterned strip that is ideal for content pages.
+
+You can change the base color of the gradient by overriding the `$brand-color` variable, or customise the gradient colors by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/suru-topped/" class="js-example">
+View example of the pattern strip suru-topped
+</a></div>
+
 ### Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -80,7 +80,7 @@ View example of the pattern strip is-shallow
 
 This is a patterned strip that is ideal for overview/main pages and can be used with images.
 
-You can change the base color of the gradient by overriding the `$brand-color` variable, or customise the gradient colors by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
+The colors of the solid gradient are based on `$color-brand` by default. The gradient colors can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
 
 You can also add classes '.is-light' and '.is-dark' to describe the background color - these will override the text color to ensure it remains visible.
 The '.is-deep' and 'is-shallow' classes are also supported, which will respectively increase or decrease the vertical padding.
@@ -93,7 +93,7 @@ View example of the pattern strip suru
 
 This is a patterned strip that is ideal for content pages.
 
-You can change the base color of the gradient by overriding the `$brand-color` variable, or customise the gradient colors by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
+The colors of the solid gradient are based on `$color-brand` by default. The gradient colors can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru-topped/" class="js-example">
 View example of the pattern strip suru-topped

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -80,7 +80,7 @@ View example of the pattern strip is-shallow
 
 This is a patterned strip that is ideal for overview or main pages, and can be used with images.
 
-The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables. A dark colour scheme is recommended, as the text colour is light by default. 
+The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables. A dark colour scheme is recommended, as the text colour is light by default.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">
 View example of the pattern strip suru

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -82,7 +82,7 @@ This is a patterned strip that is ideal for overview/main pages and can be used 
 
 The colors of the solid gradient are based on `$color-brand` by default. The gradient colors can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
 
-You can also add classes '.is-light' and '.is-dark' to describe the background color - these will override the text color to ensure it remains visible.
+The classes '.is-light' and '.is-dark' can be added to describe the background color - these will override the text color to ensure it remains visible.
 The '.is-deep' and 'is-shallow' classes are also supported, which will respectively increase or decrease the vertical padding.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -80,10 +80,7 @@ View example of the pattern strip is-shallow
 
 This is a patterned strip that is ideal for overview or main pages, and can be used with images.
 
-The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
-
-The classes '.is-light' and '.is-dark' can be added to describe the background colour - these will override the text colour to ensure it remains visible.
-The '.is-deep' and 'is-shallow' classes are also supported, which will respectively increase or decrease the vertical padding.
+The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables. A dark colour scheme is recommended, as the text colour is light by default. 
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">
 View example of the pattern strip suru

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -78,11 +78,11 @@ View example of the pattern strip is-shallow
 
 ### Suru strip
 
-This is a patterned strip that is ideal for overview/main pages and can be used with images.
+This is a patterned strip that is ideal for overview or main pages, and can be used with images.
 
-The colors of the solid gradient are based on `$color-brand` by default. The gradient colors can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
+The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
 
-The classes '.is-light' and '.is-dark' can be added to describe the background color - these will override the text color to ensure it remains visible.
+The classes '.is-light' and '.is-dark' can be added to describe the background colour - these will override the text colour to ensure it remains visible.
 The '.is-deep' and 'is-shallow' classes are also supported, which will respectively increase or decrease the vertical padding.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">
@@ -93,7 +93,7 @@ View example of the pattern strip suru
 
 This is a patterned strip that is ideal for content pages.
 
-The colors of the solid gradient are based on `$color-brand` by default. The gradient colors can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
+The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru-topped/" class="js-example">
 View example of the pattern strip suru-topped

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -83,7 +83,7 @@ This is a patterned strip that is ideal for overview/main pages and can be used 
 You can change the base color of the gradient by overriding the `$brand-color` variable, or customise the gradient colors by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
 
 You can also add classes '.is-light' and '.is-dark' to describe the background color - these will override the text color to ensure it remains visible.
-The '.is-deep' class is also supported, which will increase the vertical padding.
+The '.is-deep' and 'is-shallow' classes are also supported, which will respectively increase or decrease the vertical padding.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">
 View example of the pattern strip suru


### PR DESCRIPTION
## Done

- Added new strip classes: p-strip--suru and p-strip--suru-topped
- Added new example templates for the new classes
- Updated the documentation to include the new classes

Fixes #2539 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- Navigate to http://0.0.0.0:8101/docs/examples/patterns/strips/suru and ensure that the pattern is congruent with the [specification](https://github.com/canonical-web-and-design/vanilla-framework/issues/2539) and [meeting notes](https://github.com/canonical-web-and-design/meeting-notes/issues/596).
  - Do the same for http://0.0.0.0:8101/docs/examples/patterns/strips/suru-topped
- Navigate to the strip section in the [documentation](http://0.0.0.0:8101/docs/patterns/strip) and ensure that the copy is sensible and consistent in style to the rest of the documentation.
- Ensure that the code is sensible and consistent in style to the rest of the code.

## Screenshots

![image](https://user-images.githubusercontent.com/52562977/88785824-98a69480-d189-11ea-8d39-904b83c245b9.png)


![image](https://user-images.githubusercontent.com/52562977/88785872-ae1bbe80-d189-11ea-8acc-2454ece29bc6.png)