### PR TITLE
Application layout panel header styles

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -80,6 +80,39 @@
     }
   }
 
+  // Spacing
+  %section-padding--shallow {
+    @media only screen and (max-width: $breakpoint-large) {
+      padding-bottom: $spv-outer--shallow-scaleable * 0.5;
+      padding-top: $spv-outer--shallow-scaleable * 0.5;
+    }
+    @media only screen and (min-width: $breakpoint-large) {
+      padding-bottom: $spv-outer--shallow-scaleable;
+      padding-top: $spv-outer--shallow-scaleable;
+    }
+  }
+
+  %section-padding--default {
+    @media only screen and (max-width: $breakpoint-large) {
+      padding-bottom: $spv-outer--regular-scaleable * 0.5;
+      padding-top: $spv-outer--regular-scaleable * 0.5;
+    }
+    @media only screen and (min-width: $breakpoint-large) {
+      padding-bottom: $spv-outer--regular-scaleable;
+      padding-top: $spv-outer--regular-scaleable;
+    }
+  }
+
+  %section-padding--deep {
+    @media only screen and (max-width: $breakpoint-large) {
+      padding: $spv-outer--deep-scaleable * 0.5 0 $spv-outer--deep-scaleable * 0.5;
+    }
+
+    @media only screen and (min-width: $breakpoint-large) {
+      padding: $spv-outer--deep-scaleable 0;
+    }
+  }
+
   // Utilities
   %vf-hide-text {
     overflow: hidden;

--- a/scss/_layouts_application-panels.scss
+++ b/scss/_layouts_application-panels.scss
@@ -28,11 +28,9 @@
   }
 
   .p-panel__content {
-    overflow: hidden;
+    @extend %section-padding--shallow;
 
-    .p-panel__header + & {
-      padding-top: $spv-outer--scaleable;
-    }
+    overflow: hidden;
   }
 
   .p-panel__logo {

--- a/scss/_layouts_application-panels.scss
+++ b/scss/_layouts_application-panels.scss
@@ -1,6 +1,4 @@
 @mixin vf-l-application-panels {
-  $header-padding-bottom: $sp-unit * 6;
-
   .p-panel {
     background: $colors--light-theme--background-default;
     color: $colors--light-theme--text-default;
@@ -15,18 +13,62 @@
 
   .p-panel__header,
   .p-panel__header--sticky {
-    padding-bottom: $header-padding-bottom;
-    padding-top: $spv-outer--medium;
+    @extend %vf-grid-container-padding;
+
+    display: flex;
   }
 
   .p-panel__header--sticky {
-    background: linear-gradient(to bottom, #{$colors--light-theme--background-default} 0%, #{$colors--light-theme--background-default} 70%, transparent 100%);
     position: sticky;
     top: 0;
     z-index: 1;
+  }
 
-    .is-dark & {
-      background: linear-gradient(to bottom, #{$colors--dark-theme--background-default} 0%, #{$colors--dark-theme--background-default} 70%, transparent 100%);
+  .p-panel__content {
+    overflow: hidden;
+
+    .p-panel__header + &,
+    .p-panel__header--sticky + & {
+      padding-top: $spv-outer--regular-scaleable;
     }
+  }
+
+  .p-panel__logo {
+    align-items: center;
+    display: flex;
+    margin-bottom: 0.75rem;
+    // to center the logo inside the collapsed side navigation we have to move it a bit to the left
+    // so its position is aligned with the icons of side navigation
+    margin-left: -0.25rem; // (LOGO_SIZE - ICON_SIZE) / 2 = (1.5rem - 1rem) / 2 = 0.25rem
+    margin-top: 0.75rem;
+
+    .p-panel__logo-icon {
+      height: 1.5rem;
+    }
+
+    .p-panel__logo-name {
+      height: 1rem;
+      margin-left: 0.5rem;
+    }
+  }
+
+  .p-panel__title {
+    @extend %vf-heading-4;
+
+    margin: 0;
+    padding-bottom: $spv-inner--x-small;
+    padding-top: $spv-inner--small;
+  }
+
+  .p-panel__controls {
+    margin-left: auto;
+    padding-top: 0.5rem;
+  }
+
+  .p-panel__toggle {
+    cursor: pointer;
+    display: block;
+    margin-bottom: 0.75rem;
+    margin-top: 0.25rem;
   }
 }

--- a/scss/_layouts_application-panels.scss
+++ b/scss/_layouts_application-panels.scss
@@ -11,25 +11,27 @@
     }
   }
 
-  .p-panel__header,
-  .p-panel__header--sticky {
+  .p-panel__header {
     @extend %vf-grid-container-padding;
 
     display: flex;
   }
 
-  .p-panel__header--sticky {
+  .p-panel__header.is-sticky {
     position: sticky;
     top: 0;
     z-index: 1;
+
+    .p-panel.is-dark & {
+      background: $colors--dark-theme--background-default;
+    }
   }
 
   .p-panel__content {
     overflow: hidden;
 
-    .p-panel__header + &,
-    .p-panel__header--sticky + & {
-      padding-top: $spv-outer--regular-scaleable;
+    .p-panel__header + & {
+      padding-top: 2rem;
     }
   }
 

--- a/scss/_layouts_application-panels.scss
+++ b/scss/_layouts_application-panels.scss
@@ -31,18 +31,18 @@
     overflow: hidden;
 
     .p-panel__header + & {
-      padding-top: 2rem;
+      padding-top: $spv-outer--scaleable;
     }
   }
 
   .p-panel__logo {
     align-items: center;
     display: flex;
-    margin-bottom: 0.75rem;
+    margin-bottom: 1.25rem;
     // to center the logo inside the collapsed side navigation we have to move it a bit to the left
     // so its position is aligned with the icons of side navigation
     margin-left: -0.25rem; // (LOGO_SIZE - ICON_SIZE) / 2 = (1.5rem - 1rem) / 2 = 0.25rem
-    margin-top: 0.75rem;
+    margin-top: 1.25rem;
 
     .p-panel__logo-icon {
       height: 1.5rem;
@@ -58,19 +58,19 @@
     @extend %vf-heading-4;
 
     margin: 0;
-    padding-bottom: $spv-inner--x-small;
-    padding-top: $spv-inner--small;
+    padding-bottom: $sp-medium;
+    padding-top: $sp-medium;
   }
 
   .p-panel__controls {
     margin-left: auto;
-    padding-top: 0.5rem;
+    padding-top: $sph-inner;
   }
 
   .p-panel__toggle {
     cursor: pointer;
     display: block;
-    margin-bottom: 0.75rem;
+    margin-bottom: 1.25rem;
     margin-top: 0.25rem;
   }
 }

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -1,39 +1,6 @@
 @import 'settings';
 
 @mixin vf-p-strip {
-  %section-padding--shallow {
-    @media only screen and (max-width: $breakpoint-large) {
-      padding-bottom: $spv-outer--shallow-scaleable * 0.5;
-      padding-top: $spv-outer--shallow-scaleable * 0.5;
-    }
-    @media only screen and (min-width: $breakpoint-large) {
-      padding-bottom: $spv-outer--shallow-scaleable;
-      padding-top: $spv-outer--shallow-scaleable;
-    }
-  }
-
-  // used in strips and footer
-  %section-padding--default {
-    @media only screen and (max-width: $breakpoint-large) {
-      padding-bottom: $spv-outer--regular-scaleable * 0.5;
-      padding-top: $spv-outer--regular-scaleable * 0.5;
-    }
-    @media only screen and (min-width: $breakpoint-large) {
-      padding-bottom: $spv-outer--regular-scaleable;
-      padding-top: $spv-outer--regular-scaleable;
-    }
-  }
-
-  %section-padding--deep {
-    @media only screen and (max-width: $breakpoint-large) {
-      padding: $spv-outer--deep-scaleable * 0.5 0 $spv-outer--deep-scaleable * 0.5;
-    }
-
-    @media only screen and (min-width: $breakpoint-large) {
-      padding: $spv-outer--deep-scaleable 0;
-    }
-  }
-
   %vf-strip {
     @extend %section-padding--default;
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -36,7 +36,13 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>We added many more icons, outside of the base icon set. These icons are not included in Vanilla by default, but can be individually included as needed.</td>
     </tr>
     <tr>
-      <th><a href="/docs/patterns/navigation#application-layout">Side navigation - Application</a></th>
+      <th><a href="/docs/patterns/navigation#panels">Application layout - panels</a></th>
+      <td><div class="p-label--in-progress">In progress</div></td>
+      <td>2.21.0</td>
+      <td>We continue working on application layout panels styling. We improved the positioning of the logo, title and controls in panel headers.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/navigation#application-layout">Application layout - side navigation</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.21.0</td>
       <td>We implemented and documented improvements for <a href="/docs/patterns/navigation#application-layout">side navigation component</a> for the <a href="/docs/layouts/application#side-navigation">application layout</a>.</td>

--- a/templates/docs/examples/layouts/application/JAAS.html
+++ b/templates/docs/examples/layouts/application/JAAS.html
@@ -41,23 +41,12 @@
   }
 
   /* custom JAAS background color */
-  .p-panel.is-jaas-background {
-    background: #003b4e;
+  .is-jaas-background {
+    background: #003b4e !important;
   }
 
   .p-panel__header--sticky.is-jaas-background {
     background: linear-gradient(to bottom, #003b4e 0%, #003b4e 70%, transparent 100%);
-  }
-
-  .p-panel__content {
-    overflow: hidden;
-  }
-
-  .p-panel__logo {
-    display: flex;
-    align-items: center;
-    padding-top: 0.5rem;
-    margin-left: -4px; /* logo size - icon size -> (24px - 16px) / 2 */
   }
 </style>
 {% endblock %}
@@ -66,9 +55,14 @@
 <div class="l-application" role="presentation">
   <div class="l-navigation-bar">
     <div class="p-panel is-dark is-jaas-background">
-      <!-- TODO: these are temprorary custom styles, not a final Vanilla version -->
-      <div class="u-fixed-width u-align--right">
-        <span class="js-menu-toggle" style="display: inline-block; cursor: pointer; padding-top: 0.75rem; padding-bottom: 0.75rem">Menu</span>
+      <div class="p-panel__header">
+        <a class="p-panel__logo" href="#">
+          <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
+          <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">
+        </a>
+        <div class="p-panel__controls">
+          <span class="p-panel__toggle js-menu-toggle">Menu</span>
+        </div>
       </div>
     </div>
   </div>
@@ -77,19 +71,13 @@
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark is-jaas-background">
         <div class="p-panel__header--sticky is-jaas-background">
-          <div class="u-fixed-width u-sv-2">
-            <div class="p-inline-list--stretch">
-              <div class="p-inline-list__item">
-                <a class="p-panel__logo" href="#">
-                  <img src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
-                  <img class="is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" width="50" style="margin-left: 10px">
-                </a>
-              </div>
-              <div class="p-inline-list__item u-align--right u-hide--large">
-                <button class="p-button--base has-icon u-no-margin u-hide--medium js-menu-close"><i class="p-icon--close"></i></button>
-                <button class="p-button--base has-icon u-no-margin u-hide--small js-menu-pin"><i class="p-icon--close p-icon--pin"></i></button>
-              </div>
-            </div>
+          <a class="p-panel__logo" href="#">
+            <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
+            <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">
+          </a>
+          <div class="p-panel__controls u-hide--large">
+            <button class="p-button--base has-icon u-no-margin u-hide--medium js-menu-close"><i class="p-icon--close"></i></button>
+            <button class="p-button--base has-icon u-no-margin u-hide--small js-menu-pin"><i class="p-icon--close p-icon--pin"></i></button>
           </div>
         </div>
         <div class="p-panel__content">
@@ -103,13 +91,9 @@
   <main class="l-main">
     <div class="p-panel">
       <div class="p-panel__header">
-        <div class="u-fixed-width u-sv-2">
-          <div class="p-inline-list--stretch">
-            <h4 class="p-inline-list__item u-no-margin--bottom">8 models: 3 blocked, 2 alerts, 3 running</h4>
-            <div class="p-inline-list__item u-align--right">
-              <button class="u-no-margin--bottom js-aside-toggle">Toggle aside</button>
-            </div>
-          </div>
+        <h4 class="p-panel__title">8 models: 3 blocked, 2 alerts, 3 running</h4>
+        <div class="p-panel__controls">
+          <button class="u-no-margin--bottom js-aside-toggle">Toggle aside</button>
         </div>
       </div>
       <div class="p-panel__content">
@@ -244,13 +228,9 @@
   <aside class="l-aside is-jaas is-wide" id="aside-panel">
     <div class="p-panel">
       <div class="p-panel__header">
-        <div class="u-fixed-width u-sv-2">
-          <div class="p-inline-list--stretch">
-            <h4 class="p-inline-list__item u-no-margin--bottom">Details for 192.168.255.254</h4>
-            <div class="p-inline-list__item u-align--right">
-              <button class="p-button--base js-aside-close u-no-margin--bottom has-icon"><i class="p-icon--close"></i></button>
-            </div>
-          </div>
+        <h4 class="p-panel__title">Details for 192.168.255.254</h4>
+        <div class="p-panel__controls">
+          <button class="p-button--base js-aside-close u-no-margin--bottom has-icon"><i class="p-icon--close"></i></button>
         </div>
       </div>
       <div class="p-panel__content">

--- a/templates/docs/examples/layouts/application/JAAS.html
+++ b/templates/docs/examples/layouts/application/JAAS.html
@@ -44,10 +44,6 @@
   .is-jaas-background {
     background: #003b4e !important;
   }
-
-  .p-panel__header--sticky.is-jaas-background {
-    background: linear-gradient(to bottom, #003b4e 0%, #003b4e 70%, transparent 100%);
-  }
 </style>
 {% endblock %}
 
@@ -70,7 +66,7 @@
   <header class="l-navigation is-collapsed">
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark is-jaas-background">
-        <div class="p-panel__header--sticky is-jaas-background">
+        <div class="p-panel__header">
           <a class="p-panel__logo" href="#">
             <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
             <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">

--- a/templates/docs/examples/layouts/application/_styles.css
+++ b/templates/docs/examples/layouts/application/_styles.css
@@ -12,12 +12,6 @@ body {
   max-width: 95rem;
 }
 
-.p-panel__logo {
-  display: block;
-  max-height: 1.5rem;
-  width: auto;
-}
-
 .demo-status {
   background-color: #f7f7f7; /* $colors--light-theme--background-alt; */
   padding-bottom: 0.75rem; /* $spv-inner--medium; */

--- a/templates/docs/examples/layouts/application/default.html
+++ b/templates/docs/examples/layouts/application/default.html
@@ -26,7 +26,7 @@
   <header class="l-navigation is-collapsed">
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark">
-        <div class="p-panel__header--sticky">
+        <div class="p-panel__header is-sticky">
           <a class="p-panel__logo" href="#">
             <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
             <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">

--- a/templates/docs/examples/layouts/application/default.html
+++ b/templates/docs/examples/layouts/application/default.html
@@ -11,8 +11,14 @@
 <div class="l-application" role="presentation">
   <div class="l-navigation-bar">
     <div class="p-panel is-dark">
-      <div class="u-fixed-width u-align--right">
-        <span class="js-menu-toggle">Menu</span>
+      <div class="p-panel__header">
+        <a class="p-panel__logo" href="#">
+          <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
+          <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">
+        </a>
+        <div class="p-panel__controls">
+          <span class="p-panel__toggle js-menu-toggle">Menu</span>
+        </div>
       </div>
     </div>
   </div>
@@ -21,18 +27,13 @@
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark">
         <div class="p-panel__header--sticky">
-          <div class="u-fixed-width u-sv-2">
-            <div class="p-inline-list--stretch">
-              <div class="p-inline-list__item">
-                <a class="p-panel__logo" href="#">
-                  <img src="https://assets.ubuntu.com/v1/0b2b7bce-Vanilla-logo_88x24px_white.svg" alt="Vanilla framework" height="24">
-                </a>
-              </div>
-              <div class="p-inline-list__item u-align--right u-hide--large">
-                <button class="p-button--base has-icon u-no-margin u-hide--medium js-menu-close"><i class="p-icon--close"></i></button>
-                <button class="p-button--base has-icon u-no-margin u-hide--small js-menu-pin"><i class="p-icon--close p-icon--pin"></i></button>
-              </div>
-            </div>
+          <a class="p-panel__logo" href="#">
+            <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
+            <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">
+          </a>
+          <div class="p-panel__controls u-hide--large">
+            <button class="p-button--base has-icon u-no-margin u-hide--medium js-menu-close"><i class="p-icon--close"></i></button>
+            <button class="p-button--base has-icon u-no-margin u-hide--small js-menu-pin"><i class="p-icon--close p-icon--pin"></i></button>
           </div>
         </div>
         <div class="p-panel__content">
@@ -46,13 +47,9 @@
   <main class="l-main">
     <div class="p-panel">
       <div class="p-panel__header">
-        <div class="u-fixed-width u-sv-2">
-          <div class="p-inline-list--stretch">
-            <h4 class="p-inline-list__item u-no-margin--bottom">8 models: 3 blocked, 2 alerts, 3 running</h4>
-            <div class="p-inline-list__item u-align--right">
-              <button class="u-no-margin--bottom js-aside-toggle">Toggle aside</button>
-            </div>
-          </div>
+        <h4 class="p-panel__title">8 models: 3 blocked, 2 alerts, 3 running</h4>
+        <div class="p-panel__controls">
+          <button class="u-no-margin--bottom js-aside-toggle">Toggle aside</button>
         </div>
       </div>
       <div class="p-panel__content">
@@ -294,13 +291,9 @@
   <aside class="l-aside" id="aside-panel">
     <div class="p-panel">
       <div class="p-panel__header">
-        <div class="u-fixed-width u-sv-2">
-          <div class="p-inline-list--stretch">
-            <h4 class="p-inline-list__item u-no-margin--bottom">Aside panel</h4>
-            <div class="p-inline-list__item u-align--right">
-              <button class="p-button--base js-aside-close u-no-margin--bottom has-icon"><i class="p-icon--close"></i></button>
-            </div>
-          </div>
+        <h4 class="p-panel__title">Aside panel</h4>
+        <div class="p-panel__controls">
+          <button class="p-button--base js-aside-close u-no-margin--bottom has-icon"><i class="p-icon--close"></i></button>
         </div>
       </div>
       <div class="p-panel__content">

--- a/templates/docs/examples/layouts/application/split.html
+++ b/templates/docs/examples/layouts/application/split.html
@@ -38,7 +38,7 @@
   <header class="l-navigation is-collapsed">
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark">
-        <div class="p-panel__header--sticky">
+        <div class="p-panel__header is-sticky">
           <a class="p-panel__logo" href="#">
             <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
             <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">

--- a/templates/docs/examples/layouts/application/split.html
+++ b/templates/docs/examples/layouts/application/split.html
@@ -23,8 +23,14 @@
 <div class="l-application" role="presentation">
   <div class="l-navigation-bar">
     <div class="p-panel is-dark">
-      <div class="u-fixed-width u-align--right">
-        <span class="js-menu-toggle">Menu</span>
+      <div class="p-panel__header">
+        <a class="p-panel__logo" href="#">
+          <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
+          <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">
+        </a>
+        <div class="p-panel__controls">
+          <span class="p-panel__toggle js-menu-toggle">Menu</span>
+        </div>
       </div>
     </div>
   </div>
@@ -33,18 +39,13 @@
     <div class="l-navigation__drawer">
       <div class="p-panel is-dark">
         <div class="p-panel__header--sticky">
-          <div class="u-fixed-width u-sv-2">
-            <div class="p-inline-list--stretch">
-              <div class="p-inline-list__item">
-                <a class="p-panel__logo" href="#">
-                  <img src="https://assets.ubuntu.com/v1/0b2b7bce-Vanilla-logo_88x24px_white.svg" alt="Vanilla framework" height="24">
-                </a>
-              </div>
-              <div class="p-inline-list__item u-align--right u-hide--large">
-                <button class="p-button--base has-icon u-no-margin u-hide--medium js-menu-close"><i class="p-icon--close"></i></button>
-                <button class="p-button--base has-icon u-no-margin u-hide--small js-menu-pin"><i class="p-icon--close p-icon--pin"></i></button>
-              </div>
-            </div>
+          <a class="p-panel__logo" href="#">
+            <img class="p-panel__logo-icon" src="https://assets.ubuntu.com/v1/7144ec6d-logo-jaas-icon.svg" alt="" width="24" height="24">
+            <img class="p-panel__logo-name is-fading-when-collapsed" src="https://assets.ubuntu.com/v1/2e04d794-logo-jaas.svg" alt="JAAS" height="16">
+          </a>
+          <div class="p-panel__controls u-hide--large">
+            <button class="p-button--base has-icon u-no-margin u-hide--medium js-menu-close"><i class="p-icon--close"></i></button>
+            <button class="p-button--base has-icon u-no-margin u-hide--small js-menu-pin"><i class="p-icon--close p-icon--pin"></i></button>
           </div>
         </div>
         <div class="p-panel__content">
@@ -58,9 +59,7 @@
   <main class="l-main">
     <div class="p-panel">
       <div class="p-panel__header">
-        <div class="u-fixed-width u-sv-2">
-          <h4 class="p-inline-list__item u-no-margin--bottom">8 models: 3 blocked, 2 alerts, 3 running</h4>
-        </div>
+        <h4 class="p-panel__title">8 models: 3 blocked, 2 alerts, 3 running</h4>
       </div>
       <div class="p-panel__content">
         <div class="u-fixed-width">
@@ -301,13 +300,9 @@
   <aside class="l-aside is-pinned is-split" id="aside-panel">
     <div class="p-panel">
       <div class="p-panel__header">
-        <div class="u-fixed-width u-sv-2">
-          <div class="p-inline-list--stretch">
-            <h4 class="p-inline-list__item u-no-margin--bottom">Aside panel</h4>
-            <div class="p-inline-list__item u-align--right">
-              <button class="p-button--base js-aside-close u-no-margin--bottom has-icon"><i class="p-icon--close"></i></button>
-            </div>
-          </div>
+        <h4 class="p-panel__title">Aside panel</h4>
+        <div class="p-panel__controls">
+          <button class="p-button--base js-aside-close u-no-margin--bottom has-icon"><i class="p-icon--close"></i></button>
         </div>
       </div>
       <div class="p-panel__content">

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -85,17 +85,15 @@ View an example of the application layout structure
 
 The layout areas provide minimal styling (for example drop shadows on overlay areas). Spacing, background, should be defined by the content inside.
 
-The panel component is an integral part of the application layout (`p-panel`). It should be used as the only direct child of respective layout area (`l-navigation`, `l-main`, `l-aside`, ...). It consists of a header (`p-panel__header`) that may contain panel title, logo or any action buttons and the content of the panel in `p-panel__content`. Panel header can be optionally made sticky while scrolling with `p-panel__header--sticky`.
+The panel component (`p-panel`) is an integral part of the application layout. It should be used as the only direct child of respective layout area (`l-navigation`, `l-main`, `l-aside`, ...). It consists of a header (`p-panel__header`) and a content block (`p-panel__content`).
+
+#### Panel header
+
+The panel header (`p-panel__header`) may contain the panel title (`p-panel__title`) or logo (`p-pabel__logo`) on the left and any action buttons (`p-pabel__controls`) to the right. Panel header can be optionally made sticky while scrolling with `p-panel__header--sticky`.
 
 ### Panels example
 
 Below you can see an example of application layout with some basic panels applied.
-
-<div class="p-notification--caution">
-  <p class="p-notification__response">
-    The contents of the panels (most notably the navigation side bar) are custom built for the sake of the demo and are currently not part of Vanilla framework.
-  </p>
-</div>
 
 <div class="embedded-example"><a href="/docs/examples/layouts/application/default/" class="js-example" data-height="600">
 View an example of the application layout demo

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -89,7 +89,7 @@ The panel component (`p-panel`) is an integral part of the application layout. I
 
 #### Panel header
 
-The panel header (`p-panel__header`) may contain the panel title (`p-panel__title`) or logo (`p-pabel__logo`) on the left and any action buttons (`p-pabel__controls`) to the right. Panel header can be optionally made sticky while scrolling with `p-panel__header--sticky`.
+The panel header (`p-panel__header`) may contain the panel title (`p-panel__title`) or logo (`p-pabel__logo`) on the left and any action buttons (`p-pabel__controls`) to the right. Panel header can be optionally made sticky while scrolling by adding `is-sticky` modifier class to the `p-panel__header` element.
 
 ### Panels example
 


### PR DESCRIPTION
## Done

- Updates the styling of application layout panel headers

Fixes #3390 

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3439.demos.haus/docs/examples/layouts/application/JAAS)
- Verify that spacing of panel headers is correct (check all screen sizes)
  - https://vanilla-framework-3439.demos.haus/docs/examples/layouts/application/JAAS
  - https://vanilla-framework-3439.demos.haus/docs/examples/layouts/application/default
- Check the updated docs: https://vanilla-framework-3439.demos.haus/docs/layouts/application#panels


## Screenshots

<img width="957" alt="Screenshot 2020-12-03 at 09 43 01" src="https://user-images.githubusercontent.com/83575/100985185-f558f800-354b-11eb-93b8-bc66cfb31fa6.png">

