### PR TITLE
Make sure cookie policy is correctly styled in docs

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/_root.html" %}
 
 {% block custom_head %}
-    <link rel="stylesheet" href="/static/build/css/build.css" />
+    <link rel="stylesheet" href="/static/build/css/docs/site.css" />
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
## Done

Vanilla docs pages were not using the same stylesheet as 'brochure' site, so cookie policy dialog was not styled properly on docs pages.
This PR fixes it by including site CSS on all pages.


## QA

- Run `./run` or [demo](https://vanilla-framework-3332.demos.haus/docs)
- Go to [docs](https://vanilla-framework-3332.demos.haus/docs),  cookie dialog should be correctly styled


## Screenshots

### Before

<img width="1350" alt="Screenshot 2020-10-02 at 15 00 03" src="https://user-images.githubusercontent.com/83575/94925730-ff189d80-04bf-11eb-832c-e3ec0b468481.png">

### After

<img width="1200" alt="Screenshot 2020-10-02 at 15 00 12" src="https://user-images.githubusercontent.com/83575/94925728-fe800700-04bf-11eb-8794-33256be856b5.png">


