### PR TITLE
Apply is-inline button styles at the small breakpoint and up

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -136,7 +136,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
 @mixin vf-button-inline {
   [class*='p-button'].is-inline {
-    @media (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-x-small) {
       margin-left: $sph-outer;
       width: auto;
     }

--- a/templates/docs/examples/patterns/buttons/small.html
+++ b/templates/docs/examples/patterns/buttons/small.html
@@ -4,5 +4,5 @@
 {% block standalone_css %}patterns_buttons{% endblock %}
 
 {% block content %}
-<p><small>This is small text <button class="p-button--neutral is-small">This is a small button</button><button class="p-button--neutral is-small is-dense">This is a small, dense button</button></small></p>
+<p><small>This is small text <button class="p-button--neutral is-small is-inline">This is a small button</button><button class="p-button--neutral is-small is-dense">This is a small, dense button</button></small></p>
 {% endblock %}


### PR DESCRIPTION
## Done
Reduced the breakpoint at which `is-inline` styles are applied to `button` elements, so that the correct margin is present when the button is not full width.

Related to #3344 - once this PR is merged there's another task to remove unnecessary styles from the SummaryButton in React Components.

Fixes #3387

## QA

- Open [demo](https://vanilla-framework-3497.demos.haus/docs/examples/patterns/buttons/small)
- Reduce the width of your browser, see that the second button does not lose its left margin before it becomes full width.