### PR TITLE
Add .is-wrapped code snippet utility

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -86,7 +86,6 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
     display: inline-block;
     padding: 0 $sph-inner 0 $code-sidebar-width;
     position: relative;
-    white-space: pre-wrap;
     width: 100%;
 
     &:empty::after {

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -10,6 +10,10 @@ $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
     .p-code-snippet__block--icon,
     .p-code-snippet__block--numbered {
       margin: 0;
+
+      &.is-wrapped {
+        white-space: pre-wrap;
+      }
     }
 
     .p-code-snippet__block--icon {

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -60,6 +60,14 @@ View example of the code snippet
 View example of the code snippet
 </a></div>
 
+**Toggling wrapping within a code snippet**
+
+By default, `<pre>` elements do not wrap content, but this can be overridden by adding the `.is-wrapped` utility class to a `.p-code-snippet__block`:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/code-snippet-wrapping" class="js-example">
+View example of the code snippet
+</a></div>
+
 ### Copyable
 
 <span class="p-label--deprecated">Deprecated</span>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -22,6 +22,28 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.23 -->
+    <tr>
+      <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.23.0</td>
+      <td>We added a utility class for <code>.p-code-snippet__block</code> that allows content to wrap, rather than horizontally scroll: <code>.is-wrapped</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 2.22 -->
     <tr>
       <th><a href="/docs/base/separators">Separator</a></th>
@@ -47,21 +69,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.22.0</td>
       <td><code>.p-code-numbered</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--numbered</code> instead.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.21 -->
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Contextual Menu</a></th>

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-wrapping.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-wrapping.html
@@ -1,0 +1,16 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Code Snippet / Wrapping {% endblock %}
+
+{% block standalone_css %}patterns_code-snippet{% endblock %}
+
+{% block content %}
+<div class="p-code-snippet">
+  <div class="p-code-snippet__header">Default (no wrapping)</div>
+  <pre class="p-code-snippet__block"><code>git commit -a -m "This is an example git commit message to demonstrate the wrapping of pre elements in the code snippet"</code></pre>
+</div>
+
+<div class="p-code-snippet">
+  <div class="p-code-snippet__header">With .is-wrapped applied</div>
+  <pre class="p-code-snippet__block is-wrapped"><code>git commit -a -m "This is an example git commit message to demonstrate the wrapping of pre elements in the code snippet"</code></pre>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Done

- Added `.is-wrapped` utility class for code snippets, to allow content to wrap inside code blocks

Fixes #3478, #2457 & #2184

## QA

- Open [demo](https://vanilla-framework-3502.demos.haus/docs/examples/patterns/code-snippet/code-snippet-wrapping)
- If neither block wraps, reduce the browser width
- See that the first block does not wrap, and the second block does
- Review updated documentation:
  - [Code](https://vanilla-framework-3502.demos.haus/docs/base/code#code-snippet)
  - [Component status](https://vanilla-framework-3502.demos.haus/docs/component-status)
