### PR TITLE
Fix anchor links in side navigation on mobile

### DIFF
--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -25,15 +25,9 @@
       if (show) {
         sideNavigation.classList.remove('is-collapsed');
         sideNavigation.classList.add('is-expanded');
-
-        // disable scroll on body when drawer is open
-        document.body.style.overflow = 'hidden';
       } else {
         sideNavigation.classList.remove('is-expanded');
         sideNavigation.classList.add('is-collapsed');
-
-        // enable scroll on body when drawer is open
-        document.body.style.overflow = '';
       }
     }
   }
@@ -77,11 +71,10 @@
         var drawerPosition = window.getComputedStyle(drawerEl).position;
 
         // when screen size changes from mobile (fixed drawer) to large screen
-        // enable scroll on body and reset any styles added by opening the drawer
+        // reset any styles added by opening the drawer
         if (drawerPosition !== 'fixed') {
           sideNav.classList.remove('is-expanded');
           sideNav.classList.remove('is-collapsed');
-          document.body.style.overflow = '';
         }
       }, 200)
     );


### PR DESCRIPTION
## Done

- remove scroll block on body when side nav is open to fix in-page anchors in docs

Fixes #3292 

## QA

- Run `./run` or [demo](https://vanilla-framework-3380.demos.haus/docs)
- Go to Vanilla docs (desktop and mobile - use real mobile device, not just small browser)
- Go to long page with anchors (code, forms, etc)
- Make sure anchor links scroll correctly

<img width="408" alt="Screenshot 2020-10-30 at 13 07 33" src="https://user-images.githubusercontent.com/83575/97703420-e5637980-1ab0-11eb-9590-b3c7f421d606.png">
