### PR TITLE
Change %vf-hide-text text indent to IE friendly value

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -116,10 +116,11 @@
   // Utilities
   %vf-hide-text {
     overflow: hidden;
-    // rem value necessary because text indent in % does not work with padding;
-    // 10rem is larger than any padding value on an element you'd hide text in (buttons, icons)
-    // but still smaller than 9999px so should have better performance
-    text-indent: calc(100% + 10rem);
+    // vw value necessary because text indent in % does not work with padding,
+    // and IE 11 does not support calc() on text-indent;
+    // 110vw ensures the text is off the screen, and in most cases will
+    // still be smaller than 9999px, so should have better performance
+    text-indent: 110vw;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
## Done

Updated `text-indent` value on `%vf-hide-text` to `110vw`, from a `calc()` value incompatible with IE.

Fixes #3162 

## QA

- Login to https://www.browserstack.com/
- Within Browserstack, select IE11 and open [demo](https://vanilla-framework-3461.demos.haus)
- Visit https://vanilla-framework-3461.demos.haus/docs/examples/patterns/chip/with-dismiss
- See that the "X" icon is visible, and not obscured by text.

## Screenshots

![Screenshot from 2021-01-04 10-47-25](https://user-images.githubusercontent.com/2376968/103527767-c7344400-4e7a-11eb-9918-667acddd787d.png)

