### PR TITLE
Bump 2.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:12-slim AS yarn-dependencies
+FROM node:12 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json package.json
 ADD yarn.lock yarn.lock

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js"
   },
-  "version": "2.22.1",
+  "version": "2.23.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -50,7 +50,7 @@
               {{ side_nav_item("/docs/base/code", "Code", "updated") }}
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
-              {{ side_nav_item("/docs/base/separators", "Separators", "new") }}
+              {{ side_nav_item("/docs/base/separators", "Separators") }}
               {{ side_nav_item("/docs/base/tables", "Tables") }}
               {{ side_nav_item("/docs/base/typography", "Typography") }}
             </ul>


### PR DESCRIPTION
## Done

Bumped version of Vanilla to 2.23.0 for next release.
Updated labels in docs side nav.


## QA

- Open [demo](https://vanilla-framework-3525.demos.haus/docs)
- Make sure Vanilla version is correct next release (2.23.0)
- Review updated documentation:
  - Check [component status page](https://vanilla-framework-3525.demos.haus/docs/component-status), verify the links in latest changes
  - Make sure side navigation labels reflect changes in this version
