### PR TITLE
Fix shifting headings in sortable tables

### DIFF
--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -14,6 +14,8 @@
     content: '';
     display: inline-block;
     margin-left: $sp-x-small;
+    // table heading text is smaller than the icon, so we need to compensate with negative top margin
+    margin-top: calc(#{map-get($font-sizes, x-small)}rem - #{$default-icon-size});
     vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $default-icon-size});
   }
 


### PR DESCRIPTION
## Done

Fix table header text shifting when clicking on sortable columns

Fixes 3120

## QA

- Open [demo](https://vanilla-framework-3480.demos.haus/docs/examples/patterns/tables/table-sortable)
- Check table sortable demo - make sure that clicking on sortable columns (when icon appears) doesn't shift the text


## Screenshots

![table-sortable-fix](https://user-images.githubusercontent.com/83575/103897147-606d8f80-50f3-11eb-9f85-22f43b1bfbda.gif)

