### PR TITLE
Fix the cookie policy styling in examples

### DIFF
--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/_root.html" %}
 
 {% block custom_head %}
-    <link rel="stylesheet" href="/static/build/css/build.css" />
+    <link rel="stylesheet" href="/static/build/css/docs/site.css" />
 {% endblock %}
 
 {% block title %}Component examples{% endblock %}

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/_root.html" %}
 
 {% block custom_head %}
-    <link rel="stylesheet" href="/static/build/css/build.css" />
+    <link rel="stylesheet" href="/static/build/css/docs/site.css" />
 {% endblock %}
 
 {% block title %}Standalone component examples{% endblock %}


### PR DESCRIPTION
## Done
Build the cookie policy css and import it separately in the example listing and standalone pages.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3396

## QA
- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples
- Check you see the cookie policy, if you dont delete the `_cookies_accepted` cookie
- Go to http://0.0.0.0:8101/docs/examples/standalone and see the policy is rendered correctly too
