### PR TITLE
Update table header labels and border colours

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -45,7 +45,7 @@
     }
 
     tr {
-      border-bottom: 1px solid $color-dark;
+      border-bottom: 1px solid $colors--light-theme--border-default;
       vertical-align: top;
     }
   }
@@ -65,6 +65,6 @@
   }
 
   %table-row-border {
-    border-top: 1px solid $color-mid-light;
+    border-top: 1px solid $colors--light-theme--border-low-contrast;
   }
 }

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -223,7 +223,6 @@
   }
 
   %table-header-label {
-    @extend %muted-text;
     @extend %x-small-text;
 
     font-weight: $font-weight-bold;


### PR DESCRIPTION
## Done

- Update table header labels to `#111`
- Update header row border to light grey
- Update rest of table borders to a lighter grey

What this aimes to do: 
- Make the end of one table and beginning of next more prominent, as the grey labels are too subtle. We had some discussions around this in the jaas multiple tables on the same page

- Match recent designs:
![image](https://user-images.githubusercontent.com/2741678/90136531-35f9ef00-dd6c-11ea-87f6-dafa12bae72a.png)

- Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2836, https://github.com/canonical-web-and-design/vanilla-squad/issues/861

## QA

- Pull code
- Run `./run`
- Open docs/examples/patterns/tables/table-mobile-card or [demo]
- Verify it looks like this:

![image](https://user-images.githubusercontent.com/2741678/90136811-a739a200-dd6c-11ea-8bc5-31de2a11f7b9.png)
