### PR TITLE
Update code copyable style to match code snippet

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -63,3 +63,16 @@
     white-space: pre;
   }
 }
+
+%leading-linux-prompt-icon {
+  &::before {
+    @extend %icon;
+    @include vf-icon-linux-prompt($color-mid-dark);
+
+    content: '';
+    left: $sph-inner;
+    position: absolute;
+    top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default))};
+    width: map-get($icon-sizes, default);
+  }
+}

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -1,7 +1,5 @@
 @import 'settings';
 
-$color-pre-bg: rgba($color-x-dark, 0.03);
-
 // Base code styles
 @mixin vf-b-code {
   code,
@@ -53,7 +51,7 @@ $color-pre-bg: rgba($color-x-dark, 0.03);
   }
 
   pre {
-    background-color: $color-pre-bg;
+    background-color: $color-code-background;
     color: $color-dark;
     display: block;
     margin-bottom: $spv-outer--scaleable;

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -534,3 +534,16 @@ $social-icon-size: map-get($icon-sizes, heading-icon--small);
 
   display: inline-block;
 }
+
+%leading-linux-prompt-icon {
+  &::before {
+    @extend %icon;
+    @include vf-icon-linux-prompt($color-mid-dark);
+
+    content: '';
+    left: $sph-inner;
+    position: absolute;
+    top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default))};
+    width: map-get($icon-sizes, default);
+  }
+}

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -534,16 +534,3 @@ $social-icon-size: map-get($icon-sizes, heading-icon--small);
 
   display: inline-block;
 }
-
-%leading-linux-prompt-icon {
-  &::before {
-    @extend %icon;
-    @include vf-icon-linux-prompt($color-mid-dark);
-
-    content: '';
-    left: $sph-inner;
-    position: absolute;
-    top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default))};
-    width: map-get($icon-sizes, default);
-  }
-}

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -28,6 +28,11 @@ $cc-button-size: 36px;
   }
 
   .p-code-copyable__action {
+    // This pattern is being deprecated in 2.22, but we
+    // want a consistent look among code block patterns, so
+    // code-copyable has been updated to look like a standard
+    // code block. For that reason, we're hiding the "copy"
+    // button on existing implementations of this pattern.
     display: none;
   }
 }

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -3,36 +3,38 @@
 $cc-button-size: 36px;
 
 @mixin vf-p-code-copyable {
-  .p-code-copyable {
-    background-color: $color-code-background;
-    display: flex;
-    margin-bottom: $input-margin-bottom;
-    overflow: hidden;
-    padding: $spv-inner--x-small--scaleable $sph-inner;
-    position: relative;
+  @include deprecate('3.0.0', 'p-code-copyable is being removed, use the code snippet block instead.') {
+    .p-code-copyable {
+      background-color: $color-code-background;
+      display: flex;
+      margin-bottom: $input-margin-bottom;
+      overflow: hidden;
+      padding: $spv-inner--x-small--scaleable $sph-inner;
+      position: relative;
 
-    & + & {
-      margin-top: 0; // overrides p + p
+      & + & {
+        margin-top: 0; // overrides p + p
+      }
     }
-  }
 
-  .p-code-copyable__input {
-    background: transparent;
-    border: 0;
-    font-family: unquote($font-monospace);
-    line-height: map-get($line-heights, default-text);
-    margin-bottom: 0;
-    margin-top: 0;
-    padding: 0;
-    width: 100%;
-  }
+    .p-code-copyable__input {
+      background: transparent;
+      border: 0;
+      font-family: unquote($font-monospace);
+      line-height: map-get($line-heights, default-text);
+      margin-bottom: 0;
+      margin-top: 0;
+      padding: 0;
+      width: 100%;
+    }
 
-  .p-code-copyable__action {
-    // This pattern is being deprecated in 2.22, but we
-    // want a consistent look among code block patterns, so
-    // code-copyable has been updated to look like a standard
-    // code block. For that reason, we're hiding the "copy"
-    // button on existing implementations of this pattern.
-    display: none;
+    .p-code-copyable__action {
+      // This pattern is being deprecated in 2.22, but we
+      // want a consistent look among code block patterns, so
+      // code-copyable has been updated to look like a standard
+      // code block. For that reason, we're hiding the "copy"
+      // button on existing implementations of this pattern.
+      display: none;
+    }
   }
 }

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -4,58 +4,30 @@ $cc-button-size: 36px;
 
 @mixin vf-p-code-copyable {
   .p-code-copyable {
-    @extend %bordered-text-vertical-padding;
-    @extend %vf-bg--x-light;
-    @extend %vf-has-round-corners;
-    @extend %vf-is-bordered;
-
+    background-color: $color-code-background;
     display: flex;
     margin-bottom: $input-margin-bottom;
     overflow: hidden;
+    padding: $spv-inner--x-small--scaleable $sph-inner;
     position: relative;
 
     & + & {
       margin-top: 0; // overrides p + p
     }
-
-    &::before {
-      color: $colors--light-theme--text-muted;
-      content: '$';
-      display: block;
-      font-family: unquote($font-monospace);
-      line-height: map-get($line-heights, default-text);
-      padding: 0 $sph-inner--small;
-      position: relative;
-    }
   }
 
   .p-code-copyable__input {
+    background: transparent;
     border: 0;
-    color: $color-mid-dark;
     font-family: unquote($font-monospace);
     line-height: map-get($line-heights, default-text);
     margin-bottom: 0;
     margin-top: 0;
-    padding: 0 calc(#{$cc-button-size} + #{$sph-inner--small}) 0 0;
+    padding: 0;
     width: 100%;
   }
 
   .p-code-copyable__action {
-    @extend %vf-hide-text;
-    @extend %bordered-text-vertical-padding;
-    @include vf-icon-copy($color-mid-dark);
-    @include vf-button-pattern($button-background-color: $color-light, $button-hover-background-color: darken($color-light, 10%));
-
-    background-position: center;
-    background-repeat: no-repeat;
-    border: 0;
-    border-left: $border;
-    border-radius: 0;
-    line-height: map-get($line-heights, default-text);
-    margin: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    width: $cc-button-size;
+    display: none;
   }
 }

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -5,8 +5,9 @@ $cc-button-size: 36px;
 @mixin vf-p-code-copyable {
   @include deprecate('3.0.0', 'p-code-copyable is being removed, use the code snippet block instead.') {
     .p-code-copyable {
+      @extend %leading-linux-prompt-icon;
+
       background-color: $color-code-background;
-      display: flex;
       margin-bottom: $input-margin-bottom;
       overflow: hidden;
       padding: $spv-inner--x-small--scaleable $sph-inner;
@@ -14,17 +15,6 @@ $cc-button-size: 36px;
 
       & + & {
         margin-top: 0; // overrides p + p
-      }
-
-      &::before {
-        @extend %icon;
-        @include vf-icon-linux-prompt($color-mid-dark);
-
-        content: '';
-        left: $sph-inner;
-        position: absolute;
-        top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default))};
-        width: map-get($icon-sizes, default);
       }
     }
 

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -15,6 +15,17 @@ $cc-button-size: 36px;
       & + & {
         margin-top: 0; // overrides p + p
       }
+
+      &::before {
+        @extend %icon;
+        @include vf-icon-linux-prompt($color-mid-dark);
+
+        content: '';
+        left: $sph-inner;
+        position: absolute;
+        top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default))};
+        width: map-get($icon-sizes, default);
+      }
     }
 
     .p-code-copyable__input {
@@ -24,7 +35,7 @@ $cc-button-size: 36px;
       line-height: map-get($line-heights, default-text);
       margin-bottom: 0;
       margin-top: 0;
-      padding: 0;
+      padding: 0 0 0 (map-get($icon-sizes, default) + $spv-inner--x-small--scaleable);
       width: 100%;
     }
 

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -10,19 +10,12 @@
     }
 
     .p-code-snippet__block--icon {
+      @extend %leading-linux-prompt-icon;
+
       padding-left: #{$sph-inner + map-get($icon-sizes, default) + $sph-inner--small};
       position: relative;
 
       &::before {
-        @extend %icon;
-        @include vf-icon-linux-prompt($color-mid-dark);
-
-        content: '';
-        left: $sph-inner;
-        position: absolute;
-        top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default))};
-        width: map-get($icon-sizes, default);
-
         @if ($increase-font-size-on-larger-screens) {
           // stylelint-disable-next-line max-nesting-depth
           @media (min-width: $breakpoint-x-large) {

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -1,7 +1,5 @@
 @import 'settings';
 
-$color-snippet-heading-bg: rgba($color-x-dark, 0.08);
-
 @mixin vf-p-code-snippet {
   .p-code-snippet {
     margin-bottom: $spv-outer--scaleable;
@@ -45,7 +43,7 @@ $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
     }
 
     .p-code-snippet__header {
-      background-color: $color-snippet-heading-bg;
+      background-color: $color-code-heading-background;
       display: flex;
       justify-content: space-between;
       padding: $spv-inner--x-small--scaleable $sph-inner;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -39,6 +39,7 @@ $active-background-opacity-amount: 0.15;
 
 // NON-SEMANTIC COLOURS
 $color-label-validated: #006b75;
+$color-code-background: rgba($color-x-dark, 0.03);
 
 $states: (
   error: $color-negative,

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -40,6 +40,7 @@ $active-background-opacity-amount: 0.15;
 // NON-SEMANTIC COLOURS
 $color-label-validated: #006b75;
 $color-code-background: rgba($color-x-dark, 0.03);
+$color-code-heading-background: rgba($color-x-dark, 0.08);
 
 $states: (
   error: $color-negative,

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -47,7 +47,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
-              {{ side_nav_item("/docs/base/code", "Code") }}
+              {{ side_nav_item("/docs/base/code", "Code", "new") }}
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators", "new") }}
@@ -65,7 +65,7 @@
               {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}
               {{ side_nav_item("/docs/patterns/grid", "Grid") }}
               {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}
-              {{ side_nav_item("/docs/patterns/icons", "Icons", "new") }}
+              {{ side_nav_item("/docs/patterns/icons", "Icons") }}
               {{ side_nav_item("/docs/patterns/images", "Images") }}
               {{ side_nav_item("/docs/patterns/inline-images", "Inline images") }}
               {{ side_nav_item("/docs/patterns/labels", "Labels") }}
@@ -76,7 +76,7 @@
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}
               {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
-              {{ side_nav_item("/docs/patterns/navigation", "Navigation", "updated") }}
+              {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
               {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
               {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
@@ -113,7 +113,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
-              {{ side_nav_item("/docs/layouts/application", "Application", "updated") }}
+              {{ side_nav_item("/docs/layouts/application", "Application") }}
               {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
             </ul>
 

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -47,7 +47,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
-              {{ side_nav_item("/docs/base/code", "Code", "new") }}
+              {{ side_nav_item("/docs/base/code", "Code", "updated") }}
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators", "new") }}

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -54,26 +54,11 @@ View example of the code snippet
 
 ### Copyable
 
-This component should be used when displaying a single line of code, accompanied by a copy icon, which allows users to copy the provided code to their clipboard.
+<span class="p-label--deprecated">Deprecated</span>
 
-<div class="p-strip is-shallow">
-  <div class="row">
-     <div class="col-4">
-       <div class="p-notification--positive">
-        <p class="p-notification__response"><span class="p-notification__status">Do:</span>Use for single line terminal commands, functions or instructions.</p>
-       </div>
-     </div>
-    <div class="col-4">
-      <div class="p-notification--negative">
-        <p class="p-notification__response"><span class="p-notification__status">Don't:</span>Use for multiline code. If needed, code <a href="#block" class="p-notification__action">block</a> should be used.</p>
-      </div>
-    </div>
-  </div>
-</div>
+The code copyable element is now deprecated and will be removed in a future version of Vanilla.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/code-copyable/" class="js-example">
-View example of the code copyable pattern
-</a></div>
+It is being replaced by the new [code snippet pattern](/docs/base/code#code-snippets).
 
 ### Functionality
 
@@ -89,11 +74,7 @@ View example of the code numbered pattern
 
 ### Import
 
-To import just code copyable or numbered component into your project, copy either or both snippets below and include it in your main Sass file.
-
-```scss
-@import 'patterns_code-copyable';
-```
+To import just numbered component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
 @import 'patterns_code-numbered';

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -60,10 +60,6 @@ The code copyable element is now deprecated and will be removed in a future vers
 
 It is being replaced by the new [code snippet pattern](/docs/base/code#code-snippets).
 
-### Functionality
-
-Please copy the entire JS in the example, for copy to clipboard functionality.
-
 ### Numbered
 
 The code numbered pattern can be used when displaying large blocks of code to enable users to quickly reference a specific line.

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -44,6 +44,28 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.22 -->
+    <tr>
+      <th><a href="/docs/examples/patterns/code-copyable">Code Copyable</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.22.0</td>
+      <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block</code> instead.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 2.21 -->
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Contextual Menu</a></th>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -29,27 +29,11 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.22.0</td>
       <td>The new <code>p-separator</code> component has been added to be used as a separator between content blocks.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <!-- 2.22 -->
     <tr>
       <th><a href="/docs/examples/patterns/code-copyable">Code Copyable</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.22.0</td>
-      <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block</code> instead.</td>
+      <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Done

Updated the code copyable to match the code snippet [design](https://app.zeplin.io/project/5fa270d8eee4dbb267e579f1/screen/5fc616c95320fdb32885432e). Notably, this update hides the "copy" button if one is present, without requiring any markup changes. 

Fixes #3464 

## QA

- Open [demo](https://vanilla-framework-3484.demos.haus/docs/examples/patterns/code-copyable)
- See that the pattern matches the design
