### PR TITLE
Temporarily revert namepacing of .col-* classes

### DIFF
--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -41,7 +41,7 @@
   // mobile grid
   @media (max-width: $threshold-4-6-col) {
     @for $i from $grid-columns-small through 1 {
-      .row .#{$grid-small-col-prefix}#{$i} {
+      .#{$grid-small-col-prefix}#{$i} {
         @include vf-grid-column($i);
 
         width: 100%;
@@ -52,7 +52,7 @@
   // tablet grid
   @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
     @for $i from $grid-columns-medium through 1 {
-      .row .#{$grid-medium-col-prefix}#{$i} {
+      .#{$grid-medium-col-prefix}#{$i} {
         @include vf-grid-column($i);
 
         width: 100%;
@@ -64,7 +64,7 @@
   @media (min-width: $threshold-6-12-col) {
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
-      .row .#{$grid-large-col-prefix}#{$i} {
+      .#{$grid-large-col-prefix}#{$i} {
         // on large screens provide flex box column implementation for IE
         // on smaller screens let them display full width one under another
         @include vf-grid-flex-column($i);
@@ -75,7 +75,7 @@
 
   // span full grid on other breakpoints; (to match block level element behaviour)
   @for $i from 1 through $grid-columns-small {
-    .row .#{$grid-small-col-prefix}#{$i} {
+    .#{$grid-small-col-prefix}#{$i} {
       @extend %span-full-grid-on-tablet;
       @extend %span-full-grid-on-desktop;
       @extend %display-block;
@@ -83,7 +83,7 @@
   }
 
   @for $i from 1 through $grid-columns-medium {
-    .row .#{$grid-medium-col-prefix}#{$i} {
+    .#{$grid-medium-col-prefix}#{$i} {
       @extend %span-full-grid-on-mobile;
       @extend %span-full-grid-on-desktop;
       @extend %display-block;
@@ -91,7 +91,7 @@
   }
 
   @for $i from 1 through $grid-columns {
-    .row .#{$grid-large-col-prefix}#{$i} {
+    .#{$grid-large-col-prefix}#{$i} {
       @extend %span-full-grid-on-mobile;
       @extend %span-full-grid-on-tablet;
       @extend %display-block;

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -41,6 +41,12 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.24.0</td>
       <td>We added a new <code>l-fluid-breakout</code> layout that can be used to break out of the constraints of a 12-column grid and allow content to bleed into the page margins on larger screens.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/patterns/grid">Grid</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.24.0</td>
+      <td>We deprecated the use of `.col` classes without a direct parent with a class `.row`.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -42,8 +42,8 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>We added a new <code>l-fluid-breakout</code> layout that can be used to break out of the constraints of a 12-column grid and allow content to bleed into the page margins on larger screens.</td>
     </tr>
     <tr>
-      <th><a href="/docs/patterns/grid">Grid</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
+      <th><a href="/docs/patterns/grid">Grid - "orphan" columns</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.24.0</td>
       <td>We deprecated the use of `.col` classes without a direct parent with a class `.row`.</td>
     </tr>

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -58,3 +58,8 @@ Adding `.p-slider` class to style `<input type='range'>` is optional, so this cl
 ### Hidden cell in expanding table
 
 Using `.u-hide` utility inside expanding table to hide table heading placeholder is not recommended. Use [the recommended ARIA attribute](/docs/base/tables#expanding) (`aria-hidden="true"`) instead.
+
+
+### Grid
+
+Use of `.col` classes outside of `.row` is deprecated.

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -59,7 +59,6 @@ Adding `.p-slider` class to style `<input type='range'>` is optional, so this cl
 
 Using `.u-hide` utility inside expanding table to hide table heading placeholder is not recommended. Use [the recommended ARIA attribute](/docs/base/tables#expanding) (`aria-hidden="true"`) instead.
 
-
 ### Grid
 
-Use of `.col` classes outside of `.row` is deprecated.
+Use of `.col` classes outside of `.row` is deprecated. If you use `.col-X` class names outside of `.row` or your custom styling depends on specificity of `.col-X` class name you will need to review and update your styles accordingly.


### PR DESCRIPTION
## Done

Remove the `.row` part of the `.row .col-*` selector to prevent breaking layouts that partially override the `.col-*` class behaviour with local styles. 