### PR TITLE
Show ellipsis on buttons that launch modals

### DIFF
--- a/templates/docs/examples/patterns/contextual-menu/dark.html
+++ b/templates/docs/examples/patterns/contextual-menu/dark.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <span class="p-contextual-menu--left is-dark">
-    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
+    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action...</button>
     <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>

--- a/templates/docs/examples/patterns/contextual-menu/dark.html
+++ b/templates/docs/examples/patterns/contextual-menu/dark.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <span class="p-contextual-menu--left is-dark">
-    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action...</button>
+    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
     <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>

--- a/templates/docs/examples/patterns/contextual-menu/default.html
+++ b/templates/docs/examples/patterns/contextual-menu/default.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <span class="p-contextual-menu--left">
-    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action</button>
+    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action...</button>
     <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>

--- a/templates/docs/examples/patterns/contextual-menu/default.html
+++ b/templates/docs/examples/patterns/contextual-menu/default.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <span class="p-contextual-menu--left">
-    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action...</button>
+    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
     <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
         <span class="p-contextual-menu__group">
             <a href="#" class="p-contextual-menu__link">Commission</a>

--- a/templates/docs/examples/patterns/modal/default.html
+++ b/templates/docs/examples/patterns/modal/default.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_modal{% endblock %}
 
 {% block content %}
-<button id="showModal" aria-controls="modal">Show modal...</button>
+<button id="showModal" aria-controls="modal">Show modal&hellip;</button>
 
 <div class="p-modal" id="modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">

--- a/templates/docs/examples/patterns/modal/default.html
+++ b/templates/docs/examples/patterns/modal/default.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_modal{% endblock %}
 
 {% block content %}
-<button id="showModal" aria-controls="modal">Show modal</button>
+<button id="showModal" aria-controls="modal">Show modal...</button>
 
 <div class="p-modal" id="modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">

--- a/templates/docs/examples/patterns/modal/modal-scroll.html
+++ b/templates/docs/examples/patterns/modal/modal-scroll.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_modal{% endblock %}
 
 {% block content %}
-<button id="showModal" aria-controls="modal">Show modal</button>
+<button id="showModal" aria-controls="modal">Show modal...</button>
 
 <p>An <em>application</em> is typically a long-running service that is accessible over the network. Applications are the centre of a Juju deployment. Everything within the Juju ecosystem exists to facilitate them.</p>
 <p>It’s easiest to think of the term “application” in Juju in the same way you would think of using it day-to-day. Middleware such as database servers (PostgreSQL, MySQL, Percona Cluster, etcd, …), message queues (RabbitMQ) and other utilities (Nagios, Prometheus, …) are all applications. The term has a specialist meaning within the Juju community, however. It is broader than the ordinary use of the term in computing.</p>

--- a/templates/docs/examples/patterns/modal/modal-scroll.html
+++ b/templates/docs/examples/patterns/modal/modal-scroll.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_modal{% endblock %}
 
 {% block content %}
-<button id="showModal" aria-controls="modal">Show modal...</button>
+<button id="showModal" aria-controls="modal">Show modal&hellip;</button>
 
 <p>An <em>application</em> is typically a long-running service that is accessible over the network. Applications are the centre of a Juju deployment. Everything within the Juju ecosystem exists to facilitate them.</p>
 <p>It’s easiest to think of the term “application” in Juju in the same way you would think of using it day-to-day. Middleware such as database servers (PostgreSQL, MySQL, Percona Cluster, etcd, …), message queues (RabbitMQ) and other utilities (Nagios, Prometheus, …) are all applications. The term has a specialist meaning within the Juju community, however. It is broader than the ordinary use of the term in computing.</p>

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -81,7 +81,7 @@
 </header>
 
 <div class="p-stripe is-shallow">
-  <button id="showModal" aria-controls="modal">Show modal...</button>
+  <button id="showModal" aria-controls="modal">Show modal&hellip;</button>
 
   <p>
     Lorem ipsum dolor sit amet consectetur adipiscing elit

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -81,7 +81,7 @@
 </header>
 
 <div class="p-stripe is-shallow">
-  <button id="showModal" aria-controls="modal">Show modal</button>
+  <button id="showModal" aria-controls="modal">Show modal...</button>
 
   <p>
     Lorem ipsum dolor sit amet consectetur adipiscing elit

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -51,6 +51,10 @@ View example of the contextual menu pattern
 
 Please ensure the `aria-control` attribute matches an ID of an element. If `aria-expanded` is true, then the contextual menu will be open by default. When clicking on the `p-contextual-menu__toggle`, you must toggle the `aria-expanded` attribute on the toggle and the `aria-hidden` attribute on the drop-down.
 
+### Accessibility
+
+When using the `p-contextual-menu__toggle` class on a `button` element, please ensure that the button label contains a trailing ellipsis `…`, e.g. "Take action&hellip;". This is a convention used to indicate that the button launches a dialog.
+
 ### Theming
 
 <span class="p-label--new">New</span>

--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -27,6 +27,10 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
+### Accessibility
+
+For any elements that launch a modal, please ensure that the label contains a trailing ellipsis `…`, e.g. "Launch modal&hellip;". This is a convention used to indicate that the element launches a dialog.
+
 ### Design
 
 For more information view the [modal design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Modal) which includes the specification in markdown format and a PNG image.


### PR DESCRIPTION
## Done

- Updated buttons in modal and contextual menu examples with an ellipsis
- Documented the reason why the ellipsis should be included

Fixes #3566

## QA

- Open: 
  - [Default modal](https://vanilla-framework-3569.demos.haus/docs/examples/patterns/modal/default)
  - [Scrolling modal](https://vanilla-framework-3569.demos.haus/docs/examples/patterns/modal/modal-scroll)
  - [z-index example](https://vanilla-framework-3569.demos.haus/docs/examples/templates/z-index)
  - [Contextual menu](https://vanilla-framework-3569.demos.haus/docs/examples/patterns/contextual-menu/default)
  - [Contextual menu (dark)](https://vanilla-framework-3569.demos.haus/docs/examples/patterns/contextual-menu/dark)
- See that an ellipsis is present on buttons that launch a dialog on click.
- Review documentation updates:
  - [Modal](https://vanilla-framework-3569.demos.haus/docs/patterns/modal#accessibility)
  - [Contextual menu](https://vanilla-framework-3569.demos.haus/docs/patterns/contextual-menu#accessibility)