### PR TITLE
WIP: POC side navigation for apps improvements

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -42,7 +42,7 @@
     }
   }
 
-  $layout-navigation-collapsed-width: 3rem;
+  $layout-navigation-collapsed-width: 4rem;
   $layout-navigation-expanded-width: 15rem;
 
   .l-navigation__drawer {

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -42,7 +42,7 @@
     }
   }
 
-  $layout-navigation-collapsed-width: 4rem;
+  $layout-navigation-collapsed-width: 3rem;
   $layout-navigation-expanded-width: 15rem;
 
   .l-navigation__drawer {

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -79,6 +79,7 @@
       }
     }
 
+    .l-navigation:focus-within,
     .l-navigation:hover {
       box-shadow: $panel-drop-shadow;
       width: $layout-navigation-expanded-width;

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -153,7 +153,7 @@
   // STYLING OF SIDE NAVIGATION LINKS LIST
 
   // space for the right hand icon with default inner spacing on the left
-  $sp-sidenav--icon-spacing-width: map-get($icon-sizes, default) + $sph-inner;
+  $sp-sidenav--icon-spacing-width: map-get($icon-sizes, default) + $sph-inner + 0.5rem;
 
   %side-navigation__list {
     @extend %vf-list;

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -153,7 +153,7 @@
   // STYLING OF SIDE NAVIGATION LINKS LIST
 
   // space for the right hand icon with default inner spacing on the left
-  $sp-sidenav--icon-spacing-width: map-get($icon-sizes, default) + $sph-inner + 0.5rem;
+  $sp-sidenav--icon-spacing-width: map-get($icon-sizes, default) + $sph-inner;
 
   %side-navigation__list {
     @extend %vf-list;

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -36,37 +36,40 @@
     top: auto;
   }
 
-  .l-navigation__drawer .p-side-navigation--icons .p-side-navigation__text,
-  .l-navigation__drawer .p-side-navigation--icons .p-side-navigation__link {
-    padding-left: 3rem;
-  }
-
-  .l-navigation__drawer .p-side-navigation--icons .p-side-navigation__list::after {
-    left: 3rem;
-  }
-
-  .l-navigation__drawer .p-side-navigation--icons .p-side-navigation__icon {
-    left: 1rem;
-  }
-
   @media (min-width: 772px) and (max-width: 1035px) {
       .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list {
-        max-height: 0;
-        opacity: 0;
-        transition: opacity 300ms, max-height 300ms;
+        height: 0;
+        overflow: hidden;
       }
 
-      .l-navigaion.is-pinned .p-side-navigation__item .p-side-navigation__list,
+      .l-navigation__drawer .p-side-navigation__item {
+        position: relative;
+      }
+
+      .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list,
+      .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list .p-side-navigation__item,
+      .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list .p-side-navigation__link {
+        position: static;
+      }
+
+      .l-navigation.is-pinned .p-side-navigation__item .p-side-navigation__list,
       .l-navigation__drawer:focus-within .p-side-navigation__item .p-side-navigation__list,
       .l-navigation__drawer:hover .p-side-navigation__item .p-side-navigation__list {
-        max-height: 500px;
-        opacity: 1;
+        height: auto;
+        overflow: visible;
       }
 
-  }
-  .l-navigation__drawer .u-fixed-width {
-    padding-left: 1rem;
-    padding-right: 1rem;
+      .l-navigation.is-pinned .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list,
+      .l-navigation.is-pinned .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list .p-side-navigation__item,
+      .l-navigation.is-pinned .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list .p-side-navigation__link
+      .l-navigation__drawer:focus-within  .p-side-navigation__item .p-side-navigation__list,
+      .l-navigation__drawer:focus-within  .p-side-navigation__item .p-side-navigation__list .p-side-navigation__item,
+      .l-navigation__drawer:focus-within  .p-side-navigation__item .p-side-navigation__list .p-side-navigation__link,
+      .l-navigation__drawer:hover  .p-side-navigation__item .p-side-navigation__list,
+      .l-navigation__drawer:hover  .p-side-navigation__item .p-side-navigation__list .p-side-navigation__item,
+      .l-navigation__drawer:hover  .p-side-navigation__item .p-side-navigation__list .p-side-navigation__link {
+        position: relative;
+      }
   }
 
   /* demo JAAS CSS */

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -49,6 +49,21 @@
     left: 1rem;
   }
 
+  @media (min-width: 772px) and (max-width: 1035px) {
+      .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list {
+        max-height: 0;
+        opacity: 0;
+        transition: opacity 300ms, max-height 300ms;
+      }
+
+      .l-navigaion.is-pinned .p-side-navigation__item .p-side-navigation__list,
+      .l-navigation__drawer:focus-within .p-side-navigation__item .p-side-navigation__list,
+      .l-navigation__drawer:hover .p-side-navigation__item .p-side-navigation__list {
+        max-height: 500px;
+        opacity: 1;
+      }
+
+  }
   .l-navigation__drawer .u-fixed-width {
     padding-left: 1rem;
     padding-right: 1rem;

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -37,6 +37,16 @@
   }
 
   @media (min-width: 772px) and (max-width: 1035px) {
+      .l-navigation__drawer {
+        transform: translate(-0.5rem, 0);
+        transition: transform 0.165s;
+      }
+
+      .l-navigation__drawer [aria-current='page']::before {
+        transform: translate(0.5rem, 0);
+        transition: transform 0.165s;
+      }
+
       .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list {
         height: 0;
         overflow: hidden;
@@ -57,6 +67,19 @@
       .l-navigation__drawer:hover .p-side-navigation__item .p-side-navigation__list {
         height: auto;
         overflow: visible;
+      }
+
+      .l-navigation.is-pinned .l-navigation__drawer,
+      .l-navigation__drawer:focus-within,
+      .l-navigation__drawer:hover
+       {
+        transform: translate(0, 0);
+      }
+
+      .l-navigation.is-pinned .l-navigation__drawer [aria-current='page']::before,
+      .l-navigation__drawer:focus-within [aria-current='page']::before,
+      .l-navigation__drawer:hover [aria-current='page']::before {
+        transform: translate(0, 0);
       }
 
       .l-navigation.is-pinned .l-navigation__drawer .p-side-navigation__item .p-side-navigation__list,

--- a/templates/docs/examples/layouts/application.html
+++ b/templates/docs/examples/layouts/application.html
@@ -30,11 +30,29 @@
   /* overrides for side nav in app layout */
   .l-navigation__drawer .p-side-navigation,
   .l-navigation__drawer [class*='p-side-navigation--'] {
-      max-height: none;
-      overflow-y: visible;
-      position: static;
-      top: auto;
-    }
+    max-height: none;
+    overflow-y: hidden;
+    position: static;
+    top: auto;
+  }
+
+  .l-navigation__drawer .p-side-navigation--icons .p-side-navigation__text,
+  .l-navigation__drawer .p-side-navigation--icons .p-side-navigation__link {
+    padding-left: 3rem;
+  }
+
+  .l-navigation__drawer .p-side-navigation--icons .p-side-navigation__list::after {
+    left: 3rem;
+  }
+
+  .l-navigation__drawer .p-side-navigation--icons .p-side-navigation__icon {
+    left: 1rem;
+  }
+
+  .l-navigation__drawer .u-fixed-width {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
 
   /* demo JAAS CSS */
   .u-flex {

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -1,10 +1,9 @@
 {# used by the application layout example #}
 
-<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
+<nav aria-label="Main navigation" class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
   {% if is_dark %}
   <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
   {% endif %}
-  <nav aria-label="Main navigation">
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title">
         <a class="p-side-navigation__link" href="#">Title that is a link</a>
@@ -98,5 +97,5 @@
         <a class="p-side-navigation__link" href="#">First level link</a>
       </li>
     </ul>
-  </nav>
-  </div>
+</nav>
+


### PR DESCRIPTION
For demo purposes.

- improved icon spacing (to center icons when side nav is collapsed)
  - currently spacing is the same as grid margin (changes with breakpoints), this doesn't work with collapsed view
  - we need to hardcode specific values to make icons centered - should this be just for apps, could it be for all side navigations?
- expanding on focus
- fading secondary levels when collapsed
  - fading makes sure expanded levels are not visible in collapsed view, but this requires a lot of assumptions and hardcoding - may be hard (or impossible) to build a flexible solution that fits all possible uses