### PR TITLE
Code snippet dropdowns

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -75,3 +75,4 @@ Suru
 spec
 specs
 ×
+dropdown

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -77,6 +77,7 @@ $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
       // taken from the .u-table-cell-padding-overlap utility
       margin-bottom: -#{$table-cell-vertical-padding} !important;
       margin-top: calc(-#{$table-cell-vertical-padding} - 1px) !important;
+      min-width: min-content;
 
       // taken from the .is-dense button modifier
       padding-bottom: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -63,5 +63,23 @@ $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
       margin-bottom: 0;
       padding-top: 0;
     }
+
+    .p-code-snippet__dropdowns {
+      flex-shrink: 0;
+      margin-left: $sph-inner--small;
+    }
+
+    .p-code-snippet__toggle {
+      @extend %p-button--base;
+      @extend %p-button--with-icon;
+
+      // taken from the .u-table-cell-padding-overlap utility
+      margin-bottom: -#{$table-cell-vertical-padding} !important;
+      margin-top: calc(-#{$table-cell-vertical-padding} - 1px) !important;
+
+      // taken from the .is-dense button modifier
+      padding-bottom: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
+      padding-top: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
+    }
   }
 }

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -69,9 +69,10 @@ $color-snippet-heading-bg: rgba($color-x-dark, 0.08);
       margin-left: $sph-inner--small;
     }
 
-    .p-code-snippet__toggle {
-      @extend %p-button--base;
-      @extend %p-button--with-icon;
+    .p-code-snippet__dropdown {
+      background-color: $color-transparent;
+      border-color: $color-transparent;
+      color: $color-dark;
 
       // taken from the .u-table-cell-padding-overlap utility
       margin-bottom: -#{$table-cell-vertical-padding} !important;

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -60,6 +60,14 @@ View example of the code snippet
 View example of the code snippet
 </a></div>
 
+**Code snippet with dropdown**
+
+A [contextual menu](/docs/patterns/contextual-menu) can be included within a `.p-code-snippet__header`, and can be used alongside JS to switch between related code examples. The menu's toggle element should include the `.p-code-snippet__toggle` class.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/code-snippet-dropdown" class="js-example">
+View example of the code snippet
+</a></div>
+
 **Toggling wrapping within a code snippet**
 
 By default, `<pre>` elements do not wrap content, but this can be overridden by adding the `.is-wrapped` utility class to a `.p-code-snippet__block`:

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -62,7 +62,7 @@ View example of the code snippet
 
 **Code snippet with dropdown**
 
-A [contextual menu](/docs/patterns/contextual-menu) can be included within a `.p-code-snippet__header`, and can be used alongside JS to switch between related code examples. The menu's toggle element should include the `.p-code-snippet__toggle` class.
+A select with the class `.p-code-snippet__dropdown` can be included within a `.p-code-snippet__header`, with a small amount of JS to switch between related code examples.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/code-snippet-dropdown" class="js-example">
 View example of the code snippet

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -39,7 +39,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <th><a href="/docs/base/code#code-snippet">Code snippet - Dropdowns</a></th>
       <td><div class="p-label--updated">New</div></td>
       <td>2.23.0</td>
-      <td>We add the ability to include a contextual menu to a code snippet, allowing users to switch between related code examples.</td>
+      <td>We add the ability to include a select within in a code snippet, allowing users to switch between related code examples.</td>
     </tr>
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
@@ -47,7 +47,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.23.0</td>
       <td>We added a utility class for <code>.p-code-snippet__block</code> that allows content to wrap, rather than horizontally scroll: <code>.is-wrapped</code>.</td>
     </tr>
-  </tbody>
   </tbody>
 </table>
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -36,11 +36,18 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>We renamed <code>is-active</code> button state class to <code>is-processing</code>, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
     </tr>
     <tr>
+      <th><a href="/docs/base/code#code-snippet">Code snippet - Dropdowns</a></th>
+      <td><div class="p-label--updated">New</div></td>
+      <td>2.23.0</td>
+      <td>We add the ability to include a contextual menu to a code snippet, allowing users to switch between related code examples.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.23.0</td>
       <td>We added a utility class for <code>.p-code-snippet__block</code> that allows content to wrap, rather than horizontally scroll: <code>.is-wrapped</code>.</td>
     </tr>
+  </tbody>
   </tbody>
 </table>
 

--- a/templates/docs/examples/patterns/code-snippet/_script.js
+++ b/templates/docs/examples/patterns/code-snippet/_script.js
@@ -1,24 +1,16 @@
-function setupCodeSnippetOptions(dropdown) {
-  var dropdownLabel = dropdown.querySelector('span');
-  var targetMenu = document.getElementById(dropdown.getAttribute('aria-controls'));
-  var options = [].slice.call(targetMenu.querySelectorAll('[aria-controls]'));
+function attachDropdownEvents(dropdown) {
+  dropdown.addEventListener('change', function (e) {
+    var targetElement = document.getElementById(e.target.value);
 
-  options.forEach(function (option) {
-    option.addEventListener('click', function (e) {
-      e.preventDefault();
-      var targetPanel = document.getElementById(option.getAttribute('aria-controls'));
-
-      dropdownLabel.innerHTML = option.innerHTML;
-      togglePanel(targetPanel, options);
-    });
+    togglePanel(targetElement, dropdown.options);
   });
 }
 
 function togglePanel(targetPanel, options) {
-  options.forEach(function (option) {
-    var panel = document.getElementById(option.getAttribute('aria-controls'));
+  for (var i = 0; i < options.length; i++) {
+    var panel = document.getElementById(options[i].value);
     panel.classList.add('u-hide');
-  });
+  }
 
   targetPanel.classList.remove('u-hide');
 }
@@ -27,8 +19,8 @@ function setupCodeSnippetDropdowns(codeSnippetDropdownSelector) {
   var dropdowns = [].slice.call(document.querySelectorAll(codeSnippetDropdownSelector));
 
   dropdowns.forEach(function (dropdown) {
-    setupCodeSnippetOptions(dropdown);
+    attachDropdownEvents(dropdown);
   });
 }
 
-setupCodeSnippetDropdowns('.p-code-snippet__toggle');
+setupCodeSnippetDropdowns('.p-code-snippet__dropdown');

--- a/templates/docs/examples/patterns/code-snippet/_script.js
+++ b/templates/docs/examples/patterns/code-snippet/_script.js
@@ -1,3 +1,7 @@
+/**
+  Attaches change event listener to a given select.
+  @param {HTMLElement} dropdown Select element belonging to a code snippet.
+*/
 function attachDropdownEvents(dropdown) {
   dropdown.addEventListener('change', function (e) {
     var targetElement = document.getElementById(e.target.value);
@@ -6,6 +10,12 @@ function attachDropdownEvents(dropdown) {
   });
 }
 
+/**
+  Shows a given code snippet panel, and hides the rest.
+  @param {HTMLElement} targetPanel the panel to show.
+  @param {HTMLOptionsCollection} options collection of options
+  whose values reference panels to be hidden.
+*/
 function togglePanel(targetPanel, options) {
   for (var i = 0; i < options.length; i++) {
     var panel = document.getElementById(options[i].value);
@@ -17,6 +27,11 @@ function togglePanel(targetPanel, options) {
   targetPanel.setAttribute('aria-hidden', false);
 }
 
+/**
+  Attaches events to selects with a given classname.
+  @param {String} codeSnippetDropdownSelector class name of the select elements
+  we want to attach events to.
+*/
 function setupCodeSnippetDropdowns(codeSnippetDropdownSelector) {
   var dropdowns = [].slice.call(document.querySelectorAll(codeSnippetDropdownSelector));
 

--- a/templates/docs/examples/patterns/code-snippet/_script.js
+++ b/templates/docs/examples/patterns/code-snippet/_script.js
@@ -10,9 +10,11 @@ function togglePanel(targetPanel, options) {
   for (var i = 0; i < options.length; i++) {
     var panel = document.getElementById(options[i].value);
     panel.classList.add('u-hide');
+    panel.setAttribute('aria-hidden', true);
   }
 
   targetPanel.classList.remove('u-hide');
+  targetPanel.setAttribute('aria-hidden', false);
 }
 
 function setupCodeSnippetDropdowns(codeSnippetDropdownSelector) {

--- a/templates/docs/examples/patterns/code-snippet/_script.js
+++ b/templates/docs/examples/patterns/code-snippet/_script.js
@@ -1,7 +1,7 @@
 function setupCodeSnippetOptions(dropdown) {
   var dropdownLabel = dropdown.querySelector('span');
   var targetMenu = document.getElementById(dropdown.getAttribute('aria-controls'));
-  var options = [].slice.call(targetMenu.querySelectorAll('a'));
+  var options = [].slice.call(targetMenu.querySelectorAll('[aria-controls]'));
 
   options.forEach(function (option) {
     option.addEventListener('click', function (e) {

--- a/templates/docs/examples/patterns/code-snippet/_script.js
+++ b/templates/docs/examples/patterns/code-snippet/_script.js
@@ -1,0 +1,34 @@
+function setupCodeSnippetOptions(dropdown) {
+  var dropdownLabel = dropdown.querySelector('span');
+  var targetMenu = document.getElementById(dropdown.getAttribute('aria-controls'));
+  var options = [].slice.call(targetMenu.querySelectorAll('a'));
+
+  options.forEach(function (option) {
+    option.addEventListener('click', function (e) {
+      e.preventDefault();
+      var targetPanel = document.getElementById(option.getAttribute('aria-controls'));
+
+      dropdownLabel.innerHTML = option.innerHTML;
+      togglePanel(targetPanel, options);
+    });
+  });
+}
+
+function togglePanel(targetPanel, options) {
+  options.forEach(function (option) {
+    var panel = document.getElementById(option.getAttribute('aria-controls'));
+    panel.classList.add('u-hide');
+  });
+
+  targetPanel.classList.remove('u-hide');
+}
+
+function setupCodeSnippetDropdowns(codeSnippetDropdownSelector) {
+  var dropdowns = [].slice.call(document.querySelectorAll(codeSnippetDropdownSelector));
+
+  dropdowns.forEach(function (dropdown) {
+    setupCodeSnippetOptions(dropdown);
+  });
+}
+
+setupCodeSnippetDropdowns('.p-code-snippet__toggle');

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-dropdown.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-dropdown.html
@@ -1,0 +1,53 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Code snippet / Dropdown{% endblock %}
+
+{% block standalone_css %}patterns_code-snippet{% endblock %}
+
+{% block content %}
+<div class="p-code-snippet">
+  <div class="p-code-snippet__header">
+    <h5 class="p-code-snippet__title">Creating a code snippet</h5>
+
+    <div class="p-code-snippet__dropdowns">
+      <span class="p-contextual-menu">
+        <button 
+          id="menu-1-label" 
+          class="p-contextual-menu__toggle p-code-snippet__toggle" 
+          aria-controls="menu-1" 
+          aria-expanded="false" 
+          aria-haspopup="true" 
+        >
+          <span>HTML</span>
+          <i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
+        </button>
+
+        <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="true">
+          <a aria-controls="menu-1-html-panel" href="#" class="p-contextual-menu__link">HTML</a>
+          <a aria-controls="menu-1-css-panel" href="#" class="p-contextual-menu__link">CSS</a>
+          <a aria-controls="menu-1-js-panel" href="#" class="p-contextual-menu__link">JS</a>
+        </span>
+      </span>
+    </div>
+  </div>
+
+  <pre id="menu-1-html-panel" class="p-code-snippet__block--numbered is-wrapped"><code>&#60;h1 class="p-heading--two"&#62;How to use code snippets&#60;/h1&#62;</code></pre>
+
+  <pre id="menu-1-css-panel" class="p-code-snippet__block u-hide"><code>.p-heading--two {
+color: red;
+}</code></pre>
+
+  <pre id="menu-1-js-panel" class="p-code-snippet__block u-hide"><code>console.log("Example 1");</code></pre>
+
+  <div class="p-code-snippet__header">
+    <h5 class="p-code-snippet__title">Output</h5>
+  </div>
+
+  <pre class="p-code-snippet__block"><code>Example 1</code></pre>
+</div>
+
+<script>
+  {% include 'docs/examples/patterns/contextual-menu/_script.js' %}
+  {% include 'docs/examples/patterns/code-snippet/_script.js' %}
+</script>
+
+{% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-dropdown.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-dropdown.html
@@ -9,34 +9,21 @@
     <h5 class="p-code-snippet__title">Creating a code snippet</h5>
 
     <div class="p-code-snippet__dropdowns">
-      <span class="p-contextual-menu">
-        <button 
-          id="menu-1-label" 
-          class="p-contextual-menu__toggle p-code-snippet__toggle" 
-          aria-controls="menu-1" 
-          aria-expanded="false" 
-          aria-haspopup="true" 
-        >
-          <span>HTML</span>
-          <i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
-        </button>
-
-        <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="true">
-          <a aria-controls="menu-1-html-panel" href="#" class="p-contextual-menu__link">HTML</a>
-          <a aria-controls="menu-1-css-panel" href="#" class="p-contextual-menu__link">CSS</a>
-          <a aria-controls="menu-1-js-panel" href="#" class="p-contextual-menu__link">JS</a>
-        </span>
-      </span>
+      <select class="p-code-snippet__dropdown" name="menu1-select" id="menu1-select">
+        <option value="html-panel">HTML</option>
+        <option value="css-panel">CSS</option>
+        <option value="js-panel">JS</option>
+      </select>
     </div>
   </div>
 
-  <pre id="menu-1-html-panel" class="p-code-snippet__block--numbered is-wrapped"><code>&#60;h1 class="p-heading--two"&#62;How to use code snippets&#60;/h1&#62;</code></pre>
+  <pre id="html-panel" class="p-code-snippet__block--numbered is-wrapped"><code>&#60;h1 class="p-heading--two"&#62;How to use code snippets&#60;/h1&#62;</code></pre>
 
-  <pre id="menu-1-css-panel" class="p-code-snippet__block u-hide"><code>.p-heading--two {
+  <pre id="css-panel" class="p-code-snippet__block u-hide"><code>.p-heading--two {
 color: red;
 }</code></pre>
 
-  <pre id="menu-1-js-panel" class="p-code-snippet__block u-hide"><code>console.log("Example 1");</code></pre>
+  <pre id="js-panel" class="p-code-snippet__block u-hide"><code>console.log("Example 1");</code></pre>
 
   <div class="p-code-snippet__header">
     <h5 class="p-code-snippet__title">Output</h5>
@@ -46,8 +33,6 @@ color: red;
 </div>
 
 <script>
-  {% include 'docs/examples/patterns/contextual-menu/_script.js' %}
   {% include 'docs/examples/patterns/code-snippet/_script.js' %}
 </script>
-
 {% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/code-snippet-dropdown.html
+++ b/templates/docs/examples/patterns/code-snippet/code-snippet-dropdown.html
@@ -19,11 +19,11 @@
 
   <pre id="html-panel" class="p-code-snippet__block--numbered is-wrapped"><code>&#60;h1 class="p-heading--two"&#62;How to use code snippets&#60;/h1&#62;</code></pre>
 
-  <pre id="css-panel" class="p-code-snippet__block u-hide"><code>.p-heading--two {
+  <pre id="css-panel" class="p-code-snippet__block u-hide" aria-hidden="true"><code>.p-heading--two {
 color: red;
 }</code></pre>
 
-  <pre id="js-panel" class="p-code-snippet__block u-hide"><code>console.log("Example 1");</code></pre>
+  <pre id="js-panel" class="p-code-snippet__block u-hide" aria-hidden="true"><code>console.log("Example 1");</code></pre>
 
   <div class="p-code-snippet__header">
     <h5 class="p-code-snippet__title">Output</h5>


### PR DESCRIPTION
## Done

Added example of using a select within a code snippet

Fixes #3469 

## QA

- Open [demo](https://vanilla-framework-3511.demos.haus/docs/examples/patterns/code-snippet/code-snippet-dropdown)
- Check that the example works when selecting different options from the menu
- Compare to the [Zeplin design](https://app.zeplin.io/project/5fa270d8eee4dbb267e579f1/screen/5ffc2fdcb65e6a99b78f9d47)
- Review updated documentation:
  - [Code](https://vanilla-framework-3511.demos.haus/docs/base/code)
  - [Component status](https://vanilla-framework-3511.demos.haus/docs/component-status)
