### PR TITLE
Apply standard vanilla focus state to treeview items

### DIFF
--- a/scss/_patterns_list-tree.scss
+++ b/scss/_patterns_list-tree.scss
@@ -43,6 +43,8 @@
   }
 
   .p-list-tree__item {
+    @include vf-focus;
+
     margin-top: $sp-xx-small;
     padding-left: 0.8rem;
     position: relative;
@@ -67,11 +69,13 @@
   }
 
   .p-list-tree__toggle {
+    @include vf-focus;
+
     background: transparent;
     border: 0;
     font-weight: normal;
-    margin: 0 0 0 -1.75rem;
-    padding: 0 0 0 1.75rem;
+    margin: 0 0.5rem 0 -1.75rem;
+    padding: 0 0.5rem 0 1.75rem;
     transition-duration: 0s;
     width: auto;
 
@@ -79,11 +83,6 @@
       background: transparent;
       color: $color-link;
       text-decoration: underline;
-    }
-
-    &:focus {
-      background: transparent;
-      outline: 1px dotted $color-mid-light;
     }
   }
 }


### PR DESCRIPTION
## Done

Before:
![image](https://user-images.githubusercontent.com/2741678/94703805-27c15b80-0337-11eb-941e-f9a869523f12.png)

After:
![image](https://user-images.githubusercontent.com/2741678/94703898-3e67b280-0337-11eb-850a-7bda4d2b50ba.png)



## QA

- Inspect tree list example docs/examples/patterns/list-tree
- activate focus on an element with classname __toggle
- verify it looks as above