### PR TITLE
Remove invalid links from showcase page

### DIFF
--- a/templates/showcase.html
+++ b/templates/showcase.html
@@ -84,18 +84,6 @@
       <p>Personal project folio of Software Engineer Brian Douglass.</p>
     </div>
     <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/bb8f1550-psm-limited-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--4"><a href="http://psmlimited.com">PSM Limited</a></h3>
-      <p>For all your seamless flat roofing, balconies and car park waterproofing.</p>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-4 p-card">
-      <img src="https://assets.ubuntu.com/v1/54dfa1cc-alice-os-vf.io-showcase.png" alt="">
-      <h3 class="p-heading--4"><a href="https://aliceos.app">AliceOS</a></h3>
-      <p>AliceOS brings new features and experiences to any Ren'Py project.</p>
-    </div>
-    <div class="col-4 p-card">
       <img src="https://assets.ubuntu.com/v1/4090d18f-development-winslow-vf.io-showcase.png" alt="">
       <h3 class="p-heading--4"><a href="https://development.robinwinslow.uk">Notes on development</a></h3>
       <p>Articles and musings about web development, performance, internet security and general tech geekery.</p>


### PR DESCRIPTION
## Done

Removes invalid links from showcase page (missing pages or sites that don't use vanilla anymore)

Fixes #2909 

## QA

- Run `./run` or [demo](https://vanilla-framework-3305.demos.haus/showcase)
- Make sure [showcase](https://vanilla-framework-3305.demos.haus/showcase) page doesn't contain invalid links


