### PR TITLE
Bump version of Vanilla to 2.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.18.0",
+  "version": "2.19.0",
   "files": [
     "/scss",
     "!/scss/docs"


### PR DESCRIPTION
## Done

Bump version of Vanilla to 2.19


## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3288.demos.haus/docs)
- Check if version is correct and component status lists the changes https://vanilla-framework-3288.demos.haus/docs/component-status


