### PR TITLE
Remove empty action attributes from vanilla examples to avoid validator errors

### DIFF
--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -39,7 +39,7 @@
 
 <section id="search-docs" class="p-strip--light is-shallow">
   <div class="row">
-    <form class="p-search-box u-no-margin--bottom" action="#">
+    <form class="p-search-box u-no-margin--bottom">
       <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" />
       <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
       <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -44,7 +44,7 @@
 
 <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">
   <div class="row">
-    <form class="p-search-box u-no-margin--bottom" action="#">
+    <form class="p-search-box u-no-margin--bottom">
       <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" />
       <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
       <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>

--- a/templates/docs/examples/templates/maas-docs.html
+++ b/templates/docs/examples/templates/maas-docs.html
@@ -121,7 +121,7 @@
 
   <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">
     <div class="row">
-      <form class="p-search-box u-no-margin--bottom" action="#">
+      <form class="p-search-box u-no-margin--bottom">
         <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="">
         <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
         <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>

--- a/templates/docs/examples/templates/tick-element-comparison.html
+++ b/templates/docs/examples/templates/tick-element-comparison.html
@@ -9,7 +9,7 @@
     </div>
     <div class="row">
       <div class="col-3">
-        <form action="">
+        <form>
           <input type="checkbox" id="checkExample2">
           <label for="checkExample2">Checkbox option 2</label>
           <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
@@ -17,7 +17,7 @@
         </form>
       </div>
       <div class="col-3">
-        <form action="">
+        <form>
           <input type="text">
           <button>Button</button>
           <button class="p-button--neutral">Button</button>
@@ -30,14 +30,14 @@
         </form>
       </div>
       <div class="col-3">
-        <form action="">
+        <form>
           <input type="text">
           <input type="checkbox" id="checkExample1" checked>
           <label for="checkExample1">Checkbox option 1</label>
         </form>
       </div>
       <div class="col-3">
-        <form action="">
+        <form>
           <input type="text" placeholder="Enter email">
           <select name="" id=""></select>
         </form>


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/874

## QA

- Pull code
- Search for action="", verify there are no occurances
