### PR TITLE
Add class names for states controlled by aria attributes

### DIFF
--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -34,6 +34,8 @@
   }
 
   .p-accordion__tab {
+    @include vf-icon-plus($color-mid-dark);
+
     // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
     // and offset to align it with baseline of accordion tab text element
     $icon-top-position: calc(#{$table-cell-vertical-padding} - 1px + 0.25rem);
@@ -41,17 +43,13 @@
     background: {
       position: top $icon-top-position left $sph-inner;
       repeat: no-repeat;
+      size: $icon-size;
     }
 
     // aria-selected controls the open and closed state for the accordion tab
+    &.is-expanded,
     &[aria-expanded='true'] {
       @include vf-icon-minus($color-mid-dark);
-
-      background-size: $icon-size;
-    }
-
-    &[aria-expanded='false'] {
-      @include vf-icon-plus($color-mid-dark);
 
       background-size: $icon-size;
     }
@@ -92,12 +90,13 @@
   }
   // stylelint-enable selector-no-qualifying-type
 
-  .p-accordion__tab--with-title[aria-expanded='true'] .p-accordion__title::before {
-    @include vf-icon-minus($color-mid-dark);
+  .p-accordion__tab--with-title .p-accordion__title::before {
+    @include vf-icon-plus($color-mid-dark);
   }
 
-  .p-accordion__tab--with-title[aria-expanded='false'] .p-accordion__title::before {
-    @include vf-icon-plus($color-mid-dark);
+  .p-accordion__tab--with-title.is-expanded .p-accordion__title::before,
+  .p-accordion__tab--with-title[aria-expanded='true'] .p-accordion__title::before {
+    @include vf-icon-minus($color-mid-dark);
   }
 
   .p-accordion__panel {
@@ -106,6 +105,7 @@
     padding-left: $sph-inner + $icon-size + $sph-inner * 2;
 
     // Hides panel content
+    &.is-closed,
     &[aria-hidden='true'] {
       display: none;
     }

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -27,6 +27,7 @@
     z-index: 9; // to appear below main navigation dropdowns (that use z-index: 10)
 
     // When set to false will show the contextual menu
+    &.is-open,
     &[aria-hidden='false'] {
       display: block;
     }
@@ -84,6 +85,7 @@
     }
   }
 
+  .p-contextual-menu__toggle.is-expanded .p-contextual-menu__indicator,
   .p-contextual-menu__toggle[aria-expanded='true'] .p-contextual-menu__indicator {
     transform: rotate(180deg);
   }

--- a/scss/_patterns_list-tree.scss
+++ b/scss/_patterns_list-tree.scss
@@ -28,10 +28,12 @@
       display: none;
       margin-left: 0;
 
+      // TODO: is-expanded
       &[aria-hidden='false'] {
         display: block;
       }
 
+      // TODO: is-expanded
       &[aria-hidden='false']::after {
         @extend %list-tree-icon;
 

--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -41,6 +41,7 @@
         flex-basis: 100%;
         max-width: 100%;
 
+        &.is-closed,
         &[aria-hidden='true'] {
           display: none;
         }

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -45,6 +45,7 @@
         width: 100%;
         word-break: break-word;
 
+        // Style aria-label content as heading on small screens
         &[aria-label] {
           text-align: right;
         }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -86,6 +86,7 @@
         }
       }
 
+      &.is-active,
       &:hover,
       &[aria-selected='true'] {
         @include vf-highlight-bar($color-tabs-active-bar, bottom, false);


### PR DESCRIPTION
## Done

Adds class names for states controlled by `aria-` attributes that can be used instead of `aria` for styling.

Fixes #1507

## QA

- Run `./run` or [demo](https://vanilla-framework-3306.demos.haus)
- Make sure affected patterns work as before:



