### PR TITLE
Automate version in title of component status page

### DIFF
--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -10,9 +10,9 @@ context:
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 
-### What's new in Vanilla 2.24
+### What's new in Vanilla {{versionMinor}}
 
-<table aria-label="What's new in Vanilla 2.24">
+<table aria-label="What's new in Vanilla {{versionMinor}}">
   <thead>
     <tr>
       <th style="width: 20%">Component</th>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -142,7 +142,10 @@ def _filter_contributors(contributors):
 # Global context settings
 @app.context_processor
 def global_template_context():
-    return {"version": VANILLA_VERSION, "path": flask.request.path}
+    version_parts = VANILLA_VERSION.split(".")
+    version_minor = f"{version_parts[0]}.{version_parts[1]}"
+
+    return {"version": VANILLA_VERSION, "versionMinor": version_minor, "path": flask.request.path}
 
 
 template_finder_view = TemplateFinder.as_view("template_finder")
@@ -188,7 +191,7 @@ def contribute_index():
 
     response.cache_control.max_age = 86400
     response.cache_control.public = True
-   
+
     return response
 
 


### PR DESCRIPTION
## Done

Automate version in title of component status page to avoid updating it manually for release

## QA

- Open [demo](https://vanilla-framework-3531.demos.haus/docs/component-status)
- Review updated documentation:
  - make sure that the page heading shows vanilla version from package.json file
  - https://vanilla-framework-3531.demos.haus/docs/component-status
