### PR TITLE
Bump version of Vanilla to 2.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.14.1",
+  "version": "2.15.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -70,7 +70,7 @@
               {{ side_nav_item("/docs/patterns/labels", "Labels") }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists", "new") }}
+              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -10,7 +10,29 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### What's new in Vanilla 2.14
+### What's new in Vanilla 2.15
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- 2.15 -->
+    <tr>
+      <th><a href="/docs/patterns/chip">Chip</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.15.0</td>
+      <td>We added new <code>.p-chip</code> component to be used to display small actionable pieces of information.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
 
 <table>
   <thead>
@@ -29,21 +51,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.14.0</td>
       <td>We added the new <code>.p-inline-list--stretch</code> list variant that arranges items so they span the full width of the parent container.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.13 -->
     <tr>
       <th><a href="/docs/patterns/accordion#headings">Accordion</a></th>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -27,7 +27,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <th><a href="/docs/patterns/chip">Chip</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.15.0</td>
-      <td>We added new <code>.p-chip</code> component to be used to display small actionable pieces of information.</td>
+      <td>We added the new <code>.p-chip</code> component to be used to display small actionable pieces of information.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Done

Bumps version of Vanilla to 2.15, updates component status for new release.

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3194.demos.haus)
- Check docs if new version is displayed: https://vanilla-framework-3194.demos.haus/docs
- Check if Chip is listed as new in side navigation and status page: https://vanilla-framework-3194.demos.haus/docs/component-status

