### PR TITLE
Hide nested levels when side nav is collapsed

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -196,12 +196,24 @@ $application-layout--side-nav-width-expanded: 15rem !default;
 
   // --when-collapsed and --when-expanded mixins nest selectors inslide l-navigation
   // so we don't have to (and can't) nest it manually here
+
+  // hide nested levels when side nav is collapsed
   .p-side-navigation__list .p-side-navigation__list {
     @include vf-application-layout--when-collapsed() {
       display: none;
     }
     @include vf-application-layout--when-expanded() {
       display: block;
+    }
+  }
+
+  // disable text wrapping when side nav is collapsed
+  .p-side-navigation__item {
+    @include vf-application-layout--when-collapsed() {
+      white-space: nowrap;
+    }
+    @include vf-application-layout--when-expanded() {
+      white-space: normal;
     }
   }
 

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -11,6 +11,33 @@ $application-layout--side-nav-width-collapsed: 4rem !default;
 // width of the expanded side navigation
 $application-layout--side-nav-width-expanded: 15rem !default;
 
+@mixin vf-application-layout--when-collapsed() {
+  // when app navigation panel is collapsed
+  @media (min-width: $application-layout--breakpoint-side-nav-collapsed) {
+    .l-navigation & {
+      @content;
+    }
+  }
+}
+
+@mixin vf-application-layout--when-expanded() {
+  // when app navigation panel is collapsed, fade out unnecessary elements
+  @media (min-width: $application-layout--breakpoint-side-nav-collapsed) {
+    // keep faded elements visible when navigation is expanded on hover or pinned
+    .l-navigation.is-pinned &,
+    .l-navigation:hover & {
+      @content;
+    }
+  }
+
+  // keep faded elements visible when app navigation is expanded on largest screens
+  @media (min-width: $application-layout--breakpoint-side-nav-expanded) {
+    .l-navigation & {
+      @content;
+    }
+  }
+}
+
 @mixin vf-l-application {
   .l-application {
     display: grid;
@@ -139,20 +166,14 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   // Fading elements when navigation panel is collapsed
   %vf-application-layout--faded-when-collapsed {
     // when app navigation panel is collapsed, fade out unnecessary elements
-    @media (min-width: $application-layout--breakpoint-side-nav-collapsed) {
+    @include vf-application-layout--when-collapsed() {
       @include vf-animation($property: opacity, $duration: snap);
 
       opacity: 0;
-
-      // keep faded elements visible when navigation is expanded on hover or pinned
-      .l-navigation.is-pinned &,
-      .l-navigation:hover & {
-        opacity: 1;
-      }
     }
 
-    // keep faded elements visible when app navigation is expanded on largest screens
-    @media (min-width: $application-layout--breakpoint-side-nav-expanded) {
+    // keep faded elements visible when app navigation is expanded on hover, pin or largest screens
+    @include vf-application-layout--when-expanded() {
       opacity: 1;
     }
   }
@@ -170,6 +191,17 @@ $application-layout--side-nav-width-expanded: 15rem !default;
 
     .p-side-navigation__list::after {
       @extend %vf-application-layout--faded-when-collapsed;
+    }
+  }
+
+  // --when-collapsed and --when-expanded mixins nest selectors inslide l-navigation
+  // so we don't have to (and can't) nest it manually here
+  .p-side-navigation__list .p-side-navigation__list {
+    @include vf-application-layout--when-collapsed() {
+      display: none;
+    }
+    @include vf-application-layout--when-expanded() {
+      display: block;
     }
   }
 

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -472,6 +472,27 @@
   .p-side-navigation__item--title .p-side-navigation__link {
     color: $color-sidenav-text-active;
   }
+
+  // styles applied when side nav is used in application layout
+  @if mixin-exists(vf-application-layout--when-collapsed) {
+    .p-side-navigation__item.has-active-child {
+      // parent element that has active child should be selected when navigation is collapsed
+      @include vf-application-layout--when-collapsed() {
+        @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
+
+        background: $color-sidenav-item-background-hover;
+        color: $color-sidenav-text-active;
+      }
+
+      // parent element with active child should not be selected when navigation is expanded
+      @include vf-application-layout--when-expanded() {
+        @include vf-highlight-bar(transparent, left);
+
+        background: transparent;
+        color: $color-sidenav-text-default;
+      }
+    }
+  }
 }
 
 @mixin vf-side-navigation-theme-light {

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -36,7 +36,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>We added many more icons, outside of the base icon set. These icons are not included in Vanilla by default, but can be individually included as needed.</td>
     </tr>
     <tr>
-      <th><a href="/docs/patterns/navigation#panels">Application layout - panels</a></th>
+      <th><a href="/docs/layouts/application#panels">Application layout - panels</a></th>
       <td><div class="p-label--in-progress">In progress</div></td>
       <td>2.21.0</td>
       <td>We continue working on application layout panels styling. We improved the positioning of the logo, title and controls in panel headers.</td>

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -7,56 +7,56 @@
   <nav aria-label="Main navigation">
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title">
-        <a class="p-side-navigation__link" href="#">Title that is a link</a>
+        <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">Title that is a link</span></a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#"><i class="p-icon--information {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link</a>
+        <a class="p-side-navigation__link" href="#"><i class="p-icon--information {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label"><span class="p-side-navigation__label">First level link</span></a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#"><i class="p-icon--help {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with status<div class="p-side-navigation__status"><i class="p-icon--error {% if is_dark %}is-light{% endif %}"></i></div></a>
+        <a class="p-side-navigation__link" href="#"><i class="p-icon--help {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label">First level link with status</span><div class="p-side-navigation__status"><i class="p-icon--error {% if is_dark %}is-light{% endif %}"></i></div></a>
       </li>
       <li class="p-side-navigation__item has-active-child">
-        <a class="p-side-navigation__link" href="#"><i class="p-icon--user {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>Link with children</a>
+        <a class="p-side-navigation__link" href="#"><i class="p-icon--user {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label">Link with children</span></a>
         <ul class="p-side-navigation__list">
           <li class="p-side-navigation__item">
-            <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning {% if is_dark %}is-light{% endif %}"></i></div></a>
+            <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">Second level link</span><div class="p-side-navigation__status"><i class="p-icon--warning {% if is_dark %}is-light{% endif %}"></i></div></a>
           </li>
           <li class="p-side-navigation__item">
-            <span class="p-side-navigation__text">Second level text</span>
+            <span class="p-side-navigation__text"><span class="p-side-navigation__label">Second level text</span></span>
           </li>
           <li class="p-side-navigation__item">
-            <a class="p-side-navigation__link" href="#">Second level link with children</a>
+            <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">Second level link with children</span></a>
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item">
-                <span class="p-side-navigation__text">Third level text</span>
+                <span class="p-side-navigation__text"><span class="p-side-navigation__label">Third level text</span></span>
               </li>
               <li class="p-side-navigation__item">
-                <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status"><span class="p-label--in-progress">In progress</span></div></a>
+                <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status"><span class="p-label--in-progress">In progress</span></div></a>
               </li>
               <li class="p-side-navigation__item">
-                <a class="p-side-navigation__link" aria-current="page" href="#">Third level active link</a>
+                <a class="p-side-navigation__link" aria-current="page" href="#"><span class="p-side-navigation__label">Third level active link</span></a>
               </li>
               <li class="p-side-navigation__item">
-                <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success {% if is_dark %}is-light{% endif %}"></i></div></a>
+                <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">Third level link with status</span><div class="p-side-navigation__status"><i class="p-icon--success {% if is_dark %}is-light{% endif %}"></i></div></a>
               </li>
             </ul>
           </li>
         </ul>
       </li>
       <li class="p-side-navigation__item">
-        <span class="p-side-navigation__text"><i class="p-icon--collapse {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level item that is not a link</span>
+        <span class="p-side-navigation__text"><i class="p-icon--collapse {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label">First level item that is not a link</span></span>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
+        <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">First level link with a label</span><div class="p-side-navigation__status"><span class="p-label--new">New</span></div></a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status"><span class="p-label--updated">Updated</span></div></a>
+        <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label">First level link with a label is long and wraps wraps wraps wraps wraps wraps</span><div class="p-side-navigation__status"><span class="p-label--updated">Updated</span></div></a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status"><span class="p-label--validated">Validated</span></div></a>
+        <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status"><span class="p-label--validated">Validated</span></div></a>
       </li>
     </ul>
-    <ul class="p-side-navigation__list">
+    <ul class="p-side-navigation__list is-fading-when-collapsed">
       <li class="p-side-navigation__item--title">
         <span class="p-side-navigation__text">Title that is not a link</span>
       </li>

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -15,7 +15,7 @@
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--help {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with status<div class="p-side-navigation__status"><i class="p-icon--error {% if is_dark %}is-light{% endif %}"></i></div></a>
       </li>
-      <li class="p-side-navigation__item">
+      <li class="p-side-navigation__item has-active-child">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--user {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>Link with children</a>
         <ul class="p-side-navigation__list">
           <li class="p-side-navigation__item">

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -75,8 +75,6 @@ View an example of the application layout structure
 
 ### Panels
 
-<span class="p-label--in-progress">In progress</span>
-
 <div class="p-notification--caution">
   <p class="p-notification__response">
     <span class="p-notification__status">In progress:</span> The current implementation of the panel component is created to provide minimal consistent styling of panels, but is still work in progress and may change in the future.
@@ -108,12 +106,18 @@ View an example of the application layout demo
 Use the [side navigation component](/docs/patterns/navigation#side-navigation) to build the contents of main navigation for the application layout. You can find detailed documentation in the ["Application layout" section of the Navigation page](/docs/patterns/navigation#application-layout).
 
 <div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/application" class="js-example">
-View example of the side navigation pattern for raw HTML
+View example of the side navigation pattern in application layout
 </a></div>
 
 Side navigation component has a built-in support for responsive collapsing and expanding of the side navigation. When proper HTML structure and element class names are used, the side navigation elements and icons will be correctly positioned, and unnecessary elements will fade out when navigation collapses.
 
 Additionally, if certain custom elements need to be hidden when navigation panel is collapsed, add the `.is-fading-when-collapsed` class to them.
+
+#### Nested levels of navigation items
+
+When the navigation is collapsed to vertical bar, all nested navigation items are automatically hidden to remove the space between icons of first level items.
+
+In a case when one of nested items is highlighted as active, in order to preserve the visual indication of the active element when navigation is collapsed, a `has-active-child` class needs to be added on a top level navigation item when one of its children is active. This class name is used to highlight the top level item when only in collapsed view.
 
 ### Responsive application layout
 

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -18,7 +18,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Top specificity',
       benchmark: 40,
-      threshold: 60,
+      threshold: 61,
       result: results['top-selector-specificity'],
       selector: results['top-selector-specificity-selector'],
     },


### PR DESCRIPTION
## Done

Updates app layout side navigation to hide nested levels when navigation is collapsed and to allow selecting top level item with icon when one of the children is active.

Fixes #3394

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/ or [demo](https://vanilla-framework-3443.demos.haus/docs/examples/layouts/application/default)
- Check the application layout example, make sure side navigation nested levels behave as expected when nav is collapsed: https://vanilla-framework-3443.demos.haus/docs/examples/layouts/application/default
- Review the updated documentation: https://vanilla-framework-3443.demos.haus/docs/layouts/application#nested-levels-of-navigation-items



## Screenshots

![nestedappnav](https://user-images.githubusercontent.com/83575/101737257-e8e11c00-3ac4-11eb-889f-428d4da48004.gif)

