### PR TITLE
Fix adding custom styles to embedded examples

### DIFF
--- a/scss/_utilities_baseline-grid.scss
+++ b/scss/_utilities_baseline-grid.scss
@@ -23,6 +23,17 @@
     }
   }
 
+  // baseline grid on document should be in the background
+  // stylelint-disable-next-line selector-no-qualifying-type
+  html.u-baseline-grid {
+    background-color: transparentize($baseline-color, 0.95);
+    position: static;
+
+    &::after {
+      z-index: -1;
+    }
+  }
+
   .u-baseline-grid__toggle {
     bottom: $spv-outer--scaleable;
     position: fixed;

--- a/scss/standalone/example.scss
+++ b/scss/standalone/example.scss
@@ -1,2 +1,9 @@
+// styles specific for the example pages
+
 @import '../utilities_baseline-grid';
 @include vf-u-baseline-grid;
+
+body {
+  background: $colors--light-theme--background-default;
+  margin: 1rem;
+}

--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="en" class="u-baseline-grid">
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -8,33 +8,11 @@
 
     {% if is_standalone %}
     <link rel="stylesheet" type="text/css" href="/static/build/css/standalone/{% block standalone_css %}base{% endblock %}.css" />
-    <link rel="stylesheet" type="text/css" href="/static/build/css/standalone/example.css" />
     {% else %}
     <link rel="stylesheet" type="text/css" href="/static/build/css/build.css" />
     {% endif %}
+    <link rel="stylesheet" type="text/css" href="/static/build/css/standalone/example.css" />
     <link rel="icon" href="https://assets.ubuntu.com/v1/ab36e6ed-vanilla_favicon_32px.png" type="image/x-icon" />
-
-
-    <style>
-      html::after {
-        background: linear-gradient(to top, rgba(255,0,0,0.15), rgba(255,0,0,0.15) 1px, rgba(255,0,0,0.05) 1px, rgba(255,0,0,0.05));
-        background-size: 100% .5em;
-        bottom: 0;
-        content: '';
-        display: block;
-        left: 0;
-        pointer-events: none;
-        position: absolute;
-        right: 0;
-        top: 0;
-        z-index: -1;
-      }
-
-      body {
-        background-color: #fff;
-        margin: 1rem;
-      }
-    </style>
 
     {% block style %}{% endblock %}
 

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -63,12 +63,15 @@
   function renderCodeBlocks(placementElement, html) {
     var bodyPattern = /<body[^>]*>((.|[\n\r])*)<\/body>/im;
     var titlePattern = /<title[^>]*>((.|[\n\r])*)<\/title>/im;
+    var headPattern = /<head[^>]*>((.|[\n\r])*)<\/head>/im;
 
     var title = titlePattern.exec(html)[1].trim();
     var bodyHTML = bodyPattern.exec(html)[1].trim();
+    var headHTML = headPattern.exec(html)[1].trim();
 
     var htmlSource = stripScriptsFromSource(bodyHTML);
     var jsSource = getScriptFromSource(bodyHTML);
+    var cssSource = getStyleFromSource(headHTML);
 
     var height = placementElement.getAttribute('data-height') || CODEPEN_HEIGHT;
 
@@ -102,6 +105,10 @@
       container.appendChild(createPreCode(jsSource, 'js'));
     }
 
+    if (cssSource) {
+      container.appendChild(createPreCode(cssSource, 'css'));
+    }
+
     placementElement.parentNode.insertBefore(container, placementElement);
 
     if (window.__CPEmbed) {
@@ -111,6 +118,13 @@
       // or show the code blocks as a fallback
       container.classList.remove('u-hide');
     }
+  }
+
+  function getStyleFromSource(source) {
+    var div = document.createElement('div');
+    div.innerHTML = source;
+    var style = div.querySelector('style');
+    return style ? style.innerHTML.trim() : null;
   }
 
   function stripScriptsFromSource(source) {


### PR DESCRIPTION
## Done

Fixes rendering examples with custom styles in embeded CodePen examples.

- removes example baseline styles from example template
- adds parsing style from `<head>` and adding them to CodePen as CSS tab

Fixes #3393 

## QA

- Run `./run` or [demo](https://vanilla-framework-3395.demos.haus/docs/layouts/application)
- Go to application layout documentation, CodePen examples should show the examples without styling errors (like messy margins): https://vanilla-framework-3395.demos.haus/docs/layouts/application
- Check application layout examples directly, make sure they render ok
- Check some other examples, make sure they display baseline grid as expected

<img width="1310" alt="Screenshot 2020-11-10 at 16 18 12" src="https://user-images.githubusercontent.com/83575/98693318-6c95d480-2370-11eb-8ff1-dc6731cb7b97.png">


