### PR TITLE
Bump version to 2.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.19.0",
+  "version": "2.19.1",
   "files": [
     "/scss",
     "!/scss/docs"


### PR DESCRIPTION
## Done

Update version of Vanilla for next release.

## QA

- Run `./run` or [demo](https://vanilla-framework-3331.demos.haus/docs)
- Make sure version is correct in [docs](https://vanilla-framework-3331.demos.haus/docs)

