### PR TITLE
Add .is-overlapping utility for contextual menu dropdowns

### DIFF
--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -30,6 +30,10 @@
     &[aria-hidden='false'] {
       display: block;
     }
+
+    .is-overlapping & {
+      top: 0 !important;
+    }
   }
 
   // Alignment extension to align the menu to the left

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,12 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.23 -->
     <tr>
+      <th><a href="/docs/patterns/contextual-menu#overlapping">Contextual menu</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.23.0</td>
+      <td>We added a utility class, <code>.is-overlapping</code> that allows dropdown menus to cover their parent element</code>.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.23.0</td>

--- a/templates/docs/examples/patterns/contextual-menu/overlapping.html
+++ b/templates/docs/examples/patterns/contextual-menu/overlapping.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Contextual menu / Overlapping{% endblock %}
+
+{% block standalone_css %}patterns_contextual-menu{% endblock %}
+
+{% block content %}
+<span class="p-contextual-menu--left is-overlapping">
+  <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--chevron-down is-light p-contextual-menu__indicator"></i><span>Take action</span></button>
+  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
+    <span class="p-contextual-menu__group">
+      <a href="#" class="p-contextual-menu__link">Commission</a>
+      <a href="#" class="p-contextual-menu__link">Aquire</a>
+      <a href="#" class="p-contextual-menu__link">Deploy</a>
+    </span>
+    <span class="p-contextual-menu__group">
+      <a href="#" class="p-contextual-menu__link">Test hardware</a>
+      <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+      <a href="#" class="p-contextual-menu__link">Mark broken</a>
+    </span>
+  </span>
+</span>
+
+<script>
+  {% include 'docs/examples/patterns/contextual-menu/_script.js' %}
+</script>
+{% endblock %}

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -33,6 +33,14 @@ Using direction modifiers will change the placement of the drop-down menu. By de
 View example of the contextual menu pattern
 </a></div>
 
+### Overlapping
+
+A utility class, `.is-overlapping`, can also be used to position the menu over the parent pattern.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/contextual-menu/overlapping" class="js-example">
+View example of the contextual menu pattern
+</a></div>
+
 ### Indicator
 
 If you require a drop-down button with a state indicator then the `p-contextual-menu__toggle` class can be used alongside the `p-icon` and `p-button` components.


### PR DESCRIPTION
## Done

Add `.is-overlapping` utility class to contextual menu pattern, allowing the menu to overlap and hide the button.

## QA

- Open [demo](https://vanilla-framework-3513.demos.haus/docs/examples/patterns/contextual-menu/overlapping)
- Click the button, see that the menu overlaps the button
- Check updated documentation:
  - [Docs](https://vanilla-framework-3513.demos.haus/docs/patterns/contextual-menu#overlapping)
  - [Component status](https://vanilla-framework-3513.demos.haus/docs/component-status)
