### PR TITLE
Remove attr checked from select

### DIFF
--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -173,7 +173,7 @@
           </div>
           <div class="col-7">
             <form class="p-form--inline js-language-select">
-              <select name="language" checked="checked">
+              <select name="language">
                   <option value="de">Deutsch</option>
                   <option value="en" selected="">English</option>
                   <option value="es">Español</option>


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/873

## QA

- Pull code
- Inspect changed files, verify checked is no longer present on select. Or use this 
regex to search the codebase, there should be no occurances: <select\s+(?:[^>]*?\s+)?checked=(["'])(.*?)\1 