### PR TITLE
Install linkchecker via pip3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,9 +35,10 @@ jobs:
 
   docker:
     name: Build and run
-    runs-on: ubuntu-18.04 # linkchecker is not available in ubuntu 20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2 # for pip3 to install linkchecker
       - name: Build Docker image
         run: DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag testrun .
       - name: Run server with Docker
@@ -45,6 +46,6 @@ jobs:
       - name: Check server status
         run: curl localhost:${PORT}/_status/check -I
       - name: Install linkchecker
-        run: sudo apt update && sudo apt install linkchecker
+        run: pip3 install linkchecker
       - name: Check internal links
         run: linkchecker --ignore-url /search http://localhost:${PORT}


### PR DESCRIPTION
## Done

As suggested by @nottrobin we can use pip3 to install linkchecker.

## QA

Make sure CI checks pass (including linkchecker)