### PR TITLE
Fix table-related accessibility issues

### DIFF
--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -21,7 +21,7 @@
     table-layout: fixed;
 
     // stylelint-disable selector-no-qualifying-type
-    th[role='columnheader'] {
+    thead th {
       &[aria-sort] {
         align-items: center;
         cursor: pointer;

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -12,7 +12,7 @@ When we add, make significant updates, or deprecate a component we update their 
 
 ### What's new in Vanilla 2.18
 
-<table>
+<table aria-label="What's new in Vanilla 2.18">
   <thead>
     <tr>
       <th style="width: 20%">Component</th>

--- a/templates/docs/examples/base/forms/aligned-checkboxes.html
+++ b/templates/docs/examples/base/forms/aligned-checkboxes.html
@@ -29,7 +29,7 @@
     <input type="checkbox" id="checkExample7">
     <label for="checkExample7" class="is-muted-heading">Muted heading</label>
   </div>
-  <table>
+  <table aria-label="Example of checkboxes inside table cells">
     <thead>
       <tr>
         <th>

--- a/templates/docs/examples/base/forms/aligned-radio.html
+++ b/templates/docs/examples/base/forms/aligned-radio.html
@@ -29,7 +29,7 @@
     <input type="radio" name="RadioOptions" id="Radio6" value="option1" checked>
     <label for="Radio6" class="is-muted-heading">Muted heading</label>
   </div>
-  <table>
+  <table aria-label="Example of radio buttons inside a table">
     <thead>
       <tr>
         <th>

--- a/templates/docs/examples/base/table.html
+++ b/templates/docs/examples/base/table.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-<table>
+<table aria-label="Vanilla framework table example">
   <thead>
     <tr>
       <th></th>

--- a/templates/docs/examples/layouts/application-structure.html
+++ b/templates/docs/examples/layouts/application-structure.html
@@ -23,7 +23,7 @@
       <button class="js-aside-toggle">Toggle aside panel</button>
     </p>
 
-    <table>
+    <table aria-label="Table with demo content">
       <thead>
         <tr>
           <th></th>

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -52,9 +52,9 @@
       </div>
       <div class="p-panel__content">
         <div class="u-fixed-width">
-          <table role="grid" class="p-main-table">
+          <table class="p-main-table">
             <thead>
-              <tr role="row">
+              <tr>
                 <th role="columnheader"><span class="status-icon is-blocked">Blocked (3)</span></th>
                 <th role="columnheader"></th>
                 <th role="columnheader">Owner</th>
@@ -65,11 +65,11 @@
               </tr>
             </thead>
             <tbody>
-              <tr role="row" data-test-model-uuid="2f995dee-392e-4459-8eb9-839c501590af">
-                <td role="gridcell" class="" data-test-column="name">
+              <tr data-test-model-uuid="2f995dee-392e-4459-8eb9-839c501590af">
+                <td class="" data-test-column="name">
                   <div><a href="#/models/gomboli@external/hadoopspark">hadoopspark</a></div>
                 </td>
-                <td role="gridcell" class="u-overflow--visible" data-test-column="summary">
+                <td class="u-overflow--visible" data-test-column="summary">
                   <div class="u-flex">
                     <div class="u-flex--block p-tooltip--top-center" aria-describedby="tp-cntr">
                       <div class="has-icon"><i class="p-icon--information"></i><span>11</span></div><span class="p-tooltip__message" role="tooltip" id="tp-cntr">Applications</span>
@@ -82,17 +82,17 @@
                     </div>
                   </div>
                 </td>
-                <td role="gridcell" class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
-                <td role="gridcell" class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-east1</a></td>
-                <td role="gridcell" class="" data-test-column="credential"><a href="#_" class="p-link--soft">Algebra-json</a></td>
-                <td role="gridcell" class="" data-test-column="controller">JAAS</td>
-                <td role="gridcell" class="u-align--right" data-test-column="updated">2020-06-17</td>
+                <td class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
+                <td class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-east1</a></td>
+                <td class="" data-test-column="credential"><a href="#_" class="p-link--soft">Algebra-json</a></td>
+                <td class="" data-test-column="controller">JAAS</td>
+                <td class="u-align--right" data-test-column="updated">2020-06-17</td>
               </tr>
-              <tr role="row" data-test-model-uuid="d291b9ed-1e66-4023-84fe-57130e17a0b2">
-                <td role="gridcell" class="" data-test-column="name">
+              <tr data-test-model-uuid="d291b9ed-1e66-4023-84fe-57130e17a0b2">
+                <td class="" data-test-column="name">
                   <div><a href="#/models/gomboli@external/mymodel4">mymodel4</a></div>
                 </td>
-                <td role="gridcell" class="u-overflow--visible" data-test-column="summary">
+                <td class="u-overflow--visible" data-test-column="summary">
                   <div class="u-flex">
                     <div class="u-flex--block p-tooltip--top-center" aria-describedby="tp-cntr">
                       <div class="has-icon"><i class="p-icon--information"></i><span>7</span></div><span class="p-tooltip__message" role="tooltip" id="tp-cntr">Applications</span>
@@ -105,17 +105,17 @@
                     </div>
                   </div>
                 </td>
-                <td role="gridcell" class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
-                <td role="gridcell" class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
-                <td role="gridcell" class="" data-test-column="credential"><a href="#_" class="p-link--soft">clean-algebra-206308</a></td>
-                <td role="gridcell" class="" data-test-column="controller">JAAS</td>
-                <td role="gridcell" class="u-align--right" data-test-column="updated">2020-06-17</td>
+                <td class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
+                <td class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
+                <td class="" data-test-column="credential"><a href="#_" class="p-link--soft">clean-algebra-206308</a></td>
+                <td class="" data-test-column="controller">JAAS</td>
+                <td class="u-align--right" data-test-column="updated">2020-06-17</td>
               </tr>
-              <tr role="row" data-test-model-uuid="5f612488-b60b-4256-814a-ba1abaa7db23">
-                <td role="gridcell" class="" data-test-column="name">
+              <tr data-test-model-uuid="5f612488-b60b-4256-814a-ba1abaa7db23">
+                <td class="" data-test-column="name">
                   <div><a href="#/models/gomboli@external/testing">testing</a></div>
                 </td>
-                <td role="gridcell" class="u-overflow--visible" data-test-column="summary">
+                <td class="u-overflow--visible" data-test-column="summary">
                   <div class="u-flex">
                     <div class="u-flex--block p-tooltip--top-center" aria-describedby="tp-cntr">
                       <div class="has-icon"><i class="p-icon--information"></i><span>2</span></div><span class="p-tooltip__message" role="tooltip" id="tp-cntr">Applications</span>
@@ -128,17 +128,17 @@
                     </div>
                   </div>
                 </td>
-                <td role="gridcell" class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
-                <td role="gridcell" class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/europe-west1</a></td>
-                <td role="gridcell" class="" data-test-column="credential"><a href="#_" class="p-link--soft">clean-algebra-206308</a></td>
-                <td role="gridcell" class="" data-test-column="controller">JAAS</td>
-                <td role="gridcell" class="u-align--right" data-test-column="updated">2020-06-17</td>
+                <td class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
+                <td class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/europe-west1</a></td>
+                <td class="" data-test-column="credential"><a href="#_" class="p-link--soft">clean-algebra-206308</a></td>
+                <td class="" data-test-column="controller">JAAS</td>
+                <td class="u-align--right" data-test-column="updated">2020-06-17</td>
               </tr>
             </tbody>
           </table>
-          <table role="grid" class="p-main-table">
+          <table class="p-main-table">
             <thead>
-              <tr role="row">
+              <tr>
                 <th role="columnheader"><span class="status-icon is-alert">Alert (2)</span></th>
                 <th role="columnheader"></th>
                 <th role="columnheader">Owner</th>
@@ -149,11 +149,11 @@
               </tr>
             </thead>
             <tbody>
-              <tr role="row" data-test-model-uuid="e1e81a64-3385-4779-8643-05e3d5ed4523">
-                <td role="gridcell" class="" data-test-column="name">
+              <tr data-test-model-uuid="e1e81a64-3385-4779-8643-05e3d5ed4523">
+                <td class="" data-test-column="name">
                   <div><a href="#/models/gomboli@external/canonical-kubernetes">canonical-kubernetes</a></div>
                 </td>
-                <td role="gridcell" class="u-overflow--visible" data-test-column="summary">
+                <td class="u-overflow--visible" data-test-column="summary">
                   <div class="u-flex">
                     <div class="u-flex--block p-tooltip--top-center" aria-describedby="tp-cntr">
                       <div class="has-icon"><i class="p-icon--information"></i><span>6</span></div><span class="p-tooltip__message" role="tooltip" id="tp-cntr">Applications</span>
@@ -166,17 +166,17 @@
                     </div>
                   </div>
                 </td>
-                <td role="gridcell" class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
-                <td role="gridcell" class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
-                <td role="gridcell" class="" data-test-column="credential"><a href="#_" class="p-link--soft">clean-algebra-206308</a></td>
-                <td role="gridcell" class="" data-test-column="controller">JAAS</td>
-                <td role="gridcell" class="u-align--right" data-test-column="updated">2020-06-17</td>
+                <td class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
+                <td class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
+                <td class="" data-test-column="credential"><a href="#_" class="p-link--soft">clean-algebra-206308</a></td>
+                <td class="" data-test-column="controller">JAAS</td>
+                <td class="u-align--right" data-test-column="updated">2020-06-17</td>
               </tr>
-              <tr role="row" data-test-model-uuid="7ffe956a-06ac-4ae9-8aac-04eba4a93da5">
-                <td role="gridcell" class="" data-test-column="name">
+              <tr data-test-model-uuid="7ffe956a-06ac-4ae9-8aac-04eba4a93da5">
+                <td class="" data-test-column="name">
                   <div><a href="#/models/gomboli@external/mymodel">mymodel</a></div>
                 </td>
-                <td role="gridcell" class="u-overflow--visible" data-test-column="summary">
+                <td class="u-overflow--visible" data-test-column="summary">
                   <div class="u-flex">
                     <div class="u-flex--block p-tooltip--top-center" aria-describedby="tp-cntr">
                       <div class="has-icon"><i class="p-icon--information"></i><span>6</span></div><span class="p-tooltip__message" role="tooltip" id="tp-cntr">Applications</span>
@@ -189,17 +189,17 @@
                     </div>
                   </div>
                 </td>
-                <td role="gridcell" class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
-                <td role="gridcell" class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-east1</a></td>
-                <td role="gridcell" class="" data-test-column="credential"><a href="#_" class="p-link--soft">clean-algebra-206308</a></td>
-                <td role="gridcell" class="" data-test-column="controller">JAAS</td>
-                <td role="gridcell" class="u-align--right" data-test-column="updated">2020-06-17</td>
+                <td class="" data-test-column="owner"><a href="#_" class="p-link--soft">gomboli</a></td>
+                <td class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-east1</a></td>
+                <td class="" data-test-column="credential"><a href="#_" class="p-link--soft">clean-algebra-206308</a></td>
+                <td class="" data-test-column="controller">JAAS</td>
+                <td class="u-align--right" data-test-column="updated">2020-06-17</td>
               </tr>
             </tbody>
           </table>
-          <table role="grid" class="p-main-table">
+          <table class="p-main-table">
             <thead>
-              <tr role="row">
+              <tr>
                 <th role="columnheader"><span class="status-icon is-running">Running (3)</span></th>
                 <th role="columnheader"></th>
                 <th role="columnheader">Owner</th>
@@ -210,11 +210,11 @@
               </tr>
             </thead>
             <tbody>
-              <tr role="row" data-test-model-uuid="57650e3c-815f-4540-89df-81fd5d70b7ef">
-                <td role="gridcell" class="" data-test-column="name">
+              <tr data-test-model-uuid="57650e3c-815f-4540-89df-81fd5d70b7ef">
+                <td class="" data-test-column="name">
                   <div><a href="#/models/hatch@external/group-test">group-test</a></div>
                 </td>
-                <td role="gridcell" class="u-overflow--visible" data-test-column="summary">
+                <td class="u-overflow--visible" data-test-column="summary">
                   <div class="u-flex">
                     <div class="u-flex--block p-tooltip--top-center" aria-describedby="tp-cntr">
                       <div class="has-icon"><i class="p-icon--information"></i><span>9</span></div><span class="p-tooltip__message" role="tooltip" id="tp-cntr">Applications</span>
@@ -227,17 +227,17 @@
                     </div>
                   </div>
                 </td>
-                <td role="gridcell" class="" data-test-column="owner"><a href="#_" class="p-link--soft">hatch</a></td>
-                <td role="gridcell" class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
-                <td role="gridcell" class="" data-test-column="credential"><a href="#_" class="p-link--soft">admin</a></td>
-                <td role="gridcell" class="" data-test-column="controller">JAAS</td>
-                <td role="gridcell" class="u-align--right" data-test-column="updated">2020-06-17</td>
+                <td class="" data-test-column="owner"><a href="#_" class="p-link--soft">hatch</a></td>
+                <td class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
+                <td class="" data-test-column="credential"><a href="#_" class="p-link--soft">admin</a></td>
+                <td class="" data-test-column="controller">JAAS</td>
+                <td class="u-align--right" data-test-column="updated">2020-06-17</td>
               </tr>
-              <tr role="row" data-test-model-uuid="e6782960-fb0b-460e-82a1-64ee03f9a39b">
-                <td role="gridcell" class="" data-test-column="name">
+              <tr data-test-model-uuid="e6782960-fb0b-460e-82a1-64ee03f9a39b">
+                <td class="" data-test-column="name">
                   <div><a href="#/models/hatch@external/new-search-aggregate">new-search-aggregate</a></div>
                 </td>
-                <td role="gridcell" class="u-overflow--visible" data-test-column="summary">
+                <td class="u-overflow--visible" data-test-column="summary">
                   <div class="u-flex">
                     <div class="u-flex--block p-tooltip--top-center" aria-describedby="tp-cntr">
                       <div class="has-icon"><i class="p-icon--information"></i><span>2</span></div><span class="p-tooltip__message" role="tooltip" id="tp-cntr">Applications</span>
@@ -250,17 +250,17 @@
                     </div>
                   </div>
                 </td>
-                <td role="gridcell" class="" data-test-column="owner"><a href="#_" class="p-link--soft">hatch</a></td>
-                <td role="gridcell" class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
-                <td role="gridcell" class="" data-test-column="credential"><a href="#_" class="p-link--soft">jujuongce</a></td>
-                <td role="gridcell" class="" data-test-column="controller">JAAS</td>
-                <td role="gridcell" class="u-align--right" data-test-column="updated">2020-06-17</td>
+                <td class="" data-test-column="owner"><a href="#_" class="p-link--soft">hatch</a></td>
+                <td class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
+                <td class="" data-test-column="credential"><a href="#_" class="p-link--soft">jujuongce</a></td>
+                <td class="" data-test-column="controller">JAAS</td>
+                <td class="u-align--right" data-test-column="updated">2020-06-17</td>
               </tr>
-              <tr role="row" data-test-model-uuid="930f4bb0-070a-462a-8d4e-19d9772c08f2">
-                <td role="gridcell" class="" data-test-column="name">
+              <tr data-test-model-uuid="930f4bb0-070a-462a-8d4e-19d9772c08f2">
+                <td class="" data-test-column="name">
                   <div><a href="#/models/hatch@external/unplaced">unplaced</a></div>
                 </td>
-                <td role="gridcell" class="u-overflow--visible" data-test-column="summary">
+                <td class="u-overflow--visible" data-test-column="summary">
                   <div class="u-flex">
                     <div class="u-flex--block p-tooltip--top-center" aria-describedby="tp-cntr">
                       <div class="has-icon"><i class="p-icon--information"></i><span>5</span></div><span class="p-tooltip__message" role="tooltip" id="tp-cntr">Applications</span>
@@ -273,11 +273,11 @@
                     </div>
                   </div>
                 </td>
-                <td role="gridcell" class="" data-test-column="owner"><a href="#_" class="p-link--soft">hatch</a></td>
-                <td role="gridcell" class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
-                <td role="gridcell" class="" data-test-column="credential"><a href="#_" class="p-link--soft">juju</a></td>
-                <td role="gridcell" class="" data-test-column="controller">JAAS</td>
-                <td role="gridcell" class="u-align--right" data-test-column="updated">2020-06-17</td>
+                <td class="" data-test-column="owner"><a href="#_" class="p-link--soft">hatch</a></td>
+                <td class="" data-test-column="cloud"><a href="#_" class="p-link--soft">google/us-central1</a></td>
+                <td class="" data-test-column="credential"><a href="#_" class="p-link--soft">juju</a></td>
+                <td class="" data-test-column="controller">JAAS</td>
+                <td class="u-align--right" data-test-column="updated">2020-06-17</td>
               </tr>
             </tbody>
           </table>

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -52,16 +52,16 @@
       </div>
       <div class="p-panel__content">
         <div class="u-fixed-width">
-          <table class="p-main-table">
+          <table aria-label="JAAS table example" class="p-main-table">
             <thead>
               <tr>
-                <th role="columnheader"><span class="status-icon is-blocked">Blocked (3)</span></th>
-                <th role="columnheader"></th>
-                <th role="columnheader">Owner</th>
-                <th role="columnheader">Cloud/Region</th>
-                <th role="columnheader">Credential</th>
-                <th role="columnheader">Controller</th>
-                <th role="columnheader" class="u-align--right">Last Updated</th>
+                <th><span class="status-icon is-blocked">Blocked (3)</span></th>
+                <th></th>
+                <th>Owner</th>
+                <th>Cloud/Region</th>
+                <th>Credential</th>
+                <th>Controller</th>
+                <th class="u-align--right">Last Updated</th>
               </tr>
             </thead>
             <tbody>
@@ -136,16 +136,16 @@
               </tr>
             </tbody>
           </table>
-          <table class="p-main-table">
+          <table aria-label="JAAS table example" class="p-main-table">
             <thead>
               <tr>
-                <th role="columnheader"><span class="status-icon is-alert">Alert (2)</span></th>
-                <th role="columnheader"></th>
-                <th role="columnheader">Owner</th>
-                <th role="columnheader">Cloud/Region</th>
-                <th role="columnheader">Credential</th>
-                <th role="columnheader">Controller</th>
-                <th role="columnheader" class="u-align--right">Last Updated</th>
+                <th><span class="status-icon is-alert">Alert (2)</span></th>
+                <th></th>
+                <th>Owner</th>
+                <th>Cloud/Region</th>
+                <th>Credential</th>
+                <th>Controller</th>
+                <th class="u-align--right">Last Updated</th>
               </tr>
             </thead>
             <tbody>
@@ -197,16 +197,16 @@
               </tr>
             </tbody>
           </table>
-          <table class="p-main-table">
+          <table aria-label="JAAS table example" class="p-main-table">
             <thead>
               <tr>
-                <th role="columnheader"><span class="status-icon is-running">Running (3)</span></th>
-                <th role="columnheader"></th>
-                <th role="columnheader">Owner</th>
-                <th role="columnheader">Cloud/Region</th>
-                <th role="columnheader">Credential</th>
-                <th role="columnheader">Controller</th>
-                <th role="columnheader" class="u-align--right">Last Updated</th>
+                <th><span class="status-icon is-running">Running (3)</span></th>
+                <th></th>
+                <th>Owner</th>
+                <th>Cloud/Region</th>
+                <th>Credential</th>
+                <th>Controller</th>
+                <th class="u-align--right">Last Updated</th>
               </tr>
             </thead>
             <tbody>

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -137,7 +137,7 @@
       </ul>
 
       <h3>Tables</h3>
-      <table>
+      <table aria-label="MAAS table example">
         <thead>
           <tr>
             <th>Interface name</th>

--- a/templates/docs/examples/patterns/forms/_checkbox-inline.html
+++ b/templates/docs/examples/patterns/forms/_checkbox-inline.html
@@ -6,7 +6,7 @@
   alonside some text
 </p>
 
-<table>
+<table aria-label="Checkbox in table example">
   <thead>
     <tr>
       <th>

--- a/templates/docs/examples/patterns/forms/_radio-inline.html
+++ b/templates/docs/examples/patterns/forms/_radio-inline.html
@@ -6,7 +6,7 @@
   alonside some text
 </p>
 
-<table>
+<table aria-label="Radio button in table example">
   <thead>
     <tr>
       <th>

--- a/templates/docs/examples/patterns/forms/tick-comparison.html
+++ b/templates/docs/examples/patterns/forms/tick-comparison.html
@@ -40,7 +40,7 @@
       alongside some text
     </p>
 
-    <table>
+    <table aria-label="Checkbox in table example">
       <thead>
         <tr>
           <th>
@@ -147,7 +147,7 @@
       alongside some text
     </p>
 
-    <table>
+    <table aria-label="Radio button in table example">
       <thead>
         <tr>
           <th>

--- a/templates/docs/examples/patterns/tables/table-colored-rows.html
+++ b/templates/docs/examples/patterns/tables/table-colored-rows.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-<table>
+<table aria-label="Example of a table with tinted rows">
   <thead>
     <tr>
       <th></th>

--- a/templates/docs/examples/patterns/tables/table-expanding.html
+++ b/templates/docs/examples/patterns/tables/table-expanding.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_table-expanding{% endblock %}
 
 {% block content %}
-<table class="p-table-expanding" >
+<table class="p-table-expanding" aria-label="Example of expanding table">
     <thead>
         <tr>
             <th id="t-name" aria-sort="none">Name</th>
@@ -20,7 +20,7 @@
     </thead>
     <tbody>
         <tr>
-            <td role="rowheader" aria-label="Name">Unknown</td>
+            <td aria-label="Name">Unknown</td>
             <td aria-label="Users">2c:44:fd:80:3f:25</td>
             <td aria-label="Units">10.249.0.1</td>
             <td aria-label="Units">karura</td>
@@ -41,7 +41,7 @@
             </td>
         </tr>
         <tr>
-            <td role="rowheader" aria-label="Name">Unknown</td>
+            <td aria-label="Name">Unknown</td>
             <td aria-label="Users">52:54:00:3a:fe:e9</td>
             <td aria-label="Units">172.16.99.191</td>
             <td aria-label="Units">karura</td>
@@ -62,7 +62,7 @@
             </td>
         </tr>
         <tr>
-            <td role="rowheader" aria-label="Name">Unknown</td>
+            <td aria-label="Name">Unknown</td>
             <td aria-label="Users">52:54:00:74:c2:10</td>
             <td aria-label="Units">172.16.99.192</td>
             <td aria-label="Units">karura</td>

--- a/templates/docs/examples/patterns/tables/table-expanding.html
+++ b/templates/docs/examples/patterns/tables/table-expanding.html
@@ -4,9 +4,9 @@
 {% block standalone_css %}patterns_table-expanding{% endblock %}
 
 {% block content %}
-<table class="p-table-expanding" role="grid">
+<table class="p-table-expanding" >
     <thead>
-        <tr role="row">
+        <tr>
             <th id="t-name" aria-sort="none">Name</th>
             <th id="t-users" aria-sort="none">Mac address</th>
             <th id="t-units" aria-sort="none">IP</th>
@@ -19,13 +19,13 @@
         </tr>
     </thead>
     <tbody>
-        <tr role="row">
+        <tr>
             <td role="rowheader" aria-label="Name">Unknown</td>
-            <td role="gridcell" aria-label="Users">2c:44:fd:80:3f:25</td>
-            <td role="gridcell" aria-label="Units">10.249.0.1</td>
-            <td role="gridcell" aria-label="Units">karura</td>
-            <td role="gridcell" aria-label="Units">Thu, 25 Oct. 2018 13:55:21</td>
-            <td role="gridcell" class="u-align--right">
+            <td aria-label="Users">2c:44:fd:80:3f:25</td>
+            <td aria-label="Units">10.249.0.1</td>
+            <td aria-label="Units">karura</td>
+            <td aria-label="Units">Thu, 25 Oct. 2018 13:55:21</td>
+            <td class="u-align--right">
                 <button class="u-toggle is-dense" aria-controls="expanded-row" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
@@ -40,13 +40,13 @@
                 </div>
             </td>
         </tr>
-        <tr role="row">
+        <tr>
             <td role="rowheader" aria-label="Name">Unknown</td>
-            <td role="gridcell" aria-label="Users">52:54:00:3a:fe:e9</td>
-            <td role="gridcell" aria-label="Units">172.16.99.191</td>
-            <td role="gridcell" aria-label="Units">karura</td>
-            <td role="gridcell" aria-label="Units">Wed, 3 Oct. 2018 23:08:06</td>
-            <td role="gridcell" class="u-align--right">
+            <td aria-label="Users">52:54:00:3a:fe:e9</td>
+            <td aria-label="Units">172.16.99.191</td>
+            <td aria-label="Units">karura</td>
+            <td aria-label="Units">Wed, 3 Oct. 2018 23:08:06</td>
+            <td class="u-align--right">
                 <button class="u-toggle is-dense" aria-controls="expanded-row-2" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
@@ -61,13 +61,13 @@
                 </div>
             </td>
         </tr>
-        <tr role="row">
+        <tr>
             <td role="rowheader" aria-label="Name">Unknown</td>
-            <td role="gridcell" aria-label="Users">52:54:00:74:c2:10</td>
-            <td role="gridcell" aria-label="Units">172.16.99.192</td>
-            <td role="gridcell" aria-label="Units">karura</td>
-            <td role="gridcell" aria-label="Units">Wed, 17 Oct. 2018 12:18:18</td>
-            <td role="gridcell" class="u-align--right">
+            <td aria-label="Users">52:54:00:74:c2:10</td>
+            <td aria-label="Units">172.16.99.192</td>
+            <td aria-label="Units">karura</td>
+            <td aria-label="Units">Wed, 17 Oct. 2018 12:18:18</td>
+            <td class="u-align--right">
                 <button class="u-toggle is-dense" aria-controls="expanded-row-3" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -20,7 +20,7 @@
   </thead>
   <tbody>
     <tr>
-      <td aria-label="Test of a long label that will cause truncation">LongEnoughToCauseEllipsis</td>
+      <td aria-label="Test of a long label that will cause wrapping">Long wrapping value</td>
       <td aria-label="Power">On</td>
       <td aria-label="Status">Failed testing</td>
       <td aria-label="Owner">Caleb</td>
@@ -28,7 +28,7 @@
       <td class="u-align--right" aria-label="Cores">4</td>
       <td class="u-align--right" aria-label="RAM">2 GiB</td>
       <td class="u-align--right" aria-label="Disks">1</td>
-      <td class="u-align--right" aria-label="Storage_long_enough_to_cause_ellipsis">2TB</td>
+      <td class="u-align--right" aria-label="Storage">2TB</td>
     </tr>
     <tr>
       <td aria-label="FQDN">upward-muskox</td>
@@ -39,7 +39,7 @@
       <td class="u-align--right" aria-label="Cores">6</td>
       <td class="u-align--right" aria-label="RAM">4 GiB</td>
       <td class="u-align--right" aria-label="Disks">1</td>
-      <td class="u-align--right" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+      <td class="u-align--right" aria-label="Storage">500GB</td>
     </tr>
     <tr>
       <td aria-label="FQDN">first-cattle</td>
@@ -50,7 +50,7 @@
       <td class="u-align--right" aria-label="Cores">8</td>
       <td class="u-align--right" aria-label="RAM">16 GiB</td>
       <td class="u-align--right" aria-label="Disks">3</td>
-      <td class="u-align--right" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+      <td class="u-align--right" aria-label="Storage">6TB</td>
     </tr>
     <tr>
       <td aria-label="FQDN">golden-rodent</td>
@@ -61,7 +61,7 @@
       <td class="u-align--right" aria-label="Cores">2</td>
       <td class="u-align--right" aria-label="RAM">1 GiB</td>
       <td class="u-align--right" aria-label="Disks">1</td>
-      <td class="u-align--right" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+      <td class="u-align--right" aria-label="Storage">240GB</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -20,15 +20,15 @@
   </thead>
   <tbody>
     <tr>
-      <td aria-label="Test of a long label that will cause wrapping">Long wrapping value</td>
+      <td aria-label="FQDN">LongEnoughToCauseEllipsis</td>
       <td aria-label="Power">On</td>
       <td aria-label="Status">Failed testing</td>
       <td aria-label="Owner">Caleb</td>
       <td aria-label="Zone">london</td>
-      <td class="u-align--right" aria-label="Cores">4</td>
-      <td class="u-align--right" aria-label="RAM">2 GiB</td>
-      <td class="u-align--right" aria-label="Disks">1</td>
-      <td class="u-align--right" aria-label="Storage">2TB</td>
+      <td class="u-align--right"  aria-label="Cores">4</td>
+      <td class="u-align--right"  aria-label="RAM">2 GiB</td>
+      <td class="u-align--right"  aria-label="Disks">1</td>
+      <td class="u-align--right"  aria-label="Storagelongenoughtocauseellipsis">2TB</td>
     </tr>
     <tr>
       <td aria-label="FQDN">upward-muskox</td>
@@ -36,10 +36,10 @@
       <td aria-label="Status">Allocated</td>
       <td aria-label="Owner">sparkiegeek</td>
       <td aria-label="Zone">london</td>
-      <td class="u-align--right" aria-label="Cores">6</td>
-      <td class="u-align--right" aria-label="RAM">4 GiB</td>
-      <td class="u-align--right" aria-label="Disks">1</td>
-      <td class="u-align--right" aria-label="Storage">500GB</td>
+      <td class="u-align--right"  aria-label="Cores">6</td>
+      <td class="u-align--right"  aria-label="RAM">4 GiB</td>
+      <td class="u-align--right"  aria-label="Disks">1</td>
+      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">500GB</td>
     </tr>
     <tr>
       <td aria-label="FQDN">first-cattle</td>
@@ -47,10 +47,10 @@
       <td aria-label="Status">Failed to enter rescue mode</td>
       <td aria-label="Owner">admin</td>
       <td aria-label="Zone">london</td>
-      <td class="u-align--right" aria-label="Cores">8</td>
-      <td class="u-align--right" aria-label="RAM">16 GiB</td>
-      <td class="u-align--right" aria-label="Disks">3</td>
-      <td class="u-align--right" aria-label="Storage">6TB</td>
+      <td class="u-align--right"  aria-label="Cores">8</td>
+      <td class="u-align--right"  aria-label="RAM">16 GiB</td>
+      <td class="u-align--right"  aria-label="Disks">3</td>
+      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">6TB</td>
     </tr>
     <tr>
       <td aria-label="FQDN">golden-rodent</td>
@@ -58,10 +58,10 @@
       <td aria-label="Status">Broken</td>
       <td aria-label="Owner">&mdash;</td>
       <td aria-label="Zone">london</td>
-      <td class="u-align--right" aria-label="Cores">2</td>
-      <td class="u-align--right" aria-label="RAM">1 GiB</td>
-      <td class="u-align--right" aria-label="Disks">1</td>
-      <td class="u-align--right" aria-label="Storage">240GB</td>
+      <td class="u-align--right"  aria-label="Cores">2</td>
+      <td class="u-align--right"  aria-label="RAM">1 GiB</td>
+      <td class="u-align--right"  aria-label="Disks">1</td>
+      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">240GB</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -4,9 +4,9 @@
 {% block standalone_css %}patterns_table-mobile-card{% endblock %}
 
 {% block content %}
-<table class="p-table--mobile-card" role="grid">
+<table class="p-table--mobile-card" >
   <thead>
-    <tr role="row">
+    <tr>
       <th>FQDN</th>
       <th>Power</th>
       <th>Status</th>
@@ -19,49 +19,49 @@
     </tr>
   </thead>
   <tbody>
-    <tr role="row">
+    <tr>
       <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
-      <td role="gridcell" aria-label="Power">On</td>
-      <td role="gridcell" aria-label="Status">Failed testing</td>
-      <td role="gridcell" aria-label="Owner">Caleb</td>
-      <td role="gridcell" aria-label="Zone">london</td>
-      <td class="u-align--right" role="gridcell" aria-label="Cores">4</td>
-      <td class="u-align--right" role="gridcell" aria-label="RAM">2 GiB</td>
-      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
-      <td class="u-align--right" role="gridcell" aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+      <td aria-label="Power">On</td>
+      <td aria-label="Status">Failed testing</td>
+      <td aria-label="Owner">Caleb</td>
+      <td aria-label="Zone">london</td>
+      <td class="u-align--right"  aria-label="Cores">4</td>
+      <td class="u-align--right"  aria-label="RAM">2 GiB</td>
+      <td class="u-align--right"  aria-label="Disks">1</td>
+      <td class="u-align--right"  aria-label="Storagelongenoughtocauseellipsis">2TB</td>
     </tr>
-    <tr role="row">
+    <tr>
       <td role="rowheader" aria-label="FQDN">upward-muskox</td>
-      <td role="gridcell" aria-label="Power">Off</td>
-      <td role="gridcell" aria-label="Status">Allocated</td>
-      <td role="gridcell" aria-label="Owner">sparkiegeek</td>
-      <td role="gridcell" aria-label="Zone">london</td>
-      <td class="u-align--right" role="gridcell" aria-label="Cores">6</td>
-      <td class="u-align--right" role="gridcell" aria-label="RAM">4 GiB</td>
-      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
-      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">500GB</td>
+      <td aria-label="Power">Off</td>
+      <td aria-label="Status">Allocated</td>
+      <td aria-label="Owner">sparkiegeek</td>
+      <td aria-label="Zone">london</td>
+      <td class="u-align--right"  aria-label="Cores">6</td>
+      <td class="u-align--right"  aria-label="RAM">4 GiB</td>
+      <td class="u-align--right"  aria-label="Disks">1</td>
+      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">500GB</td>
     </tr>
-    <tr role="row">
+    <tr>
       <td role="rowheader" aria-label="FQDN">first-cattle</td>
-      <td role="gridcell" aria-label="Power">On</td>
-      <td role="gridcell" aria-label="Status">Failed to enter rescue mode</td>
-      <td role="gridcell" aria-label="Owner">admin</td>
-      <td role="gridcell" aria-label="Zone">london</td>
-      <td class="u-align--right" role="gridcell" aria-label="Cores">8</td>
-      <td class="u-align--right" role="gridcell" aria-label="RAM">16 GiB</td>
-      <td class="u-align--right" role="gridcell" aria-label="Disks">3</td>
-      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">6TB</td>
+      <td aria-label="Power">On</td>
+      <td aria-label="Status">Failed to enter rescue mode</td>
+      <td aria-label="Owner">admin</td>
+      <td aria-label="Zone">london</td>
+      <td class="u-align--right"  aria-label="Cores">8</td>
+      <td class="u-align--right"  aria-label="RAM">16 GiB</td>
+      <td class="u-align--right"  aria-label="Disks">3</td>
+      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">6TB</td>
     </tr>
-    <tr role="row">
+    <tr>
       <td role="rowheader" aria-label="FQDN">golden-rodent</td>
-      <td role="gridcell" aria-label="Power">Off</td>
-      <td role="gridcell" aria-label="Status">Broken</td>
-      <td role="gridcell" aria-label="Owner">&mdash;</td>
-      <td role="gridcell" aria-label="Zone">london</td>
-      <td class="u-align--right" role="gridcell" aria-label="Cores">2</td>
-      <td class="u-align--right" role="gridcell" aria-label="RAM">1 GiB</td>
-      <td class="u-align--right" role="gridcell" aria-label="Disks">1</td>
-      <td class="u-align--right" role="gridcell" aria-label="Storage this is long enough to cause wrapping">240GB</td>
+      <td aria-label="Power">Off</td>
+      <td aria-label="Status">Broken</td>
+      <td aria-label="Owner">&mdash;</td>
+      <td aria-label="Zone">london</td>
+      <td class="u-align--right"  aria-label="Cores">2</td>
+      <td class="u-align--right"  aria-label="RAM">1 GiB</td>
+      <td class="u-align--right"  aria-label="Disks">1</td>
+      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">240GB</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_table-mobile-card{% endblock %}
 
 {% block content %}
-<table class="p-table--mobile-card" >
+<table class="p-table--mobile-card" aria-label="Example of table transforming into mobile cards on small screens">
   <thead>
     <tr>
       <th>FQDN</th>
@@ -20,48 +20,48 @@
   </thead>
   <tbody>
     <tr>
-      <td role="rowheader" aria-label="FQDN">LongEnoughToCauseEllipsis</td>
+      <td aria-label="Test of a long label that will cause truncation">LongEnoughToCauseEllipsis</td>
       <td aria-label="Power">On</td>
       <td aria-label="Status">Failed testing</td>
       <td aria-label="Owner">Caleb</td>
       <td aria-label="Zone">london</td>
-      <td class="u-align--right"  aria-label="Cores">4</td>
-      <td class="u-align--right"  aria-label="RAM">2 GiB</td>
-      <td class="u-align--right"  aria-label="Disks">1</td>
-      <td class="u-align--right"  aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+      <td class="u-align--right" aria-label="Cores">4</td>
+      <td class="u-align--right" aria-label="RAM">2 GiB</td>
+      <td class="u-align--right" aria-label="Disks">1</td>
+      <td class="u-align--right" aria-label="Storage_long_enough_to_cause_ellipsis">2TB</td>
     </tr>
     <tr>
-      <td role="rowheader" aria-label="FQDN">upward-muskox</td>
+      <td aria-label="FQDN">upward-muskox</td>
       <td aria-label="Power">Off</td>
       <td aria-label="Status">Allocated</td>
       <td aria-label="Owner">sparkiegeek</td>
       <td aria-label="Zone">london</td>
-      <td class="u-align--right"  aria-label="Cores">6</td>
-      <td class="u-align--right"  aria-label="RAM">4 GiB</td>
-      <td class="u-align--right"  aria-label="Disks">1</td>
-      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">500GB</td>
+      <td class="u-align--right" aria-label="Cores">6</td>
+      <td class="u-align--right" aria-label="RAM">4 GiB</td>
+      <td class="u-align--right" aria-label="Disks">1</td>
+      <td class="u-align--right" aria-label="Storage this is long enough to cause wrapping">500GB</td>
     </tr>
     <tr>
-      <td role="rowheader" aria-label="FQDN">first-cattle</td>
+      <td aria-label="FQDN">first-cattle</td>
       <td aria-label="Power">On</td>
       <td aria-label="Status">Failed to enter rescue mode</td>
       <td aria-label="Owner">admin</td>
       <td aria-label="Zone">london</td>
-      <td class="u-align--right"  aria-label="Cores">8</td>
-      <td class="u-align--right"  aria-label="RAM">16 GiB</td>
-      <td class="u-align--right"  aria-label="Disks">3</td>
-      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">6TB</td>
+      <td class="u-align--right" aria-label="Cores">8</td>
+      <td class="u-align--right" aria-label="RAM">16 GiB</td>
+      <td class="u-align--right" aria-label="Disks">3</td>
+      <td class="u-align--right" aria-label="Storage this is long enough to cause wrapping">6TB</td>
     </tr>
     <tr>
-      <td role="rowheader" aria-label="FQDN">golden-rodent</td>
+      <td aria-label="FQDN">golden-rodent</td>
       <td aria-label="Power">Off</td>
       <td aria-label="Status">Broken</td>
       <td aria-label="Owner">&mdash;</td>
       <td aria-label="Zone">london</td>
-      <td class="u-align--right"  aria-label="Cores">2</td>
-      <td class="u-align--right"  aria-label="RAM">1 GiB</td>
-      <td class="u-align--right"  aria-label="Disks">1</td>
-      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">240GB</td>
+      <td class="u-align--right" aria-label="Cores">2</td>
+      <td class="u-align--right" aria-label="RAM">1 GiB</td>
+      <td class="u-align--right" aria-label="Disks">1</td>
+      <td class="u-align--right" aria-label="Storage this is long enough to cause wrapping">240GB</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/examples/patterns/tables/table-sortable.html
+++ b/templates/docs/examples/patterns/tables/table-sortable.html
@@ -7,10 +7,10 @@
 <table class="p-table--sortable" >
   <thead>
     <tr>
-      <th id="t-name" aria-sort="none" role="columnheader">Status</th>
-      <th id="t-users" aria-sort="none" role="columnheader" class="u-align--right">Cores</th>
-      <th id="t-units" aria-sort="none" role="columnheader" class="u-align--right">RAM</th>
-      <th id="t-revenue" aria-sort="none" role="columnheader" class="u-align--right">Disks</th>
+      <th id="t-name" aria-sort="none">Status</th>
+      <th id="t-users" aria-sort="none" class="u-align--right">Cores</th>
+      <th id="t-units" aria-sort="none" class="u-align--right">RAM</th>
+      <th id="t-revenue" aria-sort="none" class="u-align--right">Disks</th>
     </tr>
   </thead>
   <tbody>

--- a/templates/docs/examples/patterns/tables/table-sortable.html
+++ b/templates/docs/examples/patterns/tables/table-sortable.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_table-sortable{% endblock %}
 
 {% block content %}
-<table class="p-table--sortable" >
+<table class="p-table--sortable" aria-label="Example of a sortable table">
   <thead>
     <tr>
       <th id="t-name" aria-sort="none">Status</th>

--- a/templates/docs/examples/patterns/tables/table-sortable.html
+++ b/templates/docs/examples/patterns/tables/table-sortable.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_table-sortable{% endblock %}
 
 {% block content %}
-<table class="p-table--sortable" role="grid">
+<table class="p-table--sortable" >
   <thead>
     <tr>
       <th id="t-name" aria-sort="none" role="columnheader">Status</th>
@@ -14,23 +14,23 @@
     </tr>
   </thead>
   <tbody>
-    <tr role="row">
+    <tr>
       <td role="rowheader">Ready</td>
-      <td role="gridcell" class="u-align--right">1</td>
-      <td role="gridcell" class="u-align--right">1 GiB</td>
-      <td role="gridcell" class="u-align--right">2</td>
+      <td class="u-align--right">1</td>
+      <td class="u-align--right">1 GiB</td>
+      <td class="u-align--right">2</td>
     </tr>
-    <tr role="row">
+    <tr>
       <td role="rowheader">Ready</td>
-      <td role="gridcell" class="u-align--right">1</td>
-      <td role="gridcell" class="u-align--right">1 GiB</td>
-      <td role="gridcell" class="u-align--right">2</td>
+      <td class="u-align--right">1</td>
+      <td class="u-align--right">1 GiB</td>
+      <td class="u-align--right">2</td>
     </tr>
-    <tr role="row">
+    <tr>
       <td role="rowheader">Ready</td>
-      <td role="gridcell" class="u-align--right">8</td>
-      <td role="gridcell" class="u-align--right">3.9 GiB</td>
-      <td role="gridcell" class="u-align--right">3</td>
+      <td class="u-align--right">8</td>
+      <td class="u-align--right">3.9 GiB</td>
+      <td class="u-align--right">3</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -238,7 +238,7 @@
       </p>
 
       <div class="md-table">
-        <table>
+        <table aria-label="MAAS table example">
           <thead>
             <tr>
               <th></th>

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -125,7 +125,7 @@
         <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
         <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
       </form>
-      <table class="p-table--mobile-card">
+      <table aria-label="MAAS table example" class="p-table--mobile-card">
         <thead>
           <tr>
             <th>FQDN | MAC</th>

--- a/templates/docs/examples/templates/tick-element-comparison.html
+++ b/templates/docs/examples/templates/tick-element-comparison.html
@@ -72,7 +72,7 @@
 
 <div class="p-strip is-shallow u-no-padding--top">
   <div class="u-fixed-width">
-    <table class="p-table--mobile-card">
+    <table aria-label="Example of a table that is rendered as a series of cards on small screens" class="p-table--mobile-card">
       <thead>
         <tr>
           <th>

--- a/templates/docs/examples/utilities/table-cell-padding-overlap.html
+++ b/templates/docs/examples/utilities/table-cell-padding-overlap.html
@@ -2,7 +2,7 @@
 {% block title %}Table cell padding overlap{% endblock %}
 
 {% block content %}
-<table>
+<table aria-label="Table featuring elements that stretch into the cell padding">
   <tbody>
     <tr>
         <td><button class="u-table-cell-padding-overlap">Select</button></td>

--- a/templates/docs/examples/utilities/truncate.html
+++ b/templates/docs/examples/utilities/truncate.html
@@ -2,7 +2,7 @@
 {% block title %}Truncate text{% endblock %}
 
 {% block content %}
-<table>
+<table aria-label="Table example demonstrating how to use Vanilla's truncation utility">
     <thead>
       <tr>
         <th>FQDN</th>


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/870

- Remove grid and table-related roles from `<table>` elements
- Add aria-labels to all tables

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ table examples, ensure there are no visual or interaction changes
- Review whether aria-labels on tables are clear and understandable

Adding do not merge as this breaks the sortable table example which relies on roles. @bartaz what approach would you recommend to fix that?