### PR TITLE
Bump version of Vanilla to 2.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.16.0",
+  "version": "2.17.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -10,7 +10,35 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### What's new in Vanilla 2.16
+### What's new in Vanilla 2.17
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- 2.17 -->
+    <tr>
+      <th><a href="/docs/base/forms#checkbox">Checkbox and radio buttons components</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.17.0</td>
+      <td>We introduced new <code>.p-checkbox</code> and <code>.p-radio</code> components. They replace the existing styling of base form inputs.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/base/forms#deprecated-base-checkboxes">Checkbox and radio buttons elements</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.17.0</td>
+      <td>Base styled checkboxes and radio buttons (on <code>&lt;input type="checkbox"&gt;</code> or <code>&lt;input type="radio"&gt;</code> elements) are deprecated and they will be reverted to native browser inputs in future version of Vanilla. Please use on bWe added new layout styles for building responsive full-screen applications.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
 
 <table>
   <thead>
@@ -35,21 +63,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.16.0</td>
       <td>We added new strip variants <code>.p-strip--suru</code> and <code>.p-strip--suru-topped</code>.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.15 -->
     <tr>
       <th><a href="/docs/patterns/chip">Chip</a></th>


### PR DESCRIPTION
## Done

Bumps version of Vanilla to 2.17.0 and updates component status in preparation for release.

## QA

- `./run` or [demo](https://vanilla-framework-3229.demos.haus)
- Make sure the updated version is correct
- Check component status, make sure it lists latest changes (https://vanilla-framework-3229.demos.haus/docs/component-status)

