### PR TITLE
Fixes misaligned quotes in pull quotes component

### DIFF
--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -4,6 +4,7 @@
   color: $color-mid-dark;
   display: inline-block;
   position: absolute;
+  width: 0.5em;
 }
 
 @mixin vf-pull-quote {
@@ -11,19 +12,59 @@
   margin: $spv-outer--scaleable 0 $spv-outer--scaleable + $sp-unit;
   overflow: visible;
   position: relative;
+
+  &.has-image {
+    margin-top: calc(#{$spv-inner--x-large} + #{$spv-outer--scaleable});
+  }
 }
 
 // Pull quote styling
 @mixin vf-p-pull-quotes {
-  .p-pull-quote {
-    padding: 0 $sph-outer * 2;
+  .p-pull-quote,
+  .p-pull-quote--small,
+  .p-pull-quote--large {
+    @include vf-pull-quote;
+
+    // this needs to be nested to increase the specificity
+    .p-pull-quote__citation {
+      font-style: italic;
+      margin-top: $spv-inner--x-small--scaleable;
+    }
+  }
+
+  .p-pull-quote__image {
+    height: $sp-x-large;
+    position: absolute;
+    top: -$spv-inner--x-large;
+  }
+
+  .p-pull-quote__quote {
     position: relative;
 
-    .p-pull-quote__image {
-      height: $sp-x-large;
-      position: absolute;
-      top: -$spv-inner--x-large;
+    &:first-of-type::before {
+      @include vf-quote-mark;
+
+      content: '\201C'; // Unicode for left double quotation mark +  1/2 em space
+      left: -0.75em;
+      text-align: right;
+      top: 0.5rem;
     }
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+
+    &:last-of-type::after {
+      @include vf-quote-mark;
+
+      bottom: 0.55em;
+      content: '\201E';
+      margin-left: 0.25em;
+    }
+  }
+
+  .p-pull-quote {
+    padding: 0 $sph-outer * 2;
 
     .p-pull-quote__quote {
       @extend %vf-heading-4;
@@ -31,14 +72,6 @@
       &::before,
       &::after {
         font-size: 2em;
-      }
-
-      &:last-of-type::after {
-        bottom: 4rem;
-
-        @media (max-width: $breakpoint-heading-threshold) {
-          bottom: 3.5rem;
-        }
       }
     }
 
@@ -56,10 +89,6 @@
       &::before,
       &::after {
         font-size: 1.5em;
-      }
-
-      &:last-of-type::after {
-        bottom: 3rem;
       }
     }
 
@@ -79,14 +108,6 @@
         font-size: 2em;
         max-width: 1em;
       }
-
-      &:last-of-type::after {
-        bottom: 4rem;
-
-        @media (max-width: $breakpoint-heading-threshold) {
-          bottom: 3.5rem;
-        }
-      }
     }
 
     .p-pull-quote__citation {
@@ -94,49 +115,15 @@
     }
   }
 
+  // align the opening quote with the increased top padding of %vf-heading-3 / %vf-heading-4
   .p-pull-quote,
-  .p-pull-quote--small,
   .p-pull-quote--large {
-    @include vf-pull-quote;
-
-    .p-pull-quote__image {
-      height: $sp-x-large;
-      position: absolute;
-      top: -$spv-inner--x-large;
-    }
-
-    .p-pull-quote__citation {
-      font-style: italic;
-      margin-top: $spv-inner--x-small--scaleable;
-    }
-
-    &.has-image {
-      margin-top: calc(#{$spv-inner--x-large} + #{$spv-outer--scaleable});
-    }
-  }
-
-  .p-pull-quote__quote {
-    &:first-of-type::before {
-      @include vf-quote-mark;
-
-      content: '\201C'; // Unicode for left double quotation mark +  1/2 em space
-      left: $spv-inner--x-small;
-      top: 0.5rem;
-
-      @media (max-width: $breakpoint-heading-threshold) {
-        top: 0.75rem;
+    .p-pull-quote__quote {
+      &:first-of-type::before {
+        @media (max-width: $breakpoint-heading-threshold) {
+          top: 0.75rem;
+        }
       }
-    }
-
-    &:last-of-type {
-      margin-bottom: 0;
-    }
-
-    &:last-of-type::after {
-      @include vf-quote-mark;
-
-      content: '\201E';
-      margin-left: $spv-inner--small;
     }
   }
 }

--- a/templates/docs/examples/patterns/pull-quotes/variants.html
+++ b/templates/docs/examples/patterns/pull-quotes/variants.html
@@ -1,0 +1,121 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Pull quote / Variants{% endblock %}
+
+{% block standalone_css %}patterns_pull-quotes{% endblock %}
+
+{% block content %}
+<h2><code>.p-pull-quote</code></h2>
+<h3>Default variant - 1 paragraph with cite:</h3>
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+</blockquote>
+
+<h3>Default variant - 2 paragraphs with cite:</h3>
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
+  <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+</blockquote>
+
+<h3>Default variant - 1 paragraph, no cite:</h3>
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+</blockquote>
+
+<h3>Default variant - 2 paragraphs, no cite:</h3>
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
+  <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+</blockquote>
+
+<h3>Default variant - image, 1 paragraph, with cite:</h3>
+<blockquote class="p-pull-quote has-image">
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
+  <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
+  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
+</blockquote>
+
+<h3>Default variant - image, 1 paragraph, no cite:</h3>
+<blockquote class="p-pull-quote has-image">
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
+  <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
+</blockquote>
+
+<h2><code>.p-pull-quote--small</code></h2>
+<h3>Small variant - 1 paragraph with cite:</h3>
+<blockquote class="p-pull-quote--small">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+</blockquote>
+
+<h3>Small variant - 2 paragraphs with cite:</h3>
+<blockquote class="p-pull-quote--small">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
+  <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+</blockquote>
+
+<h3>Small variant - 1 paragraph, no cite:</h3>
+<blockquote class="p-pull-quote--small">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+</blockquote>
+
+<h3>Small variant - 2 paragraphs, no cite:</h3>
+<blockquote class="p-pull-quote--small">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
+  <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+</blockquote>
+
+<h3>Small variant - image, 1 paragraph, with cite:</h3>
+<blockquote class="p-pull-quote--small has-image">
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
+  <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
+  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
+</blockquote>
+
+<h3>Small variant - image, 1 paragraph, no cite:</h3>
+<blockquote class="p-pull-quote--small has-image">
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
+  <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
+</blockquote>
+
+
+<h2><code>.p-pull-quote--large</code></h2>
+<h3>Large variant - 1 paragraph with cite:</h3>
+<blockquote class="p-pull-quote--large">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+</blockquote>
+
+<h3>Large variant - 2 paragraphs with cite:</h3>
+<blockquote class="p-pull-quote--large">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
+  <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+</blockquote>
+
+<h3>Large variant - 1 paragraph, no cite:</h3>
+<blockquote class="p-pull-quote--large">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+</blockquote>
+
+<h3>Large variant - 2 paragraphs, no cite:</h3>
+<blockquote class="p-pull-quote--large">
+  <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
+  <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+</blockquote>
+
+<h3>Large variant - image, 1 paragraph, with cite:</h3>
+<blockquote class="p-pull-quote--large has-image">
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
+  <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
+  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
+</blockquote>
+
+<h3>Large variant - image, 1 paragraph, no cite:</h3>
+<blockquote class="p-pull-quote--large has-image">
+  <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
+  <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
+</blockquote>
+{% endblock %}


### PR DESCRIPTION
## Done

Fixes misaligned quotes in pull quotes component (when there was no cite or when cite was wrapped).
Adds new example with all combinations and all variants of pull quotes component.

Fixes #2426

## Code review

In code review it may seem like a lot of changes were made. It's because most of the code was reordered to avoid specificity warnings from linter and remove unnecessary duplicated code.

## QA

- `./run` or [demo](https://vanilla-framework-3268.demos.haus/docs/examples/patterns/pull-quotes/variants)
- Check [pull quotes examples](https://vanilla-framework-3268.demos.haus/docs/examples/patterns/pull-quotes/variants), make sure quote characters are correctly positioned regardless of variant, having `<cite>` or not, wrapping, etc
  - make sure to check different screen sizes (as pull quotes font is smaller on smaller screen size)

## Screenshots

<img width="913" alt="Screenshot 2020-09-09 at 16 24 11" src="https://user-images.githubusercontent.com/83575/92611312-f2d26380-f2b8-11ea-87e7-91560d9c93ac.png">

