### PR TITLE
Fix icons in standalone chip examples

### DIFF
--- a/scss/standalone/patterns_chip.scss
+++ b/scss/standalone/patterns_chip.scss
@@ -3,3 +3,7 @@
 
 @import '../patterns_chip';
 @include vf-p-chip;
+
+@import '../patterns_icons';
+@include vf-p-icons-common;
+@include vf-p-icon-close;


### PR DESCRIPTION
## Done

Fix icons in standalone examples of chip.

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3195.demos.haus)
- Go to chip standalone examples, make sure dismiss icon displays correctly
  -  https://vanilla-framework-3195.demos.haus/docs/examples/standalone/patterns/chip/with-dismiss
  - https://vanilla-framework-3195.demos.haus/docs/examples/standalone/patterns/chip/long-values

## Screenshots

before
<img width="200" alt="Screenshot 2020-07-30 at 15 11 41" src="https://user-images.githubusercontent.com/83575/88927027-1d231100-d277-11ea-91a6-dd609a23a26c.png">

after
<img width="166" alt="Screenshot 2020-07-30 at 15 11 49" src="https://user-images.githubusercontent.com/83575/88927020-1bf1e400-d277-11ea-8787-82f148469eda.png">


