### PR TITLE
Adjust position of hidden tick inputs

### DIFF
--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -26,7 +26,6 @@ $box-offsets-top: (
 
 @mixin vf-b-tick-elements-definitions {
   %vf-hidden-tick-input {
-    bottom: 0;
     float: none;
     height: $form-tick-box-size;
     margin: 0;

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -1,10 +1,23 @@
 @import 'settings';
 
 @mixin vf-p-form-tick-elements {
+  // contain the absolutely positioned input
+  .p-checkbox,
+  .p-checkbox--heading,
+  .p-checkbox--inline,
+  .p-radio,
+  .p-radio--heading,
+  .p-radio--inline {
+    position: relative;
+  }
+
   // specify both [type] and class to fight specificity of base `label [type]` styles
   [type='checkbox'].p-checkbox__input,
   [type='radio'].p-radio__input {
     @extend %vf-hidden-tick-input;
+
+    // adjust position of hidden inputs to place them approximately on the baseline
+    bottom: 0.2em;
   }
 
   .p-checkbox__label {
@@ -15,13 +28,6 @@
   .p-radio__label {
     @extend %vf-pseudo-tick-box;
     @extend %vf-pseudo-radio;
-  }
-
-  // contain the absolutely positioned input
-  .p-checkbox,
-  .p-checkbox--heading,
-  .p-checkbox--inline {
-    position: relative;
   }
 
   // inline variants


### PR DESCRIPTION
## Done

Follow-up to #3414 

Adjusts the positioning of hidden checkbox/radio inputs to align them with their rendered equivalents.

## QA

- Run `./run` or [demo](https://vanilla-framework-3415.demos.haus)
- Verify position of the checkbox/radio inputs in different cases:
  - [deprecated base styles](https://vanilla-framework-3415.demos.haus/docs/examples/base/forms/checkboxes)
  - [checkbox/radio pattern](https://vanilla-framework-3415.demos.haus/docs/examples/patterns/forms/tick-comparison)

Note: It's OK and expected for the input to be misplaced in deprecated base styles (when we don't control the wrapping element in pattern), but in case of p-checkbox and p-radio input should be (more or less) in line with its fake rendered element.

## Screenshots

<img width="566" alt="Screenshot 2020-11-19 at 08 49 45" src="https://user-images.githubusercontent.com/83575/99637007-87d5a380-2a44-11eb-815a-1025612c79cf.png">

