### PR TITLE
Remove margin right from contextual menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js"
   },
-  "version": "2.25.0",
+  "version": "2.25.1",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -84,8 +84,12 @@
     }
   }
 
-  .p-contextual-menu__toggle[aria-expanded='true'] .p-contextual-menu__indicator {
-    transform: rotate(180deg);
+  .p-contextual-menu__toggle {
+    margin-right: 0;
+
+    &[aria-expanded='true'] .p-contextual-menu__indicator {
+      transform: rotate(180deg);
+    }
   }
 
   // Theming

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -85,6 +85,11 @@
   }
 
   .p-contextual-menu__toggle {
+    // All buttons have a margin right, unless they are a last child.
+    // In cases where contextual menu toggle is a button, we do not want it to
+    // have a margin, but since it is never the last child in this pattern,
+    // so we need to remove the margin.
+    // https://github.com/canonical-web-and-design/vanilla-framework/pull/3584
     margin-right: 0;
 
     &[aria-expanded='true'] .p-contextual-menu__indicator {

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -53,7 +53,7 @@
     <div class="col-4">
       <div class="u-align--right">
         <span class="p-contextual-menu">
-          <a href="#" class="p-button p-contextual-menu__toggle u-no-margin--right" aria-controls="#menu" aria-expanded="false"
+          <a href="#" class="p-button p-contextual-menu__toggle" aria-controls="#menu" aria-expanded="false"
             aria-haspopup="true">
             Change pool <i class="p-icon--chevron-down"></i>
           </a>


### PR DESCRIPTION
## Done

Removed margin-right from contextual menu, which was introduced by this PR https://github.com/canonical-web-and-design/vanilla-framework/pull/3584 - since a contextual menu toggle is never the last child, in the previous setup, it _always_ had a margin right applied, when it should never have one.

## QA

- Open [demo](https://vanilla-framework-3601.demos.haus/docs/patterns/contextual-menu)
- Inspect the examples, see that each instance of a contextual menu toggle does not have a right margin
