### PR TITLE
Fixes broken pagination links in search results

### DIFF
--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -24,7 +24,7 @@
     {% if  results.queries and results.queries.previousPage %}
       <a
         class="p-article-pagination__link--previous"
-        href="/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
+        href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
       >
         <span class="p-article-pagination__label">Previous</span>
       </a>
@@ -32,7 +32,7 @@
     {% if results.queries and results.queries.nextPage %}
       <a
         class="p-article-pagination__link--next"
-        href="/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
+        href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
       >
         <span class="p-article-pagination__label">Next</span>
       </a>


### PR DESCRIPTION
## Done

- Fixed broken “Previous” and “Next” links in search results.

Fixes #3358.

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/search?q=accordion&start=11&siteSearch=vanillaframework.io/docs
- Follow the “Previous” or “Next” links.