### PR TITLE
Add example of syntax highlighting with Prism

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -16,6 +16,7 @@
 @import 'base_tables';
 @import 'base_background';
 @import 'base_grid-definitions';
+@import 'base_syntax-highlighting';
 
 @mixin vf-base {
   // Reset
@@ -36,4 +37,5 @@
   @include vf-b-media;
   @include vf-b-tables;
   @include vf-b-grid-definitions;
+  @include vf-b-syntax-highlighting;
 }

--- a/scss/_base_syntax-highlighting.scss
+++ b/scss/_base_syntax-highlighting.scss
@@ -1,0 +1,83 @@
+@import 'settings';
+
+@mixin vf-b-syntax-highlighting {
+  /*
+    http://prismjs.com/
+
+    prism.js theme based by theme by Edward Horsford for GOV.UK
+    https://github.com/alphagov/govuk_elements/blob/master/assets/sass/vendor/prism.scss
+  */
+
+  .token {
+    &.comment,
+    &.prolog,
+    &.doctype,
+    &.cdata {
+      color: #666;
+    }
+
+    &.punctuation {
+      color: #757575;
+    }
+
+    &.namespace {
+      opacity: 0.7;
+    }
+
+    &.property,
+    &.tag,
+    &.boolean,
+    &.number,
+    &.constant,
+    &.symbol,
+    &.deleted {
+      color: #0e8620;
+    }
+
+    &.selector,
+    &.attr-name,
+    &.string,
+    &.char,
+    &.builtin,
+    &.inserted {
+      color: #860048;
+    }
+
+    .operator,
+    .entity,
+    .url,
+    .language-css &.string,
+    .style &.string {
+      color: #9e5a06;
+    }
+
+    &.atrule,
+    &.attr-value,
+    &.keyword {
+      color: #06c;
+    }
+
+    &.function,
+    &.class-name {
+      color: #da3800;
+    }
+
+    &.regex,
+    &.important,
+    &.variable {
+      color: #912802;
+    }
+
+    &.important,
+    &.bold {
+      font-weight: bold;
+    }
+    &.italic {
+      font-style: italic;
+    }
+
+    &.entity {
+      cursor: help;
+    }
+  }
+}

--- a/scss/_base_syntax-highlighting.scss
+++ b/scss/_base_syntax-highlighting.scss
@@ -13,11 +13,11 @@
     &.prolog,
     &.doctype,
     &.cdata {
-      color: #666;
+      color: $colors--light-theme--text-muted;
     }
 
     &.punctuation {
-      color: #757575;
+      color: $colors--light-theme--text-default;
     }
 
     &.namespace {
@@ -31,7 +31,7 @@
     &.constant,
     &.symbol,
     &.deleted {
-      color: #0e8620;
+      color: #77216f; // √ brand light aubergine
     }
 
     &.selector,
@@ -40,7 +40,7 @@
     &.char,
     &.builtin,
     &.inserted {
-      color: #860048;
+      color: #0e8620; // positive button bg color
     }
 
     .operator,
@@ -48,24 +48,24 @@
     .url,
     .language-css &.string,
     .style &.string {
-      color: #9e5a06;
+      color: #a86500; // $color-caution darkened to meet AA
     }
 
     &.atrule,
     &.attr-value,
     &.keyword {
-      color: #06c;
+      color: #06c; // $color-link
     }
 
     &.function,
     &.class-name {
-      color: #da3800;
+      color: #c7162b; // color-negative
     }
 
     &.regex,
     &.important,
     &.variable {
-      color: #912802;
+      color: #dc3023; // secondary palette nudged to AA
     }
 
     &.important,

--- a/scss/_base_syntax-highlighting.scss
+++ b/scss/_base_syntax-highlighting.scss
@@ -40,7 +40,7 @@
     &.char,
     &.builtin,
     &.inserted {
-      color: #0e8620; // positive button bg color
+      color: #0e811f; // positive button bg color nudged to meet AA contrast req on #f7f7f7
     }
 
     .operator,

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -70,11 +70,15 @@ View example of the code snippet
 
 ### Syntax highlighting
 
-We recommend using Prism for syntax highlighting in code snippet. Vanilla framework provides a built-in Prism theme, so only JavaScript of Prism library needs to be added to the page, and `language-*` class name to the respective code blocks.
+We recommend using [Prism](https://prismjs.com/) for syntax highlighting in the code snippet. Vanilla framework provides a built-in Prism theme, so only JavaScript of Prism library needs to be added to the page, and `language-*` class names to the respective code blocks.
 
-Make sure to include language support for any required languages or the `autoloader` plug-in (that automatically loads needed languages based on used class names).
+Make sure to include [language support for any required languages](https://prismjs.com/index.html#supported-languages) or [the `autoloader` plug-in](https://prismjs.com/plugins/autoloader/) (that automatically loads needed languages based on used class names).
 
-To correctly support numbered variant of code snippet `keep-html` plug-in is needed to preserve `span` elements around the lines.
+To correctly support numbered variant of code snippet [the `keep-markup` plug-in](https://prismjs.com/plugins/keep-markup/) is needed to preserve `span` elements around the lines.
+
+JavaScript for [Prism can be downloaded from their download page](https://prismjs.com/download) where it can be bundled with any necessary languages and plug-ins. You can also use [Prism provided by CDN](https://prismjs.com/index.html#basic-usage-cdn).
+
+To avoid using JavaScript library for syntax highlighting you can prepare the code block content by manually wrapping the highlighted elements into `span`s with class names compatible with Prism theme (like `<span class="token keyword">` `<span class="token comment">`).
 
 <div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/code-snippet-prism" class="js-example">
 View example of the code snippet with syntax highlighting

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -68,6 +68,18 @@ By default, `<pre>` elements do not wrap content, but this can be overridden by 
 View example of the code snippet
 </a></div>
 
+### Syntax highlighting
+
+We recommend using Prism for syntax highlighting in code snippet. Vanilla framework provides a built-in Prism theme, so only JavaScript of Prism library needs to be added to the page, and `language-*` class name to the respective code blocks.
+
+Make sure to include language support for any required languages or the `autoloader` plug-in (that automatically loads needed languages based on used class names).
+
+To correctly support numbered variant of code snippet `keep-html` plug-in is needed to preserve `span` elements around the lines.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/code-snippet-prism" class="js-example">
+View example of the code snippet with syntax highlighting
+</a></div>
+
 ### Copyable
 
 <span class="p-label--deprecated">Deprecated</span>

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-prism.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-prism.html
@@ -28,10 +28,13 @@
               "Api-Username": api_username,
           }</code></pre>
 
-<div class="p-code-snippet__header">
-  <h5 class="p-code-snippet__title">Yaml</h5>
 </div>
-<pre class="p-code-snippet__block--numbered language-yaml"><code><span class="p-code-snippet__line">name: super-cool-app</span>
+
+<div class="p-code-snippet">
+  <div class="p-code-snippet__header">
+    <h5 class="p-code-snippet__title">Yaml (numbered)</h5>
+  </div>
+  <pre class="p-code-snippet__block--numbered language-yaml"><code><span class="p-code-snippet__line">name: super-cool-app</span>
 <span class="p-code-snippet__line">version: "1.0"</span>
 <span class="p-code-snippet__line">summary: Super Cool App</span>
 <span class="p-code-snippet__line">description: |</span>
@@ -47,6 +50,17 @@
 <span class="p-code-snippet__line">  super-cool-app:</span>
 <span class="p-code-snippet__line">    command: super_cool_app</span>
 <span class="p-code-snippet__line">    extensions: [flutter-dev]</span></code></pre>
+</div>
+
+<div class="p-code-snippet">
+  <div class="p-code-snippet__header">
+    <h5 class="p-code-snippet__title">Manual highlighting</h5>
+  </div>
+  <pre class="p-code-snippet__block">npm install --save-dev vanilla-framework
+<span class="token keyword">export</span> SASS_PATH=`pwd`/node_modules:${SASS_PATH}
+
+<span class="token comment">// Add to your main build scss file the following line</span>
+<span class="token atrule">@import</span> <span class="token string">'vanilla-framework/scss/build'</span></code></pre>
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-core.min.js"></script>

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-prism.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-prism.html
@@ -4,86 +4,6 @@
 {% block standalone_css %}patterns_code-snippet{% endblock %}
 
 {% block content %}
-<style>
-/*
-  http://prismjs.com/
-
-  prism.js theme based by theme by Edward Horsford for GOV.UK
-  https://github.com/alphagov/govuk_elements/blob/master/assets/sass/vendor/prism.scss
-*/
-
-.comment,
-.prolog,
-.doctype,
-.cdata {
-  color: #666;
-}
-
-.punctuation {
-	color: #757575;
-}
-
-.namespace {
-	opacity: .7;
-}
-
-.property,
-.tag,
-.boolean,
-.number,
-.constant,
-.symbol,
-.deleted {
-	color: #0e8620;
-}
-
-.selector,
-.attr-name,
-.string,
-.char,
-.builtin,
-.inserted {
-	color: #860048;
-}
-
-.operator,
-.entity,
-.url,
-.language-css .string,
-.style .string {
-	color: #9e5a06;
-}
-
-.atrule,
-.attr-value,
-.keyword {
-	color: #06c;
-}
-
-.function,
-.class-name {
-  color: #da3800;
-
-}
-
-.regex,
-.important,
-.variable {
-	color: #912802;
-}
-
-.important,
-.bold {
-	font-weight: bold;
-}
-.italic {
-	font-style: italic;
-}
-
-.entity {
-	cursor: help;
-}
-</style>
 <div class="p-code-snippet">
   <div class="p-code-snippet__header">
     <h5 class="p-code-snippet__title">Python</h5>
@@ -132,6 +52,4 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-core.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/keep-markup/prism-keep-markup.min.js"></script>
-
-
 {% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-prism.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-prism.html
@@ -1,0 +1,124 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Code Snippet / Syntax highlight{% endblock %}
+
+{% block standalone_css %}patterns_code-snippet{% endblock %}
+
+{% block content %}
+<style>
+/*
+  http://prismjs.com/
+
+  prism.js theme based by theme by Edward Horsford for GOV.UK
+  https://github.com/alphagov/govuk_elements/blob/master/assets/sass/vendor/prism.scss
+*/
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata,
+.token.punctuation {
+  color: #6a7276; }
+
+.namespace {
+  opacity: .7; }
+
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted,
+.token.selector,
+.token.keyword {
+  color: #900b18; }
+
+.token.attr-name,
+.token.char,
+.token.builtin,
+.token.inserted,
+.token.function,
+.token.property {
+  color: #1E8400; }
+
+.token.regex,
+.token.important,
+.token.atrule,
+.language-scss .token.keyword,
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #de272b; }
+
+.token.attr-value,
+.token.string,
+.token.variable {
+  color: #005ea5; }
+
+.language-scss .token.number,
+.language-css .token.number {
+  color: #0b0c0c; }
+
+.token.important,
+.token.bold {
+  font-weight: bold; }
+
+.token.italic {
+  font-style: italic; }
+
+.token.entity {
+  cursor: help; }
+
+</style>
+<div class="p-code-snippet">
+  <div class="p-code-snippet__header">
+    <h5 class="p-code-snippet__title">Python</h5>
+  </div>
+<pre class="p-code-snippet__block language-python"><code>class DiscourseAPI:
+  """
+  Retrieve information from a Discourse installation
+  through its API
+  """
+
+  def __init__(self, base_url, session, api_key=None, api_username=None):
+      """
+      @param base_url: The Discourse URL (e.g. https://discourse.example.com)
+      """
+
+      self.base_url = base_url.rstrip("/")
+      self.session = session
+
+      if api_key and api_username:
+          self.session.headers = {
+              "Api-Key": api_key,
+              "Api-Username": api_username,
+          }</code></pre>
+
+<div class="p-code-snippet__header">
+  <h5 class="p-code-snippet__title">Yaml</h5>
+</div>
+<pre class="p-code-snippet__block--numbered language-yaml"><code><span class="p-code-snippet__line">name: super-cool-app</span>
+<span class="p-code-snippet__line">version: "1.0"</span>
+<span class="p-code-snippet__line">summary: Super Cool App</span>
+<span class="p-code-snippet__line">description: |</span>
+<span class="p-code-snippet__line">    Super Cool App that does everything! […]</span>
+<span class="p-code-snippet__line">confinement: strict</span>
+<span class="p-code-snippet__line">base: core18</span>
+<span class="p-code-snippet__line">parts:</span>
+<span class="p-code-snippet__line">  super-cool-app:</span>
+<span class="p-code-snippet__line">    plugin: flutter</span>
+<span class="p-code-snippet__line">    source: https://github.com/kenvandine/super-cool-app.git</span>
+<span class="p-code-snippet__line">    flutter-target: lib/main.dart</span>
+<span class="p-code-snippet__line">apps:</span>
+<span class="p-code-snippet__line">  super-cool-app:</span>
+<span class="p-code-snippet__line">    command: super_cool_app</span>
+<span class="p-code-snippet__line">    extensions: [flutter-dev]</span></code></pre>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-core.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/keep-markup/prism-keep-markup.min.js"></script>
+
+
+{% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-prism.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-prism.html
@@ -12,64 +12,77 @@
   https://github.com/alphagov/govuk_elements/blob/master/assets/sass/vendor/prism.scss
 */
 
-.token.comment,
-.token.prolog,
-.token.doctype,
-.token.cdata,
-.token.punctuation {
-  color: #6a7276; }
+.comment,
+.prolog,
+.doctype,
+.cdata {
+  color: #666;
+}
+
+.punctuation {
+	color: #757575;
+}
 
 .namespace {
-  opacity: .7; }
+	opacity: .7;
+}
 
-.token.tag,
-.token.boolean,
-.token.number,
-.token.constant,
-.token.symbol,
-.token.deleted,
-.token.selector,
-.token.keyword {
-  color: #900b18; }
+.property,
+.tag,
+.boolean,
+.number,
+.constant,
+.symbol,
+.deleted {
+	color: #0e8620;
+}
 
-.token.attr-name,
-.token.char,
-.token.builtin,
-.token.inserted,
-.token.function,
-.token.property {
-  color: #1E8400; }
+.selector,
+.attr-name,
+.string,
+.char,
+.builtin,
+.inserted {
+	color: #860048;
+}
 
-.token.regex,
-.token.important,
-.token.atrule,
-.language-scss .token.keyword,
-.token.operator,
-.token.entity,
-.token.url,
-.language-css .token.string,
-.style .token.string {
-  color: #de272b; }
+.operator,
+.entity,
+.url,
+.language-css .string,
+.style .string {
+	color: #9e5a06;
+}
 
-.token.attr-value,
-.token.string,
-.token.variable {
-  color: #005ea5; }
+.atrule,
+.attr-value,
+.keyword {
+	color: #06c;
+}
 
-.language-scss .token.number,
-.language-css .token.number {
-  color: #0b0c0c; }
+.function,
+.class-name {
+  color: #da3800;
 
-.token.important,
-.token.bold {
-  font-weight: bold; }
+}
 
-.token.italic {
-  font-style: italic; }
+.regex,
+.important,
+.variable {
+	color: #912802;
+}
 
-.token.entity {
-  cursor: help; }
+.important,
+.bold {
+	font-weight: bold;
+}
+.italic {
+	font-style: italic;
+}
 
+.entity {
+	cursor: help;
+}
 </style>
 <div class="p-code-snippet">
   <div class="p-code-snippet__header">

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -72,6 +72,7 @@
     var htmlSource = stripScriptsFromSource(bodyHTML);
     var jsSource = getScriptFromSource(bodyHTML);
     var cssSource = getStyleFromSource(headHTML);
+    var externalScripts = getExternalScriptsFromSource(html);
 
     var height = placementElement.getAttribute('data-height') || CODEPEN_HEIGHT;
 
@@ -82,6 +83,11 @@
     // hide code container by default, so it doesn't flash on page
     // before CodePen is rendered
     container.classList.add('codepen-example', 'u-hide');
+
+    // pass any external scripts to CodePen
+    if (externalScripts.length) {
+      CODEPEN_PREFILL_CONFIG.scripts = externalScripts;
+    }
 
     var config = JSON.parse(JSON.stringify(CODEPEN_PREFILL_CONFIG));
     // update title in the config with title of the example page
@@ -143,5 +149,15 @@
     div.innerHTML = source;
     var script = div.querySelector('script');
     return script ? script.innerHTML.trim() : null;
+  }
+
+  function getExternalScriptsFromSource(source) {
+    var div = document.createElement('div');
+    div.innerHTML = source;
+    var scripts = div.querySelectorAll('script[src]');
+    scripts = [].slice.apply(scripts).map(function (s) {
+      return s.src;
+    });
+    return scripts;
   }
 })();


### PR DESCRIPTION
## Done

Adds Prism syntax highlighting to code snippet

Fixes #3477

## QA

- Open [demo](https://vanilla-framework-3494.demos.haus/docs/examples/patterns/code-snippet/code-snippet-prism)
- Make sure syntax coloring works as expected
- Review updated documentation:
  - https://vanilla-framework-3494.demos.haus/docs/base/code#syntax-highlighting

## Screenshots

<img width="773" alt="Screenshot 2021-01-21 at 16 45 16" src="https://user-images.githubusercontent.com/83575/105374492-0fd45700-5c08-11eb-9fb4-d30adbaae69f.png">

