### PR TITLE
Show team members and contributors on contribute page

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -2,8 +2,6 @@ domain: vanillaframework.io
 
 image: prod-comms.docker-registry.canonical.com/vanillaframework.io
 
-useProxy: false
-
 env:
   - name: SENTRY_DSN
     value: https://0ff6fb54f0a14360ac6b0157f130b807@sentry.is.canonical.com//36
@@ -12,6 +10,10 @@ env:
     secretKeyRef:
       key: google-custom-search-key
       name: google-api
+  - name: GITHUB_TOKEN
+    secretKeyRef:
+      key: vanillaframework-io
+      name: github-tokens
 
 extraHosts:
   - domain: docs.vanillaframework.io

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -10,48 +10,53 @@
     <h1 class="u-no-margin--bottom">Contribute</h1>
   </div>
 </div>
+
 <div class="p-strip is-bordered">
   <div class="row">
     <h2>Meet the team</h2>
   </div>
   <div class="row">
-    <div class="col-3">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b943a4e7-ant.jpeg" alt="">
-          <h4 class="p-heading-icon__title"><a href="https://github.com/anthonydillon">anthonydillon</a></h4>
+    {% for team_member in team_members %}
+      <div class="col-3 p-media-object">
+        {% if team_member.avatar_url %}
+          <img src="{{ team_member.avatar_url }}" class="p-media-object__image is-round" alt="">
+        {% endif %}
+        <div class="p-media-object__details">
+          <h3 class="p-media-object__title">
+            <a href="https://github.com/{{ team_member.login }}">{{ team_member.login }}</a>
+          </h3>
+          <p class="p-media-object__content u-no-margin--bottom">{{ team_member.role }}</p>
+
+          {% if team_member.contributions %}
+            <small>Contributions: {{ team_member.contributions }}</small>
+          {% endif %}
         </div>
-        <p>Lead Web Developer</p>
       </div>
-    </div>
-    <div class="col-3">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/fced2b0d-kwm14-avater.jpeg" alt="">
-          <h4 class="p-heading-icon__title"><a href="https://github.com/kwm14">kwm14</a></h4>
-        </div>
-        <p>Lead Visual Designer</p>
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9d912294-deadlight.jpeg" alt="">
-          <h4 class="p-heading-icon__title"><a href="https://github.com/deadlight">deadlight</a></h4>
-        </div>
-        <p>Web Developer</p>
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/59a13d9e-lyubomir-popov-avater.jpeg" alt="">
-          <h4 class="p-heading-icon__title"><a href="https://github.com/lyubomir-popov">lyubomir-popov</a></h4>
-        </div>
-        <p>Senior Visual Designer</p>
-      </div>
-    </div>
+    {% endfor %}
   </div>
+
+  {% if contributors %}
+    <div class="row">
+      <h2>Contributors</h2>
+    </div>
+    <div class="row">
+      {% for contributor in contributors%}
+        <div class="col-3 p-media-object">
+          <img src="{{ contributor.avatar_url }}" class="p-media-object__image is-round" alt="">
+          <div class="p-media-object__details">
+            <h3 class="p-media-object__title">
+              <a href="https://github.com/{{ contributor.login }}">{{ contributor.login }}</a>
+            </h3>
+            <p class="p-media-object__content u-no-margin--bottom">{{ contributor.role }}</p>
+
+            {% if contributor.contributions %}
+              <small>Contributions: {{ contributor.contributions }}</small>
+            {% endif %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
 </div>
 <div class="p-strip is-bordered">
   <div class="row">

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -33,10 +33,12 @@
     {% endfor %}
   </div>
 </div>
-<div class="u-fixed-width">
-  <hr>
-</div>
+
 {% if contributors %}
+  <div class="u-fixed-width">
+    <hr>
+  </div>
+  
   <div class="p-strip">
     <div class="row">
       <div class="p-strip u-no-padding--top"><h2>Contributors</h2></div>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -11,11 +11,9 @@
   </div>
 </div>
 
-<div class="p-strip is-bordered">
+<div class="p-strip">
   <div class="row">
-    <h2>Meet the team</h2>
-  </div>
-  <div class="row">
+    <div class="p-strip u-no-padding--top"><h2>Meet the team</h2></div>
     {% for team_member in team_members %}
       <div class="col-3 p-media-object">
         {% if team_member.avatar_url %}
@@ -34,10 +32,14 @@
       </div>
     {% endfor %}
   </div>
-
-  {% if contributors %}
+</div>
+<div class="u-fixed-width">
+  <hr>
+</div>
+{% if contributors %}
+  <div class="p-strip">
     <div class="row">
-      <h2>Contributors</h2>
+      <div class="p-strip u-no-padding--top"><h2>Contributors</h2></div>
     </div>
     <div class="row">
       {% for contributor in contributors%}
@@ -58,9 +60,12 @@
     </div>
   {% endif %}
 </div>
-<div class="p-strip is-bordered">
+<div class="u-fixed-width">
+  <hr>
+</div>
+<div class="p-strip">
   <div class="row">
-    <h2>Contribute</h2>
+    <div class="p-strip u-no-padding--top"><h2>Contribute</h2></div>
   </div>
   <div class="row">
     <div class="col-6">
@@ -92,6 +97,9 @@
       </div>
     </div>
   </div>
+</div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 <div class="p-strip">
   <div class="row">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2,8 +2,10 @@
 import glob
 import json
 import os
+import random
 
 # Packages
+import requests
 import flask
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
@@ -24,6 +26,17 @@ app = FlaskBase(
     template_500="500.html",
 )
 
+TEAM_MEMBERS = [
+    {"login": "anthonydillon", "role": "Engineering Director"},
+    {"login": "bartaz", "role": "Web Developer"},
+    {"login": "lyubomir-popov", "role": "Senior Visual Designer"},
+    {
+        "login": "wgx",
+        "role": "Lead UX Designer",
+    },
+    {"login": "sowasred2012", "role": "Web Developer"},
+]
+
 
 # Helpers
 # ===
@@ -33,7 +46,9 @@ def _get_title(title):
 
 def _get_examples():
     # get all example files (but ignore partials that start with _)
-    example_files = glob.glob("templates/docs/examples/*/**/[!_]*.html", recursive=True)
+    example_files = glob.glob(
+        "templates/docs/examples/*/**/[!_]*.html", recursive=True
+    )
     examples = {}
 
     for filepath in sorted(example_files):
@@ -63,6 +78,66 @@ def _get_examples():
     return examples
 
 
+def _make_github_request(endpoint):
+    github_secret = os.getenv("GITHUB_TOKEN")
+    headers = {}
+
+    if github_secret:
+        headers = {"Authorization": f"token {github_secret}"}
+
+    try:
+        response = requests.get(
+            f"https://api.github.com/{endpoint}", headers, timeout=3
+        )
+
+        response.raise_for_status()
+    except:
+        return {}
+
+    return response.json()
+
+
+def _get_team_members(contributors):
+    # based on the TEAM_MEMBERS list, see if
+    # they're in the repo's list of contributors.
+    # If they are, use their contributor data; if
+    # they aren't, make a further request to get
+    # their user data instead. If that fails, fall
+    # back to what is stored in the TEAM_MEMBERS array.
+
+    contributors = {
+        contributor["login"]: contributor for contributor in contributors
+    }
+
+    for team_member in TEAM_MEMBERS:
+        member = (
+            contributors.get(team_member["login"])
+            or _make_github_request(f'users/{team_member["login"]}')
+            or team_member
+        )
+        member["role"] = team_member["role"]
+        yield member
+
+
+def _get_contributors():
+    contributors = _make_github_request(
+        "repos/canonical-web-and-design/vanilla-framework/contributors"
+    )
+
+    return contributors
+
+
+def _filter_contributors(contributors):
+    # Distinguish team_members from contributors
+
+    member_usernames = [member["login"] for member in TEAM_MEMBERS]
+    return [
+        contributor
+        for contributor in contributors
+        if contributor["login"] not in member_usernames
+    ]
+
+
 # Global context settings
 @app.context_processor
 def global_template_context():
@@ -90,6 +165,21 @@ def standalone_examples_index():
 def standalone_example(example_path):
     return flask.render_template(
         f"docs/examples/{example_path}.html", is_standalone=True
+    )
+
+
+@app.route("/contribute")
+def contribute_index():
+    all_contributors = _get_contributors()
+    team_members = list(_get_team_members(all_contributors))
+    contributors = _filter_contributors(all_contributors)
+
+    print(contributors)
+
+    return flask.render_template(
+        "contribute.html",
+        team_members=team_members,
+        contributors=contributors,
     )
 
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -174,13 +174,16 @@ def contribute_index():
     team_members = list(_get_team_members(all_contributors))
     contributors = _filter_contributors(all_contributors)
 
-    print(contributors)
-
-    return flask.render_template(
-        "contribute.html",
-        team_members=team_members,
-        contributors=contributors,
+    response = flask.make_response(
+        flask.render_template(
+            "contribute.html",
+            team_members=team_members,
+            contributors=contributors,
+        )
     )
+
+    response.cache_control.max_age = 86400
+    return response
 
 
 app.add_url_rule("/", view_func=template_finder_view)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -183,6 +183,8 @@ def contribute_index():
     )
 
     response.cache_control.max_age = 86400
+    response.cache_control.public = True
+   
     return response
 
 


### PR DESCRIPTION
## Done

Get list of contributors from github and show them on /contribute, along with current team members.

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/contribute
- See the list of team members and contributors

![Screenshot from 2020-12-02 17-09-31](https://user-images.githubusercontent.com/2376968/100906533-2d672900-34c1-11eb-94ff-f1c7e5c2d275.png)


