### PR TITLE
Update color of side navigation headings

### DIFF
--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -467,6 +467,11 @@
   .p-side-navigation__link {
     @extend %theme-side-navigation__link;
   }
+
+  .p-side-navigation__item--title,
+  .p-side-navigation__item--title .p-side-navigation__link {
+    color: $color-sidenav-text-active;
+  }
 }
 
 @mixin vf-side-navigation-theme-light {
@@ -544,6 +549,14 @@
       background: $color-sidenav-item-background-hover;
       color: $color-sidenav-text-active;
     }
+  }
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: $color-sidenav-text-active;
   }
   // stylelint-enable selector-no-qualifying-type
 }


### PR DESCRIPTION
## Done

Fixes #3269 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3345.demos.haus/docs/examples)
- Check all variants side navigation examples (light / dark, documentation, raw html, etc) - make sure titles render with new color


## Screenshots

<img width="815" alt="Screenshot 2020-10-08 at 16 20 40" src="https://user-images.githubusercontent.com/83575/95471440-3ab0dd00-0982-11eb-9ff5-fdaac2aafdd5.png">

