### PR TITLE
Rename expanding table

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js"
   },
-  "version": "2.25.1",
+  "version": "2.26.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -121,7 +121,8 @@
   }
 
   &:active,
-  &[aria-pressed='true'] {
+  &[aria-pressed='true'],
+  &[aria-expanded='true'] {
     background-color: $button-active-background-color;
     border-color: $button-active-border-color;
     transition-duration: 0s;
@@ -131,6 +132,7 @@
   &.is-disabled {
     &:active,
     &[aria-pressed='true'],
+    &[aria-expanded='true'],
     &:hover {
       background-color: $button-disabled-background-color;
       border-color: $button-disabled-border-color;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -47,6 +47,8 @@
     &[aria-expanded='true'] {
       @include vf-icon-minus($color-mid-dark);
 
+      // override base expanded button styles
+      background-color: inherit;
       background-size: $icon-size;
     }
 
@@ -91,6 +93,11 @@
     vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $icon-size});
   }
   // stylelint-enable selector-no-qualifying-type
+
+  // override base expanded button styles
+  .p-accordion__tab--with-title[aria-expanded] {
+    background-color: inherit;
+  }
 
   .p-accordion__tab--with-title[aria-expanded='true'] .p-accordion__title::before {
     @include vf-icon-minus($color-mid-dark);

--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -1,7 +1,7 @@
 @import 'settings';
 
 @mixin vf-p-table-expanding {
-  .p-table-expanding {
+  .p-table--expanding {
     display: flex;
     flex-flow: column nowrap;
     justify-content: space-between;
@@ -39,7 +39,7 @@
         grow: 1;
       }
 
-      &.p-table-expanding__panel {
+      &.p-table__expanding-panel {
         flex-basis: 100%;
         max-width: 100%;
 
@@ -59,5 +59,17 @@
       }
     }
     // stylelint-enable selector-no-qualifying-type
+  }
+
+  @include deprecate('3.0.0', 'Use the `.p-table--expanding` instead') {
+    .p-table-expanding {
+      // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
+      @extend .p-table--expanding;
+
+      .p-table-expanding__panel {
+        // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
+        @extend .p-table__expanding-panel;
+      }
+    }
   }
 }

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -50,16 +50,16 @@
               {{ side_nav_item("/docs/base/code", "Code") }}
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
-              {{ side_nav_item("/docs/base/separators", "Separators", "new") }}
-              {{ side_nav_item("/docs/base/tables", "Tables") }}
-              {{ side_nav_item("/docs/base/typography", "Typography", "updated") }}
+              {{ side_nav_item("/docs/base/separators", "Separators") }}
+              {{ side_nav_item("/docs/base/tables", "Tables", "updated") }}
+              {{ side_nav_item("/docs/base/typography", "Typography") }}
             </ul>
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
               {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
-              {{ side_nav_item("/docs/patterns/buttons", "Buttons", "updated") }}
+              {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
               {{ side_nav_item("/docs/patterns/card", "Cards") }}
               {{ side_nav_item("/docs/patterns/chip", "Chips") }}
               {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -41,15 +41,17 @@ View example of the table sortable pattern
 
 <span class="p-label--updated">Updated</span>
 
-Using `.p-table-expanding` in conjunction with the `<table>` element will allow expanding and hidden table cells which take up the full width of the table row element.
+Using `.p-table--expanding` in conjunction with the `<table>` element will allow expanding and hidden table cells which take up the full width of the table row element.
 
 This pattern should be used when a table requires configuration fields (add, edit). Expandable rows can also be used to supply additional information not visible on the table row.
 
-Using `p-table-expanding__panel` it can be hidden using the `aria-hidden` attribute. The table must contain all table cells required. The expanding panel is implemented as additional cell in each row, so to keep the markup of the table valid, an additional cell is also needed in the table `<thead>`. This placeholder heading cell should be hidden using `aria-hidden="true"` attribute.
+Using `p-table__expanding-panel` it can be hidden using the `aria-hidden` attribute. The table must contain all table cells required. The expanding panel is implemented as additional cell in each row, so to keep the markup of the table valid, an additional cell is also needed in the table `<thead>`. This placeholder heading cell should be hidden using `aria-hidden="true"` attribute.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tables/table-expanding/" class="js-example">
 View example of the expanding table pattern
 </a></div>
+
+<span class="p-label--deprecated">Deprecated</span> We are deprecating the use of `p-table-expanding` and `p-table-expanding__panel` class names. They will be removed in future version 3.0 of Vanilla. Use `p-table--expanding` and `p-table__expanding-panel` instead.
 
 ### Responsive
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -22,6 +22,28 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.26 -->
+    <tr>
+      <th><a href="/docs/base/tables#expanding">Tables expanding</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.26.0</td>
+      <td>We renamed and deprecated <code>p-table-expanding</code> and <code>p-table-expanding__panel</code>. Use <code>p-table--expanding</code> and <code>p-table__expanding-panel</code> instead.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 2.25 -->
     <tr>
       <th><a href="/docs/base/typography#extra-small-capitalised-text">Typography / Extra small caps</a></th>
@@ -53,27 +75,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.25.0</td>
       <td>We added a dark theme to middot lists.</td>
     </tr>
-    <tr>
-      <th><a href="/docs/patterns/buttons#accessibility">Buttons -<br /> aria-pressed</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
-      <td>2.25.0</td>
-      <td>We added support for the <code>aria-pressed</code> attribute to button elements. When set to <code>true</code>, the button will retain the styles applied when in its <code>:active</code> state.</td>
-    </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.24 -->
     <tr>
       <th><a href="/docs/base/code#dropdowns">Code snippet - Dropdowns</a></th>

--- a/templates/docs/examples/patterns/contextual-menu/_script.js
+++ b/templates/docs/examples/patterns/contextual-menu/_script.js
@@ -10,7 +10,6 @@ function toggleMenu(element, show, top) {
 
   if (target) {
     element.setAttribute('aria-expanded', show);
-    element.setAttribute('aria-pressed', show);
     target.setAttribute('aria-hidden', !show);
 
     if (typeof top !== 'undefined') {

--- a/templates/docs/examples/patterns/tables/_script-expanding.js
+++ b/templates/docs/examples/patterns/tables/_script-expanding.js
@@ -1,0 +1,47 @@
+/**
+  Toggles the necessary aria- attributes' values on the table panels
+  to show or hide them.
+  @param {HTMLElement} element The tab that acts as the handles.
+  @param {Boolean} show Whether to show or hide the expanded row panel.
+*/
+function toggleExpanded(element, show) {
+  var target = document.getElementById(element.getAttribute('aria-controls'));
+
+  if (target) {
+    element.setAttribute('aria-expanded', show);
+
+    // Adjust the text of the toggle button
+    if (show) {
+      element.innerHTML = element.getAttribute('data-shown-text');
+    } else {
+      element.innerHTML = element.getAttribute('data-hidden-text');
+    }
+
+    target.setAttribute('aria-hidden', !show);
+  }
+}
+
+/**
+    Attaches event listeners for the expandable table open and close click events.
+    @param {HTMLElement} table The expandable table container element.
+  */
+function setupExpandableTable(table) {
+  // Set up an event listener on the container so that panels can be added
+  // and removed and events do not need to be managed separately.
+  table.addEventListener('click', function (event) {
+    var target = event.target;
+    var isTargetOpen = target.getAttribute('aria-expanded') === 'true';
+
+    if (target.classList.contains('u-toggle')) {
+      // Toggle visibility of the target panel.
+      toggleExpanded(target, !isTargetOpen);
+    }
+  });
+}
+
+// Setup all expandable tables on the page.
+var tables = document.querySelectorAll('.p-table--expanding, .p-table-expanding');
+
+for (var i = 0, l = tables.length; i < l; i++) {
+  setupExpandableTable(tables[i]);
+}

--- a/templates/docs/examples/patterns/tables/table-expanding-deprecated.html
+++ b/templates/docs/examples/patterns/tables/table-expanding-deprecated.html
@@ -1,10 +1,10 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Table / Expanding{% endblock %}
+{% block title %}Table / Expanding (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_table-expanding{% endblock %}
 
 {% block content %}
-<table class="p-table--expanding" aria-label="Example of expanding table">
+<table class="p-table-expanding" aria-label="Example of expanding table">
     <thead>
         <tr>
             <th id="t-name" aria-sort="none">Name</th>
@@ -29,7 +29,7 @@
                 <button class="u-toggle is-dense" aria-controls="expanded-row" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
-            <td id="expanded-row" class="p-table__expanding-panel" aria-hidden="true">
+            <td id="expanded-row" class="p-table-expanding__panel" aria-hidden="true">
                 <div class="row">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>
@@ -50,7 +50,7 @@
                 <button class="u-toggle is-dense" aria-controls="expanded-row-2" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
-            <td id="expanded-row-2" class="p-table__expanding-panel" aria-hidden="true">
+            <td id="expanded-row-2" class="p-table-expanding__panel" aria-hidden="true">
                 <div class="row">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>
@@ -71,7 +71,7 @@
                 <button class="u-toggle is-dense" aria-controls="expanded-row-3" aria-expanded="false" data-shown-text="Hide"
                     data-hidden-text="Show">Show</button>
             </td>
-            <td id="expanded-row-3" class="p-table__expanding-panel" aria-hidden="true">
+            <td id="expanded-row-3" class="p-table-expanding__panel" aria-hidden="true">
                 <div class="row">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -62,3 +62,7 @@ Using `.u-hide` utility inside expanding table to hide table heading placeholder
 ### Grid
 
 Use of `.col` classes outside of `.row` is deprecated. If you use `.col-X` class names outside of `.row` or your custom styling depends on specificity of `.col-X` class name you will need to review and update your styles accordingly.
+
+### Tables
+
+We renamed and deprecated `p-table-expanding` and `p-table-expanding__panel`. Use `p-table--expanding` and `p-table__expanding-panel` instead.


### PR DESCRIPTION
## Done

Renamed `p-table-expanding` to `p-table--expanding`(and `p-table-expanding__panel` to `p-table__expanding_panel`) for consistency.

Fixes #2946

## QA

- Open [demo](https://vanilla-framework-3596.demos.haus/docs/base/tables#expanding)
- Table expanding example should use new class names and look/work as expected: https://vanilla-framework-3596.demos.haus/docs/examples/patterns/tables/table-expanding
- Old deprecated demo should still work as expected: https://vanilla-framework-3596.demos.haus/docs/examples/patterns/tables/table-expanding-deprecated
- Review updated documentation:
  - https://vanilla-framework-3596.demos.haus/docs/base/tables#expanding
  - make sure docs are updated to use new class names
  - make sure old class names are mentioned to be deprecated
- Check component status page to see if relevant changes are mentioned there
- Check if version in package.json is updated accordingly

