### PR TITLE
Add p-checkbox and p-radio components

### DIFF
--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -2,6 +2,7 @@
 $form-tick-box-size: 1rem;
 $form-tick-height: 0.375rem;
 $form-tick-offset-top: 0.1875rem;
+$form-tick-box-nudge: 0.15rem; // to nudge the tick box a bit below baseline (to correctly align with default text size)
 
 $form-radio-inner-circle-diameter: 0.375rem;
 $form-radio-circle-offset: 0.5 * ($form-tick-box-size - $form-radio-inner-circle-diameter);
@@ -52,6 +53,7 @@ $box-offsets-top: (
       height: $form-tick-box-size;
       left: 0;
       outline-offset: 1px;
+      top: calc(#{$baseline-position} - #{$form-tick-box-size} + #{$form-tick-box-nudge});
       width: $form-tick-box-size;
     }
 
@@ -91,6 +93,7 @@ $box-offsets-top: (
       border-left: 2px solid;
       height: $form-tick-height;
       left: $form-tick-height * 0.5;
+      top: calc(#{$baseline-position} - #{$form-tick-box-size} + #{$form-tick-offset-top} + #{$form-tick-box-nudge});
       transform: rotate(-45deg);
       width: 0.625rem;
     }
@@ -105,7 +108,7 @@ $box-offsets-top: (
       border-radius: 50%;
       height: $form-radio-inner-circle-diameter;
       left: #{($form-tick-box-size - $form-radio-inner-circle-diameter) * 0.5};
-      // top: #{$box-offset-top + 0.5 * ($form-tick-box-size - $form-radio-inner-circle-diameter)};
+      top: calc(#{$baseline-position} - #{$form-tick-box-size} + #{$form-radio-circle-offset} + #{$form-tick-box-nudge});
       width: $form-radio-inner-circle-diameter;
     }
   }

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -1,0 +1,65 @@
+@import 'settings';
+
+@mixin vf-p-form-tick-elements {
+  // specify both [type] and class to fight specificity of base `label [type]` styles
+  [type='checkbox'].p-checkbox__input,
+  [type='radio'].p-radio__input {
+    @extend %vf-hidden-tick-input;
+  }
+
+  .p-checkbox__label {
+    @extend %vf-pseudo-tick-box;
+    @extend %vf-pseudo-checkbox;
+    @include vf-checkbox-light-theme;
+  }
+
+  .p-radio__label {
+    @extend %vf-pseudo-tick-box;
+    @extend %vf-pseudo-radio;
+    @include vf-radio-light-theme;
+  }
+
+  // inline variants
+  .p-checkbox--heading,
+  .p-checkbox--inline,
+  .p-radio--heading,
+  .p-radio--inline {
+    display: inline;
+  }
+
+  // nudge ticks in headings back to the baseline
+  .p-checkbox--heading .p-checkbox__label,
+  .p-radio--heading .p-radio__label {
+    &::before,
+    &::after {
+      margin-top: -$form-tick-box-nudge;
+    }
+  }
+
+  // fake tick checked state
+  .p-checkbox__input:checked + .p-checkbox__label,
+  .p-radio__input:checked + .p-radio__label {
+    @extend %vf-pseudo-tick-box-checked;
+  }
+
+  // fake tick focused state
+  .p-checkbox__input:focus + .p-checkbox__label,
+  .p-radio__input:focus + .p-radio__label {
+    @extend %vf-pseudo-tick-box-focused;
+  }
+
+  // fake tick disabled state
+  .p-checkbox__input:disabled + .p-checkbox__label,
+  .p-radio__input:disabled + .p-radio__label {
+    @extend %vf-disabled-element;
+  }
+
+  // when tick elements are following each other in the document
+  // keep them closer together by 1 baseline grid unit
+  .p-radio + .p-radio,
+  .p-checkbox + .p-checkbox,
+  .p-checkbox + .p-radio,
+  .p-radio + .p-checkbox {
+    margin-top: -$sp-unit;
+  }
+}

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -10,13 +10,11 @@
   .p-checkbox__label {
     @extend %vf-pseudo-tick-box;
     @extend %vf-pseudo-checkbox;
-    @include vf-checkbox-light-theme;
   }
 
   .p-radio__label {
     @extend %vf-pseudo-tick-box;
     @extend %vf-pseudo-radio;
-    @include vf-radio-light-theme;
   }
 
   // inline variants
@@ -61,5 +59,40 @@
   .p-checkbox + .p-radio,
   .p-radio + .p-checkbox {
     margin-top: -$sp-unit;
+  }
+
+  // Theming
+  @if ($theme-default-forms == 'dark') {
+    .p-checkbox__label {
+      @include vf-checkbox-dark-theme;
+    }
+
+    .p-radio__label {
+      @include vf-radio-dark-theme;
+    }
+
+    .p-checkbox.is-light .p-checkbox__label {
+      @include vf-checkbox-light-theme;
+    }
+
+    .p-radio.is-light .p-radio__label {
+      @include vf-radio-light-theme;
+    }
+  } @else {
+    .p-checkbox__label {
+      @include vf-checkbox-light-theme;
+    }
+
+    .p-radio__label {
+      @include vf-radio-light-theme;
+    }
+
+    .p-checkbox.is-dark .p-checkbox__label {
+      @include vf-checkbox-dark-theme;
+    }
+
+    .p-radio.is-dark .p-radio__label {
+      @include vf-radio-dark-theme;
+    }
   }
 }

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -14,6 +14,7 @@
 @import 'patterns_divider';
 @import 'patterns_form-help-text';
 @import 'patterns_form-validation';
+@import 'patterns_form-tick-elements';
 @import 'patterns_forms';
 @import 'patterns_grid';
 @import 'patterns_heading-icon';
@@ -88,6 +89,7 @@
   @include vf-p-divider;
   @include vf-p-form-help-text;
   @include vf-p-form-validation;
+  @include vf-p-form-tick-elements;
   @include vf-p-forms;
   @include deprecate('3.0.0', 'vf-p-grid-modifications mixin will be removed') {
     @include vf-p-grid-modifications;

--- a/scss/standalone/patterns_form-tick-elements.scss
+++ b/scss/standalone/patterns_form-tick-elements.scss
@@ -1,0 +1,19 @@
+@import '../base';
+@include vf-base;
+
+// grid required by stacked form example
+@import '../patterns_grid';
+@include vf-p-grid;
+
+@import '../utilities_layout';
+@include vf-u-layout;
+
+// button styles used in some form examples
+@import '../patterns_buttons';
+@include vf-p-buttons;
+
+@import '../patterns_muted-heading';
+@include vf-p-muted-heading;
+
+@import '../patterns_form-tick-elements';
+@include vf-p-form-tick-elements;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -48,7 +48,7 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
               {{ side_nav_item("/docs/base/code", "Code") }}
-              {{ side_nav_item("/docs/base/forms", "Forms") }}
+              {{ side_nav_item("/docs/base/forms", "Forms", "new") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/tables", "Tables") }}
               {{ side_nav_item("/docs/base/typography", "Typography") }}
@@ -81,7 +81,7 @@
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
               {{ side_nav_item("/docs/patterns/slider", "Slider") }}
-              {{ side_nav_item("/docs/patterns/strip", "Strip", "new") }}
+              {{ side_nav_item("/docs/patterns/strip", "Strip") }}
               {{ side_nav_item("/docs/patterns/switch", "Switch") }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
               {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -38,37 +38,79 @@ Note: The attribute `readonly` disables the input but it still retains a default
 
 ### Checkbox
 
-Use checkboxes to select one or more options, default checkboxes can appear in three states: selected, unselected and disabled.
+<span class="p-label--new">New</span>
 
-<div class="embedded-example"><a href="/docs/examples/base/forms/checkboxes/" class="js-example">
-View example of the base checkboxes
+Use the checkbox component to select one or more options. To provide fully featured Vanilla style and behaviour of the checkbox a specific markup structure is needed around the checkbox input (see example below).
+
+To disable the checkbox component a `disabled` property needs to be added on respective `<input type='checkbox'>` element.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/checkbox/" class="js-example">
+View example of the checkbox components
 </a></div>
 
-<span class="p-label--updated">Updated</span>
+#### Inline checkbox
 
-By default, checkboxes are vertically aligned to the baseline of text wrapped in a `label`, `h5`, `h6`, or `p` tag. If you need to align them to other elements, use one of the following classes:
-`is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
+When placing the checkbox component in padded containers (table cells, some list items), use the `.p-checkbox--inline` variant. It ensures the checkbox and the label text are properly aligned with other inline text.
 
-<div class="embedded-example"><a href="/docs/examples/base/forms/aligned-checkboxes/" class="js-example">
-View example of checkboxes aligned to different headings
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/checkbox-inline/" class="js-example">
+View example of the inline checkbox components
 </a></div>
+
+#### Heading checkbox
+
+To use checkbox component in headings use the `.p-checkbox--heading` variant of the component to make sure the checkbox and the label text are properly aligned.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/checkbox-heading/" class="js-example">
+View example of the heading checkbox components
+</a></div>
+
+#### Deprecated base checkboxes
+
+<span class="p-label--deprecated">Deprecated</span>
+
+The base element styling for checkbox inputs (`<input type="checkbox">`) outside of the `.p-checkbox` component is now deprecated and will be removed in a future version of Vanilla framework.
+
+This applies also to all modifier classes on checkbox elements, such as `is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
+
+Please refer to the [tick elements comparison example](/docs/examples/patterns/forms/tick-comparison) to find equivalent usage of new `.p-checkbox` component.
 
 ### Radio button
 
-Use radio buttons to select one or more options, our radio buttons can appear in four states: both selected, unselected and disabled.
+<span class="p-label--new">New</span>
 
-<div class="embedded-example"><a href="/docs/examples/base/forms/radio-buttons/" class="js-example">
-View example of the base radio buttons
+Use radio buttons to select one of the given set of options. To provide fully featured Vanilla style and behaviour of the radio button a specific markup structure is needed around the radio button input (see example below).
+
+To disable the radio component a `disabled` property needs to be added on respective `<input type='radio'>` element.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/radio/" class="js-example">
+View example of the radio components
 </a></div>
 
-<span class="p-label--updated">Updated</span>
+#### Inline radio button
 
-By default, radio buttons are vertically aligned to the baseline of text wrapped in a `label`, `h5`, `h6`, or `p` tag. If you need to align them to other elements, use one of the following classes:
-`is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
+When placing the radio component in padded containers (table cells, some list items), use the `.p-radio--inline` variant of the component to make sure the radio button and the label text are properly aligned with other inline text.
 
-<div class="embedded-example"><a href="/docs/examples/base/forms/aligned-radio/" class="js-example">
-View example of the aligned radio buttons
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/radio-inline/" class="js-example">
+View example of the inline radio components
 </a></div>
+
+#### Heading radio button
+
+To use radio component in headings use the `.p-checkbox--heading` variant of the component to make sure the radio button and the label text are properly aligned.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/radio-heading/" class="js-example">
+View example of the heading radio components
+</a></div>
+
+#### Deprecated base radio buttons
+
+<span class="p-label--deprecated">Deprecated</span>
+
+The base element styling for radio inputs (`<input type="radio">`) outside of the `.p-radio` component is now deprecated and will be removed in a future version of Vanilla framework.
+
+This applies also to all modifier classes on checkbox elements, such as `is-h1`, `is-h2`, `is-h3`, `is-h4`, `is-h5`, `is-muted-heading`, `is-muted-inline-heading`, `is-inline-label`, or `is-table-header`.
+
+Please refer to the [tick elements comparison example](/docs/examples/patterns/forms/tick-comparison) to find equivalent usage of new `.p-radio` component.
 
 ### Select
 

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -42,7 +42,7 @@ Note: The attribute `readonly` disables the input but it still retains a default
 
 Use the checkbox component to select one or more options. To provide fully featured Vanilla style and behaviour of the checkbox a specific markup structure is needed around the checkbox input (see example below).
 
-To disable the checkbox component a `disabled` property needs to be added on respective `<input type='checkbox'>` element.
+To disable the checkbox component, add the `disabled` attribute to the respecitve respective `<input type='checkbox'>` element.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/forms/checkbox/" class="js-example">
 View example of the checkbox components
@@ -80,7 +80,7 @@ Please refer to the [tick elements comparison example](/docs/examples/patterns/f
 
 Use radio buttons to select one of the given set of options. To provide fully featured Vanilla style and behaviour of the radio button a specific markup structure is needed around the radio button input (see example below).
 
-To disable the radio component a `disabled` property needs to be added on respective `<input type='radio'>` element.
+To disable the radio component, add the `disabled` attribute to the respecitve `<input type='radio'>` element.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/forms/radio/" class="js-example">
 View example of the radio components

--- a/templates/docs/examples/patterns/forms/_checkbox-heading.html
+++ b/templates/docs/examples/patterns/forms/_checkbox-heading.html
@@ -1,0 +1,27 @@
+<h1>
+  <label class="p-checkbox--heading">
+    <input type="checkbox" class="p-checkbox__input" />
+    <span class="p-checkbox__label">.p-checkbox--heading</span>
+  </label>
+</h1>
+
+<h2>
+  <label class="p-checkbox--heading">
+    <input type="checkbox" class="p-checkbox__input" />
+    <span class="p-checkbox__label">.p-checkbox--heading</span>
+  </label>
+</h2>
+
+<h3>
+  <label class="p-checkbox--heading">
+    <input type="checkbox" class="p-checkbox__input" />
+    <span class="p-checkbox__label">.p-checkbox--heading</span>
+  </label>
+</h3>
+
+<h4>
+  <label class="p-checkbox--heading">
+    <input type="checkbox" class="p-checkbox__input" />
+    <span class="p-checkbox__label">.p-checkbox--heading</span>
+  </label>
+</h4>

--- a/templates/docs/examples/patterns/forms/_checkbox-inline.html
+++ b/templates/docs/examples/patterns/forms/_checkbox-inline.html
@@ -1,0 +1,36 @@
+<p>
+  <label class="p-checkbox--inline">
+    <input type="checkbox" class="p-checkbox__input" />
+    <span class="p-checkbox__label">.p-checkbox--inline</span>
+  </label>
+  alonside some text
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        <label class="p-checkbox--inline">
+          <input type="checkbox" class="p-checkbox__input" />
+          <span class="p-checkbox__label">.p-checkbox--inline in TH</span>
+        </label>
+      </th>
+      <th>
+        Text in adjacent cell
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <label class="p-checkbox--inline">
+          <input type="checkbox" class="p-checkbox__input" />
+          <span class="p-checkbox__label">.p-checkbox--inline in TD</span>
+        </label>
+      </td>
+      <td>
+        Text in adjacent cell
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/templates/docs/examples/patterns/forms/_checkbox.html
+++ b/templates/docs/examples/patterns/forms/_checkbox.html
@@ -1,0 +1,19 @@
+<label class="p-checkbox">
+  <input type="checkbox" class="p-checkbox__input" />
+  <span class="p-checkbox__label">.p-checkbox</span>
+</label>
+
+<label class="p-checkbox">
+  <input type="checkbox" class="p-checkbox__input" />
+  <span class="p-checkbox__label">checked</span>
+</label>
+
+<label class="p-checkbox">
+  <input type="checkbox" class="p-checkbox__input" disabled/>
+  <span class="p-checkbox__label">disabled</span>
+</label>
+
+<label class="p-checkbox is-required">
+  <input type="checkbox" required class="p-checkbox__input">
+  <span class="p-checkbox__label">is-required</span>
+</label>

--- a/templates/docs/examples/patterns/forms/_radio-heading.html
+++ b/templates/docs/examples/patterns/forms/_radio-heading.html
@@ -1,0 +1,27 @@
+<h1>
+  <label class="p-radio--heading">
+    <input type="radio" class="p-radio__input" name="radioPattern" />
+    <span class="p-radio__label">.p-radio--heading</span>
+  </label>
+</h1>
+
+<h2>
+  <label class="p-radio--heading">
+    <input type="radio" class="p-radio__input" name="radioPattern" />
+    <span class="p-radio__label">.p-radio--heading</span>
+  </label>
+</h2>
+
+<h3>
+  <label class="p-radio--heading">
+    <input type="radio" class="p-radio__input" name="radioPattern" />
+    <span class="p-radio__label">.p-radio--heading</span>
+  </label>
+</h3>
+
+<h4>
+  <label class="p-radio--heading">
+    <input type="radio" class="p-radio__input" name="radioPattern" />
+    <span class="p-radio__label">.p-radio--heading</span>
+  </label>
+</h4>

--- a/templates/docs/examples/patterns/forms/_radio-inline.html
+++ b/templates/docs/examples/patterns/forms/_radio-inline.html
@@ -1,0 +1,36 @@
+<p>
+  <label class="p-radio--inline">
+    <input type="radio" class="p-radio__input" name="radioPattern" />
+    <span class="p-radio__label">.p-radio--inline</span>
+  </label>
+  alonside some text
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        <label class="p-radio--inline">
+          <input type="radio" class="p-radio__input" name="radioPattern" />
+          <span class="p-radio__label">.p-radio--inline in th</span>
+        </label>
+      </th>
+      <th>
+        Text in adjacent cell
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <label class="p-radio--inline">
+          <input type="radio" class="p-radio__input" name="radioPattern" />
+          <span class="p-radio__label">.p-radio--inline in td</span>
+        </label>
+      </td>
+      <td>
+        Text in adjacent cell
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/templates/docs/examples/patterns/forms/_radio.html
+++ b/templates/docs/examples/patterns/forms/_radio.html
@@ -1,0 +1,19 @@
+<label class="p-radio">
+  <input type="radio"  class="p-radio__input" name="radioPattern" />
+  <span class="p-radio__label" for="radioExamplePattern">.p-radio</span>
+</label>
+
+<label class="p-radio">
+  <input type="radio"  class="p-radio__input" name="radioPattern" checked />
+  <span class="p-radio__label" for="radioExamplePattern">checked</span>
+</label>
+
+<label class="p-radio">
+  <input type="radio"  class="p-radio__input" name="radioPattern" disabled />
+  <span class="p-radio__label" for="radioExamplePattern">disabled</span>
+</label>
+
+<label class="p-radio is-required">
+  <input type="radio"  class="p-radio__input" name="radioPattern" required />
+  <span class="p-radio__label" for="radioExamplePattern">is-required</span>
+</label>

--- a/templates/docs/examples/patterns/forms/checkbox-heading.html
+++ b/templates/docs/examples/patterns/forms/checkbox-heading.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Checkbox heading{% endblock %}
+
+{% block standalone_css %}patterns_form-tick-elements{% endblock %}
+
+{% block content %}
+<form>
+  {% include 'docs/examples/patterns/forms/_checkbox-heading.html' %}
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/forms/checkbox-inline.html
+++ b/templates/docs/examples/patterns/forms/checkbox-inline.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Checkbox inline{% endblock %}
+
+{% block standalone_css %}patterns_form-tick-elements{% endblock %}
+
+{% block content %}
+<form>
+  {% include 'docs/examples/patterns/forms/_checkbox-inline.html' %}
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/forms/checkbox.html
+++ b/templates/docs/examples/patterns/forms/checkbox.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Checkbox{% endblock %}
+
+{% block standalone_css %}patterns_form-tick-elements{% endblock %}
+
+{% block content %}
+<form>
+  {% include 'docs/examples/patterns/forms/_checkbox.html' %}
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/forms/radio-heading.html
+++ b/templates/docs/examples/patterns/forms/radio-heading.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Radio heading{% endblock %}
+
+{% block standalone_css %}patterns_form-tick-elements{% endblock %}
+
+{% block content %}
+<form>
+  {% include 'docs/examples/patterns/forms/_radio-heading.html' %}
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/forms/radio-inline.html
+++ b/templates/docs/examples/patterns/forms/radio-inline.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Radio inline{% endblock %}
+
+{% block standalone_css %}patterns_form-tick-elements{% endblock %}
+
+{% block content %}
+<form>
+  {% include 'docs/examples/patterns/forms/_radio-inline.html' %}
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/forms/radio.html
+++ b/templates/docs/examples/patterns/forms/radio.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Radio{% endblock %}
+
+{% block standalone_css %}patterns_form-tick-elements{% endblock %}
+
+{% block content %}
+<form>
+  {% include 'docs/examples/patterns/forms/_radio.html' %}
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/forms/tick-comparison.html
+++ b/templates/docs/examples/patterns/forms/tick-comparison.html
@@ -1,0 +1,224 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Tick elements comparison{% endblock %}
+
+{% block standalone_css %}patterns_form-tick-elements{% endblock %}
+
+{% block content %}
+<form>
+
+<div class="row">
+  <div class="col-6">
+    <h3>Base checkbox</h3>
+
+    <input type="checkbox" id="checkExampleBase">
+    <label for="checkExampleBase">checkbox</label>
+
+    <input type="checkbox" id="checkExampleBaseChecked" checked>
+    <label for="checkExampleBaseChecked">checked</label>
+
+    <input type="checkbox" id="checkExampleBaseDisabled" disabled>
+    <label for="checkExampleBaseDisabled">disabled</label>
+
+    <input type="checkbox" id="checkExampleBaseRequired" required>
+    <label class="is-required" for="checkExampleBaseRequired">required</label>
+
+    <input type="checkbox" id="checkExampleBaseH1">
+    <label class="is-h1" for="checkExampleBaseH1">.is-h1</label>
+
+    <input type="checkbox" id="checkExampleBaseH2">
+    <label class="is-h2" for="checkExampleBaseH2">.is-h2</label>
+
+    <input type="checkbox" id="checkExampleBaseH3">
+    <label class="is-h3" for="checkExampleBaseH3">.is-h3</label>
+
+    <input type="checkbox" id="checkExampleBaseH4">
+    <label class="is-h4" for="checkExampleBaseH4">.is-h4</label>
+
+    <p>
+      <input type="checkbox" id="checkExampleBaseInline">
+      <label class="is-inline-label" for="checkExampleBaseInline">.is-inline-label</label>
+      alongside some text
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>
+            <input type="checkbox" id="checkExampleBaseTable">
+            <label class="is-table-header" for="checkExampleBaseTable">.is-table-header</label>
+          </th>
+          <th>
+            Text in adjacent cell
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <input type="checkbox" id="checkExampleBaseTableCell">
+            <label class="is-inline-label" for="checkExampleBaseTableCell">.is-inline-label</label>
+          </td>
+          <td>
+            Text in adjacent cell
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="p-muted-heading">
+      <input type="checkbox" id="checkExampleBaseMuted">
+      <label class="is-muted-heading" for="checkExampleBaseMuted">.is-muted-heading</label>
+    </p>
+
+    <p>
+      <input type="checkbox" id="checkExampleBaseInlineMuted">
+      <label class="is-muted-inline-heading" for="checkExampleBaseInlineMuted">.is-muted-inline-heading</label>
+      alongside some text
+    </p>
+
+  </div>
+
+  <div class="col-6">
+    <h3>.p-checkbox component</h3>
+
+    <p><em>The <code>p-checkbox</code> markup improves spacing between consecutive checkboxes.</em></p>
+
+    {% include 'docs/examples/patterns/forms/_checkbox.html' %}
+
+    {% include 'docs/examples/patterns/forms/_checkbox-heading.html' %}
+
+    {% include 'docs/examples/patterns/forms/_checkbox-inline.html' %}
+
+    <p class="p-muted-heading">
+      <label class="p-checkbox--inline">
+        <input type="checkbox" class="p-checkbox__input" />
+        <span class="p-checkbox__label">.p-checkbox--inline in .p-muted-heading</span>
+      </label>
+    </p>
+
+    <p>
+      <span class="p-muted-heading">
+        <label class="p-checkbox--inline">
+          <input type="checkbox" class="p-checkbox__input" />
+          <span class="p-checkbox__label">.p-checkbox--inline in .p-muted-heading</span>
+        </label>
+      </span>
+      alongside text
+    </p>
+
+  </div>
+</div>
+
+<div class="u-fixed-width">
+  <input class="p-button--positive" type="submit" />
+</div>
+
+<div class="row">
+  <div class="col-6">
+    <h3>Base radio</h3>
+
+    <input type="radio" id="radioExampleBase" name="radioBase">
+    <label for="radioExampleBase">radio</label>
+
+    <input type="radio" id="radioExampleBaseChecked" name="radioBase" checked>
+    <label for="radioExampleBaseChecked">checked</label>
+
+    <input type="radio" id="radioExampleBaseDisabled" name="radioBase" disabled>
+    <label for="radioExampleBaseDisabled">disabled</label>
+
+    <input type="radio" id="radioExampleBaseRequired" name="radioBase" required>
+    <label class="is-required" for="radioExampleBaseRequired">required</label>
+
+    <input type="radio" id="radioExampleBaseH1" name="radioBase">
+    <label class="is-h1" for="radioExampleBaseH1">.is-h1</label>
+
+    <input type="radio" id="radioExampleBaseH2" name="radioBase">
+    <label class="is-h2" for="radioExampleBaseH2">.is-h2</label>
+
+    <input type="radio" id="radioExampleBaseH3" name="radioBase">
+    <label class="is-h3" for="radioExampleBaseH3">.is-h3</label>
+
+    <input type="radio" id="radioExampleBaseH4" name="radioBase">
+    <label class="is-h4" for="radioExampleBaseH4">.is-h4</label>
+
+    <p>
+      <input type="radio" id="radioExampleBaseInline" name="radioBase">
+      <label class="is-inline-label" for="radioExampleBaseInline">.is-inline-label</label>
+      alongside some text
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>
+            <input type="radio" id="radioExampleBaseTable" name="radioBase">
+            <label class="is-table-header" for="radioExampleBaseTable">.is-table-header</label>
+          </th>
+          <th>
+            Text in adjacent cell
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <input type="radio" id="radioExampleBaseTableCell" name="radioBase">
+            <label class="is-inline-label" for="radioExampleBaseTableCell">.is-inline-label</label>
+          </td>
+          <td>
+            Text in adjacent cell
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="p-muted-heading">
+      <input type="radio" id="radioExampleBaseMuted" name="radioBase">
+      <label class="is-muted-heading" for="radioExampleBaseMuted">.is-muted-heading</label>
+    </p>
+
+    <p>
+      <input type="radio" id="radioExampleBaseInlineMuted" name="radioBase">
+      <label class="is-muted-inline-heading" for="radioExampleBaseInlineMuted">.is-muted-inline-heading</label>
+      alongside some text
+    </p>
+
+  </div>
+
+  <div class="col-6">
+    <h3>.p-radio component</h3>
+
+    <p><em>The <code>p-radio</code> markup improves spacing between consecutive radio buttons.</em></p>
+
+    {% include 'docs/examples/patterns/forms/_radio.html' %}
+
+    {% include 'docs/examples/patterns/forms/_radio-heading.html' %}
+
+    {% include 'docs/examples/patterns/forms/_radio-inline.html' %}
+
+    <p class="p-muted-heading">
+      <label class="p-radio--inline">
+        <input type="radio" class="p-radio__input" name="radioPattern" />
+        <span class="p-radio__label">.p-radio--inline in .p-muted-heading</span>
+      </label>
+    </p>
+
+    <p>
+      <span class="p-muted-heading">
+        <label class="p-radio--inline">
+          <input type="radio" class="p-radio__input" name="radioPattern" />
+          <span class="p-radio__label">.p-radio--inline in .p-muted-heading</span>
+        </label>
+      </span>
+      alongside text
+    </p>
+
+  </div>
+</div>
+
+<div class="u-fixed-width">
+  <input class="p-button--positive" type="submit" />
+</div>
+
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/forms/tick-comparison.html
+++ b/templates/docs/examples/patterns/forms/tick-comparison.html
@@ -110,7 +110,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <input class="p-button--positive" type="submit" />
+  <input class="p-button--positive" type="submit" value="Submit" />
 </div>
 
 <div class="row">
@@ -217,7 +217,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <input class="p-button--positive" type="submit" />
+  <input class="p-button--positive" type="submit" value="Submit" />
 </div>
 
 </form>

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -9,7 +9,10 @@
     head: "<meta name='viewport' content='width=device-width, initial-scale=1'>",
     stylesheets: [
       // link to latest Vanilla CSS
-      'https://assets.ubuntu.com/v1/vanilla-framework-version-' + VANILLA_VERSION + '.min.css',
+      // if it's a demo, use local build.css for better QA, otherwise use latest published Vanilla
+      /demos\.haus$/.test(window.location.host)
+        ? `${window.location.origin}/static/build/css/build.css`
+        : 'https://assets.ubuntu.com/v1/vanilla-framework-version-' + VANILLA_VERSION + '.min.css',
       // link to example stylesheet (to set margin on body)
       'https://assets.ubuntu.com/v1/4653d9ba-example.css',
     ],


### PR DESCRIPTION
## Done

Replaces #3198

Adds `p-checkbox` and `p-radio` components to have a better control over styling and spacing than with base checkbox styles.

Fixes #2931 
Fixes #3181
Fixes #3177

## QA

-  `./run` or [demo](https://vanilla-framework-3224.demos.haus/docs/examples/patterns/forms/tick-comparison)
- Go to [tick elements comparison page](https://vanilla-framework-3224.demos.haus/docs/examples/patterns/forms/tick-comparison), make sure new components work as expected compared to deprecated base styles
- Check [updated docs about checkbox and radio buttons](https://vanilla-framework-3224.demos.haus/docs/base/forms#checkbox), make sure they are correct: 

## Screenshots

<img width="1287" alt="Screenshot 2020-08-27 at 12 01 06" src="https://user-images.githubusercontent.com/83575/91426796-44accf80-e85d-11ea-8051-f4e52bb30706.png">

<img width="1289" alt="Screenshot 2020-08-27 at 12 01 16" src="https://user-images.githubusercontent.com/83575/91426795-437ba280-e85d-11ea-8489-478028a9b6b4.png">
