### PR TITLE
Add numbered variant to code snippet

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -88,17 +88,12 @@ $code-sidebar-width: $sph-inner + (4 * $digit-width) !default;
   white-space: pre-wrap;
   width: 100%;
 
-  &:empty {
-    display: block;
-    min-height: $sp-xx-large;
-  }
-
   &::before {
     color: $color-mid-dark;
     content: counter(line-numbering);
     counter-increment: line-numbering;
     height: 100%;
-    left: 0;
+    left: -$digit-width;
     overflow: hidden;
     padding-right: $sph-inner;
     pointer-events: none;
@@ -110,6 +105,6 @@ $code-sidebar-width: $sph-inner + (4 * $digit-width) !default;
     -ms-user-select: none;
     user-select: none;
     // stylelint-enable property-no-vendor-prefix
-    width: $code-sidebar-width;
+    width: $code-sidebar-width + $digit-width;
   }
 }

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -1,8 +1,8 @@
 @import 'settings';
 
 $color-pre-bg: rgba($color-x-dark, 0.03);
-$digit-width: 0.5rem; // measured width of one character in the monospaced font
-$code-sidebar-width: $sph-inner + (4 * $digit-width) !default;
+$digit-width: 1ch; // measured width of one character in the monospaced font
+$code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
 
 // Base code styles
 @mixin vf-b-code {
@@ -105,6 +105,8 @@ $code-sidebar-width: $sph-inner + (4 * $digit-width) !default;
     -ms-user-select: none;
     user-select: none;
     // stylelint-enable property-no-vendor-prefix
-    width: $code-sidebar-width + $digit-width;
+    // We're adding a negative left position above of $digit-width,
+    // so the width here needs to take that into account
+    width: calc(#{$code-sidebar-width} + #{$digit-width});
   }
 }

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -104,12 +104,7 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
     pointer-events: none;
     position: absolute;
     text-align: right;
-    // stylelint-disable property-no-vendor-prefix
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
-    // stylelint-enable property-no-vendor-prefix
     // We're adding a negative left position above of $digit-width,
     // so the width here needs to take that into account
     width: calc(#{$code-sidebar-width} + #{$digit-width});

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -88,6 +88,11 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
   white-space: pre-wrap;
   width: 100%;
 
+  &:empty::after {
+    content: ' ';
+    user-select: none;
+  }
+
   &::before {
     color: $color-mid-dark;
     content: counter(line-numbering);

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -1,5 +1,9 @@
 @import 'settings';
 
+$color-pre-bg: rgba($color-x-dark, 0.03);
+$digit-width: 0.5rem; // measured width of one character in the monospaced font
+$code-sidebar-width: $sph-inner + (4 * $digit-width) + $sph-inner !default;
+
 // Base code styles
 @mixin vf-b-code {
   code,
@@ -74,5 +78,37 @@
     position: absolute;
     top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default))};
     width: map-get($icon-sizes, default);
+  }
+}
+
+%code-numbered-line {
+  display: inline-block;
+  padding: 0 $sph-inner 0 $code-sidebar-width;
+  position: relative;
+  white-space: pre-wrap;
+  width: 100%;
+
+  &:empty {
+    display: block;
+    min-height: $sp-xx-large;
+  }
+
+  &::before {
+    color: $color-mid-dark;
+    content: counter(line-numbering);
+    counter-increment: line-numbering;
+    height: 100%;
+    left: 0;
+    padding: 0 $sph-inner;
+    pointer-events: none;
+    position: absolute;
+    text-align: right;
+    // stylelint-disable property-no-vendor-prefix
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    // stylelint-enable property-no-vendor-prefix
+    width: $code-sidebar-width;
   }
 }

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -2,7 +2,7 @@
 
 $color-pre-bg: rgba($color-x-dark, 0.03);
 $digit-width: 0.5rem; // measured width of one character in the monospaced font
-$code-sidebar-width: $sph-inner + (4 * $digit-width) + $sph-inner !default;
+$code-sidebar-width: $sph-inner + (4 * $digit-width) !default;
 
 // Base code styles
 @mixin vf-b-code {
@@ -99,7 +99,8 @@ $code-sidebar-width: $sph-inner + (4 * $digit-width) + $sph-inner !default;
     counter-increment: line-numbering;
     height: 100%;
     left: 0;
-    padding: 0 $sph-inner;
+    overflow: hidden;
+    padding-right: $sph-inner;
     pointer-events: none;
     position: absolute;
     text-align: right;

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -1,5 +1,4 @@
 @import 'settings';
-$sidebar-width: 3rem !default;
 
 @mixin vf-p-code-numbered {
   @include deprecate('3.0.0', 'p-code-numbered is being removed, use the code snippet block numbered variant instead.') {

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -1,5 +1,5 @@
 @import 'settings';
-$sidebar-width: 4.5rem !default;
+$sidebar-width: 3rem !default;
 
 @mixin vf-p-code-numbered {
   @include deprecate('3.0.0', 'p-code-numbered is being removed, use the code snippet block numbered variant instead.') {
@@ -9,37 +9,11 @@ $sidebar-width: 4.5rem !default;
     }
 
     .p-code-numbered__line {
-      display: inline-block;
-      padding: 0 $sph-inner 0 ($sidebar-width + $sph-inner);
-      position: relative;
-      white-space: pre-wrap;
-      width: 100%;
-
-      &:empty {
-        display: block;
-        min-height: $sp-xx-large;
-      }
+      @extend %code-numbered-line;
 
       &::before {
         background: transparent;
-        color: $color-mid-dark;
-        content: counter(line-numbering);
-        counter-increment: line-numbering;
-        display: inline-block;
-        height: 100%;
-        left: 0;
-        padding: 0 $sph-inner;
-        pointer-events: none;
-        position: absolute;
-        text-align: right;
         top: 0;
-        // stylelint-disable property-no-vendor-prefix
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        // stylelint-enable property-no-vendor-prefix
-        width: $sidebar-width;
       }
     }
   }

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -2,43 +2,45 @@
 $sidebar-width: 4.5rem !default;
 
 @mixin vf-p-code-numbered {
-  .p-code-numbered {
-    counter-reset: line-numbering;
-    padding: $sph-inner--small 0;
-  }
-
-  .p-code-numbered__line {
-    display: inline-block;
-    padding: 0 $sph-inner 0 ($sidebar-width + $sph-inner);
-    position: relative;
-    white-space: pre-wrap;
-    width: 100%;
-
-    &:empty {
-      display: block;
-      min-height: $sp-xx-large;
+  @include deprecate('3.0.0', 'p-code-numbered is being removed, use the code snippet block numbered variant instead.') {
+    .p-code-numbered {
+      counter-reset: line-numbering;
+      padding: $sph-inner--small 0;
     }
 
-    &::before {
-      background: transparent;
-      color: $color-mid-dark;
-      content: counter(line-numbering);
-      counter-increment: line-numbering;
+    .p-code-numbered__line {
       display: inline-block;
-      height: 100%;
-      left: 0;
-      padding: 0 $sph-inner;
-      pointer-events: none;
-      position: absolute;
-      text-align: right;
-      top: 0;
-      // stylelint-disable property-no-vendor-prefix
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-      // stylelint-enable property-no-vendor-prefix
-      width: $sidebar-width;
+      padding: 0 $sph-inner 0 ($sidebar-width + $sph-inner);
+      position: relative;
+      white-space: pre-wrap;
+      width: 100%;
+
+      &:empty {
+        display: block;
+        min-height: $sp-xx-large;
+      }
+
+      &::before {
+        background: transparent;
+        color: $color-mid-dark;
+        content: counter(line-numbering);
+        counter-increment: line-numbering;
+        display: inline-block;
+        height: 100%;
+        left: 0;
+        padding: 0 $sph-inner;
+        pointer-events: none;
+        position: absolute;
+        text-align: right;
+        top: 0;
+        // stylelint-disable property-no-vendor-prefix
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        // stylelint-enable property-no-vendor-prefix
+        width: $sidebar-width;
+      }
     }
   }
 }

--- a/scss/_patterns_code-numbered.scss
+++ b/scss/_patterns_code-numbered.scss
@@ -5,16 +5,10 @@ $sidebar-width: 3rem !default;
   @include deprecate('3.0.0', 'p-code-numbered is being removed, use the code snippet block numbered variant instead.') {
     .p-code-numbered {
       counter-reset: line-numbering;
-      padding: $sph-inner--small 0;
     }
 
     .p-code-numbered__line {
       @extend %code-numbered-line;
-
-      &::before {
-        background: transparent;
-        top: 0;
-      }
     }
   }
 }

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -1,11 +1,15 @@
 @import 'settings';
 
+$color-snippet-heading-bg: rgba($color-x-dark, 0.08);
+$sidebar-width: 4.5rem !default;
+
 @mixin vf-p-code-snippet {
   .p-code-snippet {
     margin-bottom: $spv-outer--scaleable;
 
     .p-code-snippet__block,
-    .p-code-snippet__block--icon {
+    .p-code-snippet__block--icon,
+    .p-code-snippet__block--numbered {
       margin: 0;
     }
 
@@ -32,6 +36,43 @@
 
       &.is-url::before {
         @include vf-icon-get-link($color-mid-dark);
+      }
+    }
+
+    .p-code-snippet__block--numbered {
+      counter-reset: line-numbering;
+      padding: $sph-inner--small 0;
+    }
+
+    .p-code-snippet__line {
+      display: inline-block;
+      padding: 0 $sph-inner 0 ($sidebar-width + $sph-inner);
+      position: relative;
+      white-space: pre-wrap;
+      width: 100%;
+
+      &:empty {
+        display: block;
+        min-height: $sp-xx-large;
+      }
+
+      &::before {
+        color: $color-mid-dark;
+        content: counter(line-numbering);
+        counter-increment: line-numbering;
+        height: 100%;
+        left: 0;
+        padding: 0 $sph-inner;
+        pointer-events: none;
+        position: absolute;
+        text-align: right;
+        // stylelint-disable property-no-vendor-prefix
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        // stylelint-enable property-no-vendor-prefix
+        width: $sidebar-width;
       }
     }
 

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -1,8 +1,6 @@
 @import 'settings';
 
 $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
-$digit-width: 0.5rem; // measured width of one character in the monospaced font
-$snippet-sidebar-width: $sph-inner + (4 * $digit-width) + $sph-inner !default;
 
 @mixin vf-p-code-snippet {
   .p-code-snippet {
@@ -46,35 +44,7 @@ $snippet-sidebar-width: $sph-inner + (4 * $digit-width) + $sph-inner !default;
     }
 
     .p-code-snippet__line {
-      display: inline-block;
-      padding: 0 $sph-inner 0 $snippet-sidebar-width;
-      position: relative;
-      white-space: pre-wrap;
-      width: 100%;
-
-      &:empty {
-        display: block;
-        min-height: $sp-xx-large;
-      }
-
-      &::before {
-        color: $color-mid-dark;
-        content: counter(line-numbering);
-        counter-increment: line-numbering;
-        height: 100%;
-        left: 0;
-        padding: 0 $sph-inner;
-        pointer-events: none;
-        position: absolute;
-        text-align: right;
-        // stylelint-disable property-no-vendor-prefix
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        // stylelint-enable property-no-vendor-prefix
-        width: $snippet-sidebar-width;
-      }
+      @extend %code-numbered-line;
     }
 
     .p-code-snippet__header {

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -40,7 +40,6 @@ $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
 
     .p-code-snippet__block--numbered {
       counter-reset: line-numbering;
-      padding: $sph-inner--small 0;
     }
 
     .p-code-snippet__line {

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -1,7 +1,8 @@
 @import 'settings';
 
 $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
-$snippet-number-width: 3.5rem !default;
+$digit-width: 0.5rem; // measured width of one character in the monospaced font
+$snippet-sidebar-width: $sph-inner + (4 * $digit-width) + $sph-inner !default;
 
 @mixin vf-p-code-snippet {
   .p-code-snippet {
@@ -46,7 +47,7 @@ $snippet-number-width: 3.5rem !default;
 
     .p-code-snippet__line {
       display: inline-block;
-      padding: 0 $sph-inner 0 ($snippet-number-width + $sph-inner);
+      padding: 0 $sph-inner 0 $snippet-sidebar-width;
       position: relative;
       white-space: pre-wrap;
       width: 100%;
@@ -62,7 +63,7 @@ $snippet-number-width: 3.5rem !default;
         counter-increment: line-numbering;
         height: 100%;
         left: 0;
-        padding-left: $sph-inner;
+        padding: 0 $sph-inner;
         pointer-events: none;
         position: absolute;
         text-align: right;
@@ -72,7 +73,7 @@ $snippet-number-width: 3.5rem !default;
         -ms-user-select: none;
         user-select: none;
         // stylelint-enable property-no-vendor-prefix
-        width: $snippet-number-width;
+        width: $snippet-sidebar-width;
       }
     }
 

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -1,7 +1,7 @@
 @import 'settings';
 
 $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
-$sidebar-width: 4.5rem !default;
+$snippet-number-width: 3.5rem !default;
 
 @mixin vf-p-code-snippet {
   .p-code-snippet {
@@ -46,7 +46,7 @@ $sidebar-width: 4.5rem !default;
 
     .p-code-snippet__line {
       display: inline-block;
-      padding: 0 $sph-inner 0 ($sidebar-width + $sph-inner);
+      padding: 0 $sph-inner 0 ($snippet-number-width + $sph-inner);
       position: relative;
       white-space: pre-wrap;
       width: 100%;
@@ -62,7 +62,7 @@ $sidebar-width: 4.5rem !default;
         counter-increment: line-numbering;
         height: 100%;
         left: 0;
-        padding: 0 $sph-inner;
+        padding-left: $sph-inner;
         pointer-events: none;
         position: absolute;
         text-align: right;
@@ -72,7 +72,7 @@ $sidebar-width: 4.5rem !default;
         -ms-user-select: none;
         user-select: none;
         // stylelint-enable property-no-vendor-prefix
-        width: $sidebar-width;
+        width: $snippet-number-width;
       }
     }
 

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -36,6 +36,8 @@ View example of the base code block
 
 ### Code snippet
 
+<span class="p-label--new">New</span>
+
 The code snippet pattern should be used to group related code examples, making them easier to find and understand. It should consist of one or, at most, two code blocks with optional headers for their titles.
 
 **Basic code snippet**
@@ -46,7 +48,7 @@ View example of the code snippet
 
 **Code snippet with icon**
 
-A code snippet block can include an icon by using the `.p-code-snippet__block--code` class. By default, it will show the Linux prompt icon, but other icon options are available, using the `.is-windows-prompt` or `.is-url` classes.
+A code snippet block can include an icon by using the `.p-code-snippet__block--icon` class. By default, it will show the Linux prompt icon, but other icon options are available, using the `.is-windows-prompt` or `.is-url` classes.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/code-snippet-icon" class="js-example">
 View example of the code snippet

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -34,7 +34,7 @@ View example of the base pre block
 View example of the base code block
 </a></div>
 
-### Code Snippets
+### Code snippet
 
 The code snippet pattern should be used to group related code examples, making them easier to find and understand. It should consist of one or, at most, two code blocks with optional headers for their titles.
 
@@ -52,6 +52,12 @@ A code snippet block can include an icon by using the `.p-code-snippet__block--c
 View example of the code snippet
 </a></div>
 
+**Code snippet with numbered lines**
+
+<div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/code-snippet-numbered" class="js-example">
+View example of the code snippet
+</a></div>
+
 ### Copyable
 
 <span class="p-label--deprecated">Deprecated</span>
@@ -62,21 +68,11 @@ It is being replaced by the new [code snippet pattern](/docs/base/code#code-snip
 
 ### Numbered
 
-The code numbered pattern can be used when displaying large blocks of code to enable users to quickly reference a specific line.
+<span class="p-label--deprecated">Deprecated</span>
 
-<div class="embedded-example"><a href="/docs/examples/patterns/code-numbered/" class="js-example">
-View example of the code numbered pattern
-</a></div>
+The code numbered pattern is now deprecated and will be removed in a future version of Vanilla.
 
-### Import
-
-To import just numbered component into your project, copy the snippet below and include it in your main Sass file.
-
-```scss
-@import 'patterns_code-numbered';
-```
-
-For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+It is being replaced by the new [code snippet pattern](/docs/base/code#code-snippets).
 
 ### Design
 

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -64,7 +64,7 @@ View example of the code snippet
 
 The code copyable element is now deprecated and will be removed in a future version of Vanilla.
 
-It is being replaced by the new [code snippet pattern](/docs/base/code#code-snippets).
+It is being replaced by the new [code snippet pattern](/docs/base/code#code-snippet).
 
 ### Numbered
 
@@ -72,7 +72,7 @@ It is being replaced by the new [code snippet pattern](/docs/base/code#code-snip
 
 The code numbered pattern is now deprecated and will be removed in a future version of Vanilla.
 
-It is being replaced by the new [code snippet pattern](/docs/base/code#code-snippets).
+It is being replaced by the new [code snippet pattern](/docs/base/code#code-snippet).
 
 ### Design
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -30,7 +30,13 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>The new <code>p-separator</code> component has been added to be used as a separator between content blocks.</td>
     </tr>
     <tr>
-      <th><a href="/docs/examples/patterns/code-copyable">Code Copyable</a></th>
+      <th><a href="/docs/examples/patterns/code-snippet/code-snippet">Code snippet</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.22.0</td>
+      <td>The new <code>.p-code-snippet</code> component has been added, to be used to display code examples in a number of different formats.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/examples/patterns/code-copyable">Code copyable</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.22.0</td>
       <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -35,6 +35,12 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.22.0</td>
       <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/examples/patterns/code-numbered">Code numbered</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.22.0</td>
+      <td><code>.p-code-numbered</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--numbered</code> instead.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -30,19 +30,19 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>The new <code>p-separator</code> component has been added to be used as a separator between content blocks.</td>
     </tr>
     <tr>
-      <th><a href="/docs/examples/patterns/code-snippet/code-snippet">Code snippet</a></th>
+      <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.22.0</td>
       <td>The new <code>.p-code-snippet</code> component has been added, to be used to display code examples in a number of different formats.</td>
     </tr>
     <tr>
-      <th><a href="/docs/examples/patterns/code-copyable">Code copyable</a></th>
+      <th><a href="/docs/base/code#copyable">Code copyable</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.22.0</td>
       <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>
     </tr>
     <tr>
-      <th><a href="/docs/examples/patterns/code-numbered">Code numbered</a></th>
+      <th><a href="/docs/base/code#numbered">Code numbered</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.22.0</td>
       <td><code>.p-code-numbered</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--numbered</code> instead.</td>

--- a/templates/docs/examples/patterns/code-numbered.html
+++ b/templates/docs/examples/patterns/code-numbered.html
@@ -7,9 +7,11 @@
 <pre class="p-code-numbered"><code><span class="p-code-numbered__line">#!/bin/bash</span>
 <span class="p-code-numbered__line">set -eu</span>
 <span class="p-code-numbered__line">. $CONJURE_UP_SPELLSDIR/sdk/common.sh</span>
+<span class="p-code-numbered__line"></span>
 <span class="p-code-numbered__line">if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then</span>
 <span class="p-code-numbered__line">    debug "Running pre-deploy for $CONJURE_UP_SPELL"</span>
 <span class="p-code-numbered__line">    sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" || exposeResult "Failed to set profile" $? "false"</span>
 <span class="p-code-numbered__line">fi</span>
+<span class="p-code-numbered__line"></span>
 <span class="p-code-numbered__line">exposeResult "Successful pre-deploy." 0 "true"</span></code></pre>
 {% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-numbered.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-numbered.html
@@ -5,10 +5,6 @@
 
 {% block content %}
 <div class="p-code-snippet">
-  <div class="p-code-snippet__header">
-    <h5 class="p-code-snippet__title">Check you have snap installed</h5>
-  </div>
-
   <pre class="p-code-snippet__block--numbered"><code><span class="p-code-snippet__line">#!/bin/bash</span>
 <span class="p-code-snippet__line">set -eu</span>
 <span class="p-code-snippet__line">. $CONJURE_UP_SPELLSDIR/sdk/common.sh</span>

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-numbered.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-numbered.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Code Snippet / Numbered{% endblock %}
+{% block title %}Code snippet / Numbered{% endblock %}
 
 {% block standalone_css %}patterns_code-snippet{% endblock %}
 

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-numbered.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-numbered.html
@@ -1,0 +1,21 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Code Snippet / Numbered{% endblock %}
+
+{% block standalone_css %}patterns_code-snippet{% endblock %}
+
+{% block content %}
+<div class="p-code-snippet">
+  <div class="p-code-snippet__header">
+    <h5 class="p-code-snippet__title">Check you have snap installed</h5>
+  </div>
+
+  <pre class="p-code-snippet__block--numbered"><code><span class="p-code-snippet__line">#!/bin/bash</span>
+<span class="p-code-snippet__line">set -eu</span>
+<span class="p-code-snippet__line">. $CONJURE_UP_SPELLSDIR/sdk/common.sh</span>
+<span class="p-code-snippet__line">if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then</span>
+<span class="p-code-snippet__line">    debug "Running pre-deploy for $CONJURE_UP_SPELL"</span>
+<span class="p-code-snippet__line">    sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" || exposeResult "Failed to set profile" $? "false"</span>
+<span class="p-code-snippet__line">fi</span>
+<span class="p-code-snippet__line">exposeResult "Successful pre-deploy." 0 "true"</span></code></pre>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-numbered.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-numbered.html
@@ -12,10 +12,12 @@
   <pre class="p-code-snippet__block--numbered"><code><span class="p-code-snippet__line">#!/bin/bash</span>
 <span class="p-code-snippet__line">set -eu</span>
 <span class="p-code-snippet__line">. $CONJURE_UP_SPELLSDIR/sdk/common.sh</span>
+<span class="p-code-snippet__line"></span>
 <span class="p-code-snippet__line">if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then</span>
 <span class="p-code-snippet__line">    debug "Running pre-deploy for $CONJURE_UP_SPELL"</span>
 <span class="p-code-snippet__line">    sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" || exposeResult "Failed to set profile" $? "false"</span>
 <span class="p-code-snippet__line">fi</span>
+<span class="p-code-snippet__line"></span>
 <span class="p-code-snippet__line">exposeResult "Successful pre-deploy." 0 "true"</span></code></pre>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/code-snippet.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Code Snippet{% endblock %}
+{% block title %}Code snippet{% endblock %}
 
 {% block standalone_css %}patterns_code-snippet{% endblock %}
 


### PR DESCRIPTION
## Done

Added numbered line variant of code snippet block.

Fixes #3471 
## QA

- Open [demo](https://vanilla-framework-3490.demos.haus/docs/examples/patterns/code-snippet/code-snippet-numbered)
- See that it matches the [design](https://app.zeplin.io/project/5fa270d8eee4dbb267e579f1/screen/5fc616c95320fdb32885432e)
- Review updated documentation:
  - Check the updated [documentation](https://vanilla-framework-3490.demos.haus/docs/base/code) makes sense
