### PR TITLE
Fix linkchecker on GH actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
 
   docker:
     name: Build and run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04 # linkchecker is not available in ubuntu 20.04
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker image


### PR DESCRIPTION
## Done

Use ubuntu-18.04 for GH actions job with linkchecker.

Related to: https://github.com/linkchecker/linkchecker/issues/435

## QA

Make sure PR checks pass (including linkchecker)