### PR TITLE
Add name attribs to form inputs and buttons

### DIFF
--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -26,8 +26,8 @@
       {% if path.startswith('/docs') %}
       <form class="p-search-box" action="/docs/search">
         <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation" required />
-        <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right"><i class="p-icon--close"></i></button>
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+        <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close"></i></button>
+        <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search"></i></button>
       </form>
       {% endif %}
     </nav>

--- a/templates/docs/examples/base/forms/aligned-checkboxes.html
+++ b/templates/docs/examples/base/forms/aligned-checkboxes.html
@@ -6,34 +6,34 @@
 {% block content %}
 <form>
   <div>
-    <input type="checkbox" id="checkExample1">
+    <input type="checkbox" id="checkExample1" name="checkExample1">
     <label for="checkExample1" class="is-h1">h1</label>
   </div>
   <div>
-    <input type="checkbox" id="checkExample2">
+    <input type="checkbox" id="checkExample2" name="checkExample2">
     <label for="checkExample2" class="is-h2">h2</label>
   </div>
   <div>
-    <input type="checkbox" id="checkExample3">
+    <input type="checkbox" id="checkExample3" name="checkExample3">
     <label for="checkExample3" class="is-h3">h3</label>
   </div>
   <div>
-    <input type="checkbox" id="checkExample4">
+    <input type="checkbox" id="checkExample4" name="checkExample4">
     <label for="checkExample4" class="is-h4">h4</label>
   </div>
   <div>
-    <input type="checkbox" id="checkExample5">
+    <input type="checkbox" id="checkExample5" name="checkExample5">
     <label for="checkExample5" class="is-h5">h5, h6, p, default</label>
   </div>
   <div>
-    <input type="checkbox" id="checkExample7">
+    <input type="checkbox" id="checkExample7" name="checkExample7">
     <label for="checkExample7" class="is-muted-heading">Muted heading</label>
   </div>
   <table aria-label="Example of checkboxes inside table cells">
     <thead>
       <tr>
         <th>
-          <input type="checkbox" id="checkExample8">
+          <input type="checkbox" id="checkExample8" name="checkExample8">
           <label for="checkExample8" class="is-table-header">Table header text</label>
         </th>
         <th>Text in adjacent th</th>
@@ -42,7 +42,7 @@
     <tbody>
       <tr>
         <td>
-          <input type="checkbox" id="checkExample9">
+          <input type="checkbox" id="checkExample9" name="checkExample9">
           <label for="checkExample9" class="is-inline-label">Label</label>
         </td>
         <td>Text in adjacent td</td>

--- a/templates/docs/examples/base/forms/aligned-radio.html
+++ b/templates/docs/examples/base/forms/aligned-radio.html
@@ -6,34 +6,34 @@
 {% block content %}
 <form>
   <div>
-    <input type="radio" name="RadioOptions1" id="Radio1" value="option1" checked>
+    <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
     <label for="Radio1" class="is-h1">h1</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions2" id="Radio2" value="option1" checked>
+    <input type="radio" name="RadioOptions" id="Radio2" value="option1">
     <label for="Radio2" class="is-h2">h2</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions3" id="Radio3" value="option1" checked>
+    <input type="radio" name="RadioOptions" id="Radio3" value="option1">
     <label for="Radio3" class="is-h3">h3</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions4" id="Radio4" value="option1" checked>
+    <input type="radio" name="RadioOptions" id="Radio4" value="option1">
     <label for="Radio4" class="is-h4">h4</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions5" id="Radio5" value="option1" checked>
+    <input type="radio" name="RadioOptions" id="Radio5" value="option1">
     <label for="Radio5" class="is-h5">h5, h6, p, default</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions6" id="Radio6" value="option1" checked>
+    <input type="radio" name="RadioOptions" id="Radio6" value="option1">
     <label for="Radio6" class="is-muted-heading">Muted heading</label>
   </div>
   <table aria-label="Example of radio buttons inside a table">
     <thead>
       <tr>
         <th>
-          <input type="radio" name="RadioOptions7" id="Radio7" value="option1" checked>
+          <input type="radio" name="RadioOptions1" id="Radio7" value="option1" checked>
           <label for="Radio7" class="is-table-header">Table header text</label>
         </th>
         <th>Text in adjacent th</th>
@@ -42,7 +42,7 @@
     <tbody>
       <tr>
         <td>
-          <input type="radio" name="RadioOptions8" id="Radio8" value="option1" checked>
+          <input type="radio" name="RadioOptions1" id="Radio8" value="option1" checked>
           <label for="Radio8" class="is-inline-label">Label</label>
         </td>
         <td>Text in adjacent td</td>

--- a/templates/docs/examples/base/forms/aligned-radio.html
+++ b/templates/docs/examples/base/forms/aligned-radio.html
@@ -6,34 +6,34 @@
 {% block content %}
 <form>
   <div>
-    <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+    <input type="radio" name="RadioOptions1" id="Radio1" value="option1" checked>
     <label for="Radio1" class="is-h1">h1</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions" id="Radio2" value="option1" checked>
+    <input type="radio" name="RadioOptions2" id="Radio2" value="option1" checked>
     <label for="Radio2" class="is-h2">h2</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions" id="Radio3" value="option1" checked>
+    <input type="radio" name="RadioOptions3" id="Radio3" value="option1" checked>
     <label for="Radio3" class="is-h3">h3</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions" id="Radio4" value="option1" checked>
+    <input type="radio" name="RadioOptions4" id="Radio4" value="option1" checked>
     <label for="Radio4" class="is-h4">h4</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions" id="Radio5" value="option1" checked>
+    <input type="radio" name="RadioOptions5" id="Radio5" value="option1" checked>
     <label for="Radio5" class="is-h5">h5, h6, p, default</label>
   </div>
   <div>
-    <input type="radio" name="RadioOptions" id="Radio6" value="option1" checked>
+    <input type="radio" name="RadioOptions6" id="Radio6" value="option1" checked>
     <label for="Radio6" class="is-muted-heading">Muted heading</label>
   </div>
   <table aria-label="Example of radio buttons inside a table">
     <thead>
       <tr>
         <th>
-          <input type="radio" name="RadioOptions" id="Radio7" value="option1" checked>
+          <input type="radio" name="RadioOptions7" id="Radio7" value="option1" checked>
           <label for="Radio7" class="is-table-header">Table header text</label>
         </th>
         <th>Text in adjacent th</th>
@@ -42,7 +42,7 @@
     <tbody>
       <tr>
         <td>
-          <input type="radio" name="RadioOptions" id="Radio8" value="option1" checked>
+          <input type="radio" name="RadioOptions8" id="Radio8" value="option1" checked>
           <label for="Radio8" class="is-inline-label">Label</label>
         </td>
         <td>Text in adjacent td</td>

--- a/templates/docs/examples/base/forms/checkboxes.html
+++ b/templates/docs/examples/base/forms/checkboxes.html
@@ -5,11 +5,11 @@
 
 {% block content %}
 <form>
-  <input type="checkbox" id="checkExample1" checked>
+  <input type="checkbox" id="checkExample1" name="checkExample1" checked>
   <label for="checkExample1">HTML</label>
-  <input type="checkbox" id="checkExample2">
+  <input type="checkbox" id="checkExample2" name="checkExample2">
   <label for="checkExample2">CSS</label>
-  <input type="checkbox" id="checkExample3" disabled="disabled">
+  <input type="checkbox" id="checkExample3" name="checkExample3" disabled="disabled">
   <label for="checkExample3">PHP</label>
 </form>
 {% endblock %}

--- a/templates/docs/examples/base/forms/disabled-input.html
+++ b/templates/docs/examples/base/forms/disabled-input.html
@@ -6,6 +6,6 @@
 {% block content %}
 <form>
     <label for="disabled-input">Email address</label>
-    <input type="text" id="disabled-input" placeholder="example@canonical.com" disabled="disabled">
+    <input type="text" id="disabled-input" name="disabled-input" placeholder="example@canonical.com" disabled="disabled">
 </form>
 {% endblock %}

--- a/templates/docs/examples/base/forms/fieldset.html
+++ b/templates/docs/examples/base/forms/fieldset.html
@@ -7,11 +7,11 @@
 <form>
   <fieldset>
     <label for="list-input-1">First name</label>
-    <input placeholder="Joe" id="list-input-1" type="text">
+    <input placeholder="Joe" id="list-input-1" name="list-input-1" type="text">
     <label for="list-input-2">Last name</label>
-    <input placeholder="Bloggs" id="list-input-2" type="text">
+    <input placeholder="Bloggs" id="list-input-2" name="list-input-2" type="text">
     <label for="list-input-3">Email address</label>
-    <input placeholder="example@canonical.com" id="list-input-3" type="text">
+    <input placeholder="example@canonical.com" id="list-input-3" name="list-input-3" type="text">
   </fieldset>
 </form>
 {% endblock %}

--- a/templates/docs/examples/base/forms/form.html
+++ b/templates/docs/examples/base/forms/form.html
@@ -6,12 +6,12 @@
 {% block content %}
 <form>
   <label for="exampleInputEmail1">Email address</label>
-  <input type="text" id="exampleInputEmail1" placeholder="example@canonical.com">
+  <input type="text" id="exampleInputEmail1" name="exampleInputEmail1" placeholder="example@canonical.com">
   <label for="exampleInputPassword1">Password</label>
-  <input type="password" id="exampleInputPassword1" placeholder="******">
+  <input type="password" id="exampleInputPassword1" name="exampleInputPassword1" placeholder="******">
   <label for="exampleInputFile">File input</label>
-  <input type="file" id="exampleInputFile">
-  <input type="checkbox" id="CheckMe">
+  <input type="file" id="exampleInputFile" name="exampleInputFile">
+  <input type="checkbox" id="CheckMe" name="CheckMe">
   <label for="CheckMe">I agree to receive information about Canonical’s products and services.</label>
   <button type="submit">Submit</button>
 </form>

--- a/templates/docs/examples/base/forms/input.html
+++ b/templates/docs/examples/base/forms/input.html
@@ -6,6 +6,6 @@
 {% block content %}
 <form>
   <label for="exampleTextInput">Email address</label>
-  <input type="text" id="exampleTextInput" placeholder="example@canonical.com" />
+  <input type="text" id="exampleTextInput" name="exampleTextInput" placeholder="example@canonical.com" />
 </form>
 {% endblock %}

--- a/templates/docs/examples/base/forms/labels.html
+++ b/templates/docs/examples/base/forms/labels.html
@@ -6,10 +6,10 @@
 {% block content %}
 <form>
   <label for="exampleTextInput">Email address</label>
-  <input type="text" id="exampleTextInput" placeholder="example@canonical.com" />
+  <input type="text" id="exampleTextInput" name="exampleTextInput" placeholder="example@canonical.com" />
   <label for="textarea">Tell us about your project or interest</label>
-  <textarea id="textarea" rows="3">Ubuntu</textarea>
+  <textarea id="textarea" name="textarea" rows="3">Ubuntu</textarea>
   <label for="textarea2">Data privay</label>
-  <textarea id="textarea2" rows="3" readonly="readonly">Read-only</textarea>
+  <textarea id="textarea2" name="textarea2" rows="3" readonly="readonly">Read-only</textarea>
 </form>
 {% endblock %}

--- a/templates/docs/examples/base/forms/radio-buttons.html
+++ b/templates/docs/examples/base/forms/radio-buttons.html
@@ -5,11 +5,11 @@
 
 {% block content %}
 <form>
-  <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+  <input type="radio" name="RadioOptions1" id="Radio1" value="option1" checked>
   <label for="Radio1">Linux</label>
-  <input type="radio" name="RadioOptions" id="Radio2" value="option2">
+  <input type="radio" name="RadioOptions2" id="Radio2" value="option2">
   <label for="Radio2">Mac OS</label>
-  <input type="radio" name="RadioOptions" id="Radio4" value="option4" disabled="disabled">
+  <input type="radio" name="RadioOptions3" id="Radio4" value="option4" disabled="disabled">
   <label for="Radio4">Windows</label>
 </form>
 {% endblock %}

--- a/templates/docs/examples/base/forms/radio-buttons.html
+++ b/templates/docs/examples/base/forms/radio-buttons.html
@@ -5,11 +5,11 @@
 
 {% block content %}
 <form>
-  <input type="radio" name="RadioOptions1" id="Radio1" value="option1" checked>
+  <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
   <label for="Radio1">Linux</label>
-  <input type="radio" name="RadioOptions2" id="Radio2" value="option2">
+  <input type="radio" name="RadioOptions" id="Radio2" value="option2">
   <label for="Radio2">Mac OS</label>
-  <input type="radio" name="RadioOptions3" id="Radio4" value="option4" disabled="disabled">
+  <input type="radio" name="RadioOptions" id="Radio4" value="option4" disabled="disabled">
   <label for="Radio4">Windows</label>
 </form>
 {% endblock %}

--- a/templates/docs/examples/base/forms/select-multiple.html
+++ b/templates/docs/examples/base/forms/select-multiple.html
@@ -6,7 +6,7 @@
 {% block content %}
 <form>
   <label for="exampleSelectMulti">Ubuntu releases</label>
-  <select name="exampleSelectMulti" id="exampleSelectMulti" multiple>
+  <select name="exampleSelectMulti" id="exampleSelectMulti" name="exampleSelectMulti" multiple>
     <option value="" disabled="disabled">Select...</option>
     <option value="1">Cosmic Cuttlefish</option>
     <option value="2">Bionic Beaver</option>

--- a/templates/docs/examples/base/forms/selects.html
+++ b/templates/docs/examples/base/forms/selects.html
@@ -6,7 +6,7 @@
 {% block content %}
 <form>
   <label for="exampleSelect">Ubuntu releases</label>
-  <select name="exampleSelect" id="exampleSelect">
+  <select name="exampleSelect" id="exampleSelect" name="exampleSelect">
     <option value="" disabled="disabled" selected>Select an option</option>
     <option value="1">Cosmic Cuttlefish</option>
     <option value="2">Bionic Beaver</option>

--- a/templates/docs/examples/base/forms/textarea.html
+++ b/templates/docs/examples/base/forms/textarea.html
@@ -6,6 +6,6 @@
 {% block content %}
 <form>
     <label for="textarea">Tell us about your project or interest</label>
-    <textarea id="textarea" rows="3">Ubuntu</textarea>
+    <textarea id="textarea" name="textarea" rows="3">Ubuntu</textarea>
 </form>
 {% endblock %}

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -41,8 +41,9 @@
   <div class="row">
     <form class="p-search-box u-no-margin--bottom">
       <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" />
-      <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
-      <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
+      <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
+      <button type="submit" name="submitSearch" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
+
     </form>
   </div>
 </section>

--- a/templates/docs/examples/patterns/forms/_form-stacked.html
+++ b/templates/docs/examples/patterns/forms/_form-stacked.html
@@ -7,7 +7,7 @@
 
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="full-name-stacked" required>
+        <input type="text" id="full-name-stacked" name="fullName" required>
       </div>
     </div>
   </div>
@@ -19,7 +19,7 @@
 
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="username-stacked">
+        <input type="text" id="username-stacked" name="username-stacked">
         <p class="p-form-help-text">
           30 characters or fewer.
         </p>
@@ -34,7 +34,7 @@
 
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="username-stacked-error" class="p-form-validation__input" aria-invalid="true"
+        <input type="text" id="username-stacked-error" name="username-stackederror" class="p-form-validation__input" aria-invalid="true"
           aria-describedby="username-error-message-stacked">
         <p class="p-form-validation__message" id="username-error-message-stacked" role="alert">
           <strong>Error:</strong> This field is required.
@@ -50,7 +50,7 @@
 
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="address-optional-stacked">
+        <input type="text" id="address-optional-stacked" name="address-optional-stacked">
       </div>
     </div>
   </div>
@@ -62,7 +62,7 @@
 
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="address-optional-stacked">
+        <input type="text" id="address-optional-stacked" name="address-optional-stacked">
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/forms/dense.html
+++ b/templates/docs/examples/patterns/forms/dense.html
@@ -6,11 +6,11 @@
 {% block content %}
 <form>
   <label for="username">Username</label>
-  <input type="text" id="username" class="is-dense" required>
+  <input type="text" id="username" name="username" class="is-dense" required>
   <label for="address2">Email address</label>
-  <input type="text" id="address2" class="is-dense" required>
+  <input type="text" id="address2" name="address2" class="is-dense" required>
   <label for="exampleSelect">Ubuntu releases</label>
-  <select name="exampleSelect" id="exampleSelect" class="is-dense">
+  <select name="exampleSelect" id="exampleSelect" name="exampleSelect" class="is-dense">
     <option value="" disabled="disabled" selected>Select an option</option>
     <option value="1">Cosmic Cuttlefish</option>
     <option value="2">Bionic Beaver</option>

--- a/templates/docs/examples/patterns/forms/form-help-text.html
+++ b/templates/docs/examples/patterns/forms/form-help-text.html
@@ -6,7 +6,7 @@
 {% block content %}
 <form>
   <label for="exampleTextInputHelp">Email address</label>
-  <input class="p-form-validation__input" type="text" id="exampleTextInputHelp" placeholder="example@canonical.com" />
+  <input class="p-form-validation__input" type="text" id="exampleTextInputHelp" name="exampleTextInputHelp" placeholder="example@canonical.com" />
   <p class="p-form-help-text">
     A notification email will be sent to entered email address.
   </p>

--- a/templates/docs/examples/patterns/forms/form-inline.html
+++ b/templates/docs/examples/patterns/forms/form-inline.html
@@ -8,7 +8,7 @@
   <div class="p-form__group">
     <label for="username-inline" class="p-form__label">Username</label>
     <div class="p-form__control u-clearfix">
-      <input type="text" id="username-inline" class="p-form__control" required>
+      <input type="text" id="username-inline" name="username-inline" class="p-form__control" required>
       <p class="p-form-help-text">
         30 characters or fewer.
       </p>
@@ -17,7 +17,7 @@
   <div class="p-form__group p-form-validation is-error">
     <label for="address-inline2" class="p-form__label">Email address</label>
     <div class="p-form__control u-clearfix">
-      <input type="text" id="address-inline2" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline">
+      <input type="text" id="address-inline2" name="address-inline2" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline">
       <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
         <strong>Error:</strong> Please enter a valid email address.
       </p>

--- a/templates/docs/examples/patterns/forms/form-validation.html
+++ b/templates/docs/examples/patterns/forms/form-validation.html
@@ -7,7 +7,7 @@
 <form>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError">Email address</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputError" placeholder="example@canonical.com" />
+    <input class="p-form-validation__input" type="text" id="exampleTextInputError" name="exampleTextInputError" placeholder="example@canonical.com" />
     <p class="p-form-validation__message">
       <strong>Error:</strong> This field is required.
     </p>
@@ -15,7 +15,7 @@
 
   <div class="p-form-validation is-caution">
     <label for="exampleTextInputCaution">Mail configuration ID</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputCaution" placeholder="14" />
+    <input class="p-form-validation__input" type="text" id="exampleTextInputCaution" name="exampleTextInputCaution" placeholder="14" />
     <p class="p-form-validation__message">
       <strong>Caution:</strong> No validation is performed in preview mode.
     </p>
@@ -23,7 +23,7 @@
 
   <div class="p-form-validation is-success">
     <label for="exampleTextInputSuccess">Card number</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="**** **** **** ****" />
+    <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" name="exampleTextInputSuccess" placeholder="**** **** **** ****" />
     <p class="p-form-validation__message">
       <strong>Success:</strong> Verified.
     </p>
@@ -32,7 +32,7 @@
   <div class="p-form-validation is-error">
     <label for="exampleSelectInputError">Ubuntu releases</label>
     <div class="p-form-validation__select-wrapper">
-      <select class="p-form-validation__input" id="exampleSelectInputError">
+      <select class="p-form-validation__input" id="exampleSelectInputError" name="exampleSelectInputError">
         <option value="">--Select an option--</option>
         <option value="1">Cosmic Cuttlefish</option>
         <option value="2">Bionic Beaver</option>

--- a/templates/docs/examples/patterns/forms/forms-required.html
+++ b/templates/docs/examples/patterns/forms/forms-required.html
@@ -7,7 +7,7 @@
 <form>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError" class="is-required">Email address</label>
-    <input class="p-form-validation__input" required type="text" id="exampleTextInputError" placeholder="e.g joe@bloggs.com">
+    <input class="p-form-validation__input" required type="text" id="exampleTextInputError" name="exampleTextInputError" placeholder="e.g joe@bloggs.com">
     <p class="p-form-validation__message">
       <strong>Error:</strong> This field is required.
     </p>

--- a/templates/docs/examples/patterns/forms/tick-comparison.html
+++ b/templates/docs/examples/patterns/forms/tick-comparison.html
@@ -10,32 +10,32 @@
   <div class="col-6">
     <h3>Base checkbox</h3>
 
-    <input type="checkbox" id="checkExampleBase">
+    <input type="checkbox" id="checkExampleBase" name="checkExampleBase">
     <label for="checkExampleBase">checkbox</label>
 
-    <input type="checkbox" id="checkExampleBaseChecked" checked>
+    <input type="checkbox" id="checkExampleBaseChecked" name="checkExampleBaseChecked" checked>
     <label for="checkExampleBaseChecked">checked</label>
 
-    <input type="checkbox" id="checkExampleBaseDisabled" disabled>
+    <input type="checkbox" id="checkExampleBaseDisabled" name="checkExampleBaseDisabled" disabled>
     <label for="checkExampleBaseDisabled">disabled</label>
 
-    <input type="checkbox" id="checkExampleBaseRequired" required>
+    <input type="checkbox" id="checkExampleBaseRequired" name="checkExampleBaseRequired" required>
     <label class="is-required" for="checkExampleBaseRequired">required</label>
 
-    <input type="checkbox" id="checkExampleBaseH1">
+    <input type="checkbox" id="checkExampleBaseH1" name="checkExampleBaseH1">
     <label class="is-h1" for="checkExampleBaseH1">.is-h1</label>
 
-    <input type="checkbox" id="checkExampleBaseH2">
+    <input type="checkbox" id="checkExampleBaseH2" name="checkExampleBaseH2">
     <label class="is-h2" for="checkExampleBaseH2">.is-h2</label>
 
-    <input type="checkbox" id="checkExampleBaseH3">
+    <input type="checkbox" id="checkExampleBaseH3" name="checkExampleBaseH3">
     <label class="is-h3" for="checkExampleBaseH3">.is-h3</label>
 
-    <input type="checkbox" id="checkExampleBaseH4">
+    <input type="checkbox" id="checkExampleBaseH4" name="checkExampleBaseH4">
     <label class="is-h4" for="checkExampleBaseH4">.is-h4</label>
 
     <p>
-      <input type="checkbox" id="checkExampleBaseInline">
+      <input type="checkbox" id="checkExampleBaseInline" name="checkExampleBaseInline">
       <label class="is-inline-label" for="checkExampleBaseInline">.is-inline-label</label>
       alongside some text
     </p>
@@ -44,7 +44,7 @@
       <thead>
         <tr>
           <th>
-            <input type="checkbox" id="checkExampleBaseTable">
+            <input type="checkbox" id="checkExampleBaseTable" name="checkExampleBaseTable">
             <label class="is-table-header" for="checkExampleBaseTable">.is-table-header</label>
           </th>
           <th>
@@ -55,7 +55,7 @@
       <tbody>
         <tr>
           <td>
-            <input type="checkbox" id="checkExampleBaseTableCell">
+            <input type="checkbox" id="checkExampleBaseTableCell" name="checkExampleBaseTableCell">
             <label class="is-inline-label" for="checkExampleBaseTableCell">.is-inline-label</label>
           </td>
           <td>
@@ -66,12 +66,12 @@
     </table>
 
     <p class="p-muted-heading">
-      <input type="checkbox" id="checkExampleBaseMuted">
+      <input type="checkbox" id="checkExampleBaseMuted" name="checkExampleBaseMuted">
       <label class="is-muted-heading" for="checkExampleBaseMuted">.is-muted-heading</label>
     </p>
 
     <p>
-      <input type="checkbox" id="checkExampleBaseInlineMuted">
+      <input type="checkbox" id="checkExampleBaseInlineMuted" name="checkExampleBaseInlineMuted">
       <label class="is-muted-inline-heading" for="checkExampleBaseInlineMuted">.is-muted-inline-heading</label>
       alongside some text
     </p>
@@ -92,7 +92,7 @@
     <p class="p-muted-heading">
       <label class="p-checkbox--inline">
         <input type="checkbox" class="p-checkbox__input" aria-labelledby="checkboxLabel1"/>
-        <span class="p-checkbox__label" id="checkboxLabel1">.p-checkbox--inline in .p-muted-heading</span>
+        <span class="p-checkbox__label" id="checkboxLabel1" name="checkboxLabel1">.p-checkbox--inline in .p-muted-heading</span>
       </label>
     </p>
 
@@ -100,7 +100,7 @@
       <span class="p-muted-heading">
         <label class="p-checkbox--inline">
           <input type="checkbox" class="p-checkbox__input" aria-labelledby="checkboxLabel2"/>
-          <span class="p-checkbox__label" id="checkboxLabel2">.p-checkbox--inline in .p-muted-heading</span>
+          <span class="p-checkbox__label" id="checkboxLabel2" name="checkboxLabel2">.p-checkbox--inline in .p-muted-heading</span>
         </label>
       </span>
       alongside text
@@ -117,32 +117,32 @@
   <div class="col-6">
     <h3>Base radio</h3>
 
-    <input type="radio" id="radioExampleBase" name="radioBase">
+    <input type="radio" id="radioExampleBase" name="radioExampleBase" name="radioBase">
     <label for="radioExampleBase">radio</label>
 
-    <input type="radio" id="radioExampleBaseChecked" name="radioBase" checked>
+    <input type="radio" id="radioExampleBaseChecked" name="radioExampleBaseChecked" name="radioBase" checked>
     <label for="radioExampleBaseChecked">checked</label>
 
-    <input type="radio" id="radioExampleBaseDisabled" name="radioBase" disabled>
+    <input type="radio" id="radioExampleBaseDisabled" name="radioExampleBaseDisabled" name="radioBase" disabled>
     <label for="radioExampleBaseDisabled">disabled</label>
 
-    <input type="radio" id="radioExampleBaseRequired" name="radioBase" required>
+    <input type="radio" id="radioExampleBaseRequired" name="radioExampleBaseRequired" name="radioBase" required>
     <label class="is-required" for="radioExampleBaseRequired">required</label>
 
-    <input type="radio" id="radioExampleBaseH1" name="radioBase">
+    <input type="radio" id="radioExampleBaseH1" name="radioExampleBaseH1" name="radioBase">
     <label class="is-h1" for="radioExampleBaseH1">.is-h1</label>
 
-    <input type="radio" id="radioExampleBaseH2" name="radioBase">
+    <input type="radio" id="radioExampleBaseH2" name="radioExampleBaseH2" name="radioBase">
     <label class="is-h2" for="radioExampleBaseH2">.is-h2</label>
 
-    <input type="radio" id="radioExampleBaseH3" name="radioBase">
+    <input type="radio" id="radioExampleBaseH3" name="radioExampleBaseH3" name="radioBase">
     <label class="is-h3" for="radioExampleBaseH3">.is-h3</label>
 
-    <input type="radio" id="radioExampleBaseH4" name="radioBase">
+    <input type="radio" id="radioExampleBaseH4" name="radioExampleBaseH4" name="radioBase">
     <label class="is-h4" for="radioExampleBaseH4">.is-h4</label>
 
     <p>
-      <input type="radio" id="radioExampleBaseInline" name="radioBase">
+      <input type="radio" id="radioExampleBaseInline" name="radioExampleBaseInline" name="radioBase">
       <label class="is-inline-label" for="radioExampleBaseInline">.is-inline-label</label>
       alongside some text
     </p>
@@ -151,7 +151,7 @@
       <thead>
         <tr>
           <th>
-            <input type="radio" id="radioExampleBaseTable" name="radioBase">
+            <input type="radio" id="radioExampleBaseTable" name="radioExampleBaseTable" name="radioBase">
             <label class="is-table-header" for="radioExampleBaseTable">.is-table-header</label>
           </th>
           <th>
@@ -162,7 +162,7 @@
       <tbody>
         <tr>
           <td>
-            <input type="radio" id="radioExampleBaseTableCell" name="radioBase">
+            <input type="radio" id="radioExampleBaseTableCell" name="radioExampleBaseTableCell" name="radioBase">
             <label class="is-inline-label" for="radioExampleBaseTableCell">.is-inline-label</label>
           </td>
           <td>
@@ -173,12 +173,12 @@
     </table>
 
     <p class="p-muted-heading">
-      <input type="radio" id="radioExampleBaseMuted" name="radioBase">
+      <input type="radio" id="radioExampleBaseMuted" name="radioExampleBaseMuted" name="radioBase">
       <label class="is-muted-heading" for="radioExampleBaseMuted">.is-muted-heading</label>
     </p>
 
     <p>
-      <input type="radio" id="radioExampleBaseInlineMuted" name="radioBase">
+      <input type="radio" id="radioExampleBaseInlineMuted" name="radioExampleBaseInlineMuted" name="radioBase">
       <label class="is-muted-inline-heading" for="radioExampleBaseInlineMuted">.is-muted-inline-heading</label>
       alongside some text
     </p>
@@ -199,7 +199,7 @@
     <p class="p-muted-heading">
       <label class="p-radio--inline">
         <input type="radio" class="p-radio__input" name="radioPattern" aria-labelledby="radioLabel1"/>
-        <span class="p-radio__label" id="radioLabel1">.p-radio--inline in .p-muted-heading</span>
+        <span class="p-radio__label" id="radioLabel1" name="radioLabel1">.p-radio--inline in .p-muted-heading</span>
       </label>
     </p>
 
@@ -207,7 +207,7 @@
       <span class="p-muted-heading">
         <label class="p-radio--inline">
           <input type="radio" class="p-radio__input" name="radioPattern" aria-labelledby="radioLabel2"/>
-          <span class="p-radio__label" id="radioLabel2">.p-radio--inline in .p-muted-heading</span>
+          <span class="p-radio__label" id="radioLabel2" name="radioLabel2">.p-radio--inline in .p-muted-heading</span>
         </label>
       </span>
       alongside text

--- a/templates/docs/examples/patterns/forms/tick-comparison.html
+++ b/templates/docs/examples/patterns/forms/tick-comparison.html
@@ -120,29 +120,29 @@
     <input type="radio" id="radioExampleBase" name="radioExampleBase" name="radioBase">
     <label for="radioExampleBase">radio</label>
 
-    <input type="radio" id="radioExampleBaseChecked" name="radioExampleBaseChecked" name="radioBase" checked>
+    <input type="radio" id="radioExampleBaseChecked" name="radioBase" checked>
     <label for="radioExampleBaseChecked">checked</label>
 
-    <input type="radio" id="radioExampleBaseDisabled" name="radioExampleBaseDisabled" name="radioBase" disabled>
+    <input type="radio" id="radioExampleBaseDisabled" name="radioBase" disabled>
     <label for="radioExampleBaseDisabled">disabled</label>
 
-    <input type="radio" id="radioExampleBaseRequired" name="radioExampleBaseRequired" name="radioBase" required>
+    <input type="radio" id="radioExampleBaseRequired" name="radioBase" required>
     <label class="is-required" for="radioExampleBaseRequired">required</label>
 
-    <input type="radio" id="radioExampleBaseH1" name="radioExampleBaseH1" name="radioBase">
+    <input type="radio" id="radioExampleBaseH1" name="radioBase">
     <label class="is-h1" for="radioExampleBaseH1">.is-h1</label>
 
-    <input type="radio" id="radioExampleBaseH2" name="radioExampleBaseH2" name="radioBase">
+    <input type="radio" id="radioExampleBaseH2" name="radioBase">
     <label class="is-h2" for="radioExampleBaseH2">.is-h2</label>
 
-    <input type="radio" id="radioExampleBaseH3" name="radioExampleBaseH3" name="radioBase">
+    <input type="radio" id="radioExampleBaseH3" name="radioBase">
     <label class="is-h3" for="radioExampleBaseH3">.is-h3</label>
 
-    <input type="radio" id="radioExampleBaseH4" name="radioExampleBaseH4" name="radioBase">
+    <input type="radio" id="radioExampleBaseH4" name="radioBase">
     <label class="is-h4" for="radioExampleBaseH4">.is-h4</label>
 
     <p>
-      <input type="radio" id="radioExampleBaseInline" name="radioExampleBaseInline" name="radioBase">
+      <input type="radio" id="radioExampleBaseInline" name="radioBase">
       <label class="is-inline-label" for="radioExampleBaseInline">.is-inline-label</label>
       alongside some text
     </p>
@@ -151,7 +151,7 @@
       <thead>
         <tr>
           <th>
-            <input type="radio" id="radioExampleBaseTable" name="radioExampleBaseTable" name="radioBase">
+            <input type="radio" id="radioExampleBaseTable" name="radioBase">
             <label class="is-table-header" for="radioExampleBaseTable">.is-table-header</label>
           </th>
           <th>
@@ -162,7 +162,7 @@
       <tbody>
         <tr>
           <td>
-            <input type="radio" id="radioExampleBaseTableCell" name="radioExampleBaseTableCell" name="radioBase">
+            <input type="radio" id="radioExampleBaseTableCell" name="radioBase">
             <label class="is-inline-label" for="radioExampleBaseTableCell">.is-inline-label</label>
           </td>
           <td>
@@ -173,12 +173,12 @@
     </table>
 
     <p class="p-muted-heading">
-      <input type="radio" id="radioExampleBaseMuted" name="radioExampleBaseMuted" name="radioBase">
+      <input type="radio" id="radioExampleBaseMuted" name="radioBase">
       <label class="is-muted-heading" for="radioExampleBaseMuted">.is-muted-heading</label>
     </p>
 
     <p>
-      <input type="radio" id="radioExampleBaseInlineMuted" name="radioExampleBaseInlineMuted" name="radioBase">
+      <input type="radio" id="radioExampleBaseInlineMuted" name="radioBase">
       <label class="is-muted-inline-heading" for="radioExampleBaseInlineMuted">.is-muted-inline-heading</label>
       alongside some text
     </p>

--- a/templates/docs/examples/patterns/search-box/default-dark.html
+++ b/templates/docs/examples/patterns/search-box/default-dark.html
@@ -5,12 +5,12 @@
 
 {% block content %}
 <form class="p-search-box is-dark">
-  <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
+  <input aria-label="search" type="search" class="p-search-box__input" name="search" placeholder="Search" required>
   <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
   <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
 </form>
 <form class="p-search-box is-dark">
-  <input type="search" class="p-search-box__input" name="search" placeholder="Search" required disabled>
+  <input aria-label="search" type="search" class="p-search-box__input" name="search" placeholder="Search" required disabled>
   <button type="reset" class="p-search-box__reset" disabled><i class="p-icon--close"></i></button>
   <button type="submit" class="p-search-box__button" disabled><i class="p-icon--search"></i></button>
 </form>

--- a/templates/docs/examples/patterns/search-box/default.html
+++ b/templates/docs/examples/patterns/search-box/default.html
@@ -5,12 +5,12 @@
 
 {% block content %}
 <form class="p-search-box">
-  <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
+  <input aria-label="search" type="search" class="p-search-box__input" name="search" placeholder="Search" required>
   <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
   <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
 </form>
 <form class="p-search-box">
-  <input type="search" class="p-search-box__input" name="search" placeholder="Search" required disabled>
+  <input aria-label="search" type="search" class="p-search-box__input" name="search" placeholder="Search" required disabled>
   <button type="reset" class="p-search-box__reset" disabled><i class="p-icon--close"></i></button>
   <button type="submit" class="p-search-box__button" disabled><i class="p-icon--search"></i></button>
 </form>

--- a/templates/docs/examples/patterns/search-box/navigation-dark.html
+++ b/templates/docs/examples/patterns/search-box/navigation-dark.html
@@ -27,7 +27,7 @@
         <li class="p-navigation__item"><a class="p-navigation__link" href="#">Partners</a></li>
       </ul>
       <form class="p-search-box is-dark">
-        <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
+        <input aria-label="search" type="search" class="p-search-box__input" name="search" placeholder="Search" required>
         <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
         <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
       </form>

--- a/templates/docs/examples/patterns/search-box/navigation.html
+++ b/templates/docs/examples/patterns/search-box/navigation.html
@@ -27,7 +27,7 @@
         <li class="p-navigation__item"><a class="p-navigation__link" href="#">Partners</a></li>
       </ul>
       <form class="p-search-box">
-        <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
+        <input aria-label="search" type="search" class="p-search-box__input" name="search" placeholder="Search" required>
         <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
         <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
       </form>

--- a/templates/docs/examples/templates/firefox-grid-table-bug.html
+++ b/templates/docs/examples/templates/firefox-grid-table-bug.html
@@ -15,7 +15,7 @@
         <tr>
           <th>
             <form>
-              <input type="checkbox" id="checkExample5" checked="">
+              <input type="checkbox" id="checkExample5" name="checkExample5" checked="">
               <label for="checkExample5" class="is-inline-label">label</label>
             </form>
           </th>
@@ -32,7 +32,7 @@
         <tr>
           <th aria-label="FQDN | MAC">
             <form>
-              <input type="checkbox" id="checkExample6" checked="">
+              <input type="checkbox" id="checkExample6" name="checkExample6" checked="">
               <label for="checkExample6" class="is-inline-label">label</label>
             </form>
           </th>
@@ -47,7 +47,7 @@
         <tr>
           <th aria-label="FQDN | MAC">
             <form>
-              <input type="radio" name="RadioOptions" id="Radio5" value="option1" checked>
+              <input type="radio" id="Radio5" name="Radio5" value="option1" checked>
               <label for="Radio5" class="is-inline-label">label</label>
             </form>
           </th>

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -45,9 +45,10 @@
 <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">
   <div class="row">
     <form class="p-search-box u-no-margin--bottom">
-      <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" />
-      <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
-      <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
+      <input aria-label="search" type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" />
+      <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
+      <button type="submit" name="submitSearch" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
+
     </form>
   </div>
 </section>

--- a/templates/docs/examples/templates/maas-docs.html
+++ b/templates/docs/examples/templates/maas-docs.html
@@ -122,9 +122,10 @@
   <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">
     <div class="row">
       <form class="p-search-box u-no-margin--bottom">
-        <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="">
-        <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
+        <input aria-label="search" type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="">
+        <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
+        <button type="submit" name="submitSearch" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
+
       </form>
     </div>
   </section>

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -121,7 +121,7 @@
     </div>
     <div class="col-9">
       <form class="p-search-box">
-        <input type="search" class="p-search-box__input" name="search" placeholder="Search" required>
+        <input aria-label="search" type="search" class="p-search-box__input" name="search" placeholder="Search" required>
         <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
         <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
       </form>

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -169,11 +169,11 @@
         </div>
         <div class="row">
           <div class="col-2">
-            <label>Language:</label>
+            <label for="select-language">Language:</label>
           </div>
           <div class="col-7">
             <form class="p-form--inline js-language-select">
-              <select name="language">
+              <select id="select-language" name="language">
                   <option value="de">Deutsch</option>
                   <option value="en" selected="">English</option>
                   <option value="es">Español</option>

--- a/templates/docs/examples/templates/tick-element-comparison.html
+++ b/templates/docs/examples/templates/tick-element-comparison.html
@@ -10,10 +10,10 @@
     <div class="row">
       <div class="col-3">
         <form>
-          <input type="checkbox" id="checkExample2">
-          <label for="checkExample2">Checkbox option 2</label>
-          <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
-          <label for="Radio1">Radio option 1</label>
+          <input type="checkbox" id="checkExample0" name="checkExample0">
+          <label for="checkExample0">Checkbox option 2</label>
+          <input type="radio" name="RadioOptions0" id="Radio0" value="option1" checked>
+          <label for="Radio0">Radio option 0</label>
         </form>
       </div>
       <div class="col-3">
@@ -32,7 +32,7 @@
       <div class="col-3">
         <form>
           <input type="text">
-          <input type="checkbox" id="checkExample1" checked>
+          <input type="checkbox" id="checkExample1" name="checkExample1" checked>
           <label for="checkExample1">Checkbox option 1</label>
         </form>
       </div>
@@ -43,21 +43,21 @@
         </form>
       </div>
       <div class="col-3">
-        <input type="checkbox" id="checkExample2a">
-        <label for="checkExample2a">Checkbox option 2</label>
-        <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
+        <input type="checkbox" id="checkExample2" name="checkExample2">
+        <label for="checkExample2">Checkbox option 2</label>
+        <input type="radio" name="RadioOptions1" id="Radio1" value="option1" checked>
         <label for="Radio1">Radio option 1</label>
-        <input type="radio" name="RadioOptions" id="Radio2" value="option2">
+        <input type="radio" name="RadioOptions2" id="Radio2" value="option2">
         <label for="Radio2">Radio option 2</label>
       </div>
       <div class="col-3">
-        <input type="radio" name="RadioOptions" id="Radio3" value="option3" >
+        <input type="radio" name="RadioOptions3" id="Radio3" value="option3">
         <label for="Radio3">Radio option 3</label>
-        <input type="radio" name="RadioOptions" id="Radio4" value="option4">
+        <input type="radio" name="RadioOptions4" id="Radio4" value="option4">
         <label for="Radio4">Radio option 4</label>
-        <input type="checkbox" id="checkExample3" checked>
+        <input type="checkbox" id="checkExample3" name="checkExample3" checked>
         <label for="checkExample3">Checkbox option 3</label>
-        <input type="checkbox" id="checkExample4">
+        <input type="checkbox" id="checkExample4" name="checkExample4">
         <label for="checkExample4">Checkbox option 4</label>
       </div>
     </div>
@@ -77,7 +77,7 @@
         <tr>
           <th>
             <form>
-              <input type="checkbox" id="checkExample5" checked="">
+              <input type="checkbox" id="checkExample5" name="checkExample5" checked="">
               <label for="checkExample5" class="is-inline-label">label</label>
             </form>
           </th>
@@ -94,7 +94,7 @@
         <tr>
           <th aria-label="FQDN | MAC">
             <form>
-              <input type="checkbox" id="checkExample6" checked="">
+              <input type="checkbox" id="checkExample6" name="checkExample6" checked="">
               <label for="checkExample6" class="is-inline-label">label</label>
             </form>
           </th>
@@ -109,7 +109,7 @@
         <tr>
           <th aria-label="FQDN | MAC">
             <form>
-              <input type="radio" name="RadioOptions" id="Radio5" value="option1" checked>
+              <input type="radio" name="RadioOptions5" id="Radio5" value="option5" checked>
               <label for="Radio5" class="is-inline-label">label</label>
             </form>
           </th>

--- a/templates/docs/examples/templates/tick-element-comparison.html
+++ b/templates/docs/examples/templates/tick-element-comparison.html
@@ -11,8 +11,8 @@
       <div class="col-3">
         <form>
           <input type="checkbox" id="checkExample0" name="checkExample0">
-          <label for="checkExample0">Checkbox option 2</label>
-          <input type="radio" name="RadioOptions0" id="Radio0" value="option1" checked>
+          <label for="checkExample0">Checkbox option 0</label>
+          <input type="radio" name="RadioOptions" id="Radio0" value="option1" checked>
           <label for="Radio0">Radio option 0</label>
         </form>
       </div>
@@ -45,15 +45,15 @@
       <div class="col-3">
         <input type="checkbox" id="checkExample2" name="checkExample2">
         <label for="checkExample2">Checkbox option 2</label>
-        <input type="radio" name="RadioOptions1" id="Radio1" value="option1" checked>
+        <input type="radio" name="RadioOptions" id="Radio1" value="option1" checked>
         <label for="Radio1">Radio option 1</label>
-        <input type="radio" name="RadioOptions2" id="Radio2" value="option2">
+        <input type="radio" name="RadioOptions" id="Radio2" value="option2">
         <label for="Radio2">Radio option 2</label>
       </div>
       <div class="col-3">
-        <input type="radio" name="RadioOptions3" id="Radio3" value="option3">
+        <input type="radio" name="RadioOptions" id="Radio3" value="option3">
         <label for="Radio3">Radio option 3</label>
-        <input type="radio" name="RadioOptions4" id="Radio4" value="option4">
+        <input type="radio" name="RadioOptions" id="Radio4" value="option4">
         <label for="Radio4">Radio option 4</label>
         <input type="checkbox" id="checkExample3" name="checkExample3" checked>
         <label for="checkExample3">Checkbox option 3</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -210,7 +210,7 @@
           <input class="u-off-screen" aria-hidden="true" type="text" name="b_56dac47c206ba0f58ec25f314_36f7d8394e" tabindex="-1" value="" />
           <p class="p-form-help-text">Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.</p>
         </div>
-        <button type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button--positive">Subscribe</button>
+        <button name="subscribe" type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button--positive">Subscribe</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/867

the name attrib is for server side use - to denote what the value of the input is for as in a key-value pair. So I've limited the additions to only inputs / buttons / selects that look like they are intended for submission, or examples for use as submittable forms. Buttons used for frontend purpouses like toggling states in the ui do not need names as far as I understand. The name attrib itself is not mandatory.

## QA

- Pull code
- Run `./run`
- Test specifically existing search forms, verify they still work- Go through the list of changes, verify they are sensible and free of typos or ommissions
