### PR TITLE
Hide overflow when nav sidebar is collapsed.

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -85,6 +85,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
       );
 
       box-shadow: $panel-drop-shadow-transparent;
+      overflow: hidden;
       transform: translateX(0);
       width: $application-layout--side-nav-width-collapsed;
 
@@ -94,16 +95,20 @@ $application-layout--side-nav-width-expanded: 15rem !default;
       }
     }
 
+    .l-navigation:hover,
+    .l-navigation.is-pinned {
+      overflow-y: auto;
+      width: $application-layout--side-nav-width-expanded;
+    }
+
     .l-navigation:hover {
       box-shadow: $panel-drop-shadow;
-      width: $application-layout--side-nav-width-expanded;
     }
 
     .l-navigation.is-pinned {
       box-shadow: $panel-drop-shadow-transparent;
       grid-area: nav;
       position: static;
-      width: $application-layout--side-nav-width-expanded;
     }
   }
 
@@ -116,6 +121,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     .l-navigation {
       box-shadow: none;
       grid-area: nav;
+      overflow-y: auto;
       position: static;
       width: $application-layout--side-nav-width-expanded;
 


### PR DESCRIPTION
## Done

Hides scrollbars on collapsed sidebar, on Windows/Ubuntu (the issue is not present on macOS).

Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/945

## QA

- Pull code
- Run `./run`
- Open http://0.0.0.0:8101/docs/examples/layouts/application/default
- Set the width of your browser window to the point where the sidebar collapses automatically but is still visible. See that there are no scrollbars present, and that they appear when you hover over it.
