### PR TITLE
Remove word-break: break-all from code element

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -25,9 +25,7 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
   samp {
     background-color: $color-mid-x-light;
     box-decoration-break: clone;
-    box-shadow: 0 0 0 0.25rem $color-mid-x-light;
-    margin-left: 0.25rem;
-    margin-right: 0.25rem;
+    padding: 0.25rem;
   }
 
   code,
@@ -53,6 +51,7 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
     display: inline-block;
     margin-left: 0;
     margin-right: 0;
+    padding: 0;
   }
 
   pre {

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -25,7 +25,7 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
   samp {
     background-color: $color-mid-x-light;
     box-decoration-break: clone;
-    padding: 0.25rem;
+    padding: $sph-inner--x-small;
   }
 
   code,

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -28,7 +28,6 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
     box-shadow: 0 0 0 0.25rem $color-mid-x-light;
     margin-left: 0.25rem;
     margin-right: 0.25rem;
-    word-break: break-all;
   }
 
   code,

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -99,6 +99,7 @@ $spv-outer--deep-scaleable: $sp-unit * 2 * (4 + $multi) !default;
 
 // 2. HORIZONTAL SPACING
 // 2.1 Horizontal spacing inside components
+$sph-inner--x-small: $sp-unit * 0.5 !default;
 $sph-inner--small: $sp-unit !default; // input-elements,
 $sph-inner: $sp-unit * 2 !default; // buttons, accordions, tabs, menu, card padding, stepped-list bullet offset
 $sph-inner--large: $sp-unit * 3 !default;


### PR DESCRIPTION
## Done

Removed `word-break: break-all;` from `code` elements.

Fixes #3526 

## QA

- Open [demo](https://vanilla-framework-3535.demos.haus/docs/examples/layouts/documentation)
- Scroll to the "Notifications" heading
- Reduce the width of your browser, see that as you do, the code element within wraps, but wraps whole words rather than breaking words
