### PR TITLE
Update the suru strip topped pattern

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -177,16 +177,16 @@ $color-suru-end: darken($color-brand, 10%) !default;
     @extend %vf-strip;
 
     background-image: linear-gradient(to bottom left, rgba(229, 229, 229, 0.14) 0%, rgba(229, 229, 229, 0.14) 49%, transparent 50%, transparent 100%),
-      linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49%, transparent 50%, transparent 100%),
+      linear-gradient(to bottom left, rgba($color-suru-middle, 0.14) 0%, rgba($color-suru-middle, 0.14) 49%, transparent 50%, transparent 100%),
       linear-gradient(to bottom right, transparent 0%, transparent 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
-      linear-gradient(-75deg, $color-suru-start 2%, $color-suru-middle 28%, $color-suru-end 89%);
+      linear-gradient(90deg, $color-suru-start 4%, $color-suru-middle 50%, $color-suru-end 88%);
 
     @supports (background-blend-mode: multiply) {
       background-blend-mode: multiply, multiply, normal, normal;
       background-image: linear-gradient(to bottom left, rgba(229, 229, 229, 0.5) 0%, rgba(229, 229, 229, 0.5) 49%, transparent 50%, transparent 100%),
-        linear-gradient(to bottom left, rgba(205, 205, 205, 0.16) 0%, rgba(205, 205, 205, 0.16) 49%, transparent 50%, transparent 100%),
+        linear-gradient(to bottom left, rgba($color-suru-middle, 0.16) 0%, rgba($color-suru-middle, 0.16) 49%, transparent 50%, transparent 100%),
         linear-gradient(to bottom right, transparent 0%, transparent 49%, #fff 50%, #fff 100%),
-        linear-gradient(-75deg, $color-suru-start 2%, $color-suru-middle 28%, $color-suru-end 89%);
+        linear-gradient(90deg, $color-suru-start 4%, $color-suru-middle 50%, $color-suru-end 88%);
     }
 
     background-position: top right, top right, top left, top left;


### PR DESCRIPTION
## Done
Update the Suru strip topped pattern to match its usage to easy the adoption.

## QA
- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/strips/suru-topped
- Check the `linear-gradients` match the [one used on ubuntu.com](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_patterns_strip.scss#L176).
- Example pages on ubuntu.com: https://ubuntu.com/appliance