### PR TITLE
Prepare Vanilla 2.22 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js"
   },
-  "version": "2.21.0",
+  "version": "2.22.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/templates/docs/base/separators.md
+++ b/templates/docs/base/separators.md
@@ -20,6 +20,8 @@ View example of the horizontal line
 
 ### Separator
 
+<span class="p-label--new">New</span>
+
 To separate block sections of the page, use the separator component `<hr class="p-separator">`.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/separator/" class="js-example">


### PR DESCRIPTION
## Done

Bumps version of Vanilla to 2.22, updates missing labels in docs.


## QA

- Open [demo](https://vanilla-framework-3496.demos.haus/docs)
- Review updated documentation:
  - Check if Vanilla version is correct: https://vanilla-framework-3496.demos.haus/docs
  - Check if component status is up to date: https://vanilla-framework-3496.demos.haus/docs/component-status
  - Check if component status table links to correct parts of the docs
  - Check if the docs linked from component status are correct, have labels, etc
