### PR TITLE
Move hacking documentation from README.md to HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,4 +1,46 @@
-# Vanilla Development
+# Working on the Vanilla project
+
+## Local development
+
+### Via dotrun
+
+The simplest way to run the Vanilla framework on Linux is with the [dotrun snap](https://github.com/canonical-web-and-design/dotrun/), and using the `dotrun` command to build the project:
+
+```bash
+# Build CSS into the ./build/ directory,
+# and start the server:
+dotrun
+
+# Dynamically watch for changes to the
+# Sass files and build automatically:
+dotrun watch
+```
+
+When writing SCSS, it's useful to run both commands in separate terminals so changes are quickly built and ready for the browser to pick up on page reload.
+
+### Via Docker
+
+It can also be run on other operating systems by first [installing Docker](https://docs.docker.com/engine/installation/) (Linux users may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)), and then using the `./run` script:
+
+```bash
+# Build CSS into the ./build/ directory:
+./run build
+
+# Start the server:
+./run serve
+
+# Dynamically watch for changes to the
+# Sass files and build automatically:
+./run watch
+```
+
+### Viewing documentation
+
+Once the server is running, you can visit <http://0.0.0.0:8101/> in your browser to see the project.
+
+The documentation for the latest version of Vanilla framework is hosted at <https://vanillaframework.io/docs>, and the documentation markdown files live in the [`docs` folder](/docs).
+
+The [examples directory](/docs/examples) contains example markup for each component of the framework, and these examples can be viewed in the browser at <http://0.0.0.0:8101/examples/>.
 
 ## Adding new icons
 
@@ -10,3 +52,5 @@ To achieve this quickly, you can use the `icon-svgs-to-mixins` script:
 - In your terminal, run `dotrun icon-svgs-to-mixins path/to/svg/directory/`.
 
 This will output a mixin for each SVG in the directory. Each mixin will take its name from the SVG's filename i.e. "tick.svg" will output a mixin named "vf-icon-tick".
+
+Bear in mind that the actual SCSS mixins will evolve over time, so you may need to update the mixin output in this script to match them.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vanilla Framework
+# ![vanilla](https://assets.ubuntu.com/v1/70041419-vanilla-framework.png?w=35 'Vanilla') Vanilla Framework
 
 [![CircleCI build status](https://circleci.com/gh/canonical-web-and-design/vanilla-framework.svg?style=shield)](https://circleci.com/gh/canonical-web-and-design/vanilla-framework)
 [![npm version](https://badge.fury.io/js/vanilla-framework.svg)](http://badge.fury.io/js/vanilla-framework)
@@ -7,7 +7,7 @@
 [![Chat in #vanilla-framework on Freenode](https://img.shields.io/badge/chat-%23vanilla--framework-blue.svg)](http://webchat.freenode.net/?channels=vanilla-framework)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io)
 
-Vanilla Framework is a simple extensible CSS framework, built using [Sass](http://sass-lang.com/) and is designed to be used either directly or by using themes to extend or supplement its patterns.
+Vanilla Framework is an extensible CSS framework, built using [Sass](http://sass-lang.com/) and is designed to be used either directly or by using themes to extend or supplement its patterns.
 
 [Documentation](https://vanillaframework.io/docs) |
 [Join the mailing list](http://canonical.us3.list-manage2.com/subscribe?u=56dac47c206ba0f58ec25f314&id=36f7d8394e)
@@ -57,37 +57,12 @@ $color-brand: #ffffff;
 
 If you don't want the whole framework, you can just `@include` specific [parts](scss) - e.g. `@include vf-b-forms`.
 
-## Vanilla local development
-
-The simplest way to run Vanilla framework is to first [install Docker](https://docs.docker.com/engine/installation/) (Linux users may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)), and then use the `./run` script to build the site:
-
-```bash
-./run build  # Build the CSS into the ./build/ directory
-# or
-./run watch  # Dynamically watch for changes to the Sass files and build automatically
-```
-
-### Viewing documentation
-
-The documentation for the latest version of Vanilla framework is hosted at <https://vanillaframework.io/docs>.
-
-The documentation markdown files live in the [`docs` folder](/docs), and you can view this documentation in the browser by running:
-
-```bash
-./run serve
-```
-
-Once the containers are setup, you can visit <http://0.0.0.0:8101/> in your browser to see the documentation.
-
-The [examples directory](/docs/examples) contains example markup for each component of the framework, and these examples can be viewed in the browser at <http://0.0.0.0:8101/examples/>.
-
 ## Community
 
 Keep up to date with all new developments and upcoming changes with Vanilla.
 
 - Follow us on Twitter [@vanillaframewrk](https://twitter.com/vanillaframewrk)
 - Read our latest blog posts at [Ubuntu Blog](https://blog.ubuntu.com/topics/design)
-- Talk to the team in IRC on <code>irc.freenode.net</code> and join channel <code>#vanilla-framework</code>, alternatively join our workspace on [Slack](vanillaframework.slack.com)
 
 Code licensed [LGPLv3](http://opensource.org/licenses/lgpl-3.0.html) by [Canonical Ltd](http://www.canonical.com/)
 


### PR DESCRIPTION
## Done

Moved hacking instructions from the readme to the recently introduced HACKING.md, removed outdated copy and added the Vanilla logo to the readme.

Fixes #3449 

## QA

- Inspect the [README.md](https://github.com/sowasred2012/vanilla-framework/blob/readme-updates/README.md) and [HACKING.md](https://github.com/sowasred2012/vanilla-framework/blob/readme-updates/README.md), see that the contents are appropriate.
