### PR TITLE
Accessibility validator fix: Moves any `<style>` tags on example pages to the `<head>`

### DIFF
--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -36,6 +36,8 @@
       }
     </style>
 
+    {% block style %}{% endblock %}
+
     <script>
       (function() {
         function inIframe () {

--- a/templates/docs/examples/base/hr-dark.html
+++ b/templates/docs/examples/base/hr-dark.html
@@ -13,6 +13,5 @@
 {% endblock %}
 
 {% block content %}
-
 <hr class="is-dark">
 {% endblock %}

--- a/templates/docs/examples/base/hr-dark.html
+++ b/templates/docs/examples/base/hr-dark.html
@@ -3,13 +3,16 @@
 
 {% block standalone_css %}base{% endblock %}
 
-{% block content %}
+{% block style %}
 <style>
   body {
     background: #111;
     padding: 1rem 0;
   }
 </style>
+{% endblock %}
+
+{% block content %}
 
 <hr class="is-dark">
 {% endblock %}

--- a/templates/docs/examples/base/hr.html
+++ b/templates/docs/examples/base/hr.html
@@ -12,6 +12,5 @@
 {% endblock %}
 
 {% block content %}
-
 <hr>
 {% endblock %}

--- a/templates/docs/examples/base/hr.html
+++ b/templates/docs/examples/base/hr.html
@@ -3,12 +3,15 @@
 
 {% block standalone_css %}base{% endblock %}
 
-{% block content %}
+{% block style %}
 <style>
   body {
     padding: 1rem 0;
   }
 </style>
+{% endblock %}
+
+{% block content %}
 
 <hr>
 {% endblock %}

--- a/templates/docs/examples/layouts/application-structure.html
+++ b/templates/docs/examples/layouts/application-structure.html
@@ -1,6 +1,12 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}Application / Structure{% endblock %}
 
+{% block style %}
+<style>
+  body { margin: 0; }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="l-application app-demo" role="presentation">
   <div class="l-navigation-bar">
@@ -66,14 +72,6 @@
     <code>l-status</code>
   </aside>
 </div>
-
-
-
-
-
-<style>
-  body { margin: 0; }
-</style>
 
 <script>
   document.querySelector(".js-menu-toggle").addEventListener("click", function() {

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -1,6 +1,101 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}Application / Panels{% endblock %}
 
+{% block style %}
+<style>
+  body { margin: 0; }
+
+  /* application layout demo styles */
+  .p-icon--pin {
+    background: url("https://assets.ubuntu.com/v1/5cca09bb-pin.svg");
+  }
+
+  .l-application .u-fixed-width {
+    /*  temporary, as I don't want to change the global setting */
+    max-width: 95rem;
+  }
+
+  .p-panel__logo {
+    display: block;
+    max-height: 1.5rem;
+    width: auto;
+  }
+
+  .demo-status {
+    background-color: #f7f7f7; /* $colors--light-theme--background-alt; */
+    padding-bottom: .75rem; /* $spv-inner--medium; */
+    padding-top: .75rem;
+  }
+
+  /* overrides for side nav in app layout */
+  .l-navigation__drawer .p-side-navigation,
+  .l-navigation__drawer [class*='p-side-navigation--'] {
+      max-height: none;
+      overflow-y: visible;
+      position: static;
+      top: auto;
+    }
+
+  /* demo JAAS CSS */
+  .u-flex {
+    display: flex
+  }
+
+  .u-flex--block {
+      flex: 1 1 auto
+  }
+
+  .has-icon [class*="p-icon"]:first-child {
+      margin-right: .25rem;
+      margin-top: .25rem
+  }
+
+  .status-icon {
+      display: inline-block;
+      padding-left: 1.5rem;
+      position: relative
+  }
+
+  .status-icon::before {
+      content: "\00B7";
+      font-size: 5rem;
+      left: 0;
+      position: absolute;
+      top: -6px
+  }
+
+  .status-icon.is-blocked::before,.status-icon.is-down::before,.status-icon.is-error::before,.status-icon.is-provisioning::before {
+      color: #c7162b
+  }
+
+  .status-icon.is-alert::before,.status-icon.is-attention::before,.status-icon.is-maintenance::before,.status-icon.is-pending::before,.status-icon.is-stopped::before,.status-icon.is-waiting::before {
+      color: #f99b11
+  }
+
+  .status-icon.is-active::before,.status-icon.is-running::before,.status-icon.is-started::before {
+      color: #cdcdcd
+  }
+
+  .status-icon.is-unknown::before {
+      border: 1px solid #cdcdcd;
+      border-radius: 50%;
+      content: "";
+      height: .6rem;
+      left: .35rem;
+      top: .5rem;
+      width: .6rem
+  }
+
+  table thead::after {
+      content: none
+  }
+
+  td,th {
+      min-width: 150px
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="l-application" role="presentation">
   <div class="l-navigation-bar">
@@ -312,101 +407,6 @@
     </div>
   </div>
 </aside>
-
-<style>
-  body { margin: 0; }
-
-  /* application layout demo styles */
-  .p-icon--pin {
-    background: url("https://assets.ubuntu.com/v1/5cca09bb-pin.svg");
-  }
-
-  .l-application .u-fixed-width {
-    /*  temporary, as I don't want to change the global setting */
-    max-width: 95rem;
-  }
-
-  .p-panel__logo {
-    display: block;
-    max-height: 1.5rem;
-    width: auto;
-  }
-
-  .demo-status {
-    background-color: #f7f7f7; /* $colors--light-theme--background-alt; */
-    padding-bottom: .75rem; /* $spv-inner--medium; */
-    padding-top: .75rem;
-  }
-
-  /* overrides for side nav in app layout */
-  .l-navigation__drawer {
-    .p-side-navigation,
-    [class*='p-side-navigation--'] {
-      max-height: none;
-      overflow-y: visible;
-      position: static;
-      top: auto;
-    }
-  }
-
-  /* demo JAAS CSS */
-  .u-flex {
-    display: flex
-  }
-
-  .u-flex--block {
-      flex: 1 1 auto
-  }
-
-  .has-icon [class*="p-icon"]:first-child {
-      margin-right: .25rem;
-      margin-top: .25rem
-  }
-
-  .status-icon {
-      display: inline-block;
-      padding-left: 1.5rem;
-      position: relative
-  }
-
-  .status-icon:before {
-      content: "\00B7";
-      font-size: 5rem;
-      left: 0;
-      position: absolute;
-      top: -6px
-  }
-
-  .status-icon.is-blocked:before,.status-icon.is-down:before,.status-icon.is-error:before,.status-icon.is-provisioning:before {
-      color: #c7162b
-  }
-
-  .status-icon.is-alert:before,.status-icon.is-attention:before,.status-icon.is-maintenance:before,.status-icon.is-pending:before,.status-icon.is-stopped:before,.status-icon.is-waiting:before {
-      color: #f99b11
-  }
-
-  .status-icon.is-active:before,.status-icon.is-running:before,.status-icon.is-started:before {
-      color: #cdcdcd
-  }
-
-  .status-icon.is-unknown:before {
-      border: 1px solid #cdcdcd;
-      border-radius: 50%;
-      content: "";
-      height: .6rem;
-      left: .35rem;
-      top: .5rem;
-      width: .6rem
-  }
-
-  table thead:after {
-      content: none
-  }
-
-  td,th {
-      min-width: 150px
-  }
-</style>
 
 <script>
   document.querySelector(".js-menu-toggle").addEventListener("click", function() {

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -277,5 +277,4 @@
   {% include "docs/examples/patterns/side-navigation/_example_script.js" %}
   {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
 </script>
-
 {% endblock %}

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -1,6 +1,12 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}Documentation{% endblock %}
 
+{% block style %}
+<style>
+  body { margin: 0; }
+</style>
+{% endblock %}
+
 {% block content %}
 {% include "docs/examples/layouts/_global-nav.html" %}
 
@@ -272,7 +278,4 @@
   {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
 </script>
 
-<style>
-  body { margin: 0; }
-</style>
 {% endblock %}

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -12,7 +12,6 @@
 {% endblock %}
 
 {% block content %}
-
 <div class="grid-demo">
   <div class="row">
     <div class="col-2 col-medium-1 col-small-1">

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -9,6 +9,9 @@
   content: attr(class);
 }
 </style>
+{% endblock %}
+
+{% block content %}
 
 <div class="grid-demo">
   <div class="row">

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -3,7 +3,7 @@
 
 {% block standalone_css %}patterns_grid{% endblock %}
 
-{% block content %}
+{% block style %}
 <style>
 [class*='col-']::before {
   content: attr(class);

--- a/templates/docs/examples/patterns/side-navigation/dark.html
+++ b/templates/docs/examples/patterns/side-navigation/dark.html
@@ -3,9 +3,12 @@
 
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
+{% block style %}
+<style>body { background: #111 }</style>
+{% endblock %}
+
 {% block content %}
 {% set is_dark = True %}
-<style>body { background: #111 }</style>
 
 <div class="row">
   <div class="col-4">

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -1,6 +1,12 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}MAAS docs / Grid layout{% endblock %}
 
+{% block style %}
+<style>
+  body { margin: 0; }
+</style>
+{% endblock %}
+
 {% block content %}
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row row">
@@ -333,9 +339,5 @@
   {% include "docs/examples/patterns/side-navigation/_example_script.js" %}
   {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
 </script>
-
-<style>
-  body { margin: 0; }
-</style>
 
 {% endblock %}

--- a/templates/docs/examples/templates/maas-docs.html
+++ b/templates/docs/examples/templates/maas-docs.html
@@ -1,8 +1,9 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}MAAS docs / Custom docs layout{% endblock %}
 
-{% block content %}
+{% block style %}
 <style>
+
   .l-docs-wrapper {
       border-bottom: 1px solid #cdcdcd
   }
@@ -79,6 +80,9 @@
       }
   }
 </style>
+{% endblock %}
+
+{% block content %}
 
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row row">

--- a/templates/docs/examples/templates/maas-docs.html
+++ b/templates/docs/examples/templates/maas-docs.html
@@ -3,7 +3,6 @@
 
 {% block style %}
 <style>
-
   .l-docs-wrapper {
       border-bottom: 1px solid #cdcdcd
   }

--- a/templates/docs/examples/templates/maas-docs.html
+++ b/templates/docs/examples/templates/maas-docs.html
@@ -83,7 +83,6 @@
 {% endblock %}
 
 {% block content %}
-
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row row">
     <div class="p-navigation__banner">

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}Snapcraft publicise page{% endblock %}
 
-{% block content %}
+{% block style %}
 <style>
   @media only screen and (min-width: 1030px) {
       .l-docs-title,.l-docs-title[class^='p-strip'] {
@@ -22,6 +22,9 @@
       padding-bottom: 1rem
   }
 </style>
+{% endblock %}
+
+{% block content %}
 
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -25,7 +25,6 @@
 {% endblock %}
 
 {% block content %}
-
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">

--- a/templates/docs/examples/templates/typographic-spacing.html
+++ b/templates/docs/examples/templates/typographic-spacing.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}Typographic spacing{% endblock %}
 
-{% block content %}
+{% block style %}
 <style>
   .flex-container {
     display: flex;
@@ -11,6 +11,9 @@
     max-width: 100vw;
   }
 </style>
+{% endblock %}
+
+{% block content %}
 <!-- h1+others -->
 <div class="flex-container">
   <div class="flex-col">


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/869


## QA

- Pull code
- Run `./run`
- Verify styles have been moved to the head. There should be no visual changes.