### PR TITLE
Fix broken LinkedIn share plugin link

### DIFF
--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -567,7 +567,7 @@ If you wish to add share icons for Twitter, Facebook or LinkedIn, we recommend u
         <a href="https://developers.facebook.com/docs/plugins/share-button/">Facebook</a>
       </li>
       <li class="p-inline-list__item">
-        <a href="https://developer.linkedin.com/plugins/share">LinkedIn</a>
+        <a href="https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/plugins/share-plugin">LinkedIn</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Done

Fixed a broken LinkedIn link in the icons documentation.

Fixes #3475 

## QA

- Open [demo](https://vanilla-framework-3476.demos.haus/docs/patterns/icons)
- Under the heading "Share", see that the LinkedIn link takes you to a relevant page, rather than a 404