### PR TITLE
Remove unnecessary pseudo-element from tables

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -31,10 +31,6 @@
   }
 
   thead {
-    &::after {
-      content: '';
-    }
-
     th {
       @extend %table-header-label;
 


### PR DESCRIPTION
## Done

Removes unnecessary pseudo-element that is causing rendering issues sometimes.

Fixes #3087 

## QA

- Open [demo](https://vanilla-framework-3479.demos.haus/docs/examples)
- Check table examples (and Percy), make sure there are no regressions

