### PR TITLE
Update command prompt font family

### DIFF
--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -19,15 +19,13 @@ $cc-button-size: 36px;
     }
 
     &::before {
-      color: $color-mid;
+      color: $colors--light-theme--text-muted;
       content: '$';
       display: block;
-      left: 0;
+      font-family: unquote($font-monospace);
       line-height: map-get($line-heights, default-text);
-      padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 $sph-inner--small;
-      position: absolute;
-      top: $spv-inner--x-small;
-      width: 1rem;
+      padding: 0 $sph-inner--small;
+      position: relative;
     }
   }
 
@@ -38,7 +36,7 @@ $cc-button-size: 36px;
     line-height: map-get($line-heights, default-text);
     margin-bottom: 0;
     margin-top: 0;
-    padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 $sph-inner * 1.5;
+    padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 0;
     width: 100%;
   }
 


### PR DESCRIPTION
## Done

Set the `$font-monospace` font family on the command prompt character in the code copyable component.

Fixes #3428 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/patterns/code-copyable
- See the updated command prompt icon and check that the design is OK

## Screenshots

Before:
![Screenshot from 2020-11-25 11-56-12](https://user-images.githubusercontent.com/2376968/100224946-6b8aa880-2f15-11eb-80e2-ea3a81189129.png)

After:
![Screenshot from 2020-11-26 09-25-47](https://user-images.githubusercontent.com/2376968/100332543-6d15a880-2fc9-11eb-8dd3-29d823036883.png)


