### PR TITLE
fix incorrect aria-hidden value on subnavigation

### DIFF
--- a/templates/docs/examples/patterns/navigation/_script.js
+++ b/templates/docs/examples/patterns/navigation/_script.js
@@ -2,6 +2,7 @@
   Toggles visibility of given subnav by toggling is-active class to it
   and setting aria-hidden attribute on dropdown contents.
   @param {HTMLElement} subnav Root element of subnavigation to open.
+  @param {Boolean} open indicate whether we want to open or close the subnav.
 */
 function toggleSubnav(subnav, open) {
   if (open) {
@@ -16,7 +17,7 @@ function toggleSubnav(subnav, open) {
     var dropdown = document.getElementById(toggle.getAttribute('aria-controls'));
 
     if (dropdown) {
-      dropdown.setAttribute('aria-hidden', open ? 'true' : false);
+      dropdown.setAttribute('aria-hidden', open ? false : true);
     }
   }
 }


### PR DESCRIPTION
## Done

Flipped the true/false values in the ternary that sets the `aria-hidden` attribute on sub navs, to ensure that they're showing the appropriate value.

Fixes #3264 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/navigation/subnav or [demo]
- Open your console
- Click any of the navigation items, and in the page inspector, see that the `aria-hidden` attribute on the visible `ul.p-subnav__items` is `false`, and `true` on the hidden subnavs.


## Screenshots

![aria-hidden](https://user-images.githubusercontent.com/2376968/97973587-37acdf00-1dbe-11eb-8175-6acc2b56fd29.gif)
