### PR TITLE
Remove `href` from buttons

### DIFF
--- a/templates/docs/examples/patterns/contextual-menu/dark.html
+++ b/templates/docs/examples/patterns/contextual-menu/dark.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <span class="p-contextual-menu--left is-dark">
-    <button href="#" class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
+    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
     <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>

--- a/templates/docs/examples/patterns/contextual-menu/default.html
+++ b/templates/docs/examples/patterns/contextual-menu/default.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <span class="p-contextual-menu--left">
-    <button href="#" class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
+    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
     <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>

--- a/templates/docs/examples/patterns/contextual-menu/with-indicator.html
+++ b/templates/docs/examples/patterns/contextual-menu/with-indicator.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <span class="p-contextual-menu--left">
-  <button href="#" class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--contextual-menu is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
+  <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--contextual-menu is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
   <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
     <span class="p-contextual-menu__group">
       <a href="#" class="p-contextual-menu__link">Commission</a>

--- a/templates/docs/examples/templates/typographic-spacing.html
+++ b/templates/docs/examples/templates/typographic-spacing.html
@@ -1300,8 +1300,8 @@
       <h6>Heading six</h6>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-      <button href="#">Long button name</button>
-      <button href="#">Confirm</button>
+      <button>Long button name</button>
+      <button>Confirm</button>
     </div>
   </div>
 </div> -->


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/882

## QA

- Pull code
- Search repo for instances of button with href. I used this regular expression:

 <button\s+(?:[^>]*?\s+)?href=(["'])(.*?)\1

- Verify none exist. 
