### PR TITLE
Remove outline from code copyable input on Chrome

### DIFF
--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -25,6 +25,7 @@ $cc-button-size: 36px;
       line-height: map-get($line-heights, default-text);
       margin-bottom: 0;
       margin-top: 0;
+      outline: none;
       padding: 0 0 0 (map-get($icon-sizes, default) + $spv-inner--x-small--scaleable);
       width: 100%;
     }


### PR DESCRIPTION
## Done

Removed outline on code copyable input, which was previously visible when tabbing or clicking on it in Chrome.

Fixes #3328

## QA

- Open [demo]( https://vanilla-framework-3498.demos.haus/docs/examples/patterns/code-copyable) in Chrome
- Tab to or click on the component, see that text is highlighted, but there is no border/outline (compare to [live site](https://vanillaframework.io/docs/examples/patterns/code-copyable))

## Screenshots

Before
![Screenshot from 2021-01-18 16-42-44](https://user-images.githubusercontent.com/2376968/104942476-6a717700-59ac-11eb-929d-54e21bd77055.png)


After
![Screenshot from 2021-01-18 16-43-04](https://user-images.githubusercontent.com/2376968/104942496-6f362b00-59ac-11eb-82a7-a0a0d18f1504.png)


