### PR TITLE
Bump to cookie version v3.03

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ env[23]/
 
 # Project-specific ignores
 js/app.js.map
+static/js/modules

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "!/scss/docs"
   ],
   "devDependencies": {
-    "@canonical/cookie-policy": "3.0.2",
+    "@canonical/cookie-policy": "3.0.3",
     "@percy/script": "1.1.0",
     "autoprefixer": "10.0.1",
     "get-site-urls": "1.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,10 +193,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@canonical/cookie-policy@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.2.tgz#5a6a3d5f02c2fc139e38749e25e14254d4b3cdd8"
-  integrity sha512-xe25hHA9jrfgWTs+pVjO4UL/INnM1Pp0ukYgolMYTc+kwSguAmnXXDN3vhoSOToS6DPU5E6yh7U/wQqXVqos7g==
+"@canonical/cookie-policy@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.3.tgz#77ff09de8cc91c3bd12d23bfeaaf23a0206995ad"
+  integrity sha512-cTNrBAO+w5Akrn32Arkp/YGgT9KXTUuCMAgE8ipABBtkEIQ2Z708mTkZ3FNgefxPvMuDuLCVvKhvHik31SEShg==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"


### PR DESCRIPTION
## Done

- Bump cookie policy to v3.03
- Update GTM to track initial pageview


## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]
- See that it is using cookie policy 3.03
