### PR TITLE
Enforce BEM class naming

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -18,6 +18,8 @@
     "max-nesting-depth": 3,
     "function-url-scheme-allowed-list": ["data"],
     "scss/at-import-no-partial-leading-underscore": true,
-    "scss/at-import-partial-extension": "never"
+    "scss/at-import-partial-extension": "never",
+
+    "selector-class-pattern": "^(?:(?:o|c|u|t|s|is|has|_|js|qa)-)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\[.+\\])?$"
   }
 }

--- a/scss/docs/_patterns_syntax-highlight.scss
+++ b/scss/docs/_patterns_syntax-highlight.scss
@@ -43,9 +43,11 @@
     color: #795da3;
   }
 
+  // stylelint-disable selector-class-pattern
   .hljs-built_in {
     color: #77216f;
   }
+  // stylelint-enable selector-class-pattern
 
   .hljs-title {
     color: #795da3;


### PR DESCRIPTION
## Done

Added a selector-class-pattern regex to stylelint, for BEM linting.

Fixes #3013 

## QA

- Pull code
- Run `dotrun`
- Open your editor, and any scss file
- Edit a class selector to be un-BEMmy
- See that the editor highlights the problem with a `selector-class-pattern` error.

## Screenshots

![Screenshot from 2020-11-11 10-37-54](https://user-images.githubusercontent.com/2376968/98801651-0067af00-240a-11eb-98bf-e41cadb72ea9.png)

