### PR TITLE
Add .is-dark utility and theming support to middot list

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -157,11 +157,11 @@ $spv-list-item--inner: null;
 
       &::after {
         content: '\00b7';
-        font-size: 2em;
+        font-size: 1.4em;
         line-height: 0;
         position: absolute;
-        right: #{-0.6 * $sph-outer};
-        top: 0.27em;
+        right: #{-0.5 * $sph-outer};
+        top: 0.4em;
       }
 
       &:last-of-type,
@@ -203,11 +203,11 @@ $spv-list-item--inner: null;
 }
 
 @mixin vf-p-inline-list-middot-light-theme {
-  @include vf-p-inline-list-middot-theme($colors--light-theme--text-default, $color-mid-dark);
+  @include vf-p-inline-list-middot-theme($colors--light-theme--text-default, $colors--light-theme--text-muted);
 }
 
 @mixin vf-p-inline-list-middot-dark-theme {
-  @include vf-p-inline-list-middot-theme($colors--dark-theme--text-default, $color-x-light);
+  @include vf-p-inline-list-middot-theme($colors--dark-theme--text-default, $colors--dark-theme--text-muted);
 }
 
 @mixin vf-p-inline-list-stretch {

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -156,12 +156,10 @@ $spv-list-item--inner: null;
       position: relative;
 
       &::after {
-        content: '\00b7';
-        font-size: 1.4em;
-        line-height: 0;
+        content: '\2022';
+        line-height: map-get($line-heights, default-text);
         position: absolute;
-        right: #{-0.5 * $sph-outer};
-        top: 0.4em;
+        right: -$sp-unit;
       }
 
       &:last-of-type,
@@ -193,21 +191,16 @@ $spv-list-item--inner: null;
   }
 }
 
-@mixin vf-p-inline-list-middot-theme($color-list-text, $color-middot) {
+@mixin vf-p-inline-list-middot-theme($color-list-text) {
   color: $color-list-text;
-
-  .p-inline-list__item::after,
-  .p-inline-list__item:hover::after {
-    color: $color-middot;
-  }
 }
 
 @mixin vf-p-inline-list-middot-light-theme {
-  @include vf-p-inline-list-middot-theme($colors--light-theme--text-default, $colors--light-theme--text-muted);
+  @include vf-p-inline-list-middot-theme($colors--light-theme--text-default);
 }
 
 @mixin vf-p-inline-list-middot-dark-theme {
-  @include vf-p-inline-list-middot-theme($colors--dark-theme--text-default, $colors--dark-theme--text-muted);
+  @include vf-p-inline-list-middot-theme($colors--dark-theme--text-default);
 }
 
 @mixin vf-p-inline-list-stretch {

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -156,17 +156,12 @@ $spv-list-item--inner: null;
       position: relative;
 
       &::after {
-        color: $color-mid-dark;
         content: '\00b7';
-        font-size: 1.4em;
+        font-size: 2em;
         line-height: 0;
         position: absolute;
-        right: #{-0.5 * $sph-outer};
-        top: 0.4em;
-      }
-
-      &:hover::after {
-        color: $color-mid-dark;
+        right: #{-0.6 * $sph-outer};
+        top: 0.27em;
       }
 
       &:last-of-type,
@@ -177,6 +172,42 @@ $spv-list-item--inner: null;
       }
     }
   }
+
+  // Theming
+  @if ($theme-default-p-inline-list--middot == 'dark') {
+    .p-inline-list--middot {
+      @include vf-p-inline-list-middot-dark-theme;
+    }
+
+    .p-inline-list--middot.is-light {
+      @include vf-p-inline-list-middot-light-theme;
+    }
+  } @else {
+    .p-inline-list--middot {
+      @include vf-p-inline-list-middot-light-theme;
+    }
+
+    .p-inline-list--middot.is-dark {
+      @include vf-p-inline-list-middot-dark-theme;
+    }
+  }
+}
+
+@mixin vf-p-inline-list-middot-theme($color-list-text, $color-middot) {
+  color: $color-list-text;
+
+  .p-inline-list__item::after,
+  .p-inline-list__item:hover::after {
+    color: $color-middot;
+  }
+}
+
+@mixin vf-p-inline-list-middot-light-theme {
+  @include vf-p-inline-list-middot-theme($colors--light-theme--text-default, $color-mid-dark);
+}
+
+@mixin vf-p-inline-list-middot-dark-theme {
+  @include vf-p-inline-list-middot-theme($colors--dark-theme--text-default, $color-x-light);
 }
 
 @mixin vf-p-inline-list-stretch {

--- a/scss/_settings_themes.scss
+++ b/scss/_settings_themes.scss
@@ -4,3 +4,4 @@ $theme-default-nav: 'light' !default;
 $theme-default-p-side-navigation: 'light' !default;
 $theme-default-p-search-box: 'light' !default;
 $theme-default-p-contextual-menu: 'light' !default;
+$theme-default-p-inline-list--middot: 'light' !default;

--- a/scss/standalone/dark.scss
+++ b/scss/standalone/dark.scss
@@ -3,7 +3,7 @@ $theme-default-hr: 'dark';
 $theme-default-nav: 'dark';
 $theme-default-p-search-box: 'dark';
 $theme-default-p-contextual-menu: 'dark';
-$theme-default-p-inline-list--middot: 'dark' !default;
+$theme-default-p-inline-list--middot: 'dark';
 
 @import '../vanilla';
 

--- a/scss/standalone/dark.scss
+++ b/scss/standalone/dark.scss
@@ -3,6 +3,7 @@ $theme-default-hr: 'dark';
 $theme-default-nav: 'dark';
 $theme-default-p-search-box: 'dark';
 $theme-default-p-contextual-menu: 'dark';
+$theme-default-p-inline-list--middot: 'dark' !default;
 
 @import '../vanilla';
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,12 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.25 -->
     <tr>
+      <th><a href="/docs/patterns/lists#middot">Lists / Middot</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.25.0</td>
+      <td>Added dark theme to middot lists.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/buttons#accessibility">Buttons -<br /> aria-pressed</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.25.0</td>

--- a/templates/docs/examples/patterns/lists/lists-mid-dot-dark.html
+++ b/templates/docs/examples/patterns/lists/lists-mid-dot-dark.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Lists / Middot - Dark{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block style %}
+<style>
+  body {
+    background: #111;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<ul class="p-inline-list--middot is-dark">
+  <li class="p-inline-list__item">
+    Legal information
+  </li>
+  <li class="p-inline-list__item">
+    Data privacy
+  </li>
+  <li class="p-inline-list__item">
+    Report a bug on this site
+  </li>
+</ul>
+{% endblock %}

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -69,11 +69,19 @@ View example of the inline list pattern
 
 ### Middot
 
+<span class="p-label--updated">Updated</span>
+
 Apply the class `.p-inline-list--middot` to add a middot character between
 inline list items.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-mid-dot/" class="js-example">
 View example of the middot list pattern
+</a></div>
+
+The utility class `.is-dark` can also be applied to a middot list:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-mid-dot-dark/" class="js-example">
+View example of the middot list with an is-dark class
 </a></div>
 
 ### Inline stretched

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -151,19 +151,21 @@ Starting with the [2.3.0](https://github.com/canonical-web-and-design/vanilla-fr
 - [Checkbox](/docs/base/forms#checkbox) and [radio](/docs/base/forms#radio-button) form inputs
 - Horizontal rule element `<hr />`
 - [Contextual menu](/docs/patterns/contextual-menu)
+- [Lists / Middot](/docs/patterns/lists#middot)
 - [Navigation](/docs/patterns/navigation)
 - [Side navigation](/docs/patterns/navigation#side-navigation)
 - [Search box](/docs/patterns/search-box)
 
-| Element / Component | Variable                           | Default value |
-| ------------------- | ---------------------------------- | ------------- |
-| checkbox            | `$theme-default-forms`             | `light`       |
-| radio               | `$theme-default-forms`             | `light`       |
-| hr                  | `$theme-default-hr`                | `light`       |
-| Contextual menu     | `$theme-default-p-contextual-menu` | `light`       |
-| Navigation          | `$theme-default-nav`               | `light`       |
-| Side navigation     | `$theme-default-p-side-navigation` | `light`       |
-| Search box          | `$theme-default-p-search-box`      | `light`       |
+| Element / Component | Variable                               | Default value |
+| ------------------- | -------------------------------------- | ------------- |
+| checkbox            | `$theme-default-forms`                 | `light`       |
+| radio               | `$theme-default-forms`                 | `light`       |
+| hr                  | `$theme-default-hr`                    | `light`       |
+| Contextual menu     | `$theme-default-p-contextual-menu`     | `light`       |
+| Lists / Middot      | `$theme-default-p-inline-list--middot` | `light`       |
+| Navigation          | `$theme-default-nav`                   | `light`       |
+| Side navigation     | `$theme-default-p-side-navigation`     | `light`       |
+| Search box          | `$theme-default-p-search-box`          | `light`       |
 
 Future releases will expand this list to include all elements and components.
 


### PR DESCRIPTION
## Done

- Added `is-dark` utility class to middot lists
- Increased size of middot
- Added dark theme support for middot lists

Fixes #2395 

## QA

- Open [demo](https://vanilla-framework-3588.demos.haus/docs/examples/patterns/lists/lists-mid-dot-dark)
- Check that it looks good
- Review updated documentation:
  - [Middot lists](https://vanilla-framework-3588.demos.haus/docs/patterns/lists#middot)
  - [Component status](https://vanilla-framework-3588.demos.haus/docs/component-status)
  - [Color settings](https://vanilla-framework-3588.demos.haus/docs/color-settings#color-theming)