### PR TITLE
Base form tick elements refactoring

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,7 +5,7 @@
     "order/properties-alphabetical-order": true,
     "at-rule-no-unknown": null,
     "scss/at-rule-no-unknown": true,
-    "no-descending-specificity": [true, {"severity": "warning "}],
+    "no-descending-specificity": [true, {"severity": "warning"}],
 
     "scss/at-extend-no-missing-placeholder": true,
     "property-no-vendor-prefix": true,

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -1,5 +1,10 @@
 // tick element variables
 $form-tick-box-size: 1rem;
+$form-tick-height: 0.375rem;
+$form-tick-offset-top: 0.1875rem;
+
+$form-radio-inner-circle-diameter: 0.375rem;
+$form-radio-circle-offset: 0.5 * ($form-tick-box-size - $form-radio-inner-circle-diameter);
 
 // Offsets to align tick elements to the baseline of headings.
 $box-offsets-top: (
@@ -30,6 +35,9 @@ $box-offsets-top: (
   }
 
   %vf-pseudo-tick-box {
+    padding-left: $sph-inner + $form-tick-box-size;
+    position: relative;
+
     &::before,
     &::after {
       $properties: #{background-color, border-color};
@@ -54,6 +62,38 @@ $box-offsets-top: (
     }
   }
 
+  %vf-pseudo-checkbox {
+    // container
+    &::before {
+      border-radius: $border-radius;
+    }
+
+    //tick
+    &::after {
+      border-bottom: 2px solid;
+      border-left: 2px solid;
+      height: $form-tick-height;
+      left: $form-tick-height * 0.5;
+      transform: rotate(-45deg);
+      width: 0.625rem;
+    }
+  }
+
+  %vf-pseudo-radio {
+    &::before,
+    &::after {
+      border-radius: 50%;
+    }
+
+    &::after {
+      border-radius: 50%;
+      height: $form-radio-inner-circle-diameter;
+      left: #{($form-tick-box-size - $form-radio-inner-circle-diameter) * 0.5};
+      // top: #{$box-offset-top + 0.5 * ($form-tick-box-size - $form-radio-inner-circle-diameter)};
+      width: $form-radio-inner-circle-diameter;
+    }
+  }
+
   %vf-tick-in-label {
     // some basic styling for checkboxes inside labels
     float: left;
@@ -74,9 +114,6 @@ $box-offsets-top: (
 
     & + label {
       @extend %vf-pseudo-tick-box;
-
-      padding-left: $sph-inner + $form-tick-box-size;
-      position: relative;
 
       // Align with different text styles
       @media (max-width: $breakpoint-heading-threshold) {
@@ -227,24 +264,7 @@ $box-offsets-top: (
 
     // stylelint-disable selector-no-qualifying-type
     & + label {
-      // container
-      &::before {
-        border-radius: $border-radius;
-      }
-
-      //tick
-      &::after {
-        $tick-height: 0.375rem;
-
-        border-bottom: 2px solid;
-        border-left: 2px solid;
-        height: $tick-height;
-        left: $tick-height * 0.5;
-        transform: rotate(-45deg);
-        width: 0.625rem;
-      }
-
-      $tick-offset-top: 0.1875rem;
+      @extend %vf-pseudo-checkbox;
 
       // Align with different text styles
       @media (max-width: $breakpoint-heading-threshold) {
@@ -254,39 +274,39 @@ $box-offsets-top: (
         &:not(.is-h4)::after,
         &:not(.is-muted-heading)::after,
         &:not(.is-inline-label)::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
         }
 
         &.is-h2::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
         }
 
         &.is-h3::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
         }
 
         &.is-h4::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
         }
 
         &.is-inline-label::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
 
@@ -297,39 +317,39 @@ $box-offsets-top: (
         &:not(.is-h4)::after,
         &:not(.is-muted-heading)::after,
         &:not(.is-inline-label)::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h1) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h1) - $form-tick-box-size};
         }
 
         &.is-h2::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h2) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h2) - $form-tick-box-size};
         }
 
         &.is-h3::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h3) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h3) - $form-tick-box-size};
         }
 
         &.is-h4::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h4) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h4) - $form-tick-box-size};
         }
 
         &.is-inline-label::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
+          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
     }
@@ -344,23 +364,12 @@ $box-offsets-top: (
     @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
 
-    $inner-circle-diameter: 0.375rem;
-    $circle-offset-top: 0.5 * ($form-tick-box-size - $inner-circle-diameter);
+    $form-radio-inner-circle-diameter: 0.375rem;
+    $form-radio-circle-offset: 0.5 * ($form-tick-box-size - $form-radio-inner-circle-diameter);
 
     // stylelint-disable selector-no-qualifying-type
     & + label {
-      &::before,
-      &::after {
-        border-radius: 50%;
-      }
-
-      &::after {
-        border-radius: 50%;
-        height: $inner-circle-diameter;
-        left: #{($form-tick-box-size - $inner-circle-diameter) * 0.5};
-        // top: #{$box-offset-top + 0.5 * ($form-tick-box-size - $inner-circle-diameter)};
-        width: $inner-circle-diameter;
-      }
+      @extend %vf-pseudo-radio;
 
       // Align with different text styles
       @media (max-width: $breakpoint-heading-threshold) {
@@ -370,39 +379,39 @@ $box-offsets-top: (
         &:not(.is-h4)::after,
         &:not(.is-muted-heading)::after,
         &:not(.is-inline-label)::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
         }
 
         &.is-h2::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
         }
 
         &.is-h3::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
         }
 
         &.is-h4::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
         }
 
         &.is-inline-label::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
 
@@ -413,39 +422,39 @@ $box-offsets-top: (
         &:not(.is-h4)::after,
         &:not(.is-muted-heading)::after,
         &:not(.is-inline-label)::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h1) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h1) - $form-tick-box-size};
         }
 
         &.is-h2::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h2) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h2) - $form-tick-box-size};
         }
 
         &.is-h3::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h3) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h3) - $form-tick-box-size};
         }
 
         &.is-h4::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h4) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h4) - $form-tick-box-size};
         }
 
         &.is-inline-label::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
+          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
     }

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -62,6 +62,23 @@ $box-offsets-top: (
     }
   }
 
+  %vf-pseudo-tick-box-checked {
+    &::before {
+      background-color: $color-link;
+      border-color: $color-link;
+    }
+
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  %vf-pseudo-tick-box-focused {
+    &::before {
+      outline: $bar-thickness solid $color-focus;
+    }
+  }
+
   %vf-pseudo-checkbox {
     // container
     &::before {
@@ -242,19 +259,17 @@ $box-offsets-top: (
       }
     }
 
-    &:checked + label::after {
-      opacity: 1;
+    &:checked + label {
+      @extend %vf-pseudo-tick-box-checked;
     }
 
-    &:focus + label::before {
-      outline: $bar-thickness solid $color-focus;
+    &:focus + label {
+      @extend %vf-pseudo-tick-box-focused;
     }
 
-    &[disabled],
-    &[disabled='disabled'] {
-      + label {
-        @extend %vf-disabled-element;
-      }
+    &[disabled] + label,
+    &[disabled='disabled'] + label {
+      @extend %vf-disabled-element;
     }
   }
 
@@ -354,18 +369,11 @@ $box-offsets-top: (
       }
     }
     // stylelint-enable selector-no-qualifying-type
-
-    &:checked {
-      @extend %checked;
-    }
   }
 
   [type='radio'] {
     @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
-
-    $form-radio-inner-circle-diameter: 0.375rem;
-    $form-radio-circle-offset: 0.5 * ($form-tick-box-size - $form-radio-inner-circle-diameter);
 
     // stylelint-disable selector-no-qualifying-type
     & + label {
@@ -459,17 +467,6 @@ $box-offsets-top: (
       }
     }
     // stylelint-enable selector-no-qualifying-type
-
-    &:checked {
-      @extend %checked;
-    }
-  }
-
-  %checked {
-    & + label::before {
-      background-color: $color-link;
-      border-color: $color-link;
-    }
   }
 
   // Theming

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -471,35 +471,35 @@ $box-offsets-top: (
 
   // Theming
   @if ($theme-default-forms == 'dark') {
-    [type='checkbox'] {
+    [type='checkbox'] + label {
       @include vf-checkbox-dark-theme;
     }
 
-    [type='radio'] {
+    [type='radio'] + label {
       @include vf-radio-dark-theme;
     }
 
-    [type='checkbox'].is-light {
+    [type='checkbox'].is-light + label {
       @include vf-checkbox-light-theme;
     }
 
-    [type='radio'].is-light {
+    [type='radio'].is-light + label {
       @include vf-radio-light-theme;
     }
   } @else {
-    [type='checkbox'] {
+    [type='checkbox'] + label {
       @include vf-checkbox-light-theme;
     }
 
-    [type='radio'] {
+    [type='radio'] + label {
       @include vf-radio-light-theme;
     }
 
-    [type='checkbox'].is-dark {
+    [type='checkbox'].is-dark + label {
       @include vf-checkbox-dark-theme;
     }
 
-    [type='radio'].is-dark {
+    [type='radio'].is-dark + label {
       @include vf-radio-dark-theme;
     }
   }
@@ -514,13 +514,11 @@ $box-offsets-top: (
   // color of the tick element border
     $color-tick-border: $colors--light-theme--border-high-contrast
 ) {
-  & + label {
-    color: $color-tick-text;
+  color: $color-tick-text;
 
-    &::before {
-      background: $color-tick-background;
-      border: 1px solid $color-tick-border;
-    }
+  &::before {
+    background: $color-tick-background;
+    border: 1px solid $color-tick-border;
   }
 }
 
@@ -537,10 +535,8 @@ $box-offsets-top: (
 ) {
   @include vf-tick-elements-theme($color-tick-text, $color-tick-background, $color-tick-border);
 
-  & + label {
-    &::after {
-      color: $color-checkbox-tick;
-    }
+  &::after {
+    color: $color-checkbox-tick;
   }
 }
 
@@ -575,10 +571,8 @@ $box-offsets-top: (
 ) {
   @include vf-tick-elements-theme($color-tick-text, $color-tick-background, $color-tick-border);
 
-  & + label {
-    &::after {
-      background-color: $color-radio-dot;
-    }
+  &::after {
+    background-color: $color-radio-dot;
   }
 }
 

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -21,8 +21,8 @@ $box-offsets-top: (
 @mixin vf-b-tick-elements-definitions {
   %vf-hidden-tick-input {
     bottom: 0;
-    height: $form-tick-box-size;
     float: none;
+    height: $form-tick-box-size;
     margin: 0;
     opacity: 0;
     position: absolute;
@@ -53,6 +53,14 @@ $box-offsets-top: (
       opacity: 0;
     }
   }
+
+  %vf-tick-in-label {
+    // some basic styling for checkboxes inside labels
+    float: left;
+    margin: $spv-inner--x-small $sph-inner 0 0;
+    opacity: 1;
+    position: static;
+  }
 }
 
 @mixin vf-b-tick-elements {
@@ -60,6 +68,10 @@ $box-offsets-top: (
 
   // Default form checkbox and radio styles
   %vf-tick-elements {
+    label & {
+      @extend %vf-tick-in-label;
+    }
+
     & + label {
       @extend %vf-pseudo-tick-box;
 
@@ -209,17 +221,6 @@ $box-offsets-top: (
     }
   }
 
-  [type='checkbox'],
-  [type='radio'] {
-    label & {
-      // some basic styling for checkboxes inside labels
-      float: left;
-      margin: $spv-inner--x-small $sph-inner 0 0;
-      opacity: 1;
-      position: static;
-    }
-  }
-
   [type='checkbox'] {
     @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
@@ -342,6 +343,7 @@ $box-offsets-top: (
   [type='radio'] {
     @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
+
     $inner-circle-diameter: 0.375rem;
     $circle-offset-top: 0.5 * ($form-tick-box-size - $inner-circle-diameter);
 

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -1,5 +1,5 @@
 // tick element variables
-$box-size: 1rem;
+$form-tick-box-size: 1rem;
 
 // Offsets to align tick elements to the baseline of headings.
 $box-offsets-top: (
@@ -18,40 +18,53 @@ $box-offsets-top: (
   table-header: 1.9,
 ) !default;
 
-@mixin vf-b-tick-elements {
-  // Default form checkbox and radio styles
-  %vf-tick-elements {
+@mixin vf-b-tick-elements-definitions {
+  %vf-hidden-tick-input {
+    bottom: 0;
+    height: $form-tick-box-size;
+    float: none;
+    margin: 0;
     opacity: 0;
     position: absolute;
+    width: $form-tick-box-size;
+  }
 
-    label & {
-      // some basic styling for checkboxes inside labels
-      float: left;
-      margin: $spv-inner--x-small $sph-inner 0 0;
-      opacity: 1;
-      position: static;
+  %vf-pseudo-tick-box {
+    &::before,
+    &::after {
+      $properties: #{background-color, border-color};
+      @include vf-animation($properties);
+
+      position: absolute;
     }
 
+    // container
+    &::before {
+      content: '';
+      height: $form-tick-box-size;
+      left: 0;
+      outline-offset: 1px;
+      width: $form-tick-box-size;
+    }
+
+    // tick/circle
+    &::after {
+      content: '';
+      opacity: 0;
+    }
+  }
+}
+
+@mixin vf-b-tick-elements {
+  @include vf-b-tick-elements-definitions;
+
+  // Default form checkbox and radio styles
+  %vf-tick-elements {
     & + label {
-      padding-left: $sph-inner + $box-size;
+      @extend %vf-pseudo-tick-box;
+
+      padding-left: $sph-inner + $form-tick-box-size;
       position: relative;
-
-      &::before,
-      &::after {
-        $properties: #{background-color, border-color};
-        @include vf-animation($properties);
-
-        position: absolute;
-      }
-
-      // container
-      &::before {
-        content: '';
-        height: $box-size;
-        left: 0;
-        outline-offset: 1px;
-        width: $box-size;
-      }
 
       // Align with different text styles
       @media (max-width: $breakpoint-heading-threshold) {
@@ -61,39 +74,39 @@ $box-offsets-top: (
         &:not(.is-h4)::before,
         &:not(.is-muted-heading)::before,
         &:not(.is-inline-label)::before {
-          top: #{$sp-unit * map-get($box-offsets-top, default-text) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h1-small-screens) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
         }
 
         &.is-h2::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h2-small-screens) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
         }
 
         &.is-h3::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h3-small-screens) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
         }
 
         &.is-h4::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h4-small-screens) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
         }
 
         &.is-inline-label::before {
-          top: #{$sp-unit * map-get($box-offsets-top, unpadded-text) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::before {
-          top: #{$sp-unit * map-get($box-offsets-top, muted-heading) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::before {
-          top: #{$sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::before {
-          top: #{$sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
 
@@ -104,46 +117,40 @@ $box-offsets-top: (
         &:not(.is-h4)::before,
         &:not(.is-muted-heading)::before,
         &:not(.is-inline-label)::before {
-          top: #{$sp-unit * map-get($box-offsets-top, default-text) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h1) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, h1) - $form-tick-box-size};
         }
 
         &.is-h2::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h2) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, h2) - $form-tick-box-size};
         }
 
         &.is-h3::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h3) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, h3) - $form-tick-box-size};
         }
 
         &.is-h4::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h4) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, h4) - $form-tick-box-size};
         }
 
         &.is-inline-label::before {
-          top: #{$sp-unit * map-get($box-offsets-top, unpadded-text) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::before {
-          top: #{$sp-unit * map-get($box-offsets-top, muted-heading) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::before {
-          top: #{$sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::before {
-          top: #{$sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+          top: #{$sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
-      }
-
-      // tick/circle
-      &::after {
-        content: '';
-        opacity: 0;
       }
 
       &.is-h1 {
@@ -202,7 +209,19 @@ $box-offsets-top: (
     }
   }
 
+  [type='checkbox'],
+  [type='radio'] {
+    label & {
+      // some basic styling for checkboxes inside labels
+      float: left;
+      margin: $spv-inner--x-small $sph-inner 0 0;
+      opacity: 1;
+      position: static;
+    }
+  }
+
   [type='checkbox'] {
+    @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
 
     // stylelint-disable selector-no-qualifying-type
@@ -234,39 +253,39 @@ $box-offsets-top: (
         &:not(.is-h4)::after,
         &:not(.is-muted-heading)::after,
         &:not(.is-inline-label)::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
         }
 
         &.is-h2::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
         }
 
         &.is-h3::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
         }
 
         &.is-h4::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
         }
 
         &.is-inline-label::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
 
@@ -277,39 +296,39 @@ $box-offsets-top: (
         &:not(.is-h4)::after,
         &:not(.is-muted-heading)::after,
         &:not(.is-inline-label)::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h1) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h1) - $form-tick-box-size};
         }
 
         &.is-h2::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h2) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h2) - $form-tick-box-size};
         }
 
         &.is-h3::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h3) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h3) - $form-tick-box-size};
         }
 
         &.is-h4::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h4) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, h4) - $form-tick-box-size};
         }
 
         &.is-inline-label::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::after {
-          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+          top: #{$tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
     }
@@ -321,9 +340,10 @@ $box-offsets-top: (
   }
 
   [type='radio'] {
+    @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
     $inner-circle-diameter: 0.375rem;
-    $circle-offset-top: 0.5 * ($box-size - $inner-circle-diameter);
+    $circle-offset-top: 0.5 * ($form-tick-box-size - $inner-circle-diameter);
 
     // stylelint-disable selector-no-qualifying-type
     & + label {
@@ -335,8 +355,8 @@ $box-offsets-top: (
       &::after {
         border-radius: 50%;
         height: $inner-circle-diameter;
-        left: #{($box-size - $inner-circle-diameter) * 0.5};
-        // top: #{$box-offset-top + 0.5 * ($box-size - $inner-circle-diameter)};
+        left: #{($form-tick-box-size - $inner-circle-diameter) * 0.5};
+        // top: #{$box-offset-top + 0.5 * ($form-tick-box-size - $inner-circle-diameter)};
         width: $inner-circle-diameter;
       }
 
@@ -348,39 +368,39 @@ $box-offsets-top: (
         &:not(.is-h4)::after,
         &:not(.is-muted-heading)::after,
         &:not(.is-inline-label)::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
         }
 
         &.is-h2::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
         }
 
         &.is-h3::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
         }
 
         &.is-h4::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
         }
 
         &.is-inline-label::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
 
@@ -391,39 +411,39 @@ $box-offsets-top: (
         &:not(.is-h4)::after,
         &:not(.is-muted-heading)::after,
         &:not(.is-inline-label)::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
         }
 
         &.is-h1::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h1) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h1) - $form-tick-box-size};
         }
 
         &.is-h2::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h2) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h2) - $form-tick-box-size};
         }
 
         &.is-h3::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h3) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h3) - $form-tick-box-size};
         }
 
         &.is-h4::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h4) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, h4) - $form-tick-box-size};
         }
 
         &.is-inline-label::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
         }
 
         &.is-muted-heading::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
         }
 
         &.is-muted-inline-heading::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
         }
 
         &.is-table-header::after {
-          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $box-size};
+          top: #{$circle-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
         }
       }
     }

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -97,8 +97,7 @@ $box-offsets-top: (
   }
 
   %vf-pseudo-radio {
-    &::before,
-    &::after {
+    &::before {
       border-radius: 50%;
     }
 


### PR DESCRIPTION
## Done

Extracts styled tick boxes styling into placeholders, so they can be reused when building new checkbox pattern.
This is just a refactor branch, it only restructures the code, no functionality or styling changes in the branch.

## QA

- `./run` or [demo](https://vanilla-framework-3215.demos.haus)
- Make sure [tick elements](https://vanilla-framework-3215.demos.haus/docs/examples/templates/tick-element-comparison) work as before, there should be no regressions or changes to styling
