### PR TITLE
Deprecate .is-active button utility class and replace with .is-processing

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -11,6 +11,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   @include vf-button-negative;
   @include vf-button-base;
   @include vf-button-inline;
+  @include vf-button-processing;
   @include vf-button-active;
   @include vf-button-icon;
 }
@@ -143,9 +144,17 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   }
 }
 
-@mixin vf-button-active {
-  [class*='p-button'].is-active {
+@mixin vf-button-processing {
+  [class*='p-button'].is-processing {
     opacity: 1 !important;
+  }
+}
+
+@mixin vf-button-active {
+  @include deprecate('3.0.0', 'Use the `vf-button-processing instead') {
+    [class*='p-button'].is-active {
+      opacity: 1 !important;
+    }
   }
 }
 

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -59,7 +59,7 @@
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
               {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
-              {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
+              {{ side_nav_item("/docs/patterns/buttons", "Buttons", "updated") }}
               {{ side_nav_item("/docs/patterns/card", "Cards") }}
               {{ side_nav_item("/docs/patterns/chip", "Chips") }}
               {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -27,7 +27,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <th><a href="/docs/patterns/buttons#active">Active button</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.23.0</td>
-      <td>The <code>is-active</code> class was deprecated and given a more appropriate name: `is-processing`.</td>
+      <td>The <code>is-active</code> class was deprecated and given a more appropriate name: <code>is-processing</code>.</td>
     </tr>
     <tr>
       <th><a href="/docs/patterns/buttons#processing">Processing button</a></th>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,18 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.23 -->
     <tr>
+      <th><a href="/docs/patterns/buttons#active">Active button</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.23.0</td>
+      <td>The <code>is-active</code> class was deprecated and given a more appropriate name: `is-processing`.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/buttons#processing">Processing button</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.23.0</td>
+      <td>We renamed <code>is-active</code> button state class to <code>is-processing</code>, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.23.0</td>

--- a/templates/docs/examples/patterns/buttons/active.html
+++ b/templates/docs/examples/patterns/buttons/active.html
@@ -1,8 +1,0 @@
-{% extends "_layouts/examples.html" %}
-{% block title %}Buttons / Active{% endblock %}
-
-{% block standalone_css %}patterns_buttons{% endblock %}
-
-{% block content %}
-<button class="p-button--positive is-active" disabled><i class="p-icon--spinner u-animation--spin is-light"></i></button>
-{% endblock %}

--- a/templates/docs/examples/patterns/buttons/processing.html
+++ b/templates/docs/examples/patterns/buttons/processing.html
@@ -1,0 +1,8 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Buttons / Processing{% endblock %}
+
+{% block standalone_css %}patterns_buttons{% endblock %}
+
+{% block content %}
+<button class="p-button--positive is-processing" disabled><i class="p-icon--spinner u-animation--spin is-light"></i></button>
+{% endblock %}

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -102,7 +102,7 @@ View example of the processing button pattern
 
 <span class="p-label--deprecated">Deprecated</span>
 
-The `is-active` utility class was renamed to the more appropriate `is-active`, as mentioned above.
+The `is-active` utility class was renamed to the more appropriate `is-processing`, as mentioned above.
 
 ### Import
 

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -74,8 +74,6 @@ View example of the dense button pattern
 
 ### Small
 
-<span class="p-label--new">New</span>
-
 If you are working with small text and need a suitably sized button, add class `.is-small`. It can be combined with `.is-dense` for an even tighter look:
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/small/" class="js-example">
@@ -90,15 +88,21 @@ Should you wish to place an icon in a button. You will not want to button to bec
 View example of the icon button pattern
 </a></div>
 
-### Active
+### Processing
 
 <span class="p-label--new">New</span>
 
-In cases where a button needs to indicate that an action is occurring (e.g. saving data, processing a payment) while also preventing user interaction, the state class `is-active` can be added to a disabled button to maintain full opacity.
+In cases where a button needs to indicate that an action is occurring (e.g. saving data, processing a payment) while also preventing user interaction, the state class `is-processing` can be added to a disabled button to maintain full opacity.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/buttons/active/" class="js-example">
-View example of the active button pattern
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/processing/" class="js-example">
+View example of the processing button pattern
 </a></div>
+
+### Active
+
+<span class="p-label--deprecated">Deprecated</span>
+
+The `is-active` utility class was renamed to the more appropriate `is-active`, as mentioned above.
 
 ### Import
 


### PR DESCRIPTION
## Done

- Renamed existing `.is-active` button utility to the more appropriate `.is-processing`, deprecated `is-active`.

## QA

- Open [active button example](https://vanilla-framework-3515.demos.haus/docs/examples/patterns/buttons/processing)
- See that it matches the currently live `is-active` state: https://vanillaframework.io/docs/examples/patterns/buttons/active
- Review updated documentation:
  - [Deprecated active button docs](https://vanilla-framework-3515.demos.haus/docs/patterns/buttons#active)
  - [Processing button docs](https://vanilla-framework-3515.demos.haus/docs/patterns/buttons#processing)
  - [Component status](https://vanilla-framework-3515.demos.haus/docs/component-status)
