### PR TITLE
Remove unnecessary wrong media query from subnav

### DIFF
--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -163,13 +163,6 @@
       background-color: $color-subnav-background-hover;
       color: $color-subnav-text-hover;
     }
-
-    &::before {
-      @media (max-width: $color-subnav-text-hover) {
-        // separator color on small screens
-        background: $color-subnav-separator;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
## Done

Remove unnecessary wrong media query from subnav

Fixes #3371

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3372.demos.haus/docs/examples/patterns/navigation/subnav-dark)
- Subnav should work as before on different screen sizes

