### PR TITLE
Update component status for 2.25

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -50,7 +50,7 @@
               {{ side_nav_item("/docs/base/code", "Code") }}
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
-              {{ side_nav_item("/docs/base/separators", "Separators", "New") }}
+              {{ side_nav_item("/docs/base/separators", "Separators", "new") }}
               {{ side_nav_item("/docs/base/tables", "Tables") }}
               {{ side_nav_item("/docs/base/typography", "Typography", "updated") }}
             </ul>
@@ -71,7 +71,7 @@
               {{ side_nav_item("/docs/patterns/labels", "Labels") }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
+              {{ side_nav_item("/docs/patterns/lists", "Lists", "updated") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,10 +24,34 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.25 -->
     <tr>
+      <th><a href="/docs/base/typography#extra-small-capitalised-text">Typography / Extra small caps</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.25.0</td>
+      <td>We added new extra small capitalised text <code>p-text--x-small-capitalised</code>.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/base/typography#baseline-alignment-small-extra-small-and-paragraph-text">Typography / Baseline alignment</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.25.0</td>
+      <td>We added a couple of util classes to help aligning small text on the baseline along default text size.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/base/separators#muted-horizontal-rule">Separators / Muted</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.25.0</td>
+      <td>We added new muted variant of horizontal rule.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/base/separators#fixed-width-horizontal-rule">Separators / Fixed width</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.25.0</td>
+      <td>We added new fixed width variant of horizontal rule to allow aligning it with full 12-column grid layouts.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/lists#middot">Lists / Middot</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.25.0</td>
-      <td>Added dark theme to middot lists.</td>
+      <td>We added a dark theme to middot lists.</td>
     </tr>
     <tr>
       <th><a href="/docs/patterns/buttons#accessibility">Buttons -<br /> aria-pressed</a></th>


### PR DESCRIPTION
## Done

Updated component status docs for upcoming release

## QA

- Open [demo](https://vanilla-framework-3600.demos.haus/docs/component-status)
- Review updated documentation:
  - https://vanilla-framework-3600.demos.haus/docs/component-status - make sure component status is updated to latest version
  - check if all links to docs pages from component status work
  - verify if changes are reflected in side navigation

