### PR TITLE
Add missing treeitem roles on li that have ul in them

### DIFF
--- a/templates/docs/examples/patterns/list-tree.html
+++ b/templates/docs/examples/patterns/list-tree.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <ul class="p-list-tree" aria-multiselectable="true" role="tree">
-  <li class="p-list-tree__item p-list-tree__item--group">
+  <li class="p-list-tree__item p-list-tree__item--group" role="treeitem">
     <button class="p-list-tree__toggle" id="sub-1-btn" aria-controls="sub-1" aria-expanded="false">/folder</button>
     <ul class="p-list-tree" role="group" id="sub-1" aria-hidden="true" aria-labelledby="sub-1-btn">
       <li class="p-list-tree__item" role="treeitem">file</li>
@@ -17,12 +17,12 @@
   <li class="p-list-tree__item" role="treeitem">
     <a href="#">config.yaml</a>
   </li>
-  <li class="p-list-tree__item p-list-tree__item--group">
+  <li class="p-list-tree__item p-list-tree__item--group" role="treeitem">
     <button class="p-list-tree__toggle" id="sub-2-btn" aria-controls="sub-2" aria-expanded="false">/files</button>
     <ul class="p-list-tree" role="group" id="sub-2" aria-hidden="true" aria-labelledby="sub-2-btn">
       <li class="p-list-tree__item" role="treeitem">default_rsync</li>
       <li class="p-list-tree__item" role="treeitem">nagios_plugin.py</li>
-      <li class="p-list-tree__item p-list-tree__item--group">
+      <li class="p-list-tree__item p-list-tree__item--group" role="treeitem">
         <button class="p-list-tree__toggle" id="sub-3-btn"  aria-controls="sub-3" aria-expanded="false">/plugins</button>
         <ul class="p-list-tree" role="group" id="sub-3" aria-hidden="true" aria-labelledby="sub-3-btn">
           <li class="p-list-tree__item" role="treeitem">check_mem.pl</li>


### PR DESCRIPTION
## Done

Quick fix to add treeitem roles on li's that have ul with role group inside.

## QA

- Pull code
- Run `./run`
- Open docs/examples/patterns/list-tree
- verify al lli's have a role of treeitem
