### PR TITLE
Fix spell-checking of the docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -71,3 +71,7 @@ FontForge
 patterns_buttons
 unsetting
 v3.0.
+Suru
+spec
+specs
+×

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-js": "mkdir -p build/js/modules && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js build/js/modules",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "test-scss": "node -e 'require(\"./tests/parker\").parkerTest()'",
-    "test-spelling": "mdspell docs/**/*.md -r -n -a --en-gb",
+    "test-spelling": "mdspell templates/docs/**/*.md -r -n -a --en-gb",
     "test": "yarn lint-scss && yarn lint-prettier &&  yarn test-spelling && yarn test-scss",
     "lint-prettier": "prettier -c .",
     "lint-scss": "stylelint 'scss/**/*.scss'",

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -20,15 +20,15 @@ View example of inline code
 
 ### Block
 
-To create a preformatted block, use either `<pre>` (where preserving white space is important, but the text is not necesserily code) or `<pre><code>` (to indicate the contents are a piece of code):
+To create a pre-formatted block, use either `<pre>` (where preserving white space is important, but the text is not necessarily code) or `<pre><code>` (to indicate the contents are a piece of code):
 
-**Preformatted block:**
+**Pre-formatted block:**
 
 <div class="embedded-example"><a href="/docs/examples/base/pre/" class="js-example">
 View example of the base pre block
 </a></div>
 
-**Preformatted code block:**
+**Pre-formatted code block:**
 
 <div class="embedded-example"><a href="/docs/examples/base/code-block/" class="js-example">
 View example of the base code block

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -42,7 +42,7 @@ Note: The attribute `readonly` disables the input but it still retains a default
 
 Use the checkbox component to select one or more options. To provide fully featured Vanilla style and behaviour of the checkbox a specific markup structure is needed around the checkbox input (see example below).
 
-To disable the checkbox component, add the `disabled` attribute to the respecitve respective `<input type='checkbox'>` element.
+To disable the checkbox component, add the `disabled` attribute to the respective `<input type='checkbox'>` element.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/forms/checkbox/" class="js-example">
 View example of the checkbox components
@@ -80,7 +80,7 @@ Please refer to the [tick elements comparison example](/docs/examples/patterns/f
 
 Use radio buttons to select one of the given set of options. To provide fully featured Vanilla style and behaviour of the radio button a specific markup structure is needed around the radio button input (see example below).
 
-To disable the radio component, add the `disabled` attribute to the respecitve `<input type='radio'>` element.
+To disable the radio component, add the `disabled` attribute to the respective `<input type='radio'>` element.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/forms/radio/" class="js-example">
 View example of the radio components

--- a/templates/docs/layouts/documentation.md
+++ b/templates/docs/layouts/documentation.md
@@ -16,7 +16,7 @@ The documentation layout is built using Vanilla grid classes and common componen
 
 At the large breakpoint, the content area is further divided into an aside (3 columns) and a main content area (9 columns).
 
-At smaller breakpoints, the aside is moved offscreen and shown / hidden using a toggle.
+At smaller breakpoints, the aside is moved off-screen and shown / hidden using a toggle.
 
 #### Header
 
@@ -32,9 +32,9 @@ Alternatively, a search can be added in a full-width area under the top navigati
 
 #### Content area
 
-The content area is implemented as a regular strip (`.p-strip`) with a grid row (`.row`) inside. Within the standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) is deadicated to the main documentation content.
+The content area is implemented as a regular strip (`.p-strip`) with a grid row (`.row`) inside. Within the standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) is dedicated to the main documentation content.
 
-The aside area should contain the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items should be used to build the logical structure of the documentation navigation. The side navigation component has built-in responsive functionality which makes it appear / go offscreen using a toggle.
+The aside area should contain the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items should be used to build the logical structure of the documentation navigation. The side navigation component has built-in responsive functionality which makes it appear / go off-screen using a toggle.
 
 If the contents of the side navigation are generated in a way that doesn't provide the specific class names required by Vanilla, use a [raw HTML variant of the pattern](/docs/patterns/navigation#raw-html) to style the basic HTML lists of links.
 

--- a/templates/docs/patterns/breadcrumbs.md
+++ b/templates/docs/patterns/breadcrumbs.md
@@ -12,7 +12,7 @@ context:
 
 You can use the breadcrumbs pattern to indicate where the current page sits in the site's navigation.
 
-- A nav element with an `aria-label` "Breadcrumb" identifies the structure as a breadcrumb trail
+- A `<nav>` element with an `aria-label` "Breadcrumb" identifies the structure as a breadcrumb trail
 - The set of links is structured using an ordered list
 - The separators between each item are added via CSS, so you don't have to include them manually.
 

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -132,7 +132,7 @@ View example of the side navigation pattern for raw HTML
 On small screens side navigation is rendered off-screen as a drawer. To open the side navigation drawer, add `is-expanded` class to
 main `.p-side-navigation` element. To close the drawer (with the animation) remove `is-expanded` class and replace it with `is-collapsed` class.
 
-To make sure side navigation toggle works without JavaScript the toggle button for opening the side navigation drawer should be an anchor with href linking to the id attribute of the side navigation element (for example: `<a href="#drawer" class="p-side-navigation__toggle">`).
+To make sure side navigation toggle works without JavaScript the toggle button for opening the side navigation drawer should be an anchor with `href` attribute pointing to the `id` attribute of the side navigation element (for example: `<a href="#drawer" class="p-side-navigation__toggle">`).
 
 #### Theming
 
@@ -141,7 +141,7 @@ Overriding the colours of individual elements of the side navigation is discoura
 
 By default, the side navigation uses the light theme. To change the global default, set `$theme-default-p-side-navigation` to `dark`.
 
-To change the appearance of an individual instance of the sidenav, you can use the `is-dark` class.
+To change the appearance of an individual instance of the side navigation, you can use the `is-dark` class.
 
 For more details about themes in Vanilla refer to the [Color theming](/docs/settings/color-settings#color-theming) section of the documentation.
 

--- a/templates/docs/patterns/pagination.md
+++ b/templates/docs/patterns/pagination.md
@@ -40,7 +40,7 @@ View example of the pagination pattern
 
 ### Article pagination
 
-In some cases, providing information about the previous / next item in the set may be more important than being able to quckly jump to an arbitrary page. Examples of this could be chronologically ordered blog posts, articles, a sequence of instructions that need to be performed in a sequence, etc. In those cases, consider using the article pagination pattern:
+In some cases, providing information about the previous / next item in the set may be more important than being able to quickly jump to an arbitrary page. Examples of this could be chronologically ordered blog posts, articles, a sequence of instructions that need to be performed in a sequence, etc. In those cases, consider using the article pagination pattern:
 
 <div class="embedded-example"><a href="/docs/examples/patterns/article-pagination" class="js-example">
 View example of the article pagination pattern

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -83,7 +83,7 @@ This is a patterned strip that is ideal for overview or main pages, and can be u
 The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables. A dark colour scheme is recommended, as the text colour is light by default.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">
-View example of the pattern strip suru
+View example of the Suru strip pattern
 </a></div>
 
 ### Topped Suru strip
@@ -93,7 +93,7 @@ This is a patterned strip that is ideal for content pages.
 The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/strips/suru-topped/" class="js-example">
-View example of the pattern strip suru-topped
+View example of the topped Suru strip pattern
 </a></div>
 
 ### Import


### PR DESCRIPTION
## Done

It seems that since we moved docs to `template/docs` spell checking was silently failing (by not checking any files).

This PR:

- Corrects the path to the docs' markdown files passed to `mdspell` to enable spell checking again
- Fixes spelling errors introduced in the meantime


## QA

- Pull code
- Run `dotrun test-spelling`
- Verify that there are no spelling errors and that spell checker checks the files 
- Read the updated docs to check if they are correct


## Screenshots

<img width="952" alt="Screenshot 2020-11-13 at 16 05 22" src="https://user-images.githubusercontent.com/83575/99086622-11f7b500-25ca-11eb-8829-fba83f81a4b6.png">

