### PR TITLE
Add roles and correct tags to side navigation

### DIFF
--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -4,7 +4,7 @@
 {% block content %}
 {% include "docs/examples/layouts/_global-nav.html" %}
 
-<header id="navigation" class="p-navigation is-dark">
+<header id="navigation" class="p-navigation is-dark" role="banner">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -4,7 +4,7 @@
 {% block content %}
 {% include "docs/examples/layouts/_global-nav.html" %}
 
-<header id="navigation" class="p-navigation is-dark" role="banner">
+<header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation {% if is_dark %}is-dark{% endif %}" id="drawer" role="banner">
+<div class="p-side-navigation {% if is_dark %}is-dark{% endif %}" id="drawer">
 
   <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
     Toggle side navigation

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation {% if is_dark %}is-dark{% endif %}" id="drawer">
+<div class="p-side-navigation {% if is_dark %}is-dark{% endif %}" id="drawer" role="banner">
 
   <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
     Toggle side navigation
@@ -6,7 +6,7 @@
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
-  <div class="p-side-navigation__drawer">
+  <nav class="p-side-navigation__drawer">
     <div class="p-side-navigation__drawer-header">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
         Toggle side navigation
@@ -29,38 +29,38 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning"></i></div></a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text</span>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link with children</a>
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item">
                 <span class="p-side-navigation__text">Third level text</span>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status"><span class="p-label--in-progress">In progress</span></div></a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" aria-current="page" href="#">Third level active link</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success"></i></div></a>
               </li>
             </ul>
           </li>
         </ul>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level item that is not a link</span>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status"><span class="p-label--updated">Updated</span></div></a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status"><span class="p-label--validated">Validated</span></div></a>
       </li>
     </ul>
@@ -77,34 +77,34 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text</span>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text with children</span>
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item">
                 <span class="p-side-navigation__text">Third level text</span>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link is-active" href="#">Third level active item that is long and wraps wraps wraps wraps wraps wraps</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link that is truncated because it's long long long long long long long</span></a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Third level link</a>
               </li>
             </ul>
           </li>
         </ul>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level item that is not a link</span>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link</a>
       </li>
     </ul>
-  </div>
+  </nav>
 </div>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons" role="banner">
+<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
   <a href="#drawer-icons" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer-icons">
     Toggle side navigation
   </a>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
+<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons" role="banner">
   <a href="#drawer-icons" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer-icons">
     Toggle side navigation
   </a>
@@ -8,7 +8,7 @@
   {% if is_dark %}
   <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
   {% endif %}
-  <div class="p-side-navigation__drawer" style="background: {% if is_dark %}#003b4e{% else %}#f7f7f7{% endif %}">
+  <nav class="p-side-navigation__drawer" style="background: {% if is_dark %}#003b4e{% else %}#f7f7f7{% endif %}">
     <div class="p-side-navigation__drawer-header" style="background: {% if is_dark %}#003b4e{% else %}#f7f7f7{% endif %}">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer-icons">
         Toggle side navigation
@@ -31,38 +31,38 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning {% if is_dark %}is-light{% endif %}"></i></div></a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text</span>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link with children</a>
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item">
                 <span class="p-side-navigation__text">Third level text</span>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status"><span class="p-label--in-progress">In progress</span></div></a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" aria-current="page" href="#">Third level active link</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success {% if is_dark %}is-light{% endif %}"></i></div></a>
               </li>
             </ul>
           </li>
         </ul>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <span class="p-side-navigation__text"><i class="p-icon--collapse {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level item that is not a link</span>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status"><span class="p-label--updated">Updated</span></div></a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status"><span class="p-label--validated">Validated</span></div></a>
       </li>
     </ul>
@@ -79,34 +79,34 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text</span>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text with children</span>
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item">
                 <span class="p-side-navigation__text">Third level text</span>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link is-active" href="#">Third level active item that is long and wraps wraps wraps wraps wraps wraps</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link that is truncated because it's long long long long long long long</span></a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Third level link</a>
               </li>
             </ul>
           </li>
         </ul>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level item that is not a link</span>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link</a>
       </li>
     </ul>
-  </div>
+  </nav>
 </div>

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -1,9 +1,10 @@
 {# used by the application layout example #}
 
-<nav class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
+<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
   {% if is_dark %}
   <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
   {% endif %}
+  <nav aria-label="Main navigation">
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title">
         <a class="p-side-navigation__link" href="#">Title that is a link</a>
@@ -98,3 +99,4 @@
       </li>
     </ul>
   </nav>
+  </div>

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -1,6 +1,6 @@
 {# used by the application layout example #}
 
-<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
+<nav class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
   {% if is_dark %}
   <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
   {% endif %}
@@ -20,38 +20,38 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning {% if is_dark %}is-light{% endif %}"></i></div></a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text</span>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link with children</a>
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item">
                 <span class="p-side-navigation__text">Third level text</span>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status"><span class="p-label--in-progress">In progress</span></div></a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" aria-current="page" href="#">Third level active link</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success {% if is_dark %}is-light{% endif %}"></i></div></a>
               </li>
             </ul>
           </li>
         </ul>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <span class="p-side-navigation__text"><i class="p-icon--collapse {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level item that is not a link</span>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status"><span class="p-label--updated">Updated</span></div></a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status"><span class="p-label--validated">Validated</span></div></a>
       </li>
     </ul>
@@ -68,33 +68,33 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Second level link</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text</span>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text with children</span>
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item">
                 <span class="p-side-navigation__text">Third level text</span>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link is-active" href="#">Third level active item that is long and wraps wraps wraps wraps wraps wraps</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link that is truncated because it's long long long long long long long</span></a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Third level link</a>
               </li>
             </ul>
           </li>
         </ul>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level item that is not a link</span>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link</a>
       </li>
     </ul>
-</div>
+  </nav>

--- a/templates/docs/examples/patterns/side-navigation/docs.html
+++ b/templates/docs/examples/patterns/side-navigation/docs.html
@@ -11,7 +11,7 @@
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
-  <div class="p-side-navigation__drawer">
+  <nav class="p-side-navigation__drawer">
     <div class="p-side-navigation__drawer-header">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
         Toggle side navigation
@@ -25,10 +25,10 @@
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">About MAAS</a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Explore MAAS</a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Quick start<span class="p-side-navigation__status"><span class="p-label--new">New</span></span></a>
       </li>
     </ul>
@@ -36,7 +36,7 @@
       <li class="p-side-navigation__item--title">
         <a class="p-side-navigation__link" href="#">Machines</a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Commission machines</a>
       </li>
       <li class="p-side-navigation__item">
@@ -45,15 +45,15 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Hardware testings</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Network testing</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" aria-current="page" href="#">Commissioning and hardware testing scripts</a>
           </li>
         </ul>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Deploy machines</a>
       </li>
     </ul>
@@ -69,23 +69,23 @@
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Getting help</a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">MAAS 2.5 (and earlier) documentation</a>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Upgrading MAAS</a>
         <ul class="p-side-navigation__list">
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x<span class="p-side-navigation__status"><i class="p-icon--warning"></i></span></a>
           </li>
         </ul>
       </li>
     </ul>
 
-  </div>
+  </nav>
 </div>
 
 <script>

--- a/templates/docs/examples/patterns/side-navigation/icons.html
+++ b/templates/docs/examples/patterns/side-navigation/icons.html
@@ -11,7 +11,7 @@
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
-  <div class="p-side-navigation__drawer">
+  <nav class="p-side-navigation__drawer">
     <div class="p-side-navigation__drawer-header">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
         Toggle side navigation
@@ -28,12 +28,12 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Anna von Example</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Bob Anonymous</a>
           </li>
         </ul>
       </li>
-      <li class="p-side-navigation__item ">
+      <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">
           <i class="p-icon--help p-side-navigation__icon"></i>
           Get help
@@ -66,7 +66,7 @@
       </li>
     </ul>
 
-  </div>
+  </nav>
 </div>
 
 <script>

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -67,13 +67,13 @@
             <li class="p-side-navigation__item--title">
               <a class="p-side-navigation__link">Machines</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Add machines</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Power management</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Commision machines</a>
             </li>
             <li class="p-side-navigation__item">
@@ -82,18 +82,18 @@
                 <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Hardware testing</a>
                 </li>
-                <li class="p-side-navigation__item ">
+                <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" aria-current="page" href="#">Network testing</a>
                 </li>
-                <li class="p-side-navigation__item ">
+                <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Commissioning and hardware testing scripts</a>
                 </li>
               </ul>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Deploy machines</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Tags</a>
             </li>
           </ul>
@@ -105,10 +105,10 @@
             <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Getting help</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Non-snap MAAS installs</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">MAAS 2.5 (and earlier) documentation</a>
             </li>
             <li class="p-side-navigation__item">
@@ -117,7 +117,7 @@
                 <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
                 </li>
-                <li class="p-side-navigation__item ">
+                <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x</a>
                 </li>
               </ul>
@@ -128,10 +128,10 @@
             <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Getting help</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Non-snap MAAS installs</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">MAAS 2.5 (and earlier) documentation</a>
             </li>
             <li class="p-side-navigation__item">
@@ -140,7 +140,7 @@
                 <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
                 </li>
-                <li class="p-side-navigation__item ">
+                <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x</a>
                 </li>
               </ul>
@@ -154,10 +154,10 @@
             <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Getting help</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Non-snap MAAS installs</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">MAAS 2.5 (and earlier) documentation</a>
             </li>
             <li class="p-side-navigation__item">
@@ -166,7 +166,7 @@
                 <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
                 </li>
-                <li class="p-side-navigation__item ">
+                <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x</a>
                 </li>
               </ul>
@@ -177,10 +177,10 @@
             <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Getting help</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">Non-snap MAAS installs</a>
             </li>
-            <li class="p-side-navigation__item ">
+            <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#">MAAS 2.5 (and earlier) documentation</a>
             </li>
             <li class="p-side-navigation__item">
@@ -189,7 +189,7 @@
                 <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
                 </li>
-                <li class="p-side-navigation__item ">
+                <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x</a>
                 </li>
               </ul>

--- a/templates/docs/examples/templates/maas-docs.html
+++ b/templates/docs/examples/templates/maas-docs.html
@@ -133,13 +133,13 @@
           <li class="p-side-navigation__item--title">
             <a class="p-side-navigation__link">Machines</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Add machines</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Power management</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Commision machines</a>
           </li>
           <li class="p-side-navigation__item">
@@ -148,18 +148,18 @@
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Hardware testing</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" aria-current="page" href="#">Network testing</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Commissioning and hardware testing scripts</a>
               </li>
             </ul>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Deploy machines</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Tags</a>
           </li>
         </ul>
@@ -171,10 +171,10 @@
           <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Getting help</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">Non-snap MAAS installs</a>
           </li>
-          <li class="p-side-navigation__item ">
+          <li class="p-side-navigation__item">
             <a class="p-side-navigation__link" href="#">MAAS 2.5 (and earlier) documentation</a>
           </li>
           <li class="p-side-navigation__item">
@@ -183,7 +183,7 @@
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Upgrade from 2.3 to 2.4</a>
               </li>
-              <li class="p-side-navigation__item ">
+              <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#">Upgrade from 1.9 to 2.x</a>
               </li>
             </ul>


### PR DESCRIPTION
## Done

Add landmark region roles to side navigation. 
Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/865

## QA

- Pull code
- Run `./run`
- Review use of roles in all side navigation examples
- [Add additional steps]
