### PR TITLE
Application layout - side navigation improvements

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -7,7 +7,7 @@ $application-layout--breakpoint-side-nav-collapsed: $breakpoint-medium !default;
 // screen width breakpoint (min-width) at which side navigation is in expanded mode
 $application-layout--breakpoint-side-nav-expanded: $breakpoint-large !default;
 // width of the collapsed side navigation
-$application-layout--side-nav-width-collapsed: 3rem !default;
+$application-layout--side-nav-width-collapsed: 4rem !default;
 // width of the expanded side navigation
 $application-layout--side-nav-width-expanded: 15rem !default;
 
@@ -33,6 +33,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   }
 
   // Navigation panel/drawer
+  // -------------------------
   .l-navigation {
     bottom: 0;
     box-shadow: $panel-drop-shadow;
@@ -67,6 +68,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
       // use navigation bar as a grid spacer for collapsed navigation
       grid-area: nav;
       overflow: hidden;
+      visibility: hidden;
       width: $application-layout--side-nav-width-collapsed;
     }
 
@@ -122,6 +124,45 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     }
   }
 
+  // Fading elements when navigation panel is collapsed
+  %vf-application-layout--faded-when-collapsed {
+    // when app navigation panel is collapsed, fade out unnecessary elements
+    @media (min-width: $application-layout--breakpoint-side-nav-collapsed) {
+      @include vf-animation($property: opacity, $duration: snap);
+
+      opacity: 0;
+
+      // keep faded elements visible when navigation is expanded on hover or pinned
+      .l-navigation.is-pinned &,
+      .l-navigation:hover & {
+        opacity: 1;
+      }
+    }
+
+    // keep faded elements visible when app navigation is expanded on largest screens
+    @media (min-width: $application-layout--breakpoint-side-nav-expanded) {
+      opacity: 1;
+    }
+  }
+
+  .l-navigation .is-fading-when-collapsed {
+    @extend %vf-application-layout--faded-when-collapsed;
+  }
+
+  // Customisations of side navigation component
+  .l-navigation .p-side-navigation,
+  .l-navigation [class*='p-side-navigation--'] {
+    .p-side-navigation__label {
+      @extend %vf-application-layout--faded-when-collapsed;
+    }
+
+    .p-side-navigation__list::after {
+      @extend %vf-application-layout--faded-when-collapsed;
+    }
+  }
+
+  // Other panels
+  // --------------
   .l-main {
     grid-area: main;
     overflow-y: auto;

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -35,6 +35,8 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   // Navigation panel/drawer
   // -------------------------
   .l-navigation {
+    @include vf-animation(transform, fast);
+
     bottom: 0;
     box-shadow: $panel-drop-shadow;
     height: 100vh;
@@ -42,6 +44,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     overflow-y: auto;
     position: fixed;
     top: 0;
+    transform: translateX(0);
     width: 100%;
     z-index: 103; // consistent with side-navigation component, above global nav
 
@@ -50,7 +53,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     }
 
     &.is-collapsed {
-      width: 0;
+      transform: translateX(-100%);
     }
   }
 
@@ -82,9 +85,11 @@ $application-layout--side-nav-width-expanded: 15rem !default;
       );
 
       box-shadow: $panel-drop-shadow-transparent;
+      transform: translateX(0);
       width: $application-layout--side-nav-width-collapsed;
 
       &.is-collapsed {
+        transform: translateX(0);
         width: $application-layout--side-nav-width-collapsed;
       }
     }
@@ -119,6 +124,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
       }
 
       &.is-collapsed {
+        transform: translateX(0);
         width: $application-layout--side-nav-width-expanded;
       }
     }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -153,7 +153,7 @@
   // STYLING OF SIDE NAVIGATION LINKS LIST
 
   // space for the right hand icon with default inner spacing on the left
-  $sp-sidenav--icon-spacing-width: map-get($icon-sizes, default) + $sph-inner;
+  $sp-sidenav--icon-width: map-get($icon-sizes, default);
 
   %side-navigation__list {
     @extend %vf-list;
@@ -166,7 +166,7 @@
     }
 
     .p-side-navigation--icons &::after {
-      @include vf-side-navigation-spacing-left($prop: left, $offset: $sp-sidenav--icon-spacing-width);
+      @include vf-side-navigation-spacing-left($prop: left, $multiplier: 2, $offset: $sp-sidenav--icon-width);
     }
 
     &:last-of-type::after {
@@ -220,7 +220,7 @@
     @extend %side-navigation__text;
 
     .p-side-navigation--icons & {
-      @include vf-side-navigation-spacing-left($offset: $sp-sidenav--icon-spacing-width);
+      @include vf-side-navigation-spacing-left($multiplier: 2, $offset: $sp-sidenav--icon-width);
 
       position: relative;
     }
@@ -231,7 +231,7 @@
 
       // add spacing for variant with right side icons
       .p-side-navigation--icons & {
-        @include vf-side-navigation-spacing-left($multiplier: 2, $offset: $sp-sidenav--icon-spacing-width);
+        @include vf-side-navigation-spacing-left($multiplier: 3, $offset: $sp-sidenav--icon-width);
       }
     }
 
@@ -241,7 +241,7 @@
 
       // add spacing for variant with right side icons
       .p-side-navigation--icons & {
-        @include vf-side-navigation-spacing-left($multiplier: 3, $offset: $sp-sidenav--icon-spacing-width);
+        @include vf-side-navigation-spacing-left($multiplier: 4, $offset: $sp-sidenav--icon-width);
       }
     }
   }

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,12 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.21 -->
     <tr>
+      <th><a href="/docs/patterns/navigation#application-layout">Side navigation - Application</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.21.0</td>
+      <td>We implemented and documented improvements for [side navigation component](/docs/patterns/navigation#application-layout) for the [application layout](/docs/layouts/application#side-navigation).</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/navigation#sticky">Side navigation - Sticky</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.21.0</td>

--- a/templates/docs/examples/layouts/application/JAAS.html
+++ b/templates/docs/examples/layouts/application/JAAS.html
@@ -68,7 +68,7 @@
     <div class="p-panel is-dark is-jaas-background">
       <!-- TODO: these are temprorary custom styles, not a final Vanilla version -->
       <div class="u-fixed-width u-align--right">
-        <span class="js-menu-toggle" style="display: block; padding-top: 0.75rem; padding-bottom: 0.75rem">Menu</span>
+        <span class="js-menu-toggle" style="display: inline-block; cursor: pointer; padding-top: 0.75rem; padding-bottom: 0.75rem">Menu</span>
       </div>
     </div>
   </div>

--- a/templates/docs/examples/layouts/application/JAAS.html
+++ b/templates/docs/examples/layouts/application/JAAS.html
@@ -41,13 +41,23 @@
   }
 
   /* custom JAAS background color */
-  .p-panel.is-jaas-background,
-  .p-panel__header--sticky.is-jaas-background {
+  .p-panel.is-jaas-background {
     background: #003b4e;
+  }
+
+  .p-panel__header--sticky.is-jaas-background {
+    background: linear-gradient(to bottom, #003b4e 0%, #003b4e 70%, transparent 100%);
   }
 
   .p-panel__content {
     overflow: hidden;
+  }
+
+  .p-panel__logo {
+    display: flex;
+    align-items: center;
+    padding-top: 0.5rem;
+    margin-left: -4px; /* logo size - icon size -> (24px - 16px) / 2 */
   }
 </style>
 {% endblock %}
@@ -55,9 +65,10 @@
 {% block content %}
 <div class="l-application" role="presentation">
   <div class="l-navigation-bar">
-    <div class="p-panel is-dark">
+    <div class="p-panel is-dark is-jaas-background">
+      <!-- TODO: these are temprorary custom styles, not a final Vanilla version -->
       <div class="u-fixed-width u-align--right">
-        <span class="js-menu-toggle">Menu</span>
+        <span class="js-menu-toggle" style="display: block; padding-top: 0.75rem; padding-bottom: 0.75rem">Menu</span>
       </div>
     </div>
   </div>
@@ -70,7 +81,8 @@
             <div class="p-inline-list--stretch">
               <div class="p-inline-list__item">
                 <a class="p-panel__logo" href="#">
-                  <img src="https://assets.ubuntu.com/v1/a9e0ed4a-jaas-logo1.svg" alt="Vanilla framework" width="80" style="margin-top: 4px">
+                  <img src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
+                  <img class="is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" width="50" style="margin-left: 10px">
                 </a>
               </div>
               <div class="p-inline-list__item u-align--right u-hide--large">
@@ -82,7 +94,7 @@
         </div>
         <div class="p-panel__content">
           {% set is_dark = True %}
-          {% include "docs/examples/patterns/side-navigation/_layout-application.html" %}
+          {% include "docs/examples/patterns/side-navigation/_layout-JAAS.html" %}
         </div>
       </div>
     </div>
@@ -114,7 +126,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr style="background: rgba(0,0,0, 0.15)" data-test-model-uuid="2f995dee-392e-4459-8eb9-839c501590af">
+              <tr style="background: rgba(0,0,0, 0.1)" data-test-model-uuid="2f995dee-392e-4459-8eb9-839c501590af">
                 <td class="p-table__cell--icon-placeholder" data-test-column="name">
                   <div><a href="#/models/gomboli@external/hadoopspark">192.168.255.254</a></div>
                 </td>

--- a/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
@@ -1,0 +1,44 @@
+{# used by the application layout example #}
+
+<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}">
+  {% if is_dark %}
+  <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
+  {% endif %}
+  <nav aria-label="Main navigation">
+    <ul class="p-side-navigation__list">
+      <li class="p-side-navigation__item">
+        <a class="p-side-navigation__link" href="#" aria-current="page">
+          <i class="p-icon--information {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>
+          <span class="is-fading-when-collapsed">Models</span>
+        </a>
+      </li>
+      <li class="p-side-navigation__item">
+        <a class="p-side-navigation__link" href="#">
+          <i class="p-icon--help {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>
+          <span class="p-side-navigation__label">
+            Controllers
+          </span>
+          <span class="p-side-navigation__status">
+            <i class="p-icon--error {% if is_dark %}is-light{% endif %}"></i>
+          </span>
+        </a>
+      </li>
+    </ul>
+    <ul class="p-side-navigation__list is-fading-when-collapsed">
+      <li class="p-side-navigation__item">
+        <a href="#" class="p-side-navigation__link">Report a bug</a>
+      </li>
+      <li class="p-side-navigation__item">
+        <a href="#" class="p-side-navigation__link">Feedback</a>
+      </li>
+    </ul>
+    <ul class="p-side-navigation__list is-fading-when-collapsed">
+      <li class="p-side-navigation__item">
+        <span class="p-side-navigation__text">
+          Version 0.4.0
+          <div class="p-side-navigation__status"><span class="p-label--in-progress">Beta</span></div>
+        </span>
+      </li>
+    </ul>
+  </nav>
+</div>

--- a/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
@@ -1,44 +1,40 @@
 {# used by the application layout example #}
 
-<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}">
-  {% if is_dark %}
-  <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
-  {% endif %}
-  <nav aria-label="Main navigation">
-    <ul class="p-side-navigation__list">
-      <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#" aria-current="page">
-          <i class="p-icon--information {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>
-          <span class="is-fading-when-collapsed">Models</span>
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#">
-          <i class="p-icon--help {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>
-          <span class="p-side-navigation__label">
-            Controllers
-          </span>
-          <span class="p-side-navigation__status">
-            <i class="p-icon--error {% if is_dark %}is-light{% endif %}"></i>
-          </span>
-        </a>
-      </li>
-    </ul>
-    <ul class="p-side-navigation__list is-fading-when-collapsed">
-      <li class="p-side-navigation__item">
-        <a href="#" class="p-side-navigation__link">Report a bug</a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="#" class="p-side-navigation__link">Feedback</a>
-      </li>
-    </ul>
-    <ul class="p-side-navigation__list is-fading-when-collapsed">
-      <li class="p-side-navigation__item">
-        <span class="p-side-navigation__text">
-          Version 0.4.0
-          <div class="p-side-navigation__status"><span class="p-label--in-progress">Beta</span></div>
+<nav class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" aria-label="Main navigation">
+  <ul class="p-side-navigation__list">
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#" aria-current="page">
+        <i class="p-icon--information {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>
+        <span class="p-side-navigation__label">Models</span>
+      </a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a class="p-side-navigation__link" href="#">
+        <i class="p-icon--help {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>
+        <span class="p-side-navigation__label">
+          Controllers
         </span>
-      </li>
-    </ul>
-  </nav>
-</div>
+        <span class="p-side-navigation__status">
+          <i class="p-icon--error {% if is_dark %}is-light{% endif %}"></i>
+        </span>
+      </a>
+    </li>
+  </ul>
+  <ul class="p-side-navigation__list is-fading-when-collapsed">
+    <li class="p-side-navigation__item">
+      <a href="#" class="p-side-navigation__link">Report a bug</a>
+    </li>
+    <li class="p-side-navigation__item">
+      <a href="#" class="p-side-navigation__link">Feedback</a>
+    </li>
+  </ul>
+  <ul class="p-side-navigation__list is-fading-when-collapsed">
+    <li class="p-side-navigation__item">
+      <span class="p-side-navigation__text">
+        Version 0.4.0
+        <div class="p-side-navigation__status"><span class="p-label--in-progress">Beta</span></div>
+      </span>
+    </li>
+  </ul>
+</nav>
+

--- a/templates/docs/examples/patterns/side-navigation/application.html
+++ b/templates/docs/examples/patterns/side-navigation/application.html
@@ -1,0 +1,22 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Side navigation / Application{% endblock %}
+
+{% block standalone_css %}patterns_side-navigation{% endblock %}
+
+{% block style %}
+<style>
+  /*
+    Making background dark for the sake of this example.
+    In the real application you would place the side navigation inside
+    the `l-navigation` panel that should provide the background color.
+  */
+  html, body { background: #111 }
+</style>
+{% endblock %}
+
+{% block content %}
+{% with is_dark=True %}
+  {% include "docs/examples/patterns/side-navigation/_layout-JAAS.html" %}
+{% endwith %}
+
+{% endblock %}

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -103,6 +103,20 @@ View an example of the application layout demo
 
 [View the full screen example of the default panels in application layout](/docs/examples/layouts/application/default/).
 
+### Side navigation
+
+<span class="p-label--new">New</span>
+
+Use the [side navigation component](/docs/patterns/navigation#side-navigation) to build the contents of main navigation for the application layout. You can find detailed documentation in the ["Application layout" section of the Navigation page](/docs/patterns/navigation#application-layout).
+
+<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/application" class="js-example">
+View example of the side navigation pattern for raw HTML
+</a></div>
+
+Side navigation component has a built-in support for responsive collapsing and expanding of the side navigation. When proper HTML structure and element class names are used, the side navigation elements and icons will be correctly positioned, and unnecessary elements will fade out when navigation collapses.
+
+Additionally, if certain custom elements need to be hidden when navigation panel is collapsed, add the `.is-fading-when-collapsed` class to them.
+
 ### Responsive application layout
 
 The application layout is fully responsive. It is controlled by breakpoint variables that define the screen widths at which layout change occur.

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -146,6 +146,22 @@ main `.p-side-navigation` element. To close the drawer (with the animation) remo
 
 To make sure side navigation toggle works without JavaScript the toggle button for opening the side navigation drawer should be an anchor with `href` attribute pointing to the `id` attribute of the side navigation element (for example: `<a href="#drawer" class="p-side-navigation__toggle">`).
 
+#### Application layout
+
+<span class="p-label--new">New</span>
+
+For applications built with [the application layout](/docs/layouts/application) the size and positioning of the navigation panel is handled by the layout itself, so the side navigation component doesn't need it's own drawer, overlay or toggle buttons.
+
+To use side navigation in the application place `.p-side-navigation--icons` in the `l-navigation` element. You don't use `p-side-navigation__toggle`, `p-side-navigation__overlay` or `p-side-navigation__drawer` elements, just put the lists of the links `p-side-navigation__list` as direct children of `.p-side-navigation` element.
+
+Additionally, in order for application layout to fully control side navigation elements when expanding and collapsing you need to wrap the text of the side navigation items in `<span class="p-side-navigation__label">`. This will allow to fade them out when navigation collapses.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/application" class="js-example">
+View example of the side navigation pattern for raw HTML
+</a></div>
+
+For more information, read the dedicated [application layout documentation](/docs/layouts/application).
+
 #### Theming
 
 The side navigation is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_settings_colors.scss).


### PR DESCRIPTION
## Done

- Improves the way side navigation component works in application layout
  - updates the width of collapsed layout to 4rem to center the icons
  - updates side navigation to fade text of the links when collapsing
- Add the documentation to side navigation and application layout pages
- Adds the animation to hiding/showing of side navigation in app layout on small screens

Fixes #3388

## QA

- Run `./run` or [demo](https://vanilla-framework-3421.demos.haus/docs/examples/layouts/application/JAAS)
- Check the side navigation in app layout: https://vanilla-framework-3421.demos.haus/docs/examples/layouts/application/JAAS
- Check on small mobile screens if the side navigation animates when showin/hiding - make sure it works as expected in different cases (check other app layout examples)
- Check the updated documentation:
  - https://vanilla-framework-3421.demos.haus/docs/patterns/navigation#application-layout
  - https://vanilla-framework-3421.demos.haus/docs/layouts/application#side-navigation

**Note:** This PR is about side navigation links, aligning logo and pin button is scope of separate issue

## Screenshots

![app-side-nav-icons](https://user-images.githubusercontent.com/83575/99816883-81325380-2b4c-11eb-9c13-bcdc3cdb2fe7.gif)

