### PR TITLE
Bump version to 2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.17.0",
+  "version": "2.18.0",
   "files": [
     "/scss",
     "!/scss/docs"


### PR DESCRIPTION
## Done

Updates Vanilla version for next release.

## QA

- `./run` or [demo](https://vanilla-framework-3275.demos.haus)
- Make sure version is 2.18.0
