### PR TITLE
Fix Vanilla version in the docs

### DIFF
--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -10,9 +10,9 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### What's new in Vanilla 2.22
+### What's new in Vanilla 2.23
 
-<table aria-label="What's new in Vanilla 2.22">
+<table aria-label="What's new in Vanilla 2.23">
   <thead>
     <tr>
       <th style="width: 20%">Component</th>


### PR DESCRIPTION
## Done

Typo in the docs - old version in the title

## QA

- Open [demo](https://vanilla-framework-3529.demos.haus/docs/component-statusl)
- Review updated documentation:
  - Check if title says correct 2.23 version number https://vanilla-framework-3529.demos.haus/docs/component-status
