### PR TITLE
add "Edit on CodePen" link to code snippet examples

### DIFF
--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -28,16 +28,6 @@
     }
   });
 
-  document.addEventListener('click', function (e) {
-    var isCodePenLink = e.target.classList.contains('js-codepen-link');
-
-    if (isCodePenLink) {
-      var form = e.target.closest('form');
-      e.preventDefault();
-      form.submit();
-    }
-  });
-
   function fetchExample(exampleElement) {
     var link = exampleElement.href;
     var request = new XMLHttpRequest();
@@ -226,14 +216,28 @@
       input.setAttribute('value', JSONstring);
 
       link.innerHTML = 'Edit on CodePen';
-      link.classList.add('js-codepen-link');
       link.style.cssText = 'display: block; padding: 0.5rem 0;';
 
       form.appendChild(input);
       form.appendChild(link);
       container.appendChild(form);
+      handleCodePenClick(link, form);
       snippet.appendChild(container);
     }
+  }
+
+  function handleCodePenClick(link, form) {
+    link.addEventListener('click', function (e) {
+      e.preventDefault();
+      form.submit();
+    });
+
+    // handle middle mouse button click
+    link.addEventListener('mouseup', function (e) {
+      if (e.which === 2) {
+        link.click();
+      }
+    });
   }
 
   function getStyleFromSource(source) {

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -1,4 +1,23 @@
 (function () {
+  if (!window.VANILLA_VERSION) {
+    throw Error('VANILLA_VERSION not specified.');
+  }
+
+  var CODEPEN_CONFIG = {
+    title: 'Vanilla framework example',
+    head: "<meta name='viewport' content='width=device-width, initial-scale=1'>",
+    stylesheets: [
+      // link to latest Vanilla CSS
+      // if it's a demo, use local build.css for better QA, otherwise use latest published Vanilla
+      /demos\.haus$/.test(window.location.host)
+        ? `${window.location.origin}/static/build/css/build.css`
+        : 'https://assets.ubuntu.com/v1/vanilla-framework-version-' + VANILLA_VERSION + '.min.css',
+      // link to example stylesheet (to set margin on body)
+      'https://assets.ubuntu.com/v1/4653d9ba-example.css',
+    ],
+    tags: ['Vanilla framework'],
+  };
+
   document.addEventListener('DOMContentLoaded', function () {
     var examples = document.querySelectorAll('.js-example');
 
@@ -6,6 +25,16 @@
     // we use this check to skip rendering embeds in IE
     if (examples.forEach) {
       [].slice.call(examples).forEach(fetchExample);
+    }
+  });
+
+  document.addEventListener('click', function (e) {
+    var isCodePenLink = e.target.classList.contains('js-codepen-link');
+
+    if (isCodePenLink) {
+      var form = e.target.closest('form');
+      e.preventDefault();
+      form.submit();
     }
   });
 
@@ -60,6 +89,13 @@
     var htmlSource = stripScriptsFromSource(bodyHTML);
     var jsSource = getScriptFromSource(bodyHTML);
     var cssSource = getStyleFromSource(headHTML);
+    var externalScripts = getExternalScriptsFromSource(html);
+    var codePenData = {
+      html: htmlSource,
+      css: cssSource,
+      js: jsSource,
+      externalJS: externalScripts,
+    };
 
     var height = placementElement.getAttribute('data-height');
 
@@ -90,11 +126,11 @@
       codeSnippet.appendChild(createPreCode(cssSource, 'css'));
       options.push('css');
     }
+
     renderDropdown(header, options);
-
     placementElement.parentNode.insertBefore(codeSnippet, placementElement);
-
     renderIframe(codeSnippet, html, height);
+    renderCodePenEditLink(codeSnippet, codePenData);
 
     if (Prism) {
       Prism.highlightAllUnder(codeSnippet);
@@ -157,6 +193,49 @@
     return iframe;
   }
 
+  function renderCodePenEditLink(snippet, sourceData) {
+    var html = sourceData.html === null ? '' : sourceData.html;
+    var css = sourceData.css === null ? '' : sourceData.css;
+    var js = sourceData.js === null ? '' : sourceData.js;
+
+    if (html || css || js) {
+      var container = document.createElement('div');
+      var form = document.createElement('form');
+      var input = document.createElement('input');
+      var link = document.createElement('a');
+      var data = {
+        title: CODEPEN_CONFIG.title,
+        head: CODEPEN_CONFIG.head,
+        html: html,
+        css: css,
+        js: js,
+        css_external: CODEPEN_CONFIG.stylesheets.join(';'),
+        js_external: sourceData.externalJS.join(';'),
+      };
+      // Replace double quotes to avoid errors on CodePen
+      var JSONstring = JSON.stringify(data).replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+
+      container.classList.add('p-code-snippet__header');
+
+      form.setAttribute('action', 'https://codepen.io/pen/define');
+      form.setAttribute('method', 'POST');
+      form.setAttribute('target', '_blank');
+
+      input.setAttribute('type', 'hidden');
+      input.setAttribute('name', 'data');
+      input.setAttribute('value', JSONstring);
+
+      link.innerHTML = 'Edit on CodePen';
+      link.classList.add('js-codepen-link');
+      link.style.cssText = 'display: block; padding: 0.5rem 0;';
+
+      form.appendChild(input);
+      form.appendChild(link);
+      container.appendChild(form);
+      snippet.appendChild(container);
+    }
+  }
+
   function getStyleFromSource(source) {
     var div = document.createElement('div');
     div.innerHTML = source;
@@ -180,6 +259,16 @@
     div.innerHTML = source;
     var script = div.querySelector('script');
     return script ? script.innerHTML.trim() : null;
+  }
+
+  function getExternalScriptsFromSource(source) {
+    var div = document.createElement('div');
+    div.innerHTML = source;
+    var scripts = div.querySelectorAll('script[src]');
+    scripts = [].slice.apply(scripts).map(function (s) {
+      return s.src;
+    });
+    return scripts;
   }
 
   /**


### PR DESCRIPTION
## Done

Added "Edit on CodePen" link to code examples in Vanilla docs

Fixes #3558 

## QA

- Open [demo](https://vanilla-framework-3581.demos.haus/docs)
- Go to any doc with a code example, see that an "Edit on CodePen" link is present at the bottom of the code snippet.
- Click the link, see that any HTML, CSS and JS is present and correct, and that Vanilla styles have been imported.
- Visit [code snippet - syntax highlighting docs](https://vanilla-framework-3581.demos.haus/docs/base/code#syntax-highlighting)
- Click the codepen link, see that syntax highlighing is applied in the new window (this demonstrates external js is being included)

## Screenshots
![Screenshot from 2021-02-22 16-01-32](https://user-images.githubusercontent.com/2376968/108734312-4236e400-7527-11eb-9c04-af7d214234d4.png)
