### PR TITLE
Navigation highlight update option 2

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -306,26 +306,8 @@ $lightness-threshold: 70;
   }
 
   %navigation-link-selected {
-    &::after {
-      background-color: $color-background-hover;
-      content: '';
-      height: 100%;
-      left: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
-
-    &::before {
-      background-color: $color-navigation-text;
-      content: '';
-      height: $bar-thickness;
-      left: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-      z-index: 1;
-    }
+    background-color: $color-navigation-text;
+    color: $color-navigation-background;
   }
 
   %navigation-link-before {
@@ -369,7 +351,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $colors--light-theme--background-default,
       $color-navigation-text: $colors--light-theme--text-default,
       $color-navigation-separator: $colors--light-theme--border-default,
-      $color-background-hover: $colors--light-theme--background-hover
+      $color-background-hover: $colors--dark-theme--text-default
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -380,7 +362,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
       $color-navigation-separator: $colors--light-theme--border-default,
-      $color-background-hover: $colors--light-theme--background-hover
+      $color-background-hover: $colors--dark-theme--text-default
     );
   }
 }
@@ -391,7 +373,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $colors--dark-theme--background-alt,
       $color-navigation-text: $colors--dark-theme--text-default,
       $color-navigation-separator: $colors--dark-theme--border-default,
-      $color-background-hover: $colors--dark-theme--background-hover
+      $color-background-hover: $colors--dark-theme--text-default
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -402,7 +384,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
       $color-navigation-separator: $colors--dark-theme--border-default,
-      $color-background-hover: $colors--dark-theme--background-hover
+      $color-background-hover: $colors--dark-theme--text-default
     );
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -115,6 +115,10 @@ $lightness-threshold: 70;
     display: flex;
   }
 
+  %vf-reset-horizontal-padding {
+    padding-left: 0;
+    padding-right: 0;
+  }
   // no colours
   .p-navigation {
     display: flex;
@@ -131,13 +135,12 @@ $lightness-threshold: 70;
     &__row {
       @extend %fixed-width-container;
       @extend %navigation-row;
-
-      padding-left: 0;
-      padding-right: 0;
+      @extend %vf-reset-horizontal-padding;
 
       &--full-width {
         @extend %vf-grid-container-padding;
         @extend %navigation-row;
+        @extend %vf-reset-horizontal-padding;
 
         width: 100%;
       }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -282,13 +282,13 @@ $lightness-threshold: 70;
 
 @mixin vf-navigation-theme(
   // color for navigation separator on small screens
-    $color-navigation-separator,
+  $color-navigation-separator,
   // color for navigation background
-    $color-navigation-background,
+  $color-navigation-background,
   // color for navigation text
-    $color-navigation-text,
+  $color-navigation-text,
   // transparent color of selected and hovered menu item
-    $color-background-hover
+  $color-background-hover
 ) {
   background-color: $color-navigation-background;
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -286,9 +286,7 @@ $lightness-threshold: 70;
   // color for navigation background
   $color-navigation-background,
   // color for navigation text
-  $color-navigation-text,
-  // transparent color of selected and hovered menu item
-  $color-background-hover
+  $color-navigation-text
 ) {
   background-color: $color-navigation-background;
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -76,16 +76,6 @@ $lightness-threshold: 70;
       right: 0;
       top: 0;
 
-      @media (max-width: $threshold-4-6-col) {
-        left: map-get($grid-margin-widths, small);
-        right: map-get($grid-margin-widths, small);
-      }
-
-      @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
-        left: map-get($grid-margin-widths, medium);
-        right: map-get($grid-margin-widths, medium);
-      }
-
       @media (min-width: $breakpoint-navigation-threshold) {
         content: none;
       }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -348,8 +348,7 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $colors--light-theme--background-default,
       $color-navigation-text: $colors--light-theme--text-default,
-      $color-navigation-separator: $colors--light-theme--border-default,
-      $color-background-hover: $colors--dark-theme--text-default
+      $color-navigation-separator: $colors--light-theme--border-default
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -359,8 +358,7 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--light-theme--border-default,
-      $color-background-hover: $colors--dark-theme--text-default
+      $color-navigation-separator: $colors--light-theme--border-default
     );
   }
 }
@@ -370,8 +368,7 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $colors--dark-theme--background-alt,
       $color-navigation-text: $colors--dark-theme--text-default,
-      $color-navigation-separator: $colors--dark-theme--border-default,
-      $color-background-hover: $colors--dark-theme--text-default
+      $color-navigation-separator: $colors--dark-theme--border-default
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -381,8 +378,7 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--dark-theme--border-default,
-      $color-background-hover: $colors--dark-theme--text-default
+      $color-navigation-separator: $colors--dark-theme--border-default
     );
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,6 +1,5 @@
 @import 'settings';
 
-$navigation-hover-opacity: 0.58;
 $lightness-threshold: 70;
 
 @mixin vf-p-navigation {
@@ -283,15 +282,18 @@ $lightness-threshold: 70;
 
 @mixin vf-navigation-theme(
   // color for navigation separator on small screens
-  $color-navigation-separator,
+    $color-navigation-separator,
   // color for navigation background
-  $color-navigation-background,
+    $color-navigation-background,
   // color for navigation text
-  $color-navigation-text
+    $color-navigation-text,
+  // transparent color of selected and hovered menu item
+    $color-background-hover
 ) {
   background-color: $color-navigation-background;
 
   %navigation-link-theme {
+    position: relative;
     &,
     &:visited,
     &:focus {
@@ -299,12 +301,31 @@ $lightness-threshold: 70;
     }
 
     &:hover {
-      opacity: $navigation-hover-opacity;
+      @extend %navigation-link-selected;
     }
   }
 
   %navigation-link-selected {
-    opacity: $navigation-hover-opacity;
+    &::after {
+      background-color: $color-background-hover;
+      content: '';
+      height: 100%;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+
+    &::before {
+      background-color: $color-navigation-text;
+      content: '';
+      height: $bar-thickness;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      z-index: 1;
+    }
   }
 
   %navigation-link-before {
@@ -347,7 +368,8 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $colors--light-theme--background-default,
       $color-navigation-text: $colors--light-theme--text-default,
-      $color-navigation-separator: $colors--light-theme--border-default
+      $color-navigation-separator: $colors--light-theme--border-default,
+      $color-background-hover: $colors--light-theme--background-hover
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -357,7 +379,8 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--light-theme--border-default
+      $color-navigation-separator: $colors--light-theme--border-default,
+      $color-background-hover: $colors--light-theme--background-hover
     );
   }
 }
@@ -367,7 +390,8 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $colors--dark-theme--background-alt,
       $color-navigation-text: $colors--dark-theme--text-default,
-      $color-navigation-separator: $colors--dark-theme--border-default
+      $color-navigation-separator: $colors--dark-theme--border-default,
+      $color-background-hover: $colors--dark-theme--background-hover
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -377,7 +401,8 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--dark-theme--border-default
+      $color-navigation-separator: $colors--dark-theme--border-default,
+      $color-background-hover: $colors--dark-theme--background-hover
     );
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -13,23 +13,60 @@ $lightness-threshold: 70;
     }
   }
 
+  %navigation-link-responsive-padding-vertical {
+    padding-bottom: $spv-inner--medium;
+    padding-top: $spv-inner--medium;
+  }
+
+  %navigation-link-responsive-padding-left {
+    // follows grid padding to ensure nav items on small breakpoints align with grid padding
+    @media (max-width: $threshold-4-6-col) {
+      padding-left: map-get($grid-margin-widths, small);
+    }
+
+    @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+      padding-left: map-get($grid-margin-widths, medium);
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      padding-left: $sph-inner;
+    }
+  }
+
+  %navigation-link-responsive-padding-right {
+    // follows grid padding to ensure nav items on small breakpoints align with grid padding
+    @media (max-width: $threshold-4-6-col) {
+      padding-right: map-get($grid-margin-widths, small);
+    }
+
+    @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+      padding-right: map-get($grid-margin-widths, medium);
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      padding-right: $sph-inner;
+    }
+  }
+
+  %navigation-link-responsive-padding-horizontal {
+    @extend %navigation-link-responsive-padding-left;
+    @extend %navigation-link-responsive-padding-right;
+  }
+
   %navigation-link {
     $properties: #{background-color, color, opacity};
-    @include vf-animation($properties);
+    @extend %navigation-link-responsive-padding-horizontal;
+    @extend %navigation-link-responsive-padding-vertical;
+    @include vf-animation($properties, snap);
     @include vf-focus;
 
     display: block;
     line-height: map-get($line-heights, default-text);
     margin-bottom: 0;
     overflow: hidden;
-    padding: $spv-inner--medium 0;
     position: relative;
     text-overflow: ellipsis;
     white-space: nowrap;
-
-    @media (min-width: $breakpoint-navigation-threshold) {
-      padding: $spv-inner--medium $sph-inner;
-    }
 
     &::before {
       content: '';
@@ -38,6 +75,16 @@ $lightness-threshold: 70;
       position: absolute;
       right: 0;
       top: 0;
+
+      @media (max-width: $threshold-4-6-col) {
+        left: map-get($grid-margin-widths, small);
+        right: map-get($grid-margin-widths, small);
+      }
+
+      @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+        left: map-get($grid-margin-widths, medium);
+        right: map-get($grid-margin-widths, medium);
+      }
 
       @media (min-width: $breakpoint-navigation-threshold) {
         content: none;
@@ -49,6 +96,14 @@ $lightness-threshold: 70;
     &:focus,
     &:hover {
       text-decoration: none;
+    }
+
+    &:visited,
+    &:focus,
+    &:hover {
+      &::before {
+        content: none;
+      }
     }
   }
 
@@ -95,6 +150,9 @@ $lightness-threshold: 70;
       @extend %fixed-width-container;
       @extend %navigation-row;
 
+      padding-left: 0;
+      padding-right: 0;
+
       &--full-width {
         @extend %vf-grid-container-padding;
         @extend %navigation-row;
@@ -120,9 +178,23 @@ $lightness-threshold: 70;
 
     // navigation logo
     &__banner {
+      @extend %navigation-link-responsive-padding-left;
+
       display: flex;
       flex: 0 0 auto;
       justify-content: space-between;
+
+      @media (max-width: $threshold-4-6-col) {
+        padding-right: 0;
+      }
+
+      @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+        padding-right: 0;
+      }
+
+      @media (min-width: $breakpoint-navigation-threshold) {
+        padding-left: map-get($grid-margin-widths, large);
+      }
     }
 
     &__logo {
@@ -186,13 +258,23 @@ $lightness-threshold: 70;
       min-width: 10em;
       order: -1;
 
+      @media (max-width: $threshold-4-6-col) {
+        margin-left: map-get($grid-margin-widths, small);
+        margin-right: map-get($grid-margin-widths, small);
+      }
+
+      @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+        margin-left: map-get($grid-margin-widths, medium);
+        margin-right: map-get($grid-margin-widths, medium);
+      }
+
       @media (min-width: $breakpoint-navigation-threshold) {
         // align baselines of menu items and input text
         $input-gap-top: $spv-inner--medium - $spv-nudge;
 
         display: flex;
         flex: 1 1 auto;
-        margin: $input-gap-top 0 auto auto;
+        margin: $input-gap-top map-get($grid-margin-widths, large) auto auto;
         max-width: 20rem;
         min-width: initial;
         order: 1;
@@ -214,10 +296,11 @@ $lightness-threshold: 70;
 
       &--open,
       &--close {
+        @extend %navigation-link-responsive-padding-horizontal;
+        @extend %navigation-link-responsive-padding-vertical;
         @include vf-focus;
 
-        margin: 0 0 auto $sph-inner;
-        padding: $spv-inner--medium 0;
+        margin: 0 0 auto 0;
 
         &,
         &:visited,
@@ -286,7 +369,9 @@ $lightness-threshold: 70;
   // color for navigation background
   $color-navigation-background,
   // color for navigation text
-  $color-navigation-text
+  $color-navigation-text,
+  $color-navigation-background--hover,
+  $color-navigation-text--hover
 ) {
   background-color: $color-navigation-background;
 
@@ -303,8 +388,8 @@ $lightness-threshold: 70;
   }
 
   %navigation-link-selected {
-    background-color: $color-navigation-text;
-    color: $color-navigation-background;
+    background-color: $color-navigation-background--hover;
+    color: $color-navigation-text--hover;
   }
 
   %navigation-link-before {
@@ -347,7 +432,9 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $colors--light-theme--background-default,
       $color-navigation-text: $colors--light-theme--text-default,
-      $color-navigation-separator: $colors--light-theme--border-default
+      $color-navigation-separator: $colors--light-theme--border-default,
+      $color-navigation-background--hover: $colors--light-theme--background-alt,
+      $color-navigation-text--hover: $colors--light-theme--text-default
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -357,7 +444,9 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--light-theme--border-default
+      $color-navigation-separator: $colors--light-theme--border-default,
+      $color-navigation-background--hover: $colors--light-theme--background-alt,
+      $color-navigation-text--hover: $colors--light-theme--text-default
     );
   }
 }
@@ -367,7 +456,9 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $colors--dark-theme--background-alt,
       $color-navigation-text: $colors--dark-theme--text-default,
-      $color-navigation-separator: $colors--dark-theme--border-default
+      $color-navigation-separator: $colors--dark-theme--border-default,
+      $color-navigation-background--hover: $colors--dark-theme--text-default,
+      $color-navigation-text--hover: $colors--dark-theme--background-default
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -377,7 +468,9 @@ $lightness-threshold: 70;
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--dark-theme--border-default
+      $color-navigation-separator: $colors--dark-theme--border-default,
+      $color-navigation-background--hover: $colors--dark-theme--text-default,
+      $color-navigation-text--hover: $colors--dark-theme--background-default
     );
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -138,7 +138,6 @@ $lightness-threshold: 70;
       @extend %vf-reset-horizontal-padding;
 
       &--full-width {
-        @extend %vf-grid-container-padding;
         @extend %navigation-row;
         @extend %vf-reset-horizontal-padding;
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -291,7 +291,6 @@ $lightness-threshold: 70;
   background-color: $color-navigation-background;
 
   %navigation-link-theme {
-    position: relative;
     &,
     &:visited,
     &:focus {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -229,6 +229,8 @@ $lightness-threshold: 70;
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+        margin-right: map-get($grid-margin-widths, large);
+
         width: 100%;
       }
     }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -139,7 +139,6 @@ $lightness-threshold: 70;
 
       &--full-width {
         @extend %navigation-row;
-        @extend %vf-reset-horizontal-padding;
 
         width: 100%;
       }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -237,7 +237,7 @@ $lightness-threshold: 70;
     // p-search-box overrides
     .p-search-box {
       flex: 1 0 auto;
-      margin: -1px 0 $spv-inner--small 0;
+      margin-top: -1px;
       min-width: 10em;
       order: -1;
 
@@ -257,7 +257,7 @@ $lightness-threshold: 70;
 
         display: flex;
         flex: 1 1 auto;
-        margin: $input-gap-top map-get($grid-margin-widths, large) auto auto;
+        margin: $input-gap-top 0 auto auto;
         max-width: 20rem;
         min-width: initial;
         order: 1;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -230,7 +230,6 @@ $lightness-threshold: 70;
         flex-direction: row;
         justify-content: space-between;
         margin-right: map-get($grid-margin-widths, large);
-
         width: 100%;
       }
     }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -97,14 +97,6 @@ $lightness-threshold: 70;
     &:hover {
       text-decoration: none;
     }
-
-    &:visited,
-    &:focus,
-    &:hover {
-      &::before {
-        content: none;
-      }
-    }
   }
 
   %navigation-items {

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -138,6 +138,8 @@
   $color-subnav-background,
   // color of the subnav items text
   $color-subnav-text,
+  // color of the subnav items background on hover
+  $color-subnav-background-hover,
   // color of the subnav items text on hover
   $color-subnav-text-hover,
   // color of the subnav items separator on small screens
@@ -158,6 +160,7 @@
     }
 
     &:hover {
+      background-color: $color-subnav-background-hover;
       color: $color-subnav-text-hover;
     }
 
@@ -175,7 +178,8 @@
     $color-subnav-icon: $colors--light-theme--text-muted,
     $color-subnav-background: $colors--light-theme--background-default,
     $color-subnav-text: $colors--light-theme--text-default,
-    $color-subnav-text-hover: $colors--light-theme--text-hover,
+    $color-subnav-background-hover: $colors--light-theme--background-alt,
+    $color-subnav-text-hover: $colors--light-theme--text-default,
     $color-subnav-separator: $colors--light-theme--border-default
   );
 }
@@ -189,7 +193,8 @@
     $color-subnav-icon: #999,
     $color-subnav-background: $colors--dark-theme--background-alt,
     $color-subnav-text: $colors--dark-theme--text-default,
-    $color-subnav-text-hover: $colors--dark-theme--text-hover,
+    $color-subnav-text-hover: $colors--dark-theme--background-default,
+    $color-subnav-background-hover: $colors--dark-theme--text-default,
     $color-subnav-separator: $colors--dark-theme--border-default
   );
 }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -74,7 +74,7 @@
   }
 
   .p-subnav__item {
-    @extend %navigation-link-responsive-padding-left;
+    @extend %navigation-link-responsive-padding-horizontal;
 
     display: block;
     white-space: nowrap;

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -16,10 +16,21 @@
     height: $spv-inner--large;
     pointer-events: none;
     position: absolute;
-    right: calc(#{$sph-inner--small} + 1px); // 1px for the border on selects. this aligns itr with any selects underneath
     text-indent: calc(100% + 10rem);
     top: $spv-inner--large;
-    width: $sph-inner;
+    width: map-get($icon-sizes, default);
+
+    @media (max-width: $threshold-4-6-col) {
+      right: map-get($grid-margin-widths, small);
+    }
+
+    @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+      right: map-get($grid-margin-widths, medium);
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold + 1) {
+      right: calc(#{$sph-inner--small} + 1px); // 1px for the border on selects. this aligns it with any selects underneath
+    }
   }
 
   .p-subnav__items,
@@ -62,6 +73,31 @@
     padding-right: 2 * $sph-inner--small + map-get($icon-sizes, default); // icon padded with the default padding-right of selects, inputs etc.
   }
 
+  .p-subnav__item {
+    @extend %navigation-link-responsive-padding-left;
+
+    display: block;
+    white-space: nowrap;
+
+    @media (max-width: $breakpoint-navigation-threshold) {
+      padding-bottom: $spv-inner--small;
+      padding-top: $spv-inner--small;
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      padding-bottom: $spv-inner--medium;
+      padding-top: $spv-inner--medium;
+    }
+
+    &,
+    &:active,
+    &:focus,
+    &:hover,
+    &:visited {
+      text-decoration: none;
+    }
+  }
+
   .p-subnav > .p-navigation__link {
     // remove nesting in 3.0 when deprecated __link styles are removed
     @extend %subnav-link;
@@ -91,27 +127,6 @@
     .p-subnav.is-dark,
     .p-navigation.is-dark .p-subnav {
       @include vf-subnav-dark-theme;
-    }
-  }
-
-  .p-subnav__item {
-    display: block;
-    white-space: nowrap;
-
-    @media (max-width: $breakpoint-navigation-threshold) {
-      padding: $spv-inner--small 0;
-    }
-
-    @media (min-width: $breakpoint-navigation-threshold) {
-      padding: $spv-inner--medium $sph-inner;
-    }
-
-    &,
-    &:active,
-    &:focus,
-    &:hover,
-    &:visited {
-      text-decoration: none;
     }
   }
 }


### PR DESCRIPTION
## Done

Increase the prominance of hover and selected navigation items.
This is option 2, (as in charmhub).

Do not merge: the two options need to be presented and whichever is chosen can then be merged.

## QA

- Pull code
- Run `./run`
- Open /docs/examples/patterns/navigation/default-dark#navigation or [demo]
- Verify it looks like this:

## Screenshots

![image](https://user-images.githubusercontent.com/2741678/90050970-def20c80-dcce-11ea-8d49-e5e7c19842b5.png)
