### PR TITLE
Add application icons

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,12 @@
+# Vanilla Development
+
+## Adding new icons
+
+When adding new icons to Vanilla, we need to convert them from SVGs to data URLs so we can use them as background images.
+
+To achieve this quickly, you can use the `icon-svgs-to-mixins` script:
+
+- Place the SVGs to be converted in a directory somewhere on your local machine.
+- In your terminal, run `dotrun icon-svgs-to-mixins path/to/svg/directory/`.
+
+This will output a mixin for each SVG in the directory. Each mixin will take its name from the SVG's filename i.e. "tick.svg" will output a mixin named "vf-icon-tick".

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "watch:scss:skip-standalone": "node-sass  scss/docs --functions sass-functions.js --output-style compressed --output build/css/docs --watch",
     "watch": "yarn build && yarn watch:scss",
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
-    "percy": "percy exec -- node snapshots.js"
+    "percy": "percy exec -- node snapshots.js",
+    "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js"
   },
   "version": "2.20.0",
   "files": [
@@ -65,7 +66,8 @@
     "stylelint-config-standard": "20.0.0",
     "stylelint-order": "4.1.0",
     "stylelint-prettier": "1.1.2",
-    "stylelint-scss": "3.18.0"
+    "stylelint-scss": "3.18.0",
+    "svgo": "1.3.2"
   },
   "husky": {
     "hooks": {

--- a/scripts/convert-svgs-to-icon-mixins.js
+++ b/scripts/convert-svgs-to-icon-mixins.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+const mime = require('mime');
+const SVGO = require('svgo');
+
+const args = process.argv;
+const directory = args[2];
+const symbols = /[\r\n%#()<>?\[\\\]^`{|}]/g;
+const svgo = new SVGO();
+
+function encodeSVG(data) {
+  // Use single quotes instead of double to avoid encoding.
+  data = data.replace(/"/g, "'");
+
+  data = data.replace(symbols, encodeURIComponent);
+
+  // Replace any fill color values with a Vanilla function that
+  // converts a SCSS color variable to a URL friendly value.
+  data = data.replace(/fill='%23(.*)' /g, "fill='#{vf-url-friendly-color($color)}' ");
+
+  return data;
+}
+
+function convertSVGs(directory, files) {
+  files.forEach((file) => {
+    const filePath = `${directory}${file}`;
+    const fileType = mime.getType(filePath);
+    const isSVG = fileType === 'image/svg+xml';
+
+    if (isSVG) {
+      fs.readFile(filePath, 'utf-8', function (err, data) {
+        if (err) {
+          throw err;
+        }
+
+        svgo.optimize(data, {path: filePath}).then(function (result) {
+          console.log(`@mixin vf-icon-${path.parse(file).name}($color) {`);
+          console.log(`background-image: url("data:image/svg+xml,${encodeSVG(result.data)}");`);
+          console.log('}');
+        });
+      });
+    }
+  });
+}
+
+if (directory) {
+  fs.readdir(directory, (err, files) => {
+    if (err) {
+      throw err;
+    }
+
+    convertSVGs(directory, files);
+  });
+} else {
+  throw `missing directory argument`;
+}

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -144,3 +144,25 @@ $social-icon-size: map-get($icon-sizes, heading-icon--small);
 @mixin vf-icon-email {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cg fill='none'%3E%3Ccircle cx='20' cy='20' r='20' fill='%23666'/%3E%3Cpath fill='%23FFF' d='M13.688 20.68a.312.312 0 01.432 0l2.888 2.752A4.344 4.344 0 0020 24.624l.238-.006a4.344 4.344 0 002.754-1.186l2.864-2.752a.312.312 0 01.432 0l7.92 7.92a.312.312 0 01-.224.528h-28a.312.312 0 01-.216-.528zM33.8 13.184a.304.304 0 01.512.224V26.52a.304.304 0 01-.52.224l-6.664-6.728a.304.304 0 010-.432zm-27.608 0l6.664 6.4a.296.296 0 010 .432l-6.664 6.728a.304.304 0 01-.52-.224V13.408a.312.312 0 01.52-.224zm27.696-2.328a.352.352 0 01.24.608L22.544 22.496A3.688 3.688 0 0120 23.512l-.218-.006a3.656 3.656 0 01-2.326-1.01L5.864 11.464a.352.352 0 01.24-.608z'/%3E%3C/g%3E%3C/svg%3E");
 }
+
+@mixin vf-icon-applications($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 1a3 3 0 01.874 5.87c-.211.558-.58 1.198-1.163 1.832a6.21 6.21 0 01-.24.248 5.794 5.794 0 01-1.311.97c.36.37.623.837.752 1.356h2.176a3.001 3.001 0 11.014 1.501H6.898A3.001 3.001 0 011 12a3 3 0 013-3l.12.005c.86-.092 1.62-.464 2.304-1.13a4.476 4.476 0 00.77-.986A3 3 0 018 1zm-3.85 9.507l-.194.014-.236.005a1.5 1.5 0 10.43-.019zM12 10.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm-4-8a1.5 1.5 0 100 3 1.5 1.5 0 000-3z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
+}
+
+@mixin vf-icon-controllers($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12.95 3.05a7 7 0 11-9.9 9.9 7 7 0 019.9-9.9zM4.11 4.11a5.5 5.5 0 108.277.572l-3.38 3.38L7.948 7l3.38-3.38a5.501 5.501 0 00-7.216.49z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
+}
+@mixin vf-icon-fullscreen($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M15 10v2a3 3 0 01-3 3h-2v-1.5h2a1.5 1.5 0 001.493-1.356L13.5 12v-2H15zM2.5 10v2a1.5 1.5 0 001.356 1.493L4 13.5h2V15H4a3 3 0 01-3-3v-2h1.5zM6 1v1.5H4l-.144.007a1.5 1.5 0 00-1.35 1.349L2.5 4v2H1V4a3 3 0 012.824-2.995L4 1h2zm6 0a3 3 0 012.995 2.824L15 4v2h-1.5V4l-.007-.144a1.5 1.5 0 00-1.349-1.35L12 2.5h-2V1h2z' fill='#{vf-url-friendly-color($color)}' fill-rule='evenodd'/%3E%3C/svg%3E");
+}
+
+@mixin vf-icon-models($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 1a3 3 0 11-1.201 5.75 6.92 6.92 0 01-1.254 1.88c-.09.099-.185.196-.283.291-.796.775-1.684 1.31-2.654 1.598.112.194.202.403.267.622h2.25A3.001 3.001 0 0115 12a3 3 0 01-5.931.642H6.93a3.001 3.001 0 11-1.718-3.387c1.127-.083 2.119-.548 3.003-1.409.077-.075.152-.153.224-.231A5.366 5.366 0 009.46 6.033l.076-.195.03-.088a2.947 2.947 0 01-.47-.999h-2.19A3.001 3.001 0 011 4a3 3 0 015.905-.75h2.19A3.001 3.001 0 0112 1zm-8 9.5a1.5 1.5 0 10.859.27l-.03.001.002-.02A1.493 1.493 0 004 10.5zm8 0a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm-8-8a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm8 0a1.5 1.5 0 100 3 1.5 1.5 0 000-3z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
+}
+@mixin vf-icon-machines($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .99a3 3 0 013 3v1.75c0 .938-.431 1.776-1.106 2.326A2.989 2.989 0 0115 10.392v1.75a3 3 0 01-3 3H4a3 3 0 01-3-3v-1.75c0-.94.431-1.777 1.106-2.327A2.989 2.989 0 011 5.739V3.99a3 3 0 013-3h8zm0 7.902H4a1.5 1.5 0 00-1.493 1.355l-.007.145v1.75a1.5 1.5 0 001.356 1.493l.144.007h8a1.5 1.5 0 001.493-1.356l.007-.144v-1.75a1.5 1.5 0 00-1.356-1.494L12 8.892zM11.5 10a.5.5 0 01.5.5v1a.5.5 0 01-.5.5h-1a.5.5 0 01-.5-.5v-1a.5.5 0 01.5-.5h1zm.5-7.51H4a1.5 1.5 0 00-1.493 1.355l-.007.144v1.75a1.5 1.5 0 001.356 1.493L4 7.24h8a1.5 1.5 0 001.493-1.355l.007-.145V3.99a1.5 1.5 0 00-1.356-1.493L12 2.49zM11.5 4a.5.5 0 01.5.5v1a.5.5 0 01-.5.5h-1a.5.5 0 01-.5-.5v-1a.5.5 0 01.5-.5h1z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
+}
+
+@mixin vf-icon-units($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9a1 1 0 011 1v4a1 1 0 01-1 1H2a1 1 0 01-1-1v-4a1 1 0 011-1h4zm8 0a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4a1 1 0 011-1h4zm-8.5 1.5h-3v3h3v-3zm8 0h-3v3h3v-3zM14 1a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V2a1 1 0 011-1h4zm-.5 1.5h-3v3h3v-3z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
+}

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -168,3 +168,7 @@ $social-icon-size: map-get($icon-sizes, heading-icon--small);
 @mixin vf-icon-units($color) {
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9a1 1 0 011 1v4a1 1 0 01-1 1H2a1 1 0 01-1-1v-4a1 1 0 011-1h4zm8 0a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4a1 1 0 011-1h4zm-8.5 1.5h-3v3h3v-3zm8 0h-3v3h3v-3zM14 1a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V2a1 1 0 011-1h4zm-.5 1.5h-3v3h3v-3z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
+
+@mixin vf-icon-pin($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.547.119l4.412 4.412-1.06 1.06-.366-.365-2.205 2.204-1.385 2.598 1.128 1.129-1.06 1.06-3.012-3.011-4.523 4.524-1.898.916.744-1.882 4.617-4.618-3.01-3.01 1.06-1.06 1.028 1.027 2.819-1.252 2.16-2.161-.51-.51 1.06-1.061zm.381 2.76L9.897 4.912a1.5 1.5 0 01-.329.248l-.123.062L7.16 6.237l2.678 2.678 1.167-2.19a1.5 1.5 0 01.164-.246l.1-.11 2.075-2.076-1.415-1.414z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
+}

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -32,7 +32,9 @@ $social-icon-size: map-get($icon-sizes, heading-icon--small);
 }
 
 @mixin vf-icon-contextual-menu($color) {
-  @include vf-icon-chevron($color);
+  @include deprecate('3.0.0', 'Use the `vf-icon-chevron` mixin instead') {
+    @include vf-icon-chevron($color);
+  }
 }
 
 @mixin vf-icon-close($color) {

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -7,6 +7,7 @@
   @include vf-p-icon-minus;
   @include vf-p-icon-expand;
   @include vf-p-icon-collapse;
+  @include vf-p-icon-chevron;
   @include vf-p-icon-contextual-menu;
   @include vf-p-icon-close;
   @include vf-p-icon-help;
@@ -177,14 +178,33 @@
   }
 }
 
-@mixin vf-p-icon-contextual-menu {
-  .p-icon--contextual-menu {
+@mixin vf-p-icon-chevron {
+  .p-icon--chevron-up {
+    transform: rotate(180deg);
+  }
+
+  .p-icon--chevron-down,
+  .p-icon--chevron-up {
     @extend %icon;
-    @include vf-icon-contextual-menu($color-mid-dark);
+    @include vf-icon-chevron($color-mid-dark);
 
     [class*='--dark'] &,
     &.is-light {
-      @include vf-icon-contextual-menu($color-mid-x-light);
+      @include vf-icon-chevron($color-mid-x-light);
+    }
+  }
+}
+
+@mixin vf-p-icon-contextual-menu {
+  @include deprecate('3.0.0', 'Use the `p-icon--chevron` class instead') {
+    .p-icon--contextual-menu {
+      @extend %icon;
+      @include vf-icon-contextual-menu($color-mid-dark);
+
+      [class*='--dark'] &,
+      &.is-light {
+        @include vf-icon-contextual-menu($color-mid-x-light);
+      }
     }
   }
 }

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -45,6 +45,7 @@
   @include vf-p-icon-fullscreen;
   @include vf-p-icon-models;
   @include vf-p-icon-machines;
+  @include vf-p-icon-pin;
   @include vf-p-icon-units;
 }
 
@@ -545,6 +546,18 @@
     [class*='--dark'] &,
     &.is-light {
       @include vf-icon-machines($color-mid-x-light);
+    }
+  }
+}
+
+@mixin vf-p-icon-pin {
+  .p-icon--pin {
+    @extend %icon;
+    @include vf-icon-pin($color-mid-dark);
+
+    [class*='--dark'] &,
+    &.is-light {
+      @include vf-icon-pin($color-mid-x-light);
     }
   }
 }

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -38,6 +38,15 @@
   @include vf-p-icon-in-button;
 }
 
+@mixin vf-p-icons--application {
+  @include vf-p-icon-applications;
+  @include vf-p-icon-controllers;
+  @include vf-p-icon-fullscreen;
+  @include vf-p-icon-models;
+  @include vf-p-icon-machines;
+  @include vf-p-icon-units;
+}
+
 @mixin vf-p-icons-common {
   %icon {
     @extend %vf-hide-text;
@@ -456,6 +465,78 @@
       [class*='p-icon-'] {
         top: 0;
       }
+    }
+  }
+}
+
+@mixin vf-p-icon-applications {
+  .p-icon--applications {
+    @extend %icon;
+    @include vf-icon-applications($color-mid-dark);
+
+    [class*='--dark'] &,
+    &.is-light {
+      @include vf-icon-applications($color-mid-x-light);
+    }
+  }
+}
+
+@mixin vf-p-icon-controllers {
+  .p-icon--controllers {
+    @extend %icon;
+    @include vf-icon-controllers($color-mid-dark);
+
+    [class*='--dark'] &,
+    &.is-light {
+      @include vf-icon-controllers($color-mid-x-light);
+    }
+  }
+}
+
+@mixin vf-p-icon-fullscreen {
+  .p-icon--fullscreen {
+    @extend %icon;
+    @include vf-icon-fullscreen($color-mid-dark);
+
+    [class*='--dark'] &,
+    &.is-light {
+      @include vf-icon-fullscreen($color-mid-x-light);
+    }
+  }
+}
+
+@mixin vf-p-icon-models {
+  .p-icon--models {
+    @extend %icon;
+    @include vf-icon-models($color-mid-dark);
+
+    [class*='--dark'] &,
+    &.is-light {
+      @include vf-icon-models($color-mid-x-light);
+    }
+  }
+}
+
+@mixin vf-p-icon-machines {
+  .p-icon--machines {
+    @extend %icon;
+    @include vf-icon-machines($color-mid-dark);
+
+    [class*='--dark'] &,
+    &.is-light {
+      @include vf-icon-machines($color-mid-x-light);
+    }
+  }
+}
+
+@mixin vf-p-icon-units {
+  .p-icon--units {
+    @extend %icon;
+    @include vf-icon-units($color-mid-dark);
+
+    [class*='--dark'] &,
+    &.is-light {
+      @include vf-icon-units($color-mid-x-light);
     }
   }
 }

--- a/scss/docs/_patterns_icons.scss
+++ b/scss/docs/_patterns_icons.scss
@@ -41,3 +41,8 @@
     margin-right: $sph-inner;
   }
 }
+
+// These are not included in Vanilla by default,
+// so include them here for the purposes of
+// presenting the application icons on the docs page.
+@include vf-p-icons--application;

--- a/scss/standalone/patterns_contextual-menu.scss
+++ b/scss/standalone/patterns_contextual-menu.scss
@@ -7,7 +7,7 @@
 // icons are needed for indicator variant
 @import '../patterns_icons';
 @include vf-p-icons-common;
-@include vf-p-icon-contextual-menu;
+@include vf-p-icon-chevron;
 
 @import '../patterns_contextual-menu';
 @include vf-p-contextual-menu;

--- a/scss/standalone/patterns_icons-application.scss
+++ b/scss/standalone/patterns_icons-application.scss
@@ -1,0 +1,13 @@
+// This file contains everything needed to render
+// the application icon set only. This is not a standard
+// pattern, but is needed to display this icon set in
+// our examples.
+
+@import '../settings';
+@import '../base_icon-definitions';
+@import '../base_placeholders';
+@import '../patterns_icons';
+
+@include vf-b-placeholders;
+@include vf-p-icons-common;
+@include vf-p-icons--application;

--- a/scss/standalone/patterns_pagination.scss
+++ b/scss/standalone/patterns_pagination.scss
@@ -1,10 +1,10 @@
 @import '../base';
 @include vf-base;
 
-// p-icon--contextual-menu needed as next/prev icon
+// p-icon--chevron-down needed as next/prev icon
 @import '../patterns_icons';
 @include vf-p-icons-common;
-@include vf-p-icon-contextual-menu;
+@include vf-p-icon-chevron;
 
 @import '../patterns_pagination';
 @include vf-p-pagination;

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,12 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.21 -->
     <tr>
+      <th><a href="/docs/patterns/icons#standard">Icons - Contextual Menu</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.21.0</td>
+      <td>The <code>p-icon--contextual-menu</code> has been deprecated and will be removed in future release v3.0. Please use existing <code>.p-icon--chevron-down</code> and <code>.p-icon--chevron-up</code> icons instead.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/icons#application">Icons - Application</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.21.0</td>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,10 +24,16 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.21 -->
     <tr>
+      <th><a href="/docs/patterns/icons#application">Icons - Application</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.21.0</td>
+      <td>We added a set of icons specifically for applications. This set is not included in Vanilla by default, but can be added to a project with <code>@include vf-p-icons--application</code>.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/navigation#application-layout">Side navigation - Application</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.21.0</td>
-      <td>We implemented and documented improvements for [side navigation component](/docs/patterns/navigation#application-layout) for the [application layout](/docs/layouts/application#side-navigation).</td>
+      <td>We implemented and documented improvements for <a href="/docs/patterns/navigation#application-layout">side navigation component</a> for the <a href="/docs/layouts/application#side-navigation">application layout</a>.</td>
     </tr>
     <tr>
       <th><a href="/docs/patterns/navigation#sticky">Side navigation - Sticky</a></th>

--- a/templates/docs/examples/patterns/buttons/icon.html
+++ b/templates/docs/examples/patterns/buttons/icon.html
@@ -6,5 +6,5 @@
 {% block content %}
 <button class="p-button--positive has-icon"><i class="p-icon--success"></i></button>
 <button class="p-button has-icon"><i class="p-icon--plus"></i><span>Icon before text</span></button>
-<button class="p-button has-icon"><span>Icon after text</span><i class="p-icon--contextual-menu"></i></button>
+<button class="p-button has-icon"><span>Icon after text</span><i class="p-icon--chevron-down"></i></button>
 {% endblock %}

--- a/templates/docs/examples/patterns/contextual-menu/with-indicator.html
+++ b/templates/docs/examples/patterns/contextual-menu/with-indicator.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <span class="p-contextual-menu--left">
-  <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--contextual-menu is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
+  <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--chevron-down is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
   <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
     <span class="p-contextual-menu__group">
       <a href="#" class="p-contextual-menu__link">Commission</a>

--- a/templates/docs/examples/patterns/icons/icons-application.html
+++ b/templates/docs/examples/patterns/icons/icons-application.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Icons / Application{% endblock %}
+
+{% block style %}
+<link rel="stylesheet" href="/static/build/css/standalone/patterns_icons-application.css" />
+{% endblock %}
+
+{% block content %}
+<div style="background: #111">
+  <i class="p-icon--applications is-light"></i>
+  <i class="p-icon--controllers is-light"></i>
+  <i class="p-icon--fullscreen is-light"></i>
+  <i class="p-icon--models is-light"></i>
+  <i class="p-icon--machines is-light"></i>
+  <i class="p-icon--units is-light"></i>
+</div>
+
+<div>
+  <i class="p-icon--applications"></i>
+  <i class="p-icon--controllers"></i>
+  <i class="p-icon--fullscreen"></i>
+  <i class="p-icon--models"></i>
+  <i class="p-icon--machines"></i>
+  <i class="p-icon--units"></i>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/icons/icons-application.html
+++ b/templates/docs/examples/patterns/icons/icons-application.html
@@ -12,6 +12,7 @@
   <i class="p-icon--fullscreen is-light"></i>
   <i class="p-icon--models is-light"></i>
   <i class="p-icon--machines is-light"></i>
+  <i class="p-icon--pin is-light"></i>
   <i class="p-icon--units is-light"></i>
 </div>
 
@@ -21,6 +22,7 @@
   <i class="p-icon--fullscreen"></i>
   <i class="p-icon--models"></i>
   <i class="p-icon--machines"></i>
+  <i class="p-icon--pin"></i>
   <i class="p-icon--units"></i>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/icons/icons-dark.html
+++ b/templates/docs/examples/patterns/icons/icons-dark.html
@@ -10,7 +10,8 @@
   <i class="p-icon--expand is-light"></i>
   <i class="p-icon--collapse is-light"></i>
   <i class="p-icon--spinner u-animation--spin is-light"></i>
-  <i class="p-icon--contextual-menu is-light"></i>
+  <i class="p-icon--chevron-down is-light"></i>
+  <i class="p-icon--chevron-up is-light"></i>
   <i class="p-icon--close is-light"></i>
   <i class="p-icon--help is-light"></i>
   <i class="p-icon--information is-light"></i>
@@ -35,7 +36,8 @@
   <i class="p-icon--expand"></i>
   <i class="p-icon--collapse"></i>
   <i class="p-icon--spinner u-animation--spin"></i>
-  <i class="p-icon--contextual-menu"></i>
+  <i class="p-icon--chevron-down"></i>
+  <i class="p-icon--chevron-up"></i>
   <i class="p-icon--close"></i>
   <i class="p-icon--help"></i>
   <i class="p-icon--information"></i>

--- a/templates/docs/examples/patterns/icons/icons-light.html
+++ b/templates/docs/examples/patterns/icons/icons-light.html
@@ -9,7 +9,8 @@
 <i class="p-icon--expand"></i>
 <i class="p-icon--collapse"></i>
 <i class="p-icon--spinner u-animation--spin"></i>
-<i class="p-icon--contextual-menu"></i>
+<i class="p-icon--chevron-down"></i>
+<i class="p-icon--chevron-up"></i>
 <i class="p-icon--close"></i>
 <i class="p-icon--help"></i>
 <i class="p-icon--information"></i>

--- a/templates/docs/examples/patterns/pagination/pagination-disabled.html
+++ b/templates/docs/examples/patterns/pagination/pagination-disabled.html
@@ -6,7 +6,7 @@
 {% block content %}
 <ol class="p-pagination">
   <li class="p-pagination__item">
-    <span class="p-pagination__link--previous is-disabled"><i class="p-icon--contextual-menu">Previous page</i></span>
+    <span class="p-pagination__link--previous is-disabled"><i class="p-icon--chevron-down">Previous page</i></span>
   </li>
   <li class="p-pagination__item">
     <a class="p-pagination__link is-active" href="#1">1</a>
@@ -24,7 +24,7 @@
     <a class="p-pagination__link" href="#5">5</a>
   </li>
   <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
+    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
   </li>
 </ol>
 {% endblock %}

--- a/templates/docs/examples/patterns/pagination/pagination-truncated.html
+++ b/templates/docs/examples/patterns/pagination/pagination-truncated.html
@@ -6,7 +6,7 @@
 {% block content %}
 <ol class="p-pagination">
   <li class="p-pagination__item">
-    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--contextual-menu">Previous page</i></a>
+    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
   </li>
   <li class="p-pagination__item">
     <a class="p-pagination__link" href="#1">1</a>
@@ -30,7 +30,7 @@
     <a class="p-pagination__link" href="#7">100</a>
   </li>
   <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
+    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
   </li>
 </ol>
 {% endblock %}

--- a/templates/docs/examples/patterns/pagination/pagination-verbose.html
+++ b/templates/docs/examples/patterns/pagination/pagination-verbose.html
@@ -6,10 +6,10 @@
 {% block content %}
 <ol class="p-pagination">
   <li class="p-pagination__item">
-    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--contextual-menu"></i><span>Previous page</span></a>
+    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down"></i><span>Previous page</span></a>
   </li>
   <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><span>Next page</span><i class="p-icon--contextual-menu"></i></a>
+    <a class="p-pagination__link--next" href="#next" title="Next page"><span>Next page</span><i class="p-icon--chevron-down"></i></a>
   </li>
 </ol>
 {% endblock %}

--- a/templates/docs/examples/patterns/pagination/pagination.html
+++ b/templates/docs/examples/patterns/pagination/pagination.html
@@ -6,7 +6,7 @@
 {% block content %}
 <ol class="p-pagination">
   <li class="p-pagination__item">
-    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--contextual-menu">Previous page</i></a>
+    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
   </li>
   <li class="p-pagination__item">
     <a class="p-pagination__link" href="#1">1</a>
@@ -24,7 +24,7 @@
     <a class="p-pagination__link" href="#5">5</a>
   </li>
   <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--contextual-menu">Next page</i></a>
+    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
   </li>
 </ol>
 {% endblock %}

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -55,7 +55,7 @@
         <span class="p-contextual-menu">
           <a href="#" class="p-button p-contextual-menu__toggle" aria-controls="#menu" aria-expanded="false"
             aria-haspopup="true">
-            Change pool <i class="p-icon--contextual-menu"></i>
+            Change pool <i class="p-icon--chevron-down"></i>
           </a>
           <span class="p-contextual-menu__dropdown" id="menu" aria-hidden="true">
             <span class="p-contextual-menu__group">

--- a/templates/docs/examples/utilities/font-metrics.html
+++ b/templates/docs/examples/utilities/font-metrics.html
@@ -34,7 +34,7 @@
   <span class="u-visualise-font-metrics">
     Button with icon
   </span>
-  <i class="p-icon--contextual-menu">
+  <i class="p-icon--chevron-down">
   </i>
 </button>
 <button class="p-button has-icon">

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -78,7 +78,7 @@ To import just this component into your project, copy the snippet below and incl
 
 @import 'patterns_icons';
 @include vf-p-icons-common;
-@include vf-p-icon-contextual-menu;
+@include vf-p-icon-chevron;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -16,7 +16,7 @@ Icons provide visual context and enhance usability, they can be added via an `<i
 
 For accessibility purposes, you can add text inside the icon element which will not be displayed to the user. E.g.
 
-`<i class="p-icon--contextual-menu">This text will not be displayed</i>`
+`<i class="p-icon--chevron-down">This text will not be displayed</i>`
 
 ### Standard
 
@@ -68,35 +68,38 @@ Our icons have two predefined color styles: light and dark. The light variant is
         <p><i class="p-icon--external-link" style="margin-right: 1rem;"></i>p-icon--external-link</p>
       </div>
       <div class="p-card col-3 u-vertically-center">
-        <p><i class="p-icon--contextual-menu" style="margin-right: 1rem;"></i>p-icon--contextual-menu</p>
+        <p><i class="p-icon--chevron-down" style="margin-right: 1rem;"></i>p-icon--chevron-down</p>
       </div>
     </div>
 
     <div class="row u-equal-height">
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--chevron-up" style="margin-right: 1rem;"></i>p-icon--chevron-up</p>
+      </div>
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--menu" style="margin-right: 1rem;"></i>p-icon--menu</p>
       </div>
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--code" style="margin-right: 1rem;"></i>p-icon--code</p>
       </div>
-      <div class="p-card col-3 u-vertically-center">
-        <p><i class="p-icon--copy" style="margin-right: 1rem;"></i>p-icon--copy</p>
-      </div>
     </div>
 
     <div class="row u-equal-height">
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--copy" style="margin-right: 1rem;"></i>p-icon--copy</p>
+      </div>
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--search" style="margin-right: 1rem;"></i>p-icon--search</p>
       </div>
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--share" style="margin-right: 1rem;"></i>p-icon--share</p>
       </div>
-      <div class="p-card col-3 u-vertically-center">
-        <p><i class="p-icon--user" style="margin-right: 1rem;"></i>p-icon--user</p>
-      </div>
     </div>
 
     <div class="row u-equal-height">
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--user" style="margin-right: 1rem;"></i>p-icon--user</p>
+      </div>
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--anchor" style="margin-right: 1rem;"></i>p-icon--anchor</p>
       </div>
@@ -105,7 +108,7 @@ Our icons have two predefined color styles: light and dark. The light variant is
   </div>
 </section>
 
-<span class="p-label--deprecated">Deprecated</span> The `.p-icon--question` class has been deprecated and will be removed in version 3.0. Use class `.p-icon--help` instead.
+<span class="p-label--deprecated">Deprecated</span> The `.p-icon--question` class has been deprecated and will be removed in version 3.0. Use class `.p-icon--help` instead. We will also be removing <code>p-icon--contextual-menu</code>, please use <code>p-icon--chevron-down</code> instead.
 
 ### Dark theme
 
@@ -277,7 +280,7 @@ If you use a limited set of icons you may want to include them individually to r
 @include vf-p-icon-minus;
 @include vf-p-icon-expand;
 @include vf-p-icon-collapse;
-@include vf-p-icon-contextual-menu;
+@include vf-p-icon-chevron;
 @include vf-p-icon-close;
 @include vf-p-icon-help;
 @include vf-p-icon-info;

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -178,6 +178,12 @@ Outside of the standard set, additional icons are available for application-base
         <i class="p-icon--machines" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--machines
       </div>
       <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--pin" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--pin
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--units" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--units
       </div>
     </div>
@@ -316,6 +322,7 @@ If you use a limited set of icons you may want to include them individually to r
 @include vf-p-icon-fullscreen;
 @include vf-p-icon-models;
 @include vf-p-icon-machines;
+@include vf-p-icon-pin;
 @include vf-p-icon-units;
 ```
 

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -149,6 +149,39 @@ Our alert icons are used to indicate the status of a message in a notification.
   </div>
 </section>
 
+### Application
+
+Outside of the standard set, additional icons are available for application-based projects, and need to be explicitly imported using `@include vf-p-icons--application`.
+
+<section>
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row">
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--applications" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--applications
+      </div>
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--controllers" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--controllers
+      </div>
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--fullscreen" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--fullscreen
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--models" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--models
+      </div>
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--machines" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--machines
+      </div>
+      <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
+        <i class="p-icon--units" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--units
+      </div>
+    </div>
+
+  </div>
+</section>
+
 ### Social
 
 Our social icons are used to drive users to social content.
@@ -223,6 +256,13 @@ To import just this component into your project, copy the snippet below and incl
 @include vf-u-animations;
 ```
 
+The [application](#application) set of icons is not included in Vanilla by default, if you require them you can add them to your project using the below include.
+
+```scss
+@import 'patterns_icons';
+@include vf-p-icons--application;
+```
+
 If you use a limited set of icons you may want to include them individually to reduce the size of your CSS file.
 
 ```scss
@@ -266,6 +306,14 @@ If you use a limited set of icons you may want to include them individually to r
 @include vf-p-icon-email;
 @include vf-p-icon-sizes;
 @include vf-p-icon-in-button;
+
+// application icons
+@include vf-p-icon-applications;
+@include vf-p-icon-controllers;
+@include vf-p-icon-fullscreen;
+@include vf-p-icon-models;
+@include vf-p-icon-machines;
+@include vf-p-icon-units;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/patterns/pagination.md
+++ b/templates/docs/patterns/pagination.md
@@ -59,7 +59,7 @@ To import the pagination component into your project, copy the snippet below and
 // pagination uses icons for previous and next page buttons
 @import 'patterns_icons';
 @include vf-p-icons-common;
-@include vf-p-icon-contextual-menu;
+@include vf-p-icon-chevron;
 ```
 
 #### Article pagination component

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/q@^1.5.1":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
+  integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
+
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -748,6 +753,11 @@ body-parser@1.19.0, body-parser@^1.18.3:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
+boolbase@^1.0.0, boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -806,6 +816,14 @@ cacheable-request@^6.0.0:
     lowercase-keys "^2.0.0"
     normalize-url "^4.1.0"
     responselike "^1.0.2"
+
+call-bind@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.0.tgz#24127054bb3f9bdcb4b1fb82418186072f77b8ce"
+  integrity sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.0"
 
 caller-callsite@^2.0.0:
   version "2.0.0"
@@ -1068,6 +1086,15 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+coa@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/coa/-/coa-2.0.2.tgz#43f6c21151b4ef2bf57187db0d73de229e3e7ec3"
+  integrity sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==
+  dependencies:
+    "@types/q" "^1.5.1"
+    chalk "^2.4.1"
+    q "^1.1.2"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -1273,10 +1300,53 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-select-base-adapter@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
+  integrity sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==
+
+css-select@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
+  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^3.2.1"
+    domutils "^1.7.0"
+    nth-check "^1.0.2"
+
+css-tree@1.0.0-alpha.37:
+  version "1.0.0-alpha.37"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.37.tgz#98bebd62c4c1d9f960ec340cf9f7522e30709a22"
+  integrity sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==
+  dependencies:
+    mdn-data "2.0.4"
+    source-map "^0.6.1"
+
+css-tree@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz#9ae393b5dafd7dae8a622475caec78d3d8fbd7b5"
+  integrity sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
+  dependencies:
+    mdn-data "2.0.14"
+    source-map "^0.6.1"
+
+css-what@^3.2.1:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
+  integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+csso@^4.0.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-4.2.0.tgz#ea3a561346e8dc9f546d6febedd50187cf389529"
+  integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
+  dependencies:
+    css-tree "^1.1.2"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1364,6 +1434,13 @@ defer-to-connect@^1.0.1:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.1.tgz#88ae694b93f67b81815a2c8c769aef6574ac8f2f"
   integrity sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==
 
+define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1430,7 +1507,7 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@^1.5.1:
+domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
@@ -1526,6 +1603,50 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.17.2:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"
+  integrity sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.1"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.1:
+  version "1.18.0-next.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.1.tgz#6e3a0a4bda717e5023ab3b8e90bec36108d22c68"
+  integrity sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.1"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es5-ext@^0.10.35, es5-ext@^0.10.45, es5-ext@^0.10.46, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
   version "0.10.50"
@@ -2031,6 +2152,15 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-intrinsic@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz#94a9768fcbdd0595a1c9273aacf4c89d075631be"
+  integrity sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-site-urls@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/get-site-urls/-/get-site-urls-1.1.7.tgz#6b617f352c69fdf9df21c9f2f9000320866ddba7"
@@ -2278,6 +2408,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-symbols@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -2564,12 +2699,22 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
+is-callable@^1.1.4, is-callable@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
+  integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
+
 is-core-module@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.1.0.tgz#a4cc031d9b1aca63eecbd18a650e13cb4eeab946"
   integrity sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==
   dependencies:
     has "^1.0.3"
+
+is-date-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-decimal@^1.0.0:
   version "1.0.4"
@@ -2627,6 +2772,11 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -2647,6 +2797,13 @@ is-promise@^2.1, is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
+is-regex@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
+  dependencies:
+    has-symbols "^1.0.1"
+
 is-regexp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-2.1.0.tgz#cd734a56864e23b956bf4e7c66c396a4c0b22c2d"
@@ -2661,6 +2818,13 @@ is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
+is-symbol@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+  dependencies:
+    has-symbols "^1.0.1"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -3033,6 +3197,16 @@ mdast-util-to-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
   integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
+mdn-data@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
+  integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -3238,6 +3412,13 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mkdirp@~0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
+
 mri@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.6.tgz#49952e1044db21dbf90f6cd92bc9c9a777d415a6"
@@ -3421,6 +3602,13 @@ npmlog@^4.0.0, npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -3441,6 +3629,35 @@ object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-inspect@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
+  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
+
+object-keys@^1.0.12, object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object.assign@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.getownpropertydescriptors@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz#0dfda8d108074d9c563e80490c883b6661091544"
+  integrity sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+
 object.omit@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
@@ -3448,6 +3665,16 @@ object.omit@~2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.values@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.2.tgz#7a2015e06fcb0f546bd652486ce8583a4731c731"
+  integrity sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    has "^1.0.3"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -4007,6 +4234,11 @@ puppeteer@^2.0.0:
     rimraf "^2.6.1"
     ws "^6.1.0"
 
+q@^1.1.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
@@ -4394,6 +4626,11 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
+sax@~1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
@@ -4600,6 +4837,11 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+stable@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
+  integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
 stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
@@ -4656,6 +4898,22 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string.prototype.trimend@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
+  integrity sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
+  integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -4873,6 +5131,25 @@ svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
+
+svgo@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.3.2.tgz#b6dc511c063346c9e415b81e43401145b96d4167"
+  integrity sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==
+  dependencies:
+    chalk "^2.4.1"
+    coa "^2.0.2"
+    css-select "^2.0.0"
+    css-select-base-adapter "^0.1.1"
+    css-tree "1.0.0-alpha.37"
+    csso "^4.0.2"
+    js-yaml "^3.13.1"
+    mkdirp "~0.5.1"
+    object.values "^1.1.0"
+    sax "~1.2.4"
+    stable "^0.1.8"
+    unquote "~1.1.1"
+    util.promisify "~1.0.0"
 
 table@^6.0.3:
   version "6.0.4"
@@ -5099,6 +5376,11 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
+unquote@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
+  integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=
+
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -5117,6 +5399,16 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+util.promisify@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee"
+  integrity sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.2"
+    has-symbols "^1.0.1"
+    object.getownpropertydescriptors "^2.1.0"
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Done

Added a subset of application icons per [this request from the JAAS team](https://github.com/canonical-web-and-design/jaas-dashboard/issues/453#issuecomment-630949936), that are not included in Vanilla by default. 

Fixes #3426 

## QA

- Pull code
- Run `./run`
- Open https://vanilla-framework-3436.demos.haus/docs/patterns/icons#application
- See the new icons are present, and that there is documentation on how to import them is present at https://vanilla-framework-3436.demos.haus/docs/patterns/icons#import
- See that the examples also look correct: https://vanilla-framework-3436.demos.haus/docs/examples/patterns/icons/icons-application and https://vanilla-framework-3436.demos.haus/docs/examples/standalone/patterns/icons/icons-application
