### PR TITLE
Add light and dense version of hr

### DIFF
--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -5,7 +5,7 @@
   hr {
     @extend %hr;
 
-    margin-bottom: calc(#{$spv-inner--scaleable} - 1px);
+    margin-bottom: calc(#{$spv-inner--small} - 1px);
 
     // stylelint-disable-next-line selector-no-qualifying-type
     &.u-no-margin--bottom {

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -7,14 +7,10 @@
 
     margin-bottom: calc(#{$spv-inner--scaleable} - 1px);
 
-    & + p {
-      margin-top: -$sp-unit;
-    }
-
     // stylelint-disable-next-line selector-no-qualifying-type
-    &.is-dense {
+    &.u-no-margin--bottom {
       // compensate for hr thickness, to make sure it doesn't drift from baseline grid
-      margin-bottom: -1px;
+      @extend %u-no-margin--bottom--hr;
     }
 
     // stylelint-disable-next-line selector-no-qualifying-type

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -1,17 +1,36 @@
 @import 'settings';
 
+%hr {
+  border: 0;
+  height: 1px;
+  margin-top: 0;
+  position: relative;
+  width: 100%;
+}
 // Horizontal rule
 @mixin vf-b-hr {
   hr {
-    border: 0;
-    height: 1px;
+    @extend %hr;
+
     margin-bottom: calc(#{$spv-inner--scaleable} - 1px);
-    margin-top: 0;
-    position: relative;
-    width: 100%;
 
     & + p {
       margin-top: -$sp-unit;
+    }
+
+    // stylelint-disable-next-line selector-no-qualifying-type
+    &.is-dense {
+      margin-bottom: -1px;
+    }
+
+    // stylelint-disable-next-line selector-no-qualifying-type
+    &.is-light {
+      background-color: $colors--light-theme--border-low-contrast;
+    }
+
+    // stylelint-disable-next-line selector-no-qualifying-type
+    &.is-fixed-width {
+      @extend %fixed-width-container;
     }
   }
 

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -17,7 +17,7 @@
     }
 
     // stylelint-disable-next-line selector-no-qualifying-type
-    &.is-light {
+    &.is-muted {
       background-color: $colors--light-theme--border-low-contrast;
     }
 

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -13,6 +13,7 @@
 
     // stylelint-disable-next-line selector-no-qualifying-type
     &.is-dense {
+      // compensate for hr thickness, to make sure it doesn't drift from baseline grid
       margin-bottom: -1px;
     }
 

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -1,12 +1,5 @@
 @import 'settings';
 
-%hr {
-  border: 0;
-  height: 1px;
-  margin-top: 0;
-  position: relative;
-  width: 100%;
-}
 // Horizontal rule
 @mixin vf-b-hr {
   hr {

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -80,6 +80,14 @@
     }
   }
 
+  %hr {
+    border: 0;
+    height: 1px;
+    margin-top: 0;
+    position: relative;
+    width: 100%;
+  }
+
   // Spacing
   %section-padding--shallow {
     @media only screen and (max-width: $breakpoint-large) {

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -139,7 +139,7 @@
   }
 
   %u-no-margin--bottom {
-    &:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(p):not(small):not([class*='p-heading']) {
+    &:not(hr):not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(p):not(small):not([class*='p-heading']) {
       margin-bottom: 0 !important;
     }
   }
@@ -202,6 +202,11 @@
 
   %u-no-margin--bottom--small {
     margin-bottom: -#{map-get($nudges, nudge--small)} !important;
+  }
+
+  %u-no-margin--bottom--hr {
+    // compensate for hr thickness, to make sure it doesn't drift from baseline grid
+    margin-bottom: -1px !important;
   }
 
   %icon {


### PR DESCRIPTION
## Done

- add light hr
- add u-no-margin--bottom that compensaes forthe hr 1px height, thereby avoiding a drift from the baseline grid
- add hr centered (and same width) as a row, which means instead of `.row>hr` or `.u-fixed-width>hr` you can just write `hr.is-fixed-width`

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3510

## QA

- Paste this [code](https://pastebin.canonical.com/p/XYm8qkrSs6/) (pastebin link):
- Verify you see the following:
![image](https://user-images.githubusercontent.com/2741678/108075663-85461280-7062-11eb-91e7-64f1e4f6321b.png)
