### PR TITLE
Allow .p-form--inline formgroups to wrap when necessary

### DIFF
--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -31,20 +31,21 @@
       align-items: baseline;
       display: inline-flex;
       flex-direction: row;
+      flex-wrap: wrap;
 
       > * {
-        margin: 0;
+        margin-right: $sph-inner--large;
       }
     }
 
     .p-form__group {
       @media screen and (min-width: $breakpoint-medium) {
         display: flex;
+        flex-shrink: 1;
         width: auto;
 
-        + .p-form__group,
         + [class*='p-button'] {
-          margin-left: $sph-inner--large;
+          flex-shrink: 1;
         }
 
         .p-form__label,

--- a/templates/docs/examples/patterns/forms/form-inline.html
+++ b/templates/docs/examples/patterns/forms/form-inline.html
@@ -7,7 +7,7 @@
 <form class="p-form p-form--inline">
   <div class="p-form__group">
     <label for="username-inline" class="p-form__label">Username</label>
-    <div class="p-form__control u-clearfix">
+    <div class="p-form__control">
       <input type="text" id="username-inline" class="p-form__control" name="username-inline" autocomplete="username" required>
       <p class="p-form-help-text">
         30 characters or fewer.
@@ -16,7 +16,7 @@
   </div>
   <div class="p-form__group p-form-validation is-error">
     <label for="address-inline2" class="p-form__label">Email address</label>
-    <div class="p-form__control u-clearfix">
+    <div class="p-form__control">
       <input type="email" id="email" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline" name="address-inline2" autocomplete="email">
       <p class="p-form-validation__message" id="input-error-message-inline" role="alert">
         <strong>Error:</strong> Please enter a valid email address.


### PR DESCRIPTION
## Done

Fixed a bug where formgroups and buttons inside a `.p-form--inline` would not wrap and could break out of their parent element.

Fixes #1930 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/forms/form-inline or [demo]
- Reduce the width of the viewport, see that the form elements wrap when necessary

## Screenshots
### [canonical.com](https://canonical.com/careers/engineering#available-roles) 
Before:

![Screenshot from 2020-11-11 14-32-55](https://user-images.githubusercontent.com/2376968/98824814-a546b400-242b-11eb-8a2c-8bd69d5edd9b.png)

After:

![Screenshot from 2020-11-11 14-28-59](https://user-images.githubusercontent.com/2376968/98824790-9d870f80-242b-11eb-9133-7afd2b938565.png)

### Vanilla docs example
Before:
![form-inline-2](https://user-images.githubusercontent.com/2376968/98824591-64e73600-242b-11eb-8275-d9a6b3b98343.gif)

After:
![form-inline-1](https://user-images.githubusercontent.com/2376968/98824616-6dd80780-242b-11eb-837d-80ea89a6d3ef.gif)

