### PR TITLE
Add landmarks to layout examples

### DIFF
--- a/templates/docs/examples/layouts/application-structure.html
+++ b/templates/docs/examples/layouts/application-structure.html
@@ -2,12 +2,12 @@
 {% block title %}Application / Structure{% endblock %}
 
 {% block content %}
-<div class="l-application  app-demo">
+<div class="l-application app-demo" role="presentation">
   <div class="l-navigation-bar">
     <div class="u-clearfix"><code>l-navigation-bar</code> <button class="u-float-right js-menu-toggle is-dense u-no-margin">Menu</button></div>
   </div>
 
-  <div class="l-navigation">
+  <div class="l-navigation" role="banner">
     <div class="l-navigation__drawer">
       <p class="demo-controls u-hide--large u-align--right">
         <button class="js-menu-pin is-dense u-no-margin u-hide--small">Pin</button>
@@ -17,7 +17,7 @@
     </div>
   </div>
 
-  <div class="l-main">
+  <main class="l-main">
     <p><code>l-main</code></p>
     <p class="u-clearfix">
       <button class="js-aside-toggle">Toggle aside panel</button>
@@ -51,20 +51,20 @@
         </tr>
       </tfoot>
     </table>
-  </div>
+  </main>
 
-  <div class="l-aside">
+  <aside class="l-aside">
     <p class="u-align--right">
       <button class="js-aside-pin is-dense">Pin</button>
       <button class="js-aside-close is-dense">Close</button>
     </p>
     <p><code>l-aside</code></p>
     <p></p>
-  </div>
+  </aside>
 
-  <div class="l-status">
+  <aside class="l-status">
     <code>l-status</code>
-  </div>
+  </aside>
 </div>
 
 

--- a/templates/docs/examples/layouts/application-structure.html
+++ b/templates/docs/examples/layouts/application-structure.html
@@ -7,7 +7,7 @@
     <div class="u-clearfix"><code>l-navigation-bar</code> <button class="u-float-right js-menu-toggle is-dense u-no-margin">Menu</button></div>
   </div>
 
-  <div class="l-navigation" role="banner">
+  <header class="l-navigation">
     <div class="l-navigation__drawer">
       <p class="demo-controls u-hide--large u-align--right">
         <button class="js-menu-pin is-dense u-no-margin u-hide--small">Pin</button>
@@ -15,7 +15,7 @@
       </p>
       <code>l-navigation &gt;<br> l-navigation__drawer</code>
     </div>
-  </div>
+  </header>
 
   <main class="l-main">
     <p><code>l-main</code></p>

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -37,7 +37,7 @@
     </div>
   </div>
 
-  <div class="l-main">
+  <main class="l-main">
     <div class="p-panel">
       <div class="p-panel__header">
         <div class="u-fixed-width u-sv-2">
@@ -284,9 +284,9 @@
         </div>
       </div>
     </div>
-  </div>
+  </main>
 
-  <div class="l-aside is-pinned">
+  <aside class="l-aside is-pinned">
     <div class="p-panel--aside">
       <div class="p-panel__header">
         <div class="u-fixed-width u-sv-2">
@@ -302,16 +302,16 @@
         {% include "docs/examples/patterns/forms/_form-stacked.html" %}
       </div>
     </div>
-  </div>
+  </aside>
 
-  <div class="l-status">
+  <aside class="l-status">
     <div class="p-panel demo-status">
       <div class="u-fixed-width">
         Status bar
       </div>
     </div>
   </div>
-</div>
+</aside>
 
 <style>
   body { margin: 0; }

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -2,7 +2,7 @@
 {% block title %}Application / Panels{% endblock %}
 
 {% block content %}
-<div class="l-application">
+<div class="l-application" role="presentation">
   <div class="l-navigation-bar">
     <div class="p-panel is-dark">
       <div class="u-fixed-width u-align--right">
@@ -11,7 +11,7 @@
     </div>
   </div>
 
-  <div class="l-navigation is-collapsed">
+  <div class="l-navigation is-collapsed" role="banner">
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark">
         <div class="p-panel__header--sticky">

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -11,7 +11,7 @@
     </div>
   </div>
 
-  <div class="l-navigation is-collapsed" role="banner">
+  <header class="l-navigation is-collapsed">
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark">
         <div class="p-panel__header--sticky">
@@ -35,7 +35,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </header>
 
   <main class="l-main">
     <div class="p-panel">


### PR DESCRIPTION
## Done

Add landmarks to layout examples
Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/890

## QA

- Pull code
- Run `./run`
- Open the application examples [1](https://vanillaframework.io/docs/examples/layouts/application-structure), [2](https://vanillaframework.io/docs/examples/layouts/application) 
- Review use of landmarks (tags main, aside)
