### PR TITLE
Add box-decoration-break: clone to code element

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -28,6 +28,7 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
     box-shadow: 0 0 0 0.25rem $color-mid-x-light;
     margin-left: 0.25rem;
     margin-right: 0.25rem;
+    word-break: break-all;
   }
 
   code,

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -24,6 +24,7 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
   kbd,
   samp {
     background-color: $color-mid-x-light;
+    box-decoration-break: clone;
     box-shadow: 0 0 0 0.25rem $color-mid-x-light;
     margin-left: 0.25rem;
     margin-right: 0.25rem;


### PR DESCRIPTION
## Done

Fixed broken box shadow when an inline `code` element wrapped to a second line.

Technically fixes #3408 - in investigating that quite old issue, I discovered that the margin no longer seemed to be an issue, but that there was a related problem.

## QA

- Open [demo](https://vanilla-framework-3500.demos.haus/docs/examples/base/code-inline)
- Reduce the width of the browser to the point that the code element wraps to a second line (or edit the text in your browser dev tools to add a longer piece of text).
- See that the grey background doesn't look as though it has a chunk missing (compare to [live](https://vanillaframework.io/docs/examples/base/code-inline))

## Screenshots

Before:
![Screenshot from 2021-01-19 14-43-47](https://user-images.githubusercontent.com/2376968/105050455-b2a0a000-5a65-11eb-83a6-be1576cfcef8.png)

After:
![Screenshot from 2021-01-19 14-44-15](https://user-images.githubusercontent.com/2376968/105050525-c3511600-5a65-11eb-899d-b3e3f21d9100.png)


