### PR TITLE
Add "is-active" button state

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -12,6 +12,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   @include vf-button-negative;
   @include vf-button-base;
   @include vf-button-inline;
+  @include vf-button-active;
   @include vf-button-icon;
 }
 
@@ -142,6 +143,12 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
       margin-left: $sph-outer;
       width: auto;
     }
+  }
+}
+
+@mixin vf-button-active {
+  [class*='p-button'].is-active {
+    opacity: 1 !important;
   }
 }
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -29,6 +29,12 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.20.0</td>
       <td>We added an <code>is-small</code> modifier class for buttons, which can be combined with <code>is-dense</code>.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/patterns/buttons#small">Active buttons</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.20.0</td>
+      <td>We added an <code>is-active</code> state class for buttons, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/templates/docs/examples/patterns/buttons/active.html
+++ b/templates/docs/examples/patterns/buttons/active.html
@@ -1,0 +1,8 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Buttons / Active{% endblock %}
+
+{% block standalone_css %}patterns_buttons{% endblock %}
+
+{% block content %}
+<button class="p-button--positive is-active" disabled><i class="p-icon--spinner u-animation--spin is-light"></i></button>
+{% endblock %}

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -88,6 +88,14 @@ Should you wish to place an icon in a button. You will not want to button to bec
 View example of the icon button pattern
 </a></div>
 
+### Active
+
+In cases where a button needs to indicate that an action is occurring (e.g. saving data, processing a payment) while also preventing user interaction, the state class `is-active` can be added to a disabled button to maintain full opacity.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/active/" class="js-example">
+View example of the active button pattern
+</a></div>
+
 ### Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

Adds an `is-active` state class to buttons

Fixes another aspect of https://github.com/canonical-web-and-design/vanilla-framework/issues/3142

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/buttons/active or [demo]
- See that the button is not opaque, and also not interactive.
