### PR TITLE
Fix tree component roles as per spec

### DIFF
--- a/templates/docs/examples/patterns/list-tree.html
+++ b/templates/docs/examples/patterns/list-tree.html
@@ -4,28 +4,28 @@
 {% block standalone_css %}patterns_list-tree{% endblock %}
 
 {% block content %}
-<ul class="p-list-tree" aria-multiselectable="true" role="tablist">
+<ul class="p-list-tree" aria-multiselectable="true" role="tree">
   <li class="p-list-tree__item p-list-tree__item--group">
-    <button class="p-list-tree__toggle" id="sub-1-btn" role="tab" aria-controls="sub-1" aria-expanded="false">/folder</button>
-    <ul class="p-list-tree" id="sub-1" role="tabpanel" aria-hidden="true" aria-labelledby="sub-1-btn">
-      <li class="p-list-tree__item">file</li>
+    <button class="p-list-tree__toggle" id="sub-1-btn" aria-controls="sub-1" aria-expanded="false">/folder</button>
+    <ul class="p-list-tree" role="group" id="sub-1" role="treeitem" aria-hidden="true" aria-labelledby="sub-1-btn">
+      <li class="p-list-tree__item" role="treeitem">file</li>
     </ul>
   </li>
-  <li class="p-list-tree__item">
+  <li class="p-list-tree__item" role="treeitem">
     <a href="#">charm-helpers-sync.yaml</a>
   </li>
-  <li class="p-list-tree__item">
+  <li class="p-list-tree__item" role="treeitem">
     <a href="#">config.yaml</a>
   </li>
   <li class="p-list-tree__item p-list-tree__item--group">
-    <button class="p-list-tree__toggle" id="sub-2-btn" role="tab" aria-controls="sub-2" aria-expanded="false">/files</button>
-    <ul class="p-list-tree" id="sub-2" role="tabpanel" aria-hidden="true" aria-labelledby="sub-2-btn">
-      <li class="p-list-tree__item">default_rsync</li>
-      <li class="p-list-tree__item">nagios_plugin.py</li>
+    <button class="p-list-tree__toggle" id="sub-2-btn" aria-controls="sub-2" aria-expanded="false">/files</button>
+    <ul class="p-list-tree" role="group" id="sub-2" role="treeitem" aria-hidden="true" aria-labelledby="sub-2-btn">
+      <li class="p-list-tree__item" role="treeitem">default_rsync</li>
+      <li class="p-list-tree__item" role="treeitem">nagios_plugin.py</li>
       <li class="p-list-tree__item p-list-tree__item--group">
-        <button class="p-list-tree__toggle" id="sub-3-btn" role="tab" aria-controls="sub-3" aria-expanded="false">/plugins</button>
-        <ul class="p-list-tree" id="sub-3" role="tabpanel" aria-hidden="true" aria-labelledby="sub-3-btn">
-          <li class="p-list-tree__item">check_mem.pl</li>
+        <button class="p-list-tree__toggle" id="sub-3-btn"  aria-controls="sub-3" aria-expanded="false">/plugins</button>
+        <ul class="p-list-tree" role="group" id="sub-3" role="treeitem" aria-hidden="true" aria-labelledby="sub-3-btn">
+          <li class="p-list-tree__item" role="treeitem">check_mem.pl</li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3228

## QA

- Pull code
- Run `./run`
- Ensure tree example isn't broken
- Verify roles down the hierarchy are exactly as described in the [spec](https://www.w3.org/TR/wai-aria-practices/#tree_roles_states_props). There's an [example](https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-1/treeview-1a.html) to compare to.