### PR TITLE
Set position: relative on .p-checkbox

### DIFF
--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -17,6 +17,13 @@
     @extend %vf-pseudo-radio;
   }
 
+  // contain the absolutely positioned input
+  .p-checkbox,
+  .p-checkbox--heading,
+  .p-checkbox--inline {
+    position: relative;
+  }
+
   // inline variants
   .p-checkbox--heading,
   .p-checkbox--inline,


### PR DESCRIPTION
## Done

Set `position: relative;` on `.p-checkbox` to contain the absolutely positioned inputs.

Fixes #3411 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/forms/checkbox
- Inspect the `p-checkbox` elements, see that the hidden checkbox element is now contained within its bounds

## Screenshots
 Before:
![Screenshot from 2020-11-18 15-19-33](https://user-images.githubusercontent.com/2376968/99549556-b0608d80-29b1-11eb-8014-4e136eb76c7d.png)

After: 
![Screenshot from 2020-11-18 15-22-54](https://user-images.githubusercontent.com/2376968/99549835-fddcfa80-29b1-11eb-9d52-4d61d560ea6c.png)



