### PR TITLE
remove top border from first item in matrix on small screens

### DIFF
--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -25,6 +25,10 @@
     padding-bottom: $spv-inner--scaleable;
     padding-top: calc(#{$spv-inner--scaleable} - 1px);
 
+    &:first-child {
+      border-top: none;
+    }
+
     @media (min-width: $breakpoint-small) {
       display: flex;
       flex-wrap: wrap;


### PR DESCRIPTION
## Done

Removed top border from first matrix item on small screens

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/matrix or [demo]
- At the small screen breakpoint, see that the first list item doesn't have a top border
- Resize your browser through the wider breakpoints and see that the top border shows/hides appropriately
- Compare to https://vanillaframework.io/docs/examples/patterns/matrix

Fixes #2517 

## Screenshots

Before:
![Screenshot from 2020-11-03 16-52-40](https://user-images.githubusercontent.com/2376968/98015730-01d71d00-1df5-11eb-9384-d1527b3a81f0.png)

After:
![Screenshot from 2020-11-03 16-50-24](https://user-images.githubusercontent.com/2376968/98015602-dfdd9a80-1df4-11eb-8e44-52738b455b14.png)

