### PR TITLE
Fix margin right on multiple buttons of mixed element types

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -42,10 +42,11 @@
     }
 
     @media only screen and (min-width: $breakpoint-x-small + 1) {
+      margin-right: $sph-outer;
       width: auto;
 
-      &:not(:last-of-type):not(:only-of-type) {
-        margin-right: $sph-outer;
+      &:last-child {
+        margin-right: 0;
       }
     }
 
@@ -58,7 +59,7 @@
     &.is-small {
       font-size: #{map-get($font-sizes, small)}rem;
       line-height: map-get($line-heights, small);
-      margin: 0 0 $input-margin-bottom - $sp-unit 0;
+      margin-bottom: $input-margin-bottom - $sp-unit;
       padding: calc(#{map-get($nudges, nudge--small)} - 1px) $sph-inner--small;
     }
 

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -35,14 +35,14 @@
       background-color: rgba($color-x-dark, 0.15);
     }
 
-    &__lead,
-    &__value {
+    .p-chip__lead,
+    .p-chip__value {
       margin-bottom: 0;
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
-    &__lead {
+    .p-chip__lead {
       $space-between-lead-and-value: 0.25rem;
       @extend %x-small-text;
 
@@ -59,14 +59,14 @@
       }
     }
 
-    &__value {
+    .p-chip__value {
       @extend %small-text;
 
       line-height: $chip-line-height;
       padding-top: 0.05rem;
     }
 
-    &__dismiss {
+    .p-chip__dismiss {
       @include vf-button-pattern(
         $button-background-color: transparent,
         $button-border-color: transparent,
@@ -80,7 +80,7 @@
       left: $sp-unit * 0.5;
       line-height: 1rem;
       margin-bottom: 0;
-      margin-right: -$sp-unit * 0.5 !important;
+      margin-right: -$sp-unit * 0.5;
       padding: 0;
       position: relative;
       top: 0.05rem;

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -80,7 +80,7 @@
       left: $sp-unit * 0.5;
       line-height: 1rem;
       margin-bottom: 0;
-      margin-right: -$sp-unit * 0.5;
+      margin-right: -$sp-unit * 0.5 !important;
       padding: 0;
       position: relative;
       top: 0.05rem;

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -31,41 +31,41 @@
     justify-content: flex-end;
     margin-bottom: $input-margin-bottom;
     position: relative;
-  }
 
-  .p-search-box__reset {
-    @extend %search-box-button;
-    @extend %transparent-button;
+    .p-search-box__reset {
+      @extend %search-box-button;
+      @extend %transparent-button;
 
-    &:not(:last-of-type):not(:only-of-type) {
+      &:not(:last-of-type):not(:only-of-type) {
+        margin-right: $bar-thickness;
+      }
+    }
+
+    .p-search-box__input {
+      flex: 1 1 100%;
+      margin-bottom: 0;
+      padding-right: calc(2 * #{2 * $spv-nudge + map-get($line-heights, default-text)});
+      position: absolute;
+      right: 0;
+
+      &::-webkit-search-cancel-button {
+        -webkit-appearance: none; // stylelint-disable-line property-no-vendor-prefix
+      }
+
+      &:not(:valid) ~ .p-search-box__reset {
+        display: none;
+      }
+    }
+
+    .p-search-box__button {
+      @extend %search-box-button;
+      @extend %transparent-button;
+
+      border-left-style: solid;
+      border-left-width: 1px;
+      border-radius: 0 $border-radius $border-radius 0;
       margin-right: $bar-thickness;
     }
-  }
-
-  .p-search-box__input {
-    flex: 1 1 100%;
-    margin-bottom: 0;
-    padding-right: calc(2 * #{2 * $spv-nudge + map-get($line-heights, default-text)});
-    position: absolute;
-    right: 0;
-
-    &::-webkit-search-cancel-button {
-      -webkit-appearance: none; // stylelint-disable-line property-no-vendor-prefix
-    }
-
-    &:not(:valid) ~ .p-search-box__reset {
-      display: none;
-    }
-  }
-
-  .p-search-box__button {
-    @extend %search-box-button;
-    @extend %transparent-button;
-
-    border-left-style: solid;
-    border-left-width: 1px;
-    border-radius: 0 $border-radius $border-radius 0;
-    margin-right: $bar-thickness !important;
   }
 
   // Theming

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -65,7 +65,7 @@
     border-left-style: solid;
     border-left-width: 1px;
     border-radius: 0 $border-radius $border-radius 0;
-    margin-right: $bar-thickness;
+    margin-right: $bar-thickness !important;
   }
 
   // Theming

--- a/scss/standalone/patterns_notifications.scss
+++ b/scss/standalone/patterns_notifications.scss
@@ -3,3 +3,6 @@
 
 @import '../patterns_notifications';
 @include vf-p-notification;
+
+@import '../patterns_icons';
+@include vf-p-icon-close;

--- a/templates/docs/examples/patterns/buttons/alignment.html
+++ b/templates/docs/examples/patterns/buttons/alignment.html
@@ -1,0 +1,30 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Buttons / Alignment{% endblock %}
+
+{% block standalone_css %}patterns_buttons{% endblock %}
+
+{% block content %}
+<p>
+  <button>Classless button</button>
+  <button>Classless button</button>
+</p>
+
+<p>
+  <button class="p-button--neutral">Neutral button</button>
+  <button class="p-button--positive">Positive button</button>
+  <button class="p-button--negative">Negative button</button>
+</p>
+
+<p>
+  <a href="#" class="p-button--neutral">Neutral link</a>
+  <a href="#" class="p-button--positive">Positive link</a>
+  <a href="#" class="p-button--negative">Negative link</a>
+</p>
+
+<p>
+  <button>Classless button</button>
+  <button class="p-button--positive">Positive button</button>
+  <a href="#" class="p-button--neutral">Neutral link</a>
+  <button class="p-button--negative">Negative button</button>
+</p>
+{% endblock %}

--- a/templates/docs/examples/patterns/buttons/alignment.html
+++ b/templates/docs/examples/patterns/buttons/alignment.html
@@ -25,6 +25,7 @@
   <button>Classless button</button>
   <button class="p-button--positive">Positive button</button>
   <a href="#" class="p-button--neutral">Neutral link</a>
+  <button class="u-hide">Hidden button</button>
   <button class="p-button--negative">Negative button</button>
 </p>
 {% endblock %}

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -53,7 +53,7 @@
     <div class="col-4">
       <div class="u-align--right">
         <span class="p-contextual-menu">
-          <a href="#" class="p-button p-contextual-menu__toggle" aria-controls="#menu" aria-expanded="false"
+          <a href="#" class="p-button p-contextual-menu__toggle u-no-margin--right" aria-controls="#menu" aria-expanded="false"
             aria-haspopup="true">
             Change pool <i class="p-icon--chevron-down"></i>
           </a>


### PR DESCRIPTION
## Done

Added a slightly modified version of @anthonydillon's suggested fix (see [CodePen example](https://codepen.io/anthonydillon/pen/xxRqBqN)) for #3542 

## QA

- Open [button alignment example](/docs/examples/patterns/buttons/alignment/)
- See that each button in each row has a margin right, except for the last buttons in each row
- Review Percy changes

**Breaking change:** this fixes the original issue, but in instances where a button is prevented from being the `:last-child` by a hidden element, such as a contextual menu toggle, a right margin is still applied and needs to be removed with the `u-no-margin--right` utility.
