### PR TITLE
Add alt attribute to images that do not have one

### DIFF
--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="/">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/94d962aa-vanilla_white-orange_hex.svg" style="height:1.5rem" alt="Vanilla framework logo">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/94d962aa-vanilla_white-orange_hex.svg" style="height:1.5rem" alt="Vanilla framework">
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -108,7 +108,7 @@
     <div class="col-6">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="Canonical pictogram"/>
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt=""/>
           <h3 class="p-heading-icon__title">Licences</h3>
         </div>
       </div>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -108,7 +108,7 @@
     <div class="col-6">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="Canonical pictogram"/>
           <h3 class="p-heading-icon__title">Licences</h3>
         </div>
       </div>

--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -144,7 +144,7 @@ Now run the command with `yarn build`, which will bundle the code and put in a a
 
 ```
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -19,7 +19,7 @@
             <div class="p-inline-list--stretch">
               <div class="p-inline-list__item">
                 <a class="p-panel__logo" href="#">
-                  <img src="https://assets.ubuntu.com/v1/0b2b7bce-Vanilla-logo_88x24px_white.svg" alt="Vanilla framework logo" height="24">
+                  <img src="https://assets.ubuntu.com/v1/0b2b7bce-Vanilla-logo_88x24px_white.svg" alt="" height="24">
                 </a>
               </div>
               <div class="p-inline-list__item u-align--right u-hide--large">

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -19,7 +19,7 @@
             <div class="p-inline-list--stretch">
               <div class="p-inline-list__item">
                 <a class="p-panel__logo" href="#">
-                  <img src="https://assets.ubuntu.com/v1/0b2b7bce-Vanilla-logo_88x24px_white.svg" alt="" height="24">
+                  <img src="https://assets.ubuntu.com/v1/0b2b7bce-Vanilla-logo_88x24px_white.svg" alt="Vanilla framework" height="24">
                 </a>
               </div>
               <div class="p-inline-list__item u-align--right u-hide--large">

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="Canonical logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="Canonical logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="Canonical" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/card/header.html
+++ b/templates/docs/examples/patterns/card/header.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-card">
-  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="header image" />
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="" />
   <hr class="u-sv1">
   <h3 class="p-card__title">Raspberry Pi2 and Pi3</h3>
   <p class="p-card__content">For fun, for education and for profit, the RPi makes device development personal and entertaining. With support for both the Pi2 and the new Pi3, Ubuntu Core supports the world’s most beloved board.</p>

--- a/templates/docs/examples/patterns/heading-icon/heading-icon-small.html
+++ b/templates/docs/examples/patterns/heading-icon/heading-icon-small.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="p-heading-icon--small">
   <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="LXD icon"/>
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt=""/>
     <h4 class="p-heading-icon__title">LXD — system containers</h4>
   </div>
   <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>

--- a/templates/docs/examples/patterns/heading-icon/heading-icon-small.html
+++ b/templates/docs/examples/patterns/heading-icon/heading-icon-small.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="p-heading-icon--small">
   <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="LXD icon"/>
     <h4 class="p-heading-icon__title">LXD — system containers</h4>
   </div>
   <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>

--- a/templates/docs/examples/patterns/heading-icon/heading-icon-stacked.html
+++ b/templates/docs/examples/patterns/heading-icon/heading-icon-stacked.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="p-heading-icon">
   <div class="p-heading-icon__header is-stacked">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="LXD icon"/>
     <h3 class="p-heading-icon__title">LXD — system containers</h3>
   </div>
   <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>

--- a/templates/docs/examples/patterns/heading-icon/heading-icon-stacked.html
+++ b/templates/docs/examples/patterns/heading-icon/heading-icon-stacked.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="p-heading-icon">
   <div class="p-heading-icon__header is-stacked">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="LXD icon"/>
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt=""/>
     <h3 class="p-heading-icon__title">LXD — system containers</h3>
   </div>
   <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>

--- a/templates/docs/examples/patterns/heading-icon/heading-icon.html
+++ b/templates/docs/examples/patterns/heading-icon/heading-icon.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="p-heading-icon">
   <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="LXD icon"/>
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt=""/>
     <h3 class="p-heading-icon__title">LXD — system containers</h3>
   </div>
   <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>

--- a/templates/docs/examples/patterns/heading-icon/heading-icon.html
+++ b/templates/docs/examples/patterns/heading-icon/heading-icon.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="p-heading-icon">
   <div class="p-heading-icon__header">
-    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" />
+    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/425efe3a-lxd.svg" alt="LXD icon"/>
     <h3 class="p-heading-icon__title">LXD — system containers</h3>
   </div>
   <p>LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines. Economics are directly tied to density, and no other virtualisation technology is as fast or dense as LXD.</p>

--- a/templates/docs/examples/patterns/inline-images.html
+++ b/templates/docs/examples/patterns/inline-images.html
@@ -6,19 +6,19 @@
 {% block content %}
 <ul class="p-inline-images">
   <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg" alt="" />
   </li>
   <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg" alt="" />
   </li>
   <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f9832168-AstraZeneca.png?w=144" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f9832168-AstraZeneca.png?w=144" alt="" />
   </li>
   <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg" alt="" />
   </li>
   <li class="p-inline-images__item">
-    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png?w=144" alt="Placeholder image" />
+    <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png?w=144" alt="" />
   </li>
 </ul>
 {% endblock %}

--- a/templates/docs/examples/patterns/matrix.html
+++ b/templates/docs/examples/patterns/matrix.html
@@ -6,7 +6,7 @@
 {% block content %}
 <ul class="p-matrix">
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Canonical</a></h3>
       <div class="p-matrix__desc">
@@ -15,7 +15,7 @@
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Ubuntu</a></h3>
       <div class="p-matrix__desc">
@@ -24,14 +24,14 @@
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">MAAS</a></h3>
       <p class="p-matrix__desc">Create a bare-metal cloud with Metal as a Service for IPAM and provisioning</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3dee82a5-landscape-logo_smaller.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3dee82a5-landscape-logo_smaller.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Landscape</a></h3>
       <div class="p-matrix__desc">
@@ -40,21 +40,21 @@
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/6d382a53-image-juju-256.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/6d382a53-image-juju-256.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Juju</a></h3>
       <p class="p-matrix__desc">Model-driven multi-cloud operations for applications. On-premise or on-cloud SAAS app store, with big data, k8s and openstack solutions</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/fffc8205-lxd-logo_smaller.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/fffc8205-lxd-logo_smaller.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">LXD</a></h3>
       <p class="p-matrix__desc">A pure-container hypervisor. Replace legacy app VMs with containers for speed and density</p>
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/19c7461a-snapcraft-primary-icon--dark.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/19c7461a-snapcraft-primary-icon--dark.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Snaps</a></h3>
       <div class="p-matrix__desc">
@@ -63,7 +63,7 @@
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/a7916513-picto-openstack.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/a7916513-picto-openstack.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">OpenStack</a></h3>
       <div class="p-matrix__desc">
@@ -72,7 +72,7 @@
     </div>
   </li>
   <li class="p-matrix__item">
-    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="icon">
+    <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="">
     <div class="p-matrix__content">
       <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Kubernetes</a></h3>
       <div class="p-matrix__desc">

--- a/templates/docs/examples/patterns/media-object/media-object-circ-img.html
+++ b/templates/docs/examples/patterns/media-object/media-object-circ-img.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-media-object">
-  <img src="https://assets.ubuntu.com/v1/0a529437-karlos.jpeg" class="p-media-object__image is-round">
+  <img src="https://assets.ubuntu.com/v1/0a529437-karlos.jpeg" class="p-media-object__image is-round"  alt="">
   <div class="p-media-object__details">
     <h3 class="p-media-object__title">
       <a href="#">Karl Waghorn-Moyce</a>

--- a/templates/docs/examples/patterns/media-object/media-object-large.html
+++ b/templates/docs/examples/patterns/media-object/media-object-large.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-media-object--large">
-  <img src="https://assets.ubuntu.com/v1/80cd67d3-mysql.svg" class="p-media-object__image"  alt="MySQL icon">
+  <img src="https://assets.ubuntu.com/v1/80cd67d3-mysql.svg" class="p-media-object__image"  alt="">
   <div class="p-media-object__details">
     <h1 class="p-media-object__title">Mysql</h1>
     <p class="p-media-object__content">By mysql-charmers</p>

--- a/templates/docs/examples/patterns/media-object/media-object-large.html
+++ b/templates/docs/examples/patterns/media-object/media-object-large.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-media-object--large">
-  <img src="https://assets.ubuntu.com/v1/80cd67d3-mysql.svg" class="p-media-object__image">
+  <img src="https://assets.ubuntu.com/v1/80cd67d3-mysql.svg" class="p-media-object__image"  alt="MySQL icon">
   <div class="p-media-object__details">
     <h1 class="p-media-object__title">Mysql</h1>
     <p class="p-media-object__content">By mysql-charmers</p>

--- a/templates/docs/examples/patterns/media-object/media-object.html
+++ b/templates/docs/examples/patterns/media-object/media-object.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-media-object">
-  <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" class="p-media-object__image">
+  <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" class="p-media-object__image" alt="">
   <div class="p-media-object__details">
     <h3 class="p-media-object__title">
       <a href="#">NVIDIA GTC 2019</a>

--- a/templates/docs/examples/patterns/modal/default.html
+++ b/templates/docs/examples/patterns/modal/default.html
@@ -15,11 +15,11 @@
     <p id="modal-description">Learn how to operate production-ready clusters.</p>
     <div class="p-heading-icon--small">
       <div class="p-heading-icon__header">
-        <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" />
+        <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg"  alt=""/>
         <p><a class="p-heading-icon__title" href="#tutorial/get-started-canonical-kubernetes" width="24">Kubernetes tutorial</a></p>
       </div>
       <div class="p-heading-icon__header">
-        <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5e3456e3-hadoop.svg" />
+        <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5e3456e3-hadoop.svg"  alt=""/>
         <p><a class="p-heading-icon__title" href="#tutorial/get-started-hadoop-spark" width="24">Hadoop Spark tutorial</a></p>
       </div>
     </div>

--- a/templates/docs/examples/patterns/navigation/default.html
+++ b/templates/docs/examples/patterns/navigation/default.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/default.html
+++ b/templates/docs/examples/patterns/navigation/default.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/deprecated-dark.html
+++ b/templates/docs/examples/patterns/navigation/deprecated-dark.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="Canonical logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/deprecated-dark.html
+++ b/templates/docs/examples/patterns/navigation/deprecated-dark.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="Canonical logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="Canonical" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/deprecated.html
+++ b/templates/docs/examples/patterns/navigation/deprecated.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/deprecated.html
+++ b/templates/docs/examples/patterns/navigation/deprecated.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/full-width.html
+++ b/templates/docs/examples/patterns/navigation/full-width.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/full-width.html
+++ b/templates/docs/examples/patterns/navigation/full-width.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/subnav-dark.html
+++ b/templates/docs/examples/patterns/navigation/subnav-dark.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg"  alt="LXD logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/subnav-dark.html
+++ b/templates/docs/examples/patterns/navigation/subnav-dark.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg"  alt="LXD logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg"  alt="LXD" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/subnav.html
+++ b/templates/docs/examples/patterns/navigation/subnav.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="LXD logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/subnav.html
+++ b/templates/docs/examples/patterns/navigation/subnav.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="LXD logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="LXD" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/pull-quotes/default-image.html
+++ b/templates/docs/examples/patterns/pull-quotes/default-image.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <blockquote class="p-pull-quote has-image">
-  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="" />
   <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
   <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
 </blockquote>

--- a/templates/docs/examples/patterns/search-box/navigation.html
+++ b/templates/docs/examples/patterns/search-box/navigation.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/search-box/navigation.html
+++ b/templates/docs/examples/patterns/search-box/navigation.html
@@ -9,7 +9,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/strips/accent.html
+++ b/templates/docs/examples/patterns/strips/accent.html
@@ -11,7 +11,7 @@
       <p>Learn how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.</p>
     </div>
     <div class="col-4">
-      <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" alt="Placeholder image" />
+      <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" alt="" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/patterns/strips/deep.html
+++ b/templates/docs/examples/patterns/strips/deep.html
@@ -11,7 +11,7 @@
       <p>Learn about how Ubuntu Core and snaps can help you build your connected devices.</p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/808a4e5b-iot.png?h=300" alt="Placeholder image" />
+      <img src="https://assets.ubuntu.com/v1/808a4e5b-iot.png?h=300" alt="" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/patterns/strips/image.html
+++ b/templates/docs/examples/patterns/strips/image.html
@@ -12,7 +12,7 @@
         it.</p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/1abb8716-conjure-up-illustration.svg" alt="Placeholder image" />
+      <img src="https://assets.ubuntu.com/v1/1abb8716-conjure-up-illustration.svg" alt="" />
     </div>
   </div>
 </section>
@@ -25,7 +25,7 @@
         <p>It is our mission to make open source software available to people everywhere. We believe the best way to fuel innovation is to give the innovators the technology they need.</p>
       </div>
       <div class="col-4 u-hide--small u-align--center">
-        <img src="https://assets.ubuntu.com/v1/9c74eb2d-logo-canonical-white.svg" alt="Placeholder image" />
+        <img src="https://assets.ubuntu.com/v1/9c74eb2d-logo-canonical-white.svg" alt="" />
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/strips/shallow.html
+++ b/templates/docs/examples/patterns/strips/shallow.html
@@ -11,7 +11,7 @@
       <p>Learn about how Ubuntu Core and snaps can help you build your connected devices.</p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/808a4e5b-iot.png?h=300" alt="Placeholder image" />
+      <img src="https://assets.ubuntu.com/v1/808a4e5b-iot.png?h=300" alt="" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -7,7 +7,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
-          <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="Vanilla framework logo" class="p-navigation__image">
+          <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="Vanilla framework" class="p-navigation__image">
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -7,7 +7,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
-          <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="" class="p-navigation__image">
+          <img src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" alt="Vanilla framework logo" class="p-navigation__image">
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/templates/typographic-spacing.html
+++ b/templates/docs/examples/templates/typographic-spacing.html
@@ -1376,7 +1376,7 @@
           consulting&nbsp;›</a></p>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
@@ -1394,7 +1394,7 @@
       <button>Contact us</button>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
@@ -1412,7 +1412,7 @@
       <button>Contact us</button>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
@@ -1430,7 +1430,7 @@
       <button>Contact us</button>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
@@ -1448,7 +1448,7 @@
       <button>Contact us</button>
     </div>
     <div class="col-3 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow">
+      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
@@ -1629,9 +1629,11 @@
 <hr>
 <div class="row">
   <a target="_blank" rel="noopener noreferrer"
-    href="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg"><img
+    href="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg">
+    <img
       src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg"
-      alt="image" style="max-width:100%;"></a>
+      alt="" style="max-width:100%;"/>
+  </a>
   <h3>This is a heading following an image</h3>
 </div>
 <div class="row">

--- a/templates/docs/examples/templates/vertical-spacing.html
+++ b/templates/docs/examples/templates/vertical-spacing.html
@@ -38,7 +38,7 @@
         magna aliqua. Ut enim ad minim veniam</p>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/63c08d11-suru-background.png" alt="" />
+      <img src="https://assets.ubuntu.com/v1/63c08d11-suru-background.png" alt=""/>
     </div>
   </div>
 </section>
@@ -100,7 +100,7 @@
   </div>
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
-      <img src="https://assets.ubuntu.com/v1/df1e6f24-Operate-your-machines-remotely.png?h=295">
+      <img src="https://assets.ubuntu.com/v1/df1e6f24-Operate-your-machines-remotely.png?h=295" alt="">
       <h3>Operate your machines remotely</h3>
       <p>Manage individual or groups of servers.</p>
       <ul>
@@ -118,7 +118,7 @@
       </p>
     </div>
     <div class="col-6 p-divider__block">
-      <img src="https://assets.ubuntu.com/v1/6ecf284f-Provision-with-any-OS-image.png?h=293">
+      <img src="https://assets.ubuntu.com/v1/6ecf284f-Provision-with-any-OS-image.png?h=293" alt="">
       <h3>Provision with any <abbr title="Operating system">OS</abbr> image</h3>
       <p>Select the <abbr title="Operating system">OS</abbr> you require in your data centre <span
           aria-describedby="image-info">*</span></p>

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -4,7 +4,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg" alt="" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg" alt="LXD logo" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
@@ -173,11 +173,11 @@
       <p id="modal-description">Learn how to operate production-ready clusters.</p>
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" />
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt=""/>
           <p><a class="p-heading-icon__title" href="#tutorial/get-started-canonical-kubernetes" width="24">Kubernetes tutorial</a></p>
         </div>
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5e3456e3-hadoop.svg" />
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5e3456e3-hadoop.svg" alt=""/>
           <p><a class="p-heading-icon__title" href="#tutorial/get-started-hadoop-spark" width="24">Hadoop Spark tutorial</a></p>
         </div>
       </div>

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -4,7 +4,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg" alt="LXD logo" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg" alt="LXD" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/utilities/align.html
+++ b/templates/docs/examples/utilities/align.html
@@ -4,13 +4,13 @@
 {% block content %}
 <div>
   <div class="u-align--center">
-    <img src="https://assets.ubuntu.com/v1/3c941888-align-center.png" alt="" />
+    <img src="https://assets.ubuntu.com/v1/3c941888-align-center.png" alt=""/>
   </div>
   <div class="u-align--left">
-    <img src="https://assets.ubuntu.com/v1/8e93383c-align-left.png" alt="" />
+    <img src="https://assets.ubuntu.com/v1/8e93383c-align-left.png" alt=""/>
   </div>
   <div class="u-align--right">
-    <img src="https://assets.ubuntu.com/v1/de9722f5-align-right.png" alt="" />
+    <img src="https://assets.ubuntu.com/v1/de9722f5-align-right.png" alt=""/>
   </div>
   <p class="u-align-text--center">Centered text</p>
   <p class="u-align-text--left">Left-aligned text</p>

--- a/templates/docs/examples/utilities/image-position/bottom-left.html
+++ b/templates/docs/examples/utilities/image-position/bottom-left.html
@@ -5,7 +5,7 @@
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="Placeholder image" class="u-image-position--bottom u-image-position--left" />
+      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--bottom u-image-position--left" />
     </div>
     <div class="col-6">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>

--- a/templates/docs/examples/utilities/image-position/bottom-right.html
+++ b/templates/docs/examples/utilities/image-position/bottom-right.html
@@ -9,7 +9,7 @@
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="Placeholder image" class="u-image-position--bottom u-image-position--right" />
+      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--bottom u-image-position--right" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/utilities/image-position/bottom.html
+++ b/templates/docs/examples/utilities/image-position/bottom.html
@@ -9,7 +9,7 @@
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="Placeholder image" class="u-image-position--bottom" />
+      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--bottom" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/utilities/image-position/left.html
+++ b/templates/docs/examples/utilities/image-position/left.html
@@ -5,7 +5,7 @@
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="Placeholder image" class="u-image-position--left" />
+      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--left" />
     </div>
     <div class="col-6">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>

--- a/templates/docs/examples/utilities/image-position/right.html
+++ b/templates/docs/examples/utilities/image-position/right.html
@@ -9,7 +9,7 @@
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="Placeholder image" class="u-image-position--right" />
+      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--right" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/utilities/image-position/top-left.html
+++ b/templates/docs/examples/utilities/image-position/top-left.html
@@ -5,7 +5,7 @@
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
   <div class="row">
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="Placeholder image" class="u-image-position--top u-image-position--left" />
+      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--top u-image-position--left" />
     </div>
     <div class="col-6">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>

--- a/templates/docs/examples/utilities/image-position/top-right.html
+++ b/templates/docs/examples/utilities/image-position/top-right.html
@@ -9,7 +9,7 @@
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="Placeholder image" class="u-image-position--top u-image-position--right" />
+      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--top u-image-position--right" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/utilities/image-position/top.html
+++ b/templates/docs/examples/utilities/image-position/top.html
@@ -9,7 +9,7 @@
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
     <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="Placeholder image" class="u-image-position--top" />
+      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--top" />
     </div>
   </div>
 </section>

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -119,7 +119,7 @@ These guidelines are the framework upon which we have built our system for how c
 
 You can define a brand color (`$color-brand`) that can be used for call-to-action buttons and other highlights across the framework. The default Vanilla brand color is `$color-dark`.
 
-<img class="p-image--bordered" src="https://assets.ubuntu.com/v1/7446a44a-basics-brand-color.png" alt="brand-color">
+<img class="p-image--bordered" src="https://assets.ubuntu.com/v1/7446a44a-basics-brand-color.png" alt="">
 
 ### Accessibility
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt="" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt=""/>
           <h3 class="p-heading-icon__title">Lightweight</h3>
         </div>
         <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
@@ -35,7 +35,7 @@
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt="" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt=""/>
           <h3 class="p-heading-icon__title">Composable</h3>
         </div>
         <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
@@ -44,7 +44,7 @@
     <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
-          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt="" />
+          <img class="b-lazy p-heading-icon__img" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt=""/>
           <h3 class="p-heading-icon__title">Open source</h3>
         </div>
         <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/877

## QA

- Search for images without alt or with empty alt. I used the following: (<img(?!.*?alt=(['"]).*?\2)[^>]*)(>)
- Verify there are none
- Go through the changes, verify the alt text is plausible
