### PR TITLE
Add .is-small button class

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -55,6 +55,19 @@
       padding-top: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
     }
 
+    &.is-small {
+      font-size: #{map-get($font-sizes, small)}rem;
+      line-height: map-get($line-heights, small);
+      margin: 0 0 $input-margin-bottom - $sp-unit 0;
+      padding: calc(#{map-get($nudges, nudge--small)} - 1px) $sph-inner--small;
+    }
+
+    &.is-small.is-dense {
+      margin-bottom: $spv-nudge-compensation;
+      padding-bottom: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
+      padding-top: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
+    }
+
     // The following three rules address buttons nested in <p>'s;
     p & {
       margin-bottom: $spv-outer--small-scaleable - $spv-nudge;

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -22,18 +22,12 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-    <!-- 2.19 -->
+    <!-- 2.20 -->
     <tr>
-      <th><a href="/docs/base/tables#expanding">Expanding table column placeholder</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
-      <td>2.20.0</td>
-      <td>We started using <code>aria-hidden="true"</code> attribute to hide the dummy table header in place of previously used <code>u-hide</code> utility.</td>
-    </tr>
-    <tr>
-      <th><a href="/docs/base/tables#icons">Table icons</a></th>
+      <th><a href="/docs/patterns/buttons#small">Small buttons</a></th>
       <td><div class="p-label--new">New</div></td>
-      <td>2.19.0</td>
-      <td>We added a <code>p-table__cell--icon-placeholder</code> class to properly align icons in table cells.</td>
+      <td>2.20.0</td>
+      <td>We added an <code>is-small</code> modifier class for buttons, which can be combined with <code>is-dense</code>.</td>
     </tr>
   </tbody>
 </table>
@@ -50,6 +44,19 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.19 -->
+    <tr>
+      <th><a href="/docs/base/tables#expanding">Expanding table column placeholder</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.19.2</td>
+      <td>We started using <code>aria-hidden="true"</code> attribute to hide the dummy table header in place of previously used <code>u-hide</code> utility.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/base/tables#icons">Table icons</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.19.0</td>
+      <td>We added a <code>p-table__cell--icon-placeholder</code> class to properly align icons in table cells.</td>
+    </tr>
     <!-- 2.18 -->
     <tr>
       <th><a href="/docs/patterns/breadcrumbs">Breadcrumbs</a></th>

--- a/templates/docs/examples/patterns/buttons/small.html
+++ b/templates/docs/examples/patterns/buttons/small.html
@@ -1,0 +1,8 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Buttons / Small{% endblock %}
+
+{% block standalone_css %}patterns_buttons{% endblock %}
+
+{% block content %}
+<small>This is small text <button class="p-button--neutral is-small">This is a small button</button><button class="p-button--neutral is-small is-dense">This is a small, dense button</button></small>
+{% endblock %}

--- a/templates/docs/examples/patterns/buttons/small.html
+++ b/templates/docs/examples/patterns/buttons/small.html
@@ -4,5 +4,5 @@
 {% block standalone_css %}patterns_buttons{% endblock %}
 
 {% block content %}
-<small>This is small text <button class="p-button--neutral is-small">This is a small button</button><button class="p-button--neutral is-small is-dense">This is a small, dense button</button></small>
+<p><small>This is small text <button class="p-button--neutral is-small">This is a small button</button><button class="p-button--neutral is-small is-dense">This is a small, dense button</button></small></p>
 {% endblock %}

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -72,6 +72,14 @@ In contexts where vertical space is limited, you might want a button with reduce
 View example of the dense button pattern
 </a></div>
 
+### Small
+
+If you are working with small text and need a suitably sized button, add class `.is-small`. It can be combined with `.is-dense` for an even tighter look:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/small/" class="js-example">
+View example of the small button pattern
+</a></div>
+
 ### Icon
 
 Should you wish to place an icon in a button. You will not want to button to become full width on small screens. Therefore, you can add the state class `has-icon` to the button. If the contrast between the icon chosen and the button background is not sufficient then the `is-dark` or `is-light` classes can be added to the icon where appropriate.


### PR DESCRIPTION
## Done

Added `.is-small` modifier class for buttons, and `.is-dense` combo modifier.

Fixes #3341 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/buttons/small
- See that the buttons match the visual given in the issue https://github.com/canonical-web-and-design/vanilla-framework/issues/3341

## Screenshots

![Screenshot from 2020-11-12 12-19-31](https://user-images.githubusercontent.com/2376968/98939451-5fe4be00-24e1-11eb-9512-703492f1379a.png)

