### PR TITLE
Fix spacing between different `p-button` element types

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -42,10 +42,11 @@
     }
 
     @media only screen and (min-width: $breakpoint-x-small + 1) {
+      margin-right: $sph-outer;
       width: auto;
 
-      &:not(:last-of-type):not(:only-of-type) {
-        margin-right: $sph-outer;
+      &:last-child {
+        margin-right: 0;
       }
     }
 

--- a/templates/docs/examples/patterns/buttons/alignment.html
+++ b/templates/docs/examples/patterns/buttons/alignment.html
@@ -1,0 +1,30 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Buttons / Alignment{% endblock %}
+
+{% block standalone_css %}patterns_buttons{% endblock %}
+
+{% block content %}
+<p>
+  <button>Classless button</button>
+  <button>Classless button</button>
+</p>
+
+<p>
+  <button class="p-button--neutral">Neutral button</button>
+  <button class="p-button--positive">Positive button</button>
+  <button class="p-button--negative">Negative button</button>
+</p>
+
+<p>
+  <a href="#" class="p-button--neutral">Neutral link</a>
+  <a href="#" class="p-button--positive">Positive link</a>
+  <a href="#" class="p-button--negative">Negative link</a>
+</p>
+
+<p>
+  <button>Classless button</button>
+  <button class="p-button--positive">Positive button</button>
+  <a href="#" class="p-button--neutral">Neutral link</a>
+  <button class="p-button--negative">Negative button</button>
+</p>
+{% endblock %}

--- a/templates/docs/examples/patterns/buttons/neutral.html
+++ b/templates/docs/examples/patterns/buttons/neutral.html
@@ -5,5 +5,8 @@
 
 {% block content %}
 <button class="p-button--neutral">Neutral button</button>
+
+<a href="#" class="p-button--neutral">Neutral button (link)</a>
+
 <button class="p-button--neutral" disabled>Neutral button disabled</button>
 {% endblock %}


### PR DESCRIPTION
## Done

Multiple sibling elements with the `p-button` class should have extra margin applied to ensure nice spacing between them, but this wouldn't happen if the siblings were different types of element.

~This PR updates the selectors used to apply the margin so that the type of element isn't a factor.~
See comments below - using various combinations of selectors introduced other issues, so this PR now applies a right margin to all `p-button` elements except a `:last-child`.

Fixes #1897 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/buttons/neutral or [demo]
- See that the three elements have consistent margin between them, and compare it to what happens in Vanilla currently https://codepen.io/sowasred2012/pen/GRqGEjv

Make sure PR has one of the following labels to automatically categorise it in release notes:
`Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.

## Screenshots

Before:
![Screenshot from 2020-11-03 14-36-13](https://user-images.githubusercontent.com/2376968/97999182-e82cda00-1de2-11eb-9acc-308a5d94b307.png)

After:
![Screenshot from 2020-11-04 11-05-45](https://user-images.githubusercontent.com/2376968/98104169-fab01d80-1e8d-11eb-9c5d-09cf54368593.png)

