### PR TITLE
Fix show utility to correctly set initial value

### DIFF
--- a/scss/_utilities_show.scss
+++ b/scss/_utilities_show.scss
@@ -3,23 +3,30 @@
 // Show elements with explicit breakpoints
 @mixin vf-u-show {
   .u-show {
+    // We keep inherit for IE that doesn't support `initial`.
+    // It's not ideal (makes things inline/block based on their parent, not their own initial value),
+    // but at least makes stuff visible again.
     display: inherit !important;
+    display: initial !important;
 
     &--small {
       @media screen and (max-width: $breakpoint-medium) {
         display: inherit !important;
+        display: initial !important;
       }
     }
 
     &--medium {
       @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
         display: inherit !important;
+        display: initial !important;
       }
     }
 
     &--large {
       @media screen and (min-width: $breakpoint-large) {
         display: inherit !important;
+        display: initial !important;
       }
     }
   }

--- a/templates/docs/examples/utilities/show.html
+++ b/templates/docs/examples/utilities/show.html
@@ -2,7 +2,15 @@
 {% block title %}Show{% endblock %}
 
 {% block content %}
-<div class="u-show--small">Shown on small screens</div>
-<div class="u-show--medium">Shown on medium screens</div>
-<div class="u-show--large">Shown on large screens</div>
+<div class="u-hide u-show--small">Shown on small screens</div>
+<div class="u-hide u-show--medium">Shown on medium screens</div>
+<div class="u-hide u-show--large">Shown on large screens</div>
+
+<p>
+  This is a
+    <strong class="u-hide u-show--small">small</strong>
+    <strong class="u-hide u-show--medium">medium</strong>
+    <strong class="u-hide u-show--large">large</strong>
+  screen.
+</p>
 {% endblock %}


### PR DESCRIPTION
## Done

Fix `u-show` utility to correctly set display to `initial` (but keep `inherit` for IE).

Fixes #3321

## QA

- Run `./run` or [demo](https://vanilla-framework-3330.demos.haus/docs/examples/utilities/show)
- Check the [show utility example](https://vanilla-framework-3330.demos.haus/docs/examples/utilities/show), make sure it correctly displays elements on relevant screen sizes, resetting inline elements back to inline state.

