### PR TITLE
Update base code block styles to match code snippet pattern

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -1,5 +1,7 @@
 @import 'settings';
 
+$color-pre-bg: rgba($color-x-dark, 0.03);
+
 // Base code styles
 @mixin vf-b-code {
   code,
@@ -51,9 +53,7 @@
   }
 
   pre {
-    background-color: $color-light;
-    border: 1px solid $color-mid-light;
-    border-radius: $border-radius;
+    background-color: $color-pre-bg;
     color: $color-dark;
     display: block;
     margin-bottom: $spv-outer--scaleable;

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -4,13 +4,14 @@ $sidebar-width: 4.5rem !default;
 @mixin vf-p-code-numbered {
   .p-code-numbered {
     counter-reset: line-numbering;
-    padding: 0;
+    padding: $sph-inner--small 0;
   }
 
   .p-code-numbered__line {
     display: inline-block;
-    padding: $spv-inner--small $sph-inner 0 ($sidebar-width + $sph-inner);
+    padding: 0 $sph-inner 0 ($sidebar-width + $sph-inner);
     position: relative;
+    white-space: pre-wrap;
     width: 100%;
 
     &:empty {
@@ -19,15 +20,14 @@ $sidebar-width: 4.5rem !default;
     }
 
     &::before {
-      background: $color-x-light;
-      border-right: 1px solid $color-mid-light;
+      background: transparent;
       color: $color-mid-dark;
       content: counter(line-numbering);
       counter-increment: line-numbering;
       display: inline-block;
       height: 100%;
       left: 0;
-      padding: $spv-inner--small $sph-inner 0 $sph-inner;
+      padding: 0 $sph-inner;
       pointer-events: none;
       position: absolute;
       text-align: right;

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -40,10 +40,5 @@ $sidebar-width: 4.5rem !default;
       // stylelint-enable property-no-vendor-prefix
       width: $sidebar-width;
     }
-
-    &:last-of-type,
-    &:last-of-type::before {
-      padding-bottom: $spv-inner--small;
-    }
   }
 }

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -1,14 +1,10 @@
 @import 'settings';
 
 $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
-$color-snippet-bg: rgba($color-x-dark, 0.03);
 
 @mixin vf-p-code-snippet {
   .p-code-snippet {
     .p-code-snippet__block {
-      background-color: $color-snippet-bg;
-      border: 0;
-      border-radius: 0;
       margin: 0;
     }
 

--- a/templates/docs/examples/patterns/code-numbered.html
+++ b/templates/docs/examples/patterns/code-numbered.html
@@ -7,9 +7,9 @@
 <pre class="p-code-numbered"><code><span class="p-code-numbered__line">#!/bin/bash</span>
 <span class="p-code-numbered__line">set -eu</span>
 <span class="p-code-numbered__line">. $CONJURE_UP_SPELLSDIR/sdk/common.sh</span>
-<span class="p-code-numbered__line">if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then
-    debug "Running pre-deploy for $CONJURE_UP_SPELL"
-    sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" || exposeResult "Failed to set profile" $? "false"
-fi</span>
+<span class="p-code-numbered__line">if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then</span>
+<span class="p-code-numbered__line">    debug "Running pre-deploy for $CONJURE_UP_SPELL"</span>
+<span class="p-code-numbered__line">    sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" || exposeResult "Failed to set profile" $? "false"</span>
+<span class="p-code-numbered__line">fi</span>
 <span class="p-code-numbered__line">exposeResult "Successful pre-deploy." 0 "true"</span></code></pre>
 {% endblock %}


### PR DESCRIPTION
## Done

Updated the base code style, and the code-numbered pattern, to match the one seen in the [new code snippet design](https://app.zeplin.io/project/5fa270d8eee4dbb267e579f1/screen/5fc616c95320fdb32885432e)

Fixes #3463 & #3465

## QA

- Open [code block example](https://vanilla-framework-3483.demos.haus/docs/examples/base/code-block)
- Check that the code block matches the design, and looks similar to the blocks in the [code snippet example](/docs/examples/standalone/patterns/code-snippet/code-snippet)
- Open [code numbered example](https://vanilla-framework-3483.demos.haus/docs/examples/patterns/code-numbered)
- Check that the code numbered block matches the design
