### PR TITLE
Update navigation highlight: option 1

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -320,6 +320,8 @@ $lightness-threshold: 70;
   %navigation-link-selected {
     @extend %navigation-link-hover;
 
+    font-weight: $font-weight-bold;
+
     &::before {
       background-color: $color-navigation-text;
       content: '';

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -329,7 +329,7 @@ $lightness-threshold: 70;
       left: 0;
       position: absolute;
       right: 0;
-      top: 0;
+      top: 1px;
       z-index: 1;
     }
   }
@@ -375,7 +375,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $colors--light-theme--background-default,
       $color-navigation-text: $colors--light-theme--text-default,
       $color-navigation-separator: $colors--light-theme--border-default,
-      $color-background-hover: $colors--light-theme--background-hover
+      $color-background-hover: rgba($colors--light-theme--text-default, $active-background-opacity-amount)
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -386,7 +386,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
       $color-navigation-separator: $colors--light-theme--border-default,
-      $color-background-hover: $colors--light-theme--background-hover
+      $color-background-hover: rgba($colors--light-theme--text-default, $active-background-opacity-amount)
     );
   }
 }
@@ -397,7 +397,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $colors--dark-theme--background-alt,
       $color-navigation-text: $colors--dark-theme--text-default,
       $color-navigation-separator: $colors--dark-theme--border-default,
-      $color-background-hover: $colors--dark-theme--background-hover
+      $color-background-hover: rgba($colors--dark-theme--text-default, $active-background-opacity-amount)
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -408,7 +408,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
       $color-navigation-separator: $colors--dark-theme--border-default,
-      $color-background-hover: $colors--dark-theme--background-hover
+      $color-background-hover: rgba($colors--dark-theme--text-default, $active-background-opacity-amount)
     );
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,6 +1,5 @@
 @import 'settings';
 
-$navigation-hover-opacity: 0.58;
 $lightness-threshold: 70;
 
 @mixin vf-p-navigation {
@@ -287,11 +286,14 @@ $lightness-threshold: 70;
   // color for navigation background
     $color-navigation-background,
   // color for navigation text
-    $color-navigation-text
+    $color-navigation-text,
+  // transparent color of selected and hovered menu item
+    $color-background-hover
 ) {
   background-color: $color-navigation-background;
 
   %navigation-link-theme {
+    position: relative;
     &,
     &:visited,
     &:focus {
@@ -299,12 +301,31 @@ $lightness-threshold: 70;
     }
 
     &:hover {
-      opacity: $navigation-hover-opacity;
+      @extend %navigation-link-selected;
     }
   }
 
   %navigation-link-selected {
-    opacity: $navigation-hover-opacity;
+    &::after {
+      background-color: $color-background-hover;
+      content: '';
+      height: 100%;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+
+    &::before {
+      background-color: $color-navigation-text;
+      content: '';
+      height: $bar-thickness;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      z-index: 1;
+    }
   }
 
   %navigation-link-before {
@@ -347,7 +368,8 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $colors--light-theme--background-default,
       $color-navigation-text: $colors--light-theme--text-default,
-      $color-navigation-separator: $colors--light-theme--border-default
+      $color-navigation-separator: $colors--light-theme--border-default,
+      $color-background-hover: $colors--light-theme--background-hover
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -357,7 +379,8 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--light-theme--border-default
+      $color-navigation-separator: $colors--light-theme--border-default,
+      $color-background-hover: $colors--light-theme--background-hover
     );
   }
 }
@@ -367,7 +390,8 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $colors--dark-theme--background-alt,
       $color-navigation-text: $colors--dark-theme--text-default,
-      $color-navigation-separator: $colors--dark-theme--border-default
+      $color-navigation-separator: $colors--dark-theme--border-default,
+      $color-background-hover: $colors--dark-theme--background-hover
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -377,7 +401,8 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--dark-theme--border-default
+      $color-navigation-separator: $colors--dark-theme--border-default,
+      $color-background-hover: $colors--dark-theme--background-hover
     );
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -301,11 +301,11 @@ $lightness-threshold: 70;
     }
 
     &:hover {
-      @extend %navigation-link-selected;
+      @extend %navigation-link-hover;
     }
   }
 
-  %navigation-link-selected {
+  %navigation-link-hover {
     &::after {
       background-color: $color-background-hover;
       content: '';
@@ -315,6 +315,10 @@ $lightness-threshold: 70;
       right: 0;
       top: 0;
     }
+  }
+
+  %navigation-link-selected {
+    @extend %navigation-link-hover;
 
     &::before {
       background-color: $color-navigation-text;


### PR DESCRIPTION
## Done

Increase the prominance of hover and selected navigation items. 
This is option one of two, option 2 (as in charmhub) will be on a separate branch.

Do not merge: the two options need to be presented and whichever is chosen can then be merged.

## QA

- Pull code
- Run `./run`
- Open /docs/examples/patterns/navigation/default-dark#navigation or [demo]
- Verify it looks like this:

## Screenshots
![image](https://user-images.githubusercontent.com/2741678/90045161-8d458400-dcc6-11ea-885c-6415e843dd2c.png)