### PR TITLE
update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,14 +6,14 @@ Fixes [list issues/bugs if needed]
 
 ## QA
 
-- Pull code
-- Run `./run`
-- Open http://0.0.0.0:8101/ or [demo]
-- [Add additional steps]
+- Open [demo](insert-demo-url)
+- [Add QA steps]
+- Review updated documentation:
+  - [List any updated documentation for review]
 
 Make sure PR has one of the following labels to automatically categorise it in release notes:
 `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
 
 ## Screenshots
 
-[if relevant, include a screenshot]
+[if relevant, include a screenshot or screen capture]


### PR DESCRIPTION
## Done

Updated PR template to promote QAing on demos, rather than locally.

Fixes #3448 

## QA

- Review [PULL_REQUEST_TEMPLATE.md](https://github.com/sowasred2012/vanilla-framework/blob/pr-template/.github/PULL_REQUEST_TEMPLATE.md), see that it is updated and reflects more closely how PRs tend to be QA'd currently.
