### PR TITLE
Add aria-pressed state to buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js"
   },
-  "version": "2.24.1",
+  "version": "2.25.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -119,7 +119,8 @@
     border-color: $button-hover-border-color;
   }
 
-  &:active {
+  &:active,
+  &[aria-pressed='true'] {
     background-color: $button-active-background-color;
     border-color: $button-active-border-color;
     transition-duration: 0s;
@@ -128,6 +129,7 @@
   &:disabled,
   &.is-disabled {
     &:active,
+    &[aria-pressed='true'],
     &:hover {
       background-color: $button-disabled-background-color;
       border-color: $button-disabled-border-color;

--- a/scss/standalone/patterns_buttons.scss
+++ b/scss/standalone/patterns_buttons.scss
@@ -5,5 +5,9 @@
 @import '../patterns_icons';
 @include vf-p-icons;
 
+// needed in aria-pressed example
+@import '../patterns_contextual-menu';
+@include vf-p-contextual-menu;
+
 @import '../patterns_buttons';
 @include vf-p-buttons;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -47,7 +47,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
-              {{ side_nav_item("/docs/base/code", "Code", "updated") }}
+              {{ side_nav_item("/docs/base/code", "Code") }}
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
@@ -115,7 +115,7 @@
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
               {{ side_nav_item("/docs/layouts/application", "Application") }}
               {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
-              {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout", "new") }}
+              {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
 
             </ul>
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -22,6 +22,28 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.25 -->
+    <tr>
+      <th><a href="/docs/patterns/buttons#accessibility">Buttons -<br /> aria-pressed</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.25.0</td>
+      <td>We added support for the <code>aria-pressed</code> attribute to button elements. When set to <code>true</code>, the button will retain the styles applied when in its <code>:active</code> state.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 2.24 -->
     <tr>
       <th><a href="/docs/base/code#dropdowns">Code snippet - Dropdowns</a></th>
@@ -47,21 +69,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.24.0</td>
       <td>We deprecated the use of `.col` classes without a direct parent with a class `.row`.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.23 -->
     <tr>
       <th><a href="/docs/patterns/buttons#active">Active button</a></th>

--- a/templates/docs/examples/patterns/buttons/pressed.html
+++ b/templates/docs/examples/patterns/buttons/pressed.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Buttons / Pressed{% endblock %}
+
+{% block standalone_css %}patterns_buttons{% endblock %}
+
+{% block content %}
+<span class="p-contextual-menu--left">
+    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
+    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Commission</a>
+            <a href="#" class="p-contextual-menu__link">Aquire</a>
+            <a href="#" class="p-contextual-menu__link">Deploy</a>
+        </span>
+        <span class="p-contextual-menu__group">
+            <a href="#" class="p-contextual-menu__link">Test harware</a>
+            <a href="#" class="p-contextual-menu__link">Rescue mode</a>
+            <a href="#" class="p-contextual-menu__link">Mark broken</a>
+        </span>
+    </span>
+</span>
+
+<script>
+  {% include 'docs/examples/patterns/contextual-menu/_script.js' %}
+</script>
+{% endblock %}

--- a/templates/docs/examples/patterns/contextual-menu/_script.js
+++ b/templates/docs/examples/patterns/contextual-menu/_script.js
@@ -10,6 +10,7 @@ function toggleMenu(element, show, top) {
 
   if (target) {
     element.setAttribute('aria-expanded', show);
+    element.setAttribute('aria-pressed', show);
     target.setAttribute('aria-hidden', !show);
 
     if (typeof top !== 'undefined') {

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -90,8 +90,6 @@ View example of the icon button pattern
 
 ### Processing
 
-<span class="p-label--new">New</span>
-
 In cases where a button needs to indicate that an action is occurring (e.g. saving data, processing a payment) while also preventing user interaction, the state class `is-processing` can be added to a disabled button to maintain full opacity.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/processing/" class="js-example">
@@ -103,6 +101,16 @@ View example of the processing button pattern
 <span class="p-label--deprecated">Deprecated</span>
 
 The `is-active` utility class was renamed to the more appropriate `is-processing`, as mentioned above.
+
+### Accessibility
+
+<span class="p-label--new">New</span>
+
+In some contexts, it may be necessary to indicate to the user that a button is in a pressed state, such as when a button opens a contextual menu. This can be done by adding `aria-pressed="true"` to the button with JavaScript when the button is clicked, and removed when necessary.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/pressed" class="js-example" data-height="270">
+View example of the contextual menu pattern
+</a></div>
 
 ### Import
 

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 250000,
+      threshold: 260000,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

Added `aria-pressed` styles to buttons.

Fixes #3568 

## QA

- Open [demo](https://vanilla-framework-3583.demos.haus/docs/examples/patterns/buttons/pressed)
- Click the button, see that when the dropdown is open, the button remains in a pressed state after releasing the mouse button.
- Click the button again, see that the pressed state is no longer active.
- Review updated documentation:
  - [Buttons](https://vanilla-framework-3583.demos.haus/docs/patterns/buttons#accessibility)
  - [Component status](https://vanilla-framework-3583.demos.haus/docs/component-status)

## Screenshots

![Peek 2021-02-23 11-33](https://user-images.githubusercontent.com/2376968/108838066-0f462c00-75cb-11eb-8bd9-cd9fd093df64.gif)
