### PR TITLE
Unquote fontfamily so the $font-monospace can be used directly

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -6,7 +6,7 @@
   kbd,
   pre,
   samp {
-    font-family: unquote($font-monospace);
+    font-family: $font-monospace;
     font-weight: $font-weight-regular-text;
     text-align: left;
 

--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -1,5 +1,5 @@
 @mixin vf-b-typography-fontfaces {
-  @if str-index(quote($font-base-family), 'Ubuntu') {
+  @if str-index($font-base-family + '', 'Ubuntu') {
     @if $font-use-subset-latin {
       @font-face {
         font-display: $font-display-option;

--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -1,5 +1,5 @@
 @mixin vf-b-typography-fontfaces {
-  @if str-index($font-base-family, 'Ubuntu') {
+  @if str-index(quote($font-base-family), 'Ubuntu') {
     @if $font-use-subset-latin {
       @font-face {
         font-display: $font-display-option;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -29,7 +29,7 @@
     border-radius: 0;
     box-shadow: inset 0 1px 1px $color-input-shadow;
     color: $color-dark;
-    font-family: unquote($font-base-family);
+    font-family: $font-base-family;
     font-size: 1rem;
     font-weight: $font-weight-regular-text;
     line-height: map-get($line-heights, default-text);

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -13,7 +13,7 @@
 
   html {
     color: $color-dark;
-    font-family: unquote($font-base-family);
+    font-family: $font-base-family;
     // These vendor prefixes are unique and cannot be added by autoprefixer
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -34,7 +34,7 @@ $cc-button-size: 36px;
   .p-code-copyable__input {
     border: 0;
     color: $color-mid-dark;
-    font-family: unquote($font-monospace);
+    font-family: $font-monospace;
     line-height: map-get($line-heights, default-text);
     margin-bottom: 0;
     margin-top: 0;

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -1,6 +1,6 @@
 // Global font settings
-$font-base-family: '"Ubuntu", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
-$font-monospace: '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
+$font-base-family: 'Ubuntu', -apple-system, 'Segoe UI', 'Roboto', 'Oxygen', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif !default;
+$font-monospace: 'Ubuntu Mono', Consolas, Monaco, Courier, monospace !default;
 $font-heading-family: $font-base-family !default;
 $font-use-subset-latin: false !default;
 $font-display-option: fallback !default;

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -1,6 +1,6 @@
 // Global font settings
 $font-base-family: 'Ubuntu', -apple-system, 'Segoe UI', 'Roboto', 'Oxygen', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif !default;
-$font-monospace: 'Ubuntu Mono', Consolas, Monaco, Courier, monospace !default;
+$font-monospace: 'Ubuntu Mono', consolas, monaco, courier, monospace !default;
 $font-heading-family: $font-base-family !default;
 $font-use-subset-latin: false !default;
 $font-display-option: fallback !default;

--- a/templates/docs/settings/font-settings.md
+++ b/templates/docs/settings/font-settings.md
@@ -14,12 +14,12 @@ All Ubuntu sites and applications should use the Ubuntu font, as it has been spe
 
 [Read more about the Ubuntu typeface](http://font.ubuntu.com/)
 
-| Setting                | Default value                                         |
-| ---------------------- | ----------------------------------------------------- |
-| `$font-base-family`    | 'Ubuntu, Arial, "libra sans", sans-serif'             |
-| `$font-monospace`      | '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' |
-| `$font-base-size`      | `1rem`                                                |
-| `$font-heading-family` | `$font-base-family`                                   |
+| Setting                | Default value                                       |
+| ---------------------- | --------------------------------------------------- |
+| `$font-base-family`    | Ubuntu, Arial, "libra sans", sans-serif             |
+| `$font-monospace`      | "Ubuntu Mono", Consolas, Monaco, Courier, monospace |
+| `$font-base-size`      | `1rem`                                              |
+| `$font-heading-family` | `$font-base-family`                                 |
 
 <br>
 <hr>


### PR DESCRIPTION
## Done

Unquoted the values of `$font-base-family` and `$font-monospace` so that their values can be used directly without `unquote()`.

Fixes #3369 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo]()
- Make sure all the fonts are rendered appropriately.