### PR TITLE
Include %vf-button-white-success-icon in base button mixin

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -84,6 +84,12 @@
       }
     }
   }
+
+  %vf-button-white-success-icon {
+    & .p-icon--success {
+      @include vf-icon-success($color-x-light, $color-transparent);
+    }
+  }
 }
 
 /// mixin for all the buttons

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -4,7 +4,6 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
 // Default button styling
 @mixin vf-p-buttons {
-  @include vf-button-white-success-icon;
   @include vf-button-plain;
   @include vf-button-neutral;
   @include vf-button-brand;
@@ -17,10 +16,8 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 }
 
 @mixin vf-button-white-success-icon {
-  %vf-button-white-success-icon {
-    & .p-icon--success {
-      @include vf-icon-success($color-x-light, $color-transparent);
-    }
+  @include deprecate('3.0.0', 'vf-button-white-success-icon mixin will be removed, use @extend %vf-button-white-success-icon instead') {
+    //
   }
 }
 

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -16,7 +16,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 }
 
 @mixin vf-button-white-success-icon {
-  @include deprecate('3.0.0', 'vf-button-white-success-icon mixin will be removed, use @extend %vf-button-white-success-icon instead') {
+  @include deprecate('3.0.0', 'vf-button-white-success-icon mixin will be removed as it is not needed, %vf-button-white-success-icon is part of base styles') {
     //
   }
 }


### PR DESCRIPTION
## Done

Moved `%vf-button-white-success-icon` to the base button styles, so as not to break builds when including just Vanilla base.

Fixes #3438 
