### PR TITLE
Update u-hide util for table columns and fix table expanding issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js"
   },
-  "version": "2.19.1",
+  "version": "2.19.2",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -6,7 +6,9 @@
     flex-flow: column nowrap;
     justify-content: space-between;
 
+    thead,
     tbody {
+      display: block; // for IE we need to force display block
       margin: 0;
     }
 
@@ -50,6 +52,10 @@
           padding: 0;
           width: 100%;
         }
+      }
+
+      &[aria-hidden='true'] {
+        display: none;
       }
     }
     // stylelint-enable selector-no-qualifying-type

--- a/scss/_utilities_hide.scss
+++ b/scss/_utilities_hide.scss
@@ -1,22 +1,81 @@
 @import 'settings';
 
+// mixin for hiding table columns
+@mixin vf-hide-table-column {
+  display: table-cell !important; // override display: none from standard u-hide
+  opacity: 0 !important;
+  overflow: hidden !important; // make sure content doesn't overflow
+  padding: 0 !important;
+  white-space: nowrap !important; // prevent content from wrapping in 0 width column
+  width: 0 !important;
+}
+
 // Hide elements with explicit breakpoints
 @mixin vf-u-hide {
   .u-hide-text {
     @extend %vf-hide-text;
   }
 
+  // mixin for hiding using display none (for all breakpoints)
   .u-hide {
     display: none !important;
 
     &--small {
-      @media screen and (max-width: $breakpoint-medium) {
+      @media screen and (max-width: $breakpoint-medium - 1) {
         display: none !important;
       }
     }
 
     &--medium {
-      @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
+      @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large - 1) {
+        display: none !important;
+      }
+    }
+
+    &--large {
+      @media screen and (min-width: $breakpoint-large) {
+        display: none !important;
+      }
+    }
+  }
+
+  // stylelint-disable selector-no-qualifying-type
+  td.u-hide,
+  th.u-hide {
+    @include vf-hide-table-column;
+
+    &--small {
+      @media screen and (max-width: $breakpoint-medium - 1) {
+        @include vf-hide-table-column;
+      }
+    }
+
+    &--medium {
+      @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large - 1) {
+        @include vf-hide-table-column;
+      }
+    }
+
+    &--large {
+      @media screen and (min-width: $breakpoint-large) {
+        @include vf-hide-table-column;
+      }
+    }
+  }
+  // stylelint-enable selector-no-qualifying-type
+
+  // expanding table uses flex layout, so use standard u-hide for it
+  .p-table-expanding .u-hide {
+    display: none !important;
+
+    &--small {
+      @media screen and (max-width: $breakpoint-medium - 1) {
+        display: none !important;
+      }
+    }
+
+    &--medium {
+      @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large - 1) {
         display: none !important;
       }
     }

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -39,11 +39,13 @@ View example of the table sortable pattern
 
 ### Expanding
 
+<span class="p-label--updated">Updated</span>
+
 Using `.p-table-expanding` in conjunction with the `<table>` element will allow expanding and hidden table cells which take up the full width of the table row element.
 
 This pattern should be used when a table requires configuration fields (add, edit). Expandable rows can also be used to supply additional information not visible on the table row.
 
-Using `p-table-expanding__panel` it can be hidden using the `aria-hidden` attribute. The table must contain all table cells required.
+Using `p-table-expanding__panel` it can be hidden using the `aria-hidden` attribute. The table must contain all table cells required. The expanding panel is implemented as additional cell in each row, so to keep the markup of the table valid, an additional cell is also needed in the table `<thead>`. This placeholder heading cell should be hidden using `aria-hidden="true"` attribute.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tables/table-expanding/" class="js-example">
 View example of the expanding table pattern

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -12,7 +12,7 @@ When we add, make significant updates, or deprecate a component we update their 
 
 ### What's new in Vanilla 2.19
 
-<table aria-label="What's new in Vanilla 2.18">
+<table aria-label="What's new in Vanilla 2.19">
   <thead>
     <tr>
       <th style="width: 20%">Component</th>
@@ -23,6 +23,12 @@ When we add, make significant updates, or deprecate a component we update their 
   </thead>
   <tbody>
     <!-- 2.19 -->
+    <tr>
+      <th><a href="/docs/base/tables#expanding">Expanding table column placeholder</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.20.0</td>
+      <td>We started using <code>aria-hidden="true"</code> attribute to hide the dummy table header in place of previously used <code>u-hide</code> utility.</td>
+    </tr>
     <tr>
       <th><a href="/docs/base/tables#icons">Table icons</a></th>
       <td><div class="p-label--new">New</div></td>

--- a/templates/docs/examples/patterns/tables/table-expanding.html
+++ b/templates/docs/examples/patterns/tables/table-expanding.html
@@ -13,8 +13,8 @@
             <th id="t-units1" aria-sort="none">Rack</th>
             <th id="t-units2" aria-sort="none">Last seen</th>
             <th id="t-revenue" aria-sort="none" class="u-align--right">Actions</th>
-            <th class="u-hide">
-                <!-- empty cell required for validation -->
+            <th aria-hidden="true">
+                <!-- hidden empty cell required for validation -->
             </th>
         </tr>
     </thead>

--- a/templates/docs/examples/utilities/hide-table-columns.html
+++ b/templates/docs/examples/utilities/hide-table-columns.html
@@ -1,0 +1,28 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Hide / Table columns{% endblock %}
+
+{% block content %}
+<table class="p-table">
+    <thead>
+        <tr>
+            <th>Always visible</th>
+            <th class="u-hide--small">Hidden on small screens</th>
+            <th class="u-hide--medium">Hidden on medium screens</th>
+            <th class="u-hide--large">Hidden on large screens</th>
+            <th class="u-hide">Always hidden</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Always visible</td>
+            <td class="u-hide--small">Hidden on small screens</td>
+            <td class="u-hide--medium">Hidden on medium screens</td>
+            <td class="u-hide--large">Hidden on large screens</td>
+            <td class="u-hide">Always hidden</td>
+        </tr>
+        <tr>
+            <td colspan="5">Cells with <code>colspan</code> should work correctly regardless of hidden columns</th>
+        </tr>
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -54,3 +54,7 @@ Unnecessary mixin `vf-p-grid-modifications` will be removed. Any references to i
 ### Slider
 
 Adding `.p-slider` class to style `<input type='range'>` is optional, so this class name can be safely removed from HTML if it's used solely to style range inputs. Classes `.p-slider__wrapper` and `.p-slider__input` are still used when building [slider with text input](/docs/patterns/slider) combo.
+
+### Hidden cell in expanding table
+
+Using `.u-hide` utility inside expanding table to hide table heading placeholder is not recommended. Use [the recommended ARIA attribute](/docs/base/tables#expanding) (`aria-hidden="true"`) instead.

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -55,7 +55,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Total !important keywords',
       benchmark: 50,
-      threshold: 90,
+      threshold: 150,
       result: results['total-important-keywords'],
     },
     {


### PR DESCRIPTION
## Done

- Updates `u-hide` utility to work properly with table columns (we collapse columns to 0 width instead of hiding with display), with an exception of expanding table (which uses flex layout and needs to use display none for hiding).
- Updates expanding table to remove use of `u-hide` util and provide hiding using `aria-hidden`
- Fix IE rendering issues with expanding table

Fixes #3337
Fixes #2726

## QA

- `./run` or [demo](https://vanilla-framework-3363.demos.haus/docs)
- Check [new example for hiding table columns](https://vanilla-framework-3363.demos.haus/docs/examples/utilities/hide-table-columns)
  - check different screen widths, different browsers
- Check updated [example of expanding table](https://vanilla-framework-3363.demos.haus/docs/examples/patterns/tables/table-expanding)
  - Make sure to check it in IE
- Check updated docs for [expanding table](https://vanilla-framework-3363.demos.haus/docs/base/tables#expanding)


