### PR TITLE
Remove width attrib from anchors, remove invalid aria-labels from contextual menu

### DIFF
--- a/templates/docs/examples/patterns/contextual-menu/dark.html
+++ b/templates/docs/examples/patterns/contextual-menu/dark.html
@@ -6,7 +6,7 @@
 {% block content %}
 <span class="p-contextual-menu--left is-dark">
     <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
-    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
+    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>
             <a href="#" class="p-contextual-menu__link">Aquire</a>
@@ -22,7 +22,7 @@
 
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left is-dark">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="true" aria-haspopup="true">take action left</a>
-    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="false" aria-label="submenu">
+    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="false">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>
@@ -36,7 +36,7 @@
     </span>
 </span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center is-dark">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
-    <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true" aria-label="submenu">
+    <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>
@@ -50,7 +50,7 @@
     </span>
 </span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu is-dark">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
-    <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true" aria-label="submenu">
+    <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>

--- a/templates/docs/examples/patterns/contextual-menu/default.html
+++ b/templates/docs/examples/patterns/contextual-menu/default.html
@@ -6,7 +6,7 @@
 {% block content %}
 <span class="p-contextual-menu--left">
     <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
-    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
+    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>
             <a href="#" class="p-contextual-menu__link">Aquire</a>
@@ -22,7 +22,7 @@
 
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="true" aria-haspopup="true">take action left</a>
-    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="false" aria-label="submenu">
+    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="false">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>
@@ -36,7 +36,7 @@
     </span>
 </span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
-    <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true" aria-label="submenu">
+    <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>
@@ -50,7 +50,7 @@
     </span>
 </span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
-    <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true" aria-label="submenu">
+    <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>

--- a/templates/docs/examples/patterns/contextual-menu/with-indicator.html
+++ b/templates/docs/examples/patterns/contextual-menu/with-indicator.html
@@ -6,7 +6,7 @@
 {% block content %}
 <span class="p-contextual-menu--left">
   <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--contextual-menu is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
-  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" aria-label="submenu">
+  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
     <span class="p-contextual-menu__group">
       <a href="#" class="p-contextual-menu__link">Commission</a>
       <a href="#" class="p-contextual-menu__link">Aquire</a>

--- a/templates/docs/examples/patterns/modal/default.html
+++ b/templates/docs/examples/patterns/modal/default.html
@@ -16,11 +16,11 @@
     <div class="p-heading-icon--small">
       <div class="p-heading-icon__header">
         <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg"  alt=""/>
-        <p><a class="p-heading-icon__title" href="#tutorial/get-started-canonical-kubernetes" width="24">Kubernetes tutorial</a></p>
+        <p><a class="p-heading-icon__title" href="#tutorial/get-started-canonical-kubernetes">Kubernetes tutorial</a></p>
       </div>
       <div class="p-heading-icon__header">
         <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5e3456e3-hadoop.svg"  alt=""/>
-        <p><a class="p-heading-icon__title" href="#tutorial/get-started-hadoop-spark" width="24">Hadoop Spark tutorial</a></p>
+        <p><a class="p-heading-icon__title" href="#tutorial/get-started-hadoop-spark">Hadoop Spark tutorial</a></p>
       </div>
     </div>
   </div>

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -57,7 +57,7 @@
             aria-haspopup="true">
             Change pool <i class="p-icon--contextual-menu"></i>
           </a>
-          <span class="p-contextual-menu__dropdown" id="menu" aria-hidden="true" aria-label="submenu">
+          <span class="p-contextual-menu__dropdown" id="menu" aria-hidden="true">
             <span class="p-contextual-menu__group">
               <a href="#" class="p-contextual-menu__link">Link</a>
               <a href="#" class="p-contextual-menu__link">Link</a>

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -87,7 +87,7 @@
     Lorem ipsum dolor sit amet consectetur adipiscing elit
     <span class="p-contextual-menu--left">
       <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="true" aria-haspopup="true">take action left</a>
-      <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="false" aria-label="submenu">
+      <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="false">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>
@@ -103,7 +103,7 @@
     nunc dolor. Arcu molestie non arcu porttitor
     <span class="p-contextual-menu--center">
       <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
-      <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true" aria-label="submenu">
+      <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>
@@ -119,7 +119,7 @@
     volutpat rutrum ipsum nunc lacus ligula ornare et diam
     <span class="p-contextual-menu">
       <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
-      <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true" aria-label="submenu">
+      <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true">
         <span class="p-contextual-menu__group">
           <a href="#" class="p-contextual-menu__link">Commission</a>
           <a href="#" class="p-contextual-menu__link">Aquire</a>

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -174,11 +174,11 @@
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt=""/>
-          <p><a class="p-heading-icon__title" href="#tutorial/get-started-canonical-kubernetes" width="24">Kubernetes tutorial</a></p>
+          <p><a class="p-heading-icon__title" href="#tutorial/get-started-canonical-kubernetes">Kubernetes tutorial</a></p>
         </div>
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5e3456e3-hadoop.svg" alt=""/>
-          <p><a class="p-heading-icon__title" href="#tutorial/get-started-hadoop-spark" width="24">Hadoop Spark tutorial</a></p>
+          <p><a class="p-heading-icon__title" href="#tutorial/get-started-hadoop-spark">Hadoop Spark tutorial</a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Remove width from anchor elements ([validator complaints](https://validator.w3.org/nu/?showoutline=yes&doc=https%3A%2F%2Fvanillaframework.io%2Fdocs%2Fexamples%2Fpatterns%2Fmodal%2Fdefault))

- Remove "submenu" aria-labels ([validator complaints](https://validator.w3.org/nu/?showoutline=yes&doc=https%3A%2F%2Fvanillaframework.io%2Fdocs%2Fexamples%2Ftemplates%2Fz-index))

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/878

## QA

- Pull code
- Run `./run`
- Inspect code, verify the issues highlighte by the vbalidator have been resolved (only limited to aria-label and anchor width, the rest will be on separate prs)
