### PR TITLE
Document hr classes is-muted, is-fixed-width

### DIFF
--- a/templates/docs/base/separators.md
+++ b/templates/docs/base/separators.md
@@ -10,11 +10,18 @@ context:
 
 Vanilla gives you multiple ways to separate parts of the content with a horizontal line.
 
-### Horizontal line
+### Horizontal rule
 
-Standard `<hr>` element can be used to separate parts of the longer pieces of text.
+Use the standard `<hr>` element to introduce section breaks.
 
 <div class="embedded-example"><a href="/docs/examples/base/hr/" class="js-example">
+View example of the horizontal line
+</a></div>
+
+Add the `is-muted` class to an `<hr>` to make the horizontal rule lighter in colour.
+This can be useful when trying to create a more subtle partitioning within a section within a container, or between standard horizontal rules.
+
+<div class="embedded-example"><a href="/docs/examples/base/hr-muted/" class="js-example">
 View example of the horizontal line
 </a></div>
 

--- a/templates/docs/base/separators.md
+++ b/templates/docs/base/separators.md
@@ -29,7 +29,7 @@ View example of the muted horizontal line
 
 #### Fixed width horizontal rule
 
-Often it is useful to add a rule that aligns with content placed in a grid `row` class. One way to do that is to wrap an `<hr>` in a div with class `row`. To avoid the need for a wrapping element, add the class `is-fixed-width` directly on the `<hr>`.
+Often it is useful to add a rule that aligns with content placed in a grid `row` class. One way to do that is to wrap an `<hr>` in a `div` with class `row`. To avoid the need for a wrapping element, add the class `is-fixed-width` directly on the `<hr>`.
 
 <div class="embedded-example"><a href="/docs/examples/base/hr-fixed-width/" class="js-example">
 View example of the fixed-width horizontal line

--- a/templates/docs/base/separators.md
+++ b/templates/docs/base/separators.md
@@ -18,11 +18,21 @@ Use the standard `<hr>` element to introduce section breaks.
 View example of the horizontal line
 </a></div>
 
+#### Muted horizontal rule
+
 Add the `is-muted` class to an `<hr>` to make the horizontal rule lighter in colour.
 This can be useful when trying to create a more subtle partitioning within a section within a container, or between standard horizontal rules.
 
 <div class="embedded-example"><a href="/docs/examples/base/hr-muted/" class="js-example">
-View example of the horizontal line
+View example of the muted horizontal line
+</a></div>
+
+#### Fixed width horizontal rule
+
+Often it is useful to add a rule that aligns with content placed in a grid `row` class. One way to do that is to wrap an `<hr>` in a div with class `row`. To avoid the need for a wrapping element, add the class `is-fixed-width` directly on the `<hr>`.
+
+<div class="embedded-example"><a href="/docs/examples/base/hr-fixed-width/" class="js-example">
+View example of the fixed-width horizontal line
 </a></div>
 
 ### Separator

--- a/templates/docs/examples/base/hr-fixed-width.html
+++ b/templates/docs/examples/base/hr-fixed-width.html
@@ -1,0 +1,16 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}HR muted{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block style %}
+<style>
+  body {
+    padding: 1rem 0;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<hr class="is-muted">
+{% endblock %}

--- a/templates/docs/examples/base/hr-fixed-width.html
+++ b/templates/docs/examples/base/hr-fixed-width.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}HR muted{% endblock %}
+{% block title %}HR fixed width{% endblock %}
 
 {% block standalone_css %}base{% endblock %}
 
@@ -12,5 +12,5 @@
 {% endblock %}
 
 {% block content %}
-<hr class="is-muted">
+<hr class="is-fixed-width">
 {% endblock %}

--- a/templates/docs/examples/base/hr-muted.html
+++ b/templates/docs/examples/base/hr-muted.html
@@ -1,0 +1,16 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}HR muted{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block style %}
+<style>
+  body {
+    padding: 1rem 0;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<hr class="is-muted">
+{% endblock %}


### PR DESCRIPTION
## Done

Document hr classes is-muted, is-fixed-width

## QA

- Open /docs/base/separators
- Proofread sections "Muted horizontal rule", "Fixed width horizontal rule"
