### PR TITLE
Focus on first focusable element within a dialog when launching

### DIFF
--- a/templates/docs/examples/patterns/contextual-menu/_script.js
+++ b/templates/docs/examples/patterns/contextual-menu/_script.js
@@ -17,12 +17,7 @@ function toggleMenu(element, show, top) {
     }
 
     if (show) {
-      var focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-      var firstFocusable = target.querySelector(focusableElements);
-
-      if (firstFocusable) {
-        firstFocusable.focus();
-      }
+      target.focus();
     }
   }
 }

--- a/templates/docs/examples/patterns/contextual-menu/_script.js
+++ b/templates/docs/examples/patterns/contextual-menu/_script.js
@@ -15,6 +15,15 @@ function toggleMenu(element, show, top) {
     if (typeof top !== 'undefined') {
       target.style.top = top + 'px';
     }
+
+    if (show) {
+      var focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+      var firstFocusable = target.querySelector(focusableElements);
+
+      if (firstFocusable) {
+        firstFocusable.focus();
+      }
+    }
   }
 }
 

--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -5,7 +5,15 @@
 function toggleModal(modal) {
   if (modal && modal.classList.contains('p-modal')) {
     if (modal.style.display === 'none') {
+      var focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+      var firstFocusable = modal.querySelector(focusableElements);
+
       modal.style.display = 'flex';
+
+      if (firstFocusable) {
+        console.log(firstFocusable);
+        firstFocusable.focus();
+      }
     } else {
       modal.style.display = 'none';
     }

--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -5,15 +5,8 @@
 function toggleModal(modal) {
   if (modal && modal.classList.contains('p-modal')) {
     if (modal.style.display === 'none') {
-      var focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-      var firstFocusable = modal.querySelector(focusableElements);
-
       modal.style.display = 'flex';
-
-      if (firstFocusable) {
-        console.log(firstFocusable);
-        firstFocusable.focus();
-      }
+      modal.focus();
     } else {
       modal.style.display = 'none';
     }

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -55,6 +55,8 @@ Please ensure the `aria-control` attribute matches an ID of an element. If `aria
 
 When using the `p-contextual-menu__toggle` class on a `button` element, please ensure that the button label contains a trailing ellipsis `…`, e.g. "Take action&hellip;". This is a convention used to indicate that the button launches a dialog.
 
+In cases where a contextual menu is shown on click, focus should be set within the menu element, using JavaScript.
+
 ### Theming
 
 <span class="p-label--new">New</span>

--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -31,6 +31,8 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 For any elements that launch a modal, please ensure that the label contains a trailing ellipsis `…`, e.g. "Launch modal&hellip;". This is a convention used to indicate that the element launches a dialog.
 
+When a modal is launched, focus should be set within the modal element, using JavaScript.
+
 ### Design
 
 For more information view the [modal design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Modal) which includes the specification in markdown format and a PNG image.


### PR DESCRIPTION
## Done

- Added JS to focus on the launched target when a modal or contextual menu is launched.
- Documented recommended behaviour in docs

Fixes #3567 

## QA

- Open [contextual menu demo](https://vanilla-framework-3572.demos.haus/docs/examples/patterns/contextual-menu/default)
- Click "Take action"
- Press tab key - the first item in the launched dialog should be highlighted
- Open [modal demo](/docs/examples/patterns/modal/default)
- Press tab key - the first item in the launched dialog should be highlighted
- Review updated documentation:
  - [Contextual menu](https://vanilla-framework-3572.demos.haus/docs/patterns/contextual-menu#accessibility)
  - [Modal](https://vanilla-framework-3572.demos.haus/docs/patterns/modal#accessibility)
