### PR TITLE
Add focus-visible support to vf-focus mixin

### DIFF
--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -58,12 +58,24 @@
   }
 }
 
-// Adds visiual focus to elements on :focus
+// Adds visual focus to elements on :focus-visible,
+// or :focus if the browser doesn't support the former
 @mixin vf-focus($color: $color-focus, $width: $bar-thickness, $has-validation: false) {
   &:focus {
     outline: $width solid $color;
     outline-offset: -#{$width};
   }
+
+  &:focus-visible {
+    outline: $width solid $color;
+    outline-offset: -#{$width};
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: 0;
+    outline-offset: 0;
+  }
+
   @if ($has-validation) {
     .is-error &:focus {
       outline-color: $color-negative;


### PR DESCRIPTION
## Done

Added `:focus-visible` to the vf-focus mixin.

Fixes #3352 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ in Chrome/Chromium
- Tab through the page, see that links still receive a focus state. Click any of the links and see that the focus state is _not_ applied.

This does not yet work on browsers other than Chrome ([MDN Compatibility list](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#Browser_compatibility)). Firefox supposedly supports it using the alternative name `:moz-focusring`, but it seemed to have no effect. Browsers that don't support `:focus-visible` will fall back to the current `:focus` styling.