### PR TITLE
Fix errors when building with dart-sass

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,18 @@ jobs:
       - run: yarn build
       - run: yarn test
 
+  dart:
+    name: Test build with dart-sass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: yarn install
+      - run: yarn add sass
+      - run: npx sass scss/build.scss
+
   docker:
     name: Build and run
     runs-on: ubuntu-latest

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -82,9 +82,9 @@
   $button-disabled-background-color: $color-transparent,
   $button-disabled-border-color: $colors--light-theme--border-high-contrast,
   $button-border-color: $colors--light-theme--border-high-contrast,
-  $button-hover-background-color: scale-color($color-x-light, $lightness: -$hover-background-opacity-amount * 100),
+  $button-hover-background-color: scale-color($color-x-light, $lightness: -$hover-background-opacity-amount * 100%),
   $button-hover-border-color: $colors--light-theme--border-high-contrast,
-  $button-active-background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-amount * 100),
+  $button-active-background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-amount * 100%),
   $button-active-border-color: $colors--light-theme--border-high-contrast
 ) {
   background-color: $button-background-color;

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -1,6 +1,6 @@
 @import 'settings';
-$active-background-opacity-percentage: $active-background-opacity-amount * 100;
-$hover-background-opacity-percentage: $hover-background-opacity-amount * 100;
+$active-background-opacity-percentage: $active-background-opacity-amount * 100%;
+$hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
 // Default button styling
 @mixin vf-p-buttons {

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -6,7 +6,7 @@
     @include vf-button-pattern;
 
     &.is-active {
-      background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-amount * 100);
+      background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-amount * 100%);
       color: $color-dark;
       text-decoration: none;
     }


### PR DESCRIPTION
## Done

Adds missing % unit to lightness parameter of the scale-color function. This fixes errors when building with dart-sass.
Also adds GitHub workflow to test building with dart-sass when PR is pushed to make sure we catch such errors in future.

Fixes #3266

## QA

- All CI checks should pass
- Make sure new dart check runs and passes
- Verify the affected patterns look the same
  - [base buttons](https://vanilla-framework-3267.demos.haus/docs/examples/base/button)
  - [component buttons](https://vanilla-framework-3267.demos.haus/docs/examples/patterns/buttons/positive)
  - [pagination](https://vanilla-framework-3267.demos.haus/docs/examples/patterns/pagination/pagination)

