### PR TITLE
Add ability to set foreground (tick) color on success icon

### DIFF
--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -83,8 +83,8 @@ $social-icon-size: map-get($icon-sizes, heading-icon--small);
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
 
-@mixin vf-icon-success($color: $color-positive) {
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle fill='#{vf-url-friendly-color($color)}' cx='8' cy='8' r='7'/%3E%3Cpath fill='%23FFF' fill-rule='nonzero' d='M10.83 4.501l1.208.89-5.033 6.83-2.922-3.096 1.091-1.029 1.689 1.789z'/%3E%3C/g%3E%3C/svg%3E");
+@mixin vf-icon-success($bg-color: $color-positive, $fg-color: $color-x-light) {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cg fill='none' fill-rule='nonzero'%3E%3Cpath fill='#{vf-url-friendly-color($bg-color)}' d='M8 1a7 7 0 110 14A7 7 0 018 1zm2.83 3.502L6.863 9.884 5.174 8.096l-1.09 1.03 2.92 3.096 5.034-6.83-1.208-.89z'/%3E%3Cpath fill='#{vf-url-friendly-color($fg-color)}' d='M10.83 4.502l1.208.89-5.033 6.83-2.922-3.096 1.091-1.03 1.689 1.789z'/%3E%3C/g%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-share($color) {

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -4,6 +4,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
 // Default button styling
 @mixin vf-p-buttons {
+  @include vf-button-white-success-icon;
   @include vf-button-plain;
   @include vf-button-neutral;
   @include vf-button-brand;
@@ -12,6 +13,14 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   @include vf-button-base;
   @include vf-button-inline;
   @include vf-button-icon;
+}
+
+@mixin vf-button-white-success-icon {
+  %vf-button-white-success-icon {
+    & .p-icon--success {
+      @include vf-icon-success($color-x-light, $color-transparent);
+    }
+  }
 }
 
 @mixin vf-button-plain {
@@ -56,6 +65,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
   .p-button--brand {
     @extend %p-button--brand;
+    @extend %vf-button-white-success-icon;
   }
 }
 
@@ -78,6 +88,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
   .p-button--positive {
     @extend %p-button--positive;
+    @extend %vf-button-white-success-icon;
   }
 }
 
@@ -101,6 +112,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
   .p-button--negative {
     @extend %p-button--negative;
+    @extend %vf-button-white-success-icon;
   }
 }
 

--- a/templates/docs/examples/patterns/buttons/icon.html
+++ b/templates/docs/examples/patterns/buttons/icon.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_buttons{% endblock %}
 
 {% block content %}
-<button class="p-button--positive has-icon"><i class="p-icon--minus is-light"></i></button>
+<button class="p-button--positive has-icon"><i class="p-icon--success"></i></button>
 <button class="p-button has-icon"><i class="p-icon--plus"></i><span>Icon before text</span></button>
 <button class="p-button has-icon"><span>Icon after text</span><i class="p-icon--contextual-menu"></i></button>
 {% endblock %}

--- a/templates/docs/examples/templates/tick-element-comparison.html
+++ b/templates/docs/examples/templates/tick-element-comparison.html
@@ -27,6 +27,8 @@
           <button class="p-button--positive" disabled>Button</button>
           <button>Button</button>
           <button disabled>Button</button>
+          <button class="p-button--negative"><i class="p-icon--success"></i></button>
+          <button class="p-button--positive"><i class="p-icon--success"></i></button>
         </form>
       </div>
       <div class="col-3">


### PR DESCRIPTION
## Done

Adds a `fg-color` parameter to the success icon mixin and, when the icon is a child of a button, switches the foreground/tick color to transparent, and sets the background/circle color to white.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3142
## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/buttons/icon or [demo](https://vanilla-framework-3410.demos.haus/docs/examples/patterns/buttons/icon)
- See the success icon on each button looks good.