### PR TITLE
Bump version of Vanilla to 2.16, update components status

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.15.0",
+  "version": "2.16.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -60,7 +60,7 @@
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
               {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
               {{ side_nav_item("/docs/patterns/card", "Cards") }}
-              {{ side_nav_item("/docs/patterns/chip", "Chips", "new") }}
+              {{ side_nav_item("/docs/patterns/chip", "Chips") }}
               {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}
               {{ side_nav_item("/docs/patterns/grid", "Grid") }}
               {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -10,7 +10,35 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### What's new in Vanilla 2.15
+### What's new in Vanilla 2.16
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- 2.16 -->
+    <tr>
+      <th><a href="/docs/layouts/application">Application layout</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.16.0</td>
+      <td>We added new layout styles for building responsive full-screen applications.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/strip#suru-strip">Suru strip</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.16.0</td>
+      <td>We added new strip variants <code>.p-strip--suru</code> and <code>.p-strip--suru-topped</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
 
 <table>
   <thead>
@@ -29,21 +57,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.15.0</td>
       <td>We added the new <code>.p-chip</code> component to be used to display small actionable pieces of information.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.14 -->
     <tr>
       <th><a href="/docs/patterns/lists#inline-stretched">List inline stretched</a></th>


### PR DESCRIPTION
## Done

Bump version of Vanilla and update component status in docs in preparation for next release.

## QA

- `./run` or http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3200.demos.haus)
- Visit [docs](https://vanilla-framework-3200.demos.haus), make sure Vanilla version is correct
- Check [component status](https://vanilla-framework-3200.demos.haus/docs/component-status), make sure it's up to date

