### PR TITLE
Ubuntu mono font bugs

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -91,6 +91,13 @@ $code-inline-padding: 0.25rem;
       position: absolute;
       top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default))};
       width: map-get($icon-sizes, default);
+
+      @if ($increase-font-size-on-larger-screens) {
+        // stylelint-disable-next-line max-nesting-depth
+        @media (min-width: $breakpoint-x-large) {
+          top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) * $font-size-ratio--largescreen - map-get($icon-sizes, default))};
+        }
+      }
     }
   }
 

--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -117,7 +117,7 @@
         font-family: 'Ubuntu Mono';
         font-style: normal;
         font-weight: 400;
-        src: url('#{$assets-path}fdd692b9-UbuntuMono-R_W.woff2') format('woff2'), url('#{$assets-path}85edb898-UbuntuMono-R_W.woff') format('woff');
+        src: url('#{$assets-path}dd4acb63-UbuntuMono-B.woff2') format('woff2'), url('#{$assets-path}e8e36b19-UbuntuMono-B.woff') format('woff');
       }
     }
 

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -22,6 +22,7 @@ $cc-button-size: 36px;
       background: transparent;
       border: 0;
       font-family: unquote($font-monospace);
+      font-weight: 300;
       line-height: map-get($line-heights, default-text);
       margin-bottom: 0;
       margin-top: 0;

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -23,15 +23,6 @@ $code-snippet-header-v-spacing: $spv-inner--x-small--scaleable;
       padding-left: #{$sph-inner + map-get($icon-sizes, default) + $sph-inner--small};
       position: relative;
 
-      &::before {
-        @if ($increase-font-size-on-larger-screens) {
-          // stylelint-disable-next-line max-nesting-depth
-          @media (min-width: $breakpoint-x-large) {
-            top: #{$spv-inner--x-small--scaleable + 0.5 * (map-get($line-heights, default-text) * $font-size-ratio--largescreen - map-get($icon-sizes, default))};
-          }
-        }
-      }
-
       &.is-windows-prompt::before {
         @include vf-icon-chevron($color-mid-dark);
 


### PR DESCRIPTION
## Done

- Set font-weight to 300 on code copyable component
- Replace font file used in non-subset Ubuntu Mono, font-weight 400 font face with a bold variant, rather than the regular font beign used previously

Fixes #3564 & #3565 

## QA

- Pull this branch, `dotrun` the project and visit http://0.0.0.0:8101/docs/examples/patterns/code-copyable
- See that the font weight looks correct
- In `_settings_font.scss`, change `$font-use-subset-latin` value to `true`
- Reload the code copyable page, see that the font looks the same, and isn't bold
