### PR TITLE
Add .is-dark support for inline code element

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -30,10 +30,6 @@ $code-inline-padding: 0.25rem;
     color: inherit;
     line-height: map-get($line-heights, default-text) - $code-inline-padding;
     padding: calc(#{$code-inline-padding} - 1px) $code-inline-padding;
-
-    .is-dark & {
-      background-color: $color-code-background-dark;
-    }
   }
 
   code,
@@ -57,6 +53,7 @@ $code-inline-padding: 0.25rem;
     background: none;
     box-shadow: none;
     display: inline-block;
+    line-height: map-get($line-heights, default-text);
     margin-left: 0;
     margin-right: 0;
     padding: 0;
@@ -74,6 +71,15 @@ $code-inline-padding: 0.25rem;
     text-shadow: none;
     white-space: pre;
   }
+
+  // dark theme
+  // stylelint-disable selector-no-qualifying-type
+  [class*='--dark'] code,
+  code.is-dark {
+    background-color: $color-code-background-dark;
+    color: $colors--dark-theme--text-default;
+  }
+  // stylelint-enable selector-no-qualifying-type
 
   %leading-linux-prompt-icon {
     &::before {

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -3,6 +3,7 @@
 $color-pre-bg: rgba($color-x-dark, 0.03);
 $digit-width: 1ch; // measured width of one character in the monospaced font
 $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
+$code-inline-padding: 0.25rem;
 
 // Base code styles
 @mixin vf-b-code {
@@ -23,9 +24,11 @@ $code-sidebar-width: calc(#{$sph-inner} + (4 * #{$digit-width})) !default;
   code,
   kbd,
   samp {
-    background-color: $color-mid-x-light;
-    box-decoration-break: clone;
-    padding: $sph-inner--x-small;
+    background-color: $color-code-background;
+    border-radius: $border-radius;
+    box-decoration-break: slice;
+    line-height: map-get($line-heights, default-text) - $code-inline-padding;
+    padding: calc(#{$code-inline-padding} - 0.5px) $code-inline-padding;
   }
 
   code,

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -27,8 +27,13 @@ $code-inline-padding: 0.25rem;
     background-color: $color-code-background;
     border-radius: $border-radius;
     box-decoration-break: slice;
+    color: inherit;
     line-height: map-get($line-heights, default-text) - $code-inline-padding;
     padding: calc(#{$code-inline-padding} - 1px) $code-inline-padding;
+
+    .is-dark & {
+      background-color: $color-code-background-dark;
+    }
   }
 
   code,

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -28,7 +28,7 @@ $code-inline-padding: 0.25rem;
     border-radius: $border-radius;
     box-decoration-break: slice;
     line-height: map-get($line-heights, default-text) - $code-inline-padding;
-    padding: calc(#{$code-inline-padding} - 0.5px) $code-inline-padding;
+    padding: calc(#{$code-inline-padding} - 1px) $code-inline-padding;
   }
 
   code,

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -284,7 +284,8 @@ $application-layout--side-nav-width-expanded: 15rem !default;
 
     & > .l-navigation-bar,
     & > .l-navigation .l-navigation__drawer {
-      background: $color-mid-x-light;
+      background: $color-dark;
+      color: $colors--dark-theme--text-default;
     }
 
     & > .l-navigation-bar {

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -284,7 +284,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
 
     & > .l-navigation-bar,
     & > .l-navigation .l-navigation__drawer {
-      background: $color-dark;
+      background: $color-mid-x-light;
     }
 
     & > .l-navigation-bar {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -40,6 +40,7 @@ $active-background-opacity-amount: 0.15;
 // NON-SEMANTIC COLOURS
 $color-label-validated: #006b75;
 $color-code-background: rgba($color-x-dark, 0.03);
+$color-code-background-dark: rgba($color-x-light, 0.3);
 $color-code-heading-background: rgba($color-x-dark, 0.08);
 
 $states: (

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -12,9 +12,17 @@ Vanilla gives you multiple ways to display code using the standard HTML elements
 
 ### Inline
 
+<span class="p-label--updated">Updated</span>
+
 When you refer to code inline with other text, use the <code>&lt;code></code> tag.
 
 <div class="embedded-example"><a href="/docs/examples/base/code-inline/" class="js-example">
+View example of inline code
+</a></div>
+
+An inline `code` element can also be nested within a parent element that has a dark background and the `.is-dark` utility class:
+
+<div class="embedded-example"><a href="/docs/examples/base/code-inline-dark/" class="js-example">
 View example of inline code
 </a></div>
 

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -20,7 +20,7 @@ When you refer to code inline with other text, use the <code>&lt;code></code> ta
 View example of inline code
 </a></div>
 
-An inline `code` element can also be nested within a parent element that has a dark background and the `.is-dark` utility class:
+An inline `code` element can be nested within a `.p-strip--dark` element, and can also use the `.is-dark` utility class as necessary:
 
 <div class="embedded-example"><a href="/docs/examples/base/code-inline-dark/" class="js-example">
 View example of inline code

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -33,7 +33,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <th><a href="/docs/base/code#dropdowns">Code inline - dark</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.24.0</td>
-      <td>We've updated inline <code>code</code> elements to support being nested within an <code>.is-dark</code> parent element.</td>
+      <td>We've updated inline <code>code</code> elements to support being nested within a <code>.p-strip--dark</code> element, and to support an <code>.is-dark</code> utility class.</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -30,7 +30,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>We added the ability to accommodate multiple selects within a <code>.p-code-snippet__header</code>, either inline, using the <code>.is-stacked</code> utility to class to have the dropdowns below the title.</td>
     </tr>
     <tr>
-      <th><a href="/docs/base/code#dropdowns">Code inline - dark</a></th>
+      <th><a href="/docs/base/code#inline">Code inline - dark</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.24.0</td>
       <td>We've updated inline <code>code</code> elements to support being nested within a <code>.p-strip--dark</code> element, and to support an <code>.is-dark</code> utility class.</td>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -29,6 +29,12 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.24.0</td>
       <td>We added the ability to accommodate multiple selects within a <code>.p-code-snippet__header</code>, either inline, using the <code>.is-stacked</code> utility to class to have the dropdowns below the title.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/base/code#dropdowns">Code inline - dark</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.24.0</td>
+      <td>We've updated inline <code>code</code> elements to support being nested within an <code>.is-dark</code> parent element.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/templates/docs/examples/base/code-inline-dark.html
+++ b/templates/docs/examples/base/code-inline-dark.html
@@ -1,0 +1,14 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Code - inline / dark{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block content %}
+<div class="p-strip--dark is-dark">
+  <div class="row">
+    <div class="col-12">
+      <p>The quick brown <code>fox&nbsp;jumps</code> over the lazy dog</p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/base/code-inline-dark.html
+++ b/templates/docs/examples/base/code-inline-dark.html
@@ -7,7 +7,7 @@
 <div class="p-strip--dark" style="background: #111">
   <div class="row">
     <div class="col-12">
-      <p>The quick brown <code>fox&nbsp;jumps</code> over the lazy dog</p>
+      <p style="color: #fff;">The quick brown <code>fox&nbsp;jumps</code> over the lazy dog</p>
     </div>
   </div>
 </div>

--- a/templates/docs/examples/base/code-inline-dark.html
+++ b/templates/docs/examples/base/code-inline-dark.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-<div class="p-strip--dark is-dark">
+<div class="p-strip--dark">
   <div class="row">
     <div class="col-12">
       <p>The quick brown <code>fox&nbsp;jumps</code> over the lazy dog</p>

--- a/templates/docs/examples/base/code-inline-dark.html
+++ b/templates/docs/examples/base/code-inline-dark.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-<div class="p-strip--dark">
+<div class="p-strip--dark" style="background: #111">
   <div class="row">
     <div class="col-12">
       <p>The quick brown <code>fox&nbsp;jumps</code> over the lazy dog</p>

--- a/templates/docs/examples/layouts/application/structure.html
+++ b/templates/docs/examples/layouts/application/structure.html
@@ -13,14 +13,14 @@
     <div class="u-clearfix"><code>l-navigation-bar</code> <button class="u-float-right js-menu-toggle is-dense u-no-margin">Menu</button></div>
   </div>
 
-  <header class="l-navigation is-dark">
+  <header class="l-navigation">
     <div class="l-navigation__drawer">
       <p class="demo-controls u-hide--large u-align--right">
         <button class="js-menu-pin is-dense u-no-margin u-hide--small">Pin</button>
         <button class="js-menu-close is-dense u-no-margin u-hide--medium">Close</button>
       </p>
       
-      <code>l-navigation &gt;<br> l-navigation__drawer</code>
+      <code class="is-dark">l-navigation &gt;<br> l-navigation__drawer</code>
     </div>
   </header>
 

--- a/templates/docs/examples/layouts/application/structure.html
+++ b/templates/docs/examples/layouts/application/structure.html
@@ -13,7 +13,7 @@
     <div class="u-clearfix"><code>l-navigation-bar</code> <button class="u-float-right js-menu-toggle is-dense u-no-margin">Menu</button></div>
   </div>
 
-  <header class="l-navigation">
+  <header class="l-navigation is-dark">
     <div class="l-navigation__drawer">
       <p class="demo-controls u-hide--large u-align--right">
         <button class="js-menu-pin is-dense u-no-margin u-hide--small">Pin</button>

--- a/templates/docs/examples/layouts/application/structure.html
+++ b/templates/docs/examples/layouts/application/structure.html
@@ -19,6 +19,7 @@
         <button class="js-menu-pin is-dense u-no-margin u-hide--small">Pin</button>
         <button class="js-menu-close is-dense u-no-margin u-hide--medium">Close</button>
       </p>
+      
       <code>l-navigation &gt;<br> l-navigation__drawer</code>
     </div>
   </header>


### PR DESCRIPTION
## Done

- Updated the background color of the inline code element to match the transparent color in use on the new code snippet
- Added support for code elements within an `is-dark` parent

Fixes #3540 

## QA

- Open [demo](https://vanilla-framework-3543.demos.haus/docs/examples/base/code-inline)
- Check that the inline code element looks good, and sits on the baseline.
- Open [dark demo](https://vanilla-framework-3543.demos.haus/docs/examples/base/code-inline-dark)
- See that the code element is nicely visible
- Check the [updated application structure](https://vanilla-framework-3543.demos.haus/docs/examples/layouts/documentation#notifications), see that "l-navigation >l-navigation__drawer" is visible in the side bar.

