### PR TITLE
Add selector-max-type linting rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -15,6 +15,7 @@
     "at-rule-no-vendor-prefix": true,
     "selector-no-qualifying-type": true,
     "selector-max-id": 0,
+    "selector-max-type": 0,
     "max-nesting-depth": 3,
     "function-url-scheme-allowed-list": ["data"],
     "scss/at-import-no-partial-leading-underscore": true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,7 +13,6 @@
     "selector-no-vendor-prefix": true,
     "media-feature-name-no-vendor-prefix": true,
     "at-rule-no-vendor-prefix": true,
-    "selector-no-qualifying-type": true,
     "selector-max-id": 0,
     "selector-max-type": 0,
     "max-nesting-depth": 3,

--- a/scss/_base_background.scss
+++ b/scss/_base_background.scss
@@ -1,5 +1,5 @@
 @mixin vf-base-background {
-  // stylelint-disable-next-line selector-max-type
+  // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
   html {
     background: $color-x-light;
   }

--- a/scss/_base_background.scss
+++ b/scss/_base_background.scss
@@ -1,4 +1,5 @@
 @mixin vf-base-background {
+  // stylelint-disable-next-line selector-max-type
   html {
     background: $color-x-light;
   }

--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -2,6 +2,7 @@
 
 // Base blockquotes styling
 @mixin vf-b-blockquotes {
+  // stylelint-disable selector-max-type
   blockquote {
     border-left: 2px solid $color-mid-dark;
     margin-bottom: $spv-inner--large;
@@ -20,4 +21,5 @@
       font-style: normal;
     }
   }
+  // stylelint-enable selector-max-type
 }

--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -2,7 +2,7 @@
 
 // Base blockquotes styling
 @mixin vf-b-blockquotes {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   blockquote {
     border-left: 2px solid $color-mid-dark;
     margin-bottom: $spv-inner--large;

--- a/scss/_base_box-sizing.scss
+++ b/scss/_base_box-sizing.scss
@@ -3,6 +3,7 @@
 // Box-sizing FTW!
 //https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/
 @mixin vf-b-box-sizing {
+  // stylelint-disable-next-line selector-max-type
   html {
     box-sizing: border-box;
   }

--- a/scss/_base_box-sizing.scss
+++ b/scss/_base_box-sizing.scss
@@ -3,7 +3,7 @@
 // Box-sizing FTW!
 //https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/
 @mixin vf-b-box-sizing {
-  // stylelint-disable-next-line selector-max-type
+  // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
   html {
     box-sizing: border-box;
   }

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -2,7 +2,7 @@
 
 // Base button styles
 @mixin vf-b-button {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   button {
     @extend %vf-button-base;
     @include vf-button-pattern;

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -2,6 +2,7 @@
 
 // Base button styles
 @mixin vf-b-button {
+  // stylelint-disable selector-max-type
   button {
     @extend %vf-button-base;
     @include vf-button-pattern;
@@ -84,6 +85,7 @@
         margin-top: $spv-outer--small + $spv-nudge-compensation;
       }
     }
+    // stylelint-enable selector-max-type
   }
 
   %vf-button-white-success-icon {

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -7,6 +7,7 @@ $code-inline-padding: 0.25rem;
 
 // Base code styles
 @mixin vf-b-code {
+  // stylelint-disable selector-max-type
   code,
   kbd,
   pre,
@@ -79,7 +80,7 @@ $code-inline-padding: 0.25rem;
     background-color: $color-code-background-dark;
     color: $colors--dark-theme--text-default;
   }
-  // stylelint-enable selector-no-qualifying-type
+  // stylelint-enable selector-no-qualifying-type, selector-max-type
 
   %leading-linux-prompt-icon {
     &::before {

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -7,7 +7,7 @@ $code-inline-padding: 0.25rem;
 
 // Base code styles
 @mixin vf-b-code {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   code,
   kbd,
   pre,

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -74,13 +74,11 @@ $code-inline-padding: 0.25rem;
   }
 
   // dark theme
-  // stylelint-disable selector-no-qualifying-type
   [class*='--dark'] code,
   code.is-dark {
     background-color: $color-code-background-dark;
     color: $colors--dark-theme--text-default;
   }
-  // stylelint-enable selector-no-qualifying-type, selector-max-type
 
   %leading-linux-prompt-icon {
     &::before {

--- a/scss/_base_details.scss
+++ b/scss/_base_details.scss
@@ -1,4 +1,5 @@
 @mixin vf-b-details {
+  // stylelint-disable selector-max-type
   details {
     margin-bottom: $spv-outer--scaleable;
     overflow: auto;
@@ -12,4 +13,5 @@
     margin-bottom: $spv-nudge; //push subsequent text onto baseline
     padding-bottom: 2 * $sp-unit - map-get($nudges, nudge--p); // use padding instead of margin-bottom in order to make the focus state symmetric
   }
+  // stylelint-enable selector-max-type
 }

--- a/scss/_base_details.scss
+++ b/scss/_base_details.scss
@@ -1,5 +1,5 @@
 @mixin vf-b-details {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   details {
     margin-bottom: $spv-outer--scaleable;
     overflow: auto;

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -7,7 +7,7 @@
   $track-border: $track-border-size solid $colors--light-theme--border-high-contrast;
   $track-radius: $bar-thickness;
 
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   // stylelint-disable-next-line selector-no-qualifying-type
   input[type='range'] {
     // stylelint-disable property-no-vendor-prefix

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -7,8 +7,8 @@
   $track-border: $track-border-size solid $colors--light-theme--border-high-contrast;
   $track-radius: $bar-thickness;
 
-  // stylelint-disable-next-line selector-no-qualifying-type
   // stylelint-disable selector-max-type
+  // stylelint-disable-next-line selector-no-qualifying-type
   input[type='range'] {
     // stylelint-disable property-no-vendor-prefix
     -webkit-appearance: none;

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -8,7 +8,6 @@
   $track-radius: $bar-thickness;
 
   // stylelint-disable selector-max-type -- base styles can use type selectors
-  // stylelint-disable-next-line selector-no-qualifying-type
   input[type='range'] {
     // stylelint-disable property-no-vendor-prefix
     -webkit-appearance: none;

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -8,6 +8,7 @@
   $track-radius: $bar-thickness;
 
   // stylelint-disable-next-line selector-no-qualifying-type
+  // stylelint-disable selector-max-type
   input[type='range'] {
     // stylelint-disable property-no-vendor-prefix
     -webkit-appearance: none;
@@ -135,5 +136,6 @@
     &:disabled {
       opacity: 0.5;
     }
+    // stylelint-enable selector-max-type
   }
 }

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -126,7 +126,7 @@ $box-offsets-top: (
 
   // Default form checkbox and radio styles
   %vf-tick-elements {
-    // stylelint-disable-next-line selector-max-type
+    // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
     label & {
       @extend %vf-tick-in-label;
     }

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -126,6 +126,7 @@ $box-offsets-top: (
 
   // Default form checkbox and radio styles
   %vf-tick-elements {
+    // stylelint-disable-next-line selector-max-type
     label & {
       @extend %vf-tick-in-label;
     }
@@ -278,7 +279,7 @@ $box-offsets-top: (
     @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
 
-    // stylelint-disable selector-no-qualifying-type
+    // stylelint-disable selector-no-qualifying-type, selector-max-type
     & + label {
       @extend %vf-pseudo-checkbox;
 
@@ -369,14 +370,14 @@ $box-offsets-top: (
         }
       }
     }
-    // stylelint-enable selector-no-qualifying-type
+    // stylelint-enable selector-no-qualifying-type, selector-max-type
   }
 
   [type='radio'] {
     @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
 
-    // stylelint-disable selector-no-qualifying-type
+    // stylelint-disable selector-no-qualifying-type, selector-max-type
     & + label {
       @extend %vf-pseudo-radio;
 
@@ -503,6 +504,7 @@ $box-offsets-top: (
     [type='radio'].is-dark + label {
       @include vf-radio-dark-theme;
     }
+    // stylelint-enable selector-max-type
   }
 }
 

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -279,7 +279,7 @@ $box-offsets-top: (
     @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
 
-    // stylelint-disable selector-no-qualifying-type, selector-max-type
+    // stylelint-disable selector-max-type
     & + label {
       @extend %vf-pseudo-checkbox;
 
@@ -370,14 +370,14 @@ $box-offsets-top: (
         }
       }
     }
-    // stylelint-enable selector-no-qualifying-type, selector-max-type
+    // stylelint-enable selector-max-type
   }
 
   [type='radio'] {
     @extend %vf-hidden-tick-input;
     @extend %vf-tick-elements;
 
-    // stylelint-disable selector-no-qualifying-type, selector-max-type
+    // stylelint-disable selector-max-type
     & + label {
       @extend %vf-pseudo-radio;
 
@@ -468,7 +468,6 @@ $box-offsets-top: (
         }
       }
     }
-    // stylelint-enable selector-no-qualifying-type
   }
 
   // Theming

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -89,7 +89,7 @@
     }
   }
 
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   label {
     @include p-max-width;
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -89,6 +89,7 @@
     }
   }
 
+  // stylelint-disable selector-max-type
   label {
     @include p-max-width;
 
@@ -218,4 +219,5 @@
     margin-right: 0;
     padding: calc(#{$spv-inner--large} - 1px);
   }
+  // stylelint-enable selector-max-type
 }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -100,7 +100,6 @@
     padding-top: map-get($nudges, nudge--p);
     width: fit-content;
 
-    // stylelint-disable-next-line selector-no-qualifying-type
     &.is-required::after {
       color: $color-negative;
       content: '*';
@@ -184,7 +183,6 @@
       cursor: pointer;
     }
 
-    // stylelint-disable selector-no-qualifying-type
     &[multiple],
     &[size] {
       background-image: none;
@@ -197,7 +195,6 @@
         padding: $spv-inner--small $sph-inner--small;
       }
     }
-    // stylelint-enable selector-no-qualifying-type
   }
 
   // Textarea styles

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -2,7 +2,7 @@
 
 // Horizontal rule
 @mixin vf-b-hr {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   hr {
     @extend %hr;
 

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -8,7 +8,6 @@
 
     margin-bottom: calc(#{$spv-inner--small} - 1px);
 
-    // stylelint-disable selector-no-qualifying-type
     &.u-no-margin--bottom {
       // compensate for hr thickness, to make sure it doesn't drift from baseline grid
       @extend %u-no-margin--bottom--hr;
@@ -62,7 +61,7 @@
       @include vf-hr-dark-theme;
     }
   }
-  // stylelint-enable selector-no-qualifying-type, selector-max-type
+  // stylelint-enable selector-max-type
 }
 
 @mixin vf-hr-theme(

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -2,6 +2,7 @@
 
 // Horizontal rule
 @mixin vf-b-hr {
+  // stylelint-disable selector-max-type
   hr {
     @extend %hr;
 
@@ -61,7 +62,7 @@
       @include vf-hr-dark-theme;
     }
   }
-  // stylelint-enable selector-no-qualifying-type
+  // stylelint-enable selector-no-qualifying-type, selector-max-type
 }
 
 @mixin vf-hr-theme(

--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -2,6 +2,7 @@
 
 // Base styling for links
 @mixin vf-b-links {
+  // stylelint-disable selector-max-type
   a {
     @include vf-focus;
 
@@ -21,4 +22,5 @@
       color: $color-link-visited;
     }
   }
+  // stylelint-enable selector-max-type
 }

--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -2,7 +2,7 @@
 
 // Base styling for links
 @mixin vf-b-links {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   a {
     @include vf-focus;
 

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -1,6 +1,7 @@
 @import 'settings';
 
 @mixin vf-b-lists {
+  // stylelint-disable selector-max-type
   ol,
   ul {
     margin-bottom: $spv-outer--scaleable;
@@ -46,4 +47,5 @@
     @extend %default-text;
     @extend %bold;
   }
+  // stylelint-enable selector-max-type
 }

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -1,7 +1,7 @@
 @import 'settings';
 
 @mixin vf-b-lists {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   ol,
   ul {
     margin-bottom: $spv-outer--scaleable;

--- a/scss/_base_media.scss
+++ b/scss/_base_media.scss
@@ -2,7 +2,7 @@
 
 // Media element styles
 @mixin vf-b-media {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   img {
     border: 0;
     border-radius: $border-radius;

--- a/scss/_base_media.scss
+++ b/scss/_base_media.scss
@@ -2,6 +2,7 @@
 
 // Media element styles
 @mixin vf-b-media {
+  // stylelint-disable selector-max-type
   img {
     border: 0;
     border-radius: $border-radius;
@@ -49,6 +50,7 @@
     display: none;
     height: 0;
   }
+  // stylelint-enable selector-max-type
 
   [hidden] {
     display: none;

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -2,7 +2,7 @@
 
 // Tables
 @mixin vf-b-tables {
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   table {
     border: 0;
     border-collapse: collapse;

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -2,6 +2,7 @@
 
 // Tables
 @mixin vf-b-tables {
+  // stylelint-disable selector-max-type
   table {
     border: 0;
     border-collapse: collapse;
@@ -59,6 +60,7 @@
       }
     }
   }
+  // stylelint-enable selector-max-type
 
   %table-row-border {
     border-top: 1px solid $colors--light-theme--border-low-contrast;

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -11,7 +11,7 @@
     @include vf-b-typography-max-widths;
   }
 
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- base styles can use type selectors
   html {
     color: $color-dark;
     font-family: unquote($font-base-family);

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -11,6 +11,7 @@
     @include vf-b-typography-max-widths;
   }
 
+  // stylelint-disable selector-max-type
   html {
     color: $color-dark;
     font-family: unquote($font-base-family);
@@ -161,4 +162,5 @@
     cursor: help;
     text-decoration: none;
   }
+  // stylelint-enable selector-max-type
 }

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -75,7 +75,6 @@
   .p-text--small {
     @extend %small-text;
 
-    // stylelint-disable-next-line selector-no-qualifying-type
     &.dense {
       margin-bottom: map-get($sp-after, small--dense) + map-get($line-heights, default-text) - map-get($line-heights, small) - map-get($nudges, nudge--small);
     }
@@ -156,7 +155,6 @@
     vertical-align: baseline;
   }
 
-  // stylelint-disable-next-line selector-no-qualifying-type
   abbr[title] {
     border-bottom: 0.1em dotted;
     cursor: help;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -75,6 +75,7 @@
     }
   }
 
+  // FIXME: we shouldn't be targeting types directly here
   // stylelint-disable selector-max-type
   h2.p-accordion__title::before {
     // make icon bigger for h2 (same as p-icon)

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -75,7 +75,7 @@
     }
   }
 
-  // stylelint-disable selector-no-qualifying-type, selector-max-type
+  // stylelint-disable selector-max-type
   h2.p-accordion__title::before {
     // make icon bigger for h2 (same as p-icon)
     $icon-size-h2: $x-height;
@@ -92,7 +92,7 @@
 
     vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $icon-size});
   }
-  // stylelint-enable selector-no-qualifying-type, selector-max-type
+  // stylelint-enable selector-max-type
 
   // override base expanded button styles
   .p-accordion__tab--with-title[aria-expanded] {

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -75,7 +75,7 @@
     }
   }
 
-  // stylelint-disable selector-no-qualifying-type
+  // stylelint-disable selector-no-qualifying-type, selector-max-type
   h2.p-accordion__title::before {
     // make icon bigger for h2 (same as p-icon)
     $icon-size-h2: $x-height;
@@ -92,7 +92,7 @@
 
     vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $icon-size});
   }
-  // stylelint-enable selector-no-qualifying-type
+  // stylelint-enable selector-no-qualifying-type, selector-max-type
 
   // override base expanded button styles
   .p-accordion__tab--with-title[aria-expanded] {

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -81,6 +81,7 @@
   }
 
   [class*='p-card'] {
+    // FIXME: this is overly complex
     // stylelint-disable selector-max-type
     > p:not([class*='p-heading--']),
     > h5,

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -81,6 +81,7 @@
   }
 
   [class*='p-card'] {
+    // stylelint-disable selector-max-type
     > p:not([class*='p-heading--']),
     > h5,
     > h6 {
@@ -92,5 +93,6 @@
         margin-top: -#{$sp-unit};
       }
     }
+    // stylelint-enable selector-max-type
   }
 }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -12,7 +12,7 @@
   .p-form-validation {
     @include vf-validation-wrapper;
 
-    // stylelint-disable-next-line selector-max-type
+    // stylelint-disable-next-line selector-max-type -- selector type is acceptable in this case
     :not(select).p-form-validation__input {
       // Not using parent selector here as two classes are required to override atribute selectors in reset
       background-position: calc(100% - #{$sph-inner--small}) 50%;

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -12,6 +12,7 @@
   .p-form-validation {
     @include vf-validation-wrapper;
 
+    // stylelint-disable-next-line selector-max-type
     :not(select).p-form-validation__input {
       // Not using parent selector here as two classes are required to override atribute selectors in reset
       background-position: calc(100% - #{$sph-inner--small}) 50%;
@@ -72,6 +73,7 @@
       border-color: $color-positive;
     }
 
+    // stylelint-disable-next-line selector-max-type
     :not(select).p-form-validation__input,
     .p-form-validation__select-wrapper::after {
       @include vf-icon-success($color-positive);
@@ -83,6 +85,7 @@
       border-color: $color-caution;
     }
 
+    // stylelint-disable-next-line selector-max-type
     :not(select).p-form-validation__input,
     .p-form-validation__select-wrapper::after {
       @include vf-icon-warning($color-caution);
@@ -94,6 +97,7 @@
       border-color: $color-negative;
     }
 
+    // stylelint-disable-next-line selector-max-type
     :not(select).p-form-validation__input,
     .p-form-validation__select-wrapper::after {
       @include vf-icon-error($color-negative);

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -4,6 +4,7 @@
   @include vf-p-forms-stacked;
   @include vf-p-forms-inline;
 
+  // stylelint-disable-next-line selector-max-type
   form + [class*='p-button'] {
     margin-top: $spv-outer--scaleable;
   }

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -4,6 +4,8 @@
   @include vf-p-forms-stacked;
   @include vf-p-forms-inline;
 
+  // FIXME: should buttons outside of a form be related to the form?
+  // We should avoid targetting form element types
   // stylelint-disable-next-line selector-max-type
   form + [class*='p-button'] {
     margin-top: $spv-outer--scaleable;

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -40,6 +40,7 @@
 }
 
 @mixin vf-p-icons-common {
+  // stylelint-disable selector-max-type
   h1,
   .p-heading--1,
   .p-heading--one,
@@ -81,6 +82,7 @@
       vertical-align: 0;
     }
   }
+  // stylelint-enable selector-max-type
 }
 
 /// Icons

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -39,6 +39,7 @@ $spv-list-item--inner: null;
     padding-bottom: $spv-list-item--inner;
     padding-top: $spv-list-item--inner;
 
+    // stylelint-disable selector-max-type
     form & {
       padding-bottom: 0;
       padding-top: 0;
@@ -47,6 +48,7 @@ $spv-list-item--inner: null;
         margin-bottom: $spv-nudge-compensation;
       }
     }
+    // stylelint-enable selector-max-type
   }
 }
 

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -39,6 +39,7 @@ $spv-list-item--inner: null;
     padding-bottom: $spv-list-item--inner;
     padding-top: $spv-list-item--inner;
 
+    // FIXME: we need a better way to handle forms within lists
     // stylelint-disable selector-max-type
     form & {
       padding-bottom: 0;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -225,7 +225,7 @@ $lightness-threshold: 70;
       &__link {
         @extend %navigation-item;
 
-        // stylelint-disable-next-line selector-max-type
+        // stylelint-disable-next-line selector-max-type -- this is deprecated use, will be removed
         & > a {
           @extend %navigation-link;
         }
@@ -398,7 +398,7 @@ $lightness-threshold: 70;
   }
 
   @include deprecate('3.0.0', 'Use .p-navigation__items, .p-navigation__item, .p-navigation__link classes instead.') {
-    // stylelint-disable selector-max-type
+    // stylelint-disable selector-max-type -- this is deprecated use, will be removed
     .p-navigation__link > a {
       @extend %navigation-link-theme;
     }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -225,6 +225,7 @@ $lightness-threshold: 70;
       &__link {
         @extend %navigation-item;
 
+        // stylelint-disable-next-line selector-max-type
         & > a {
           @extend %navigation-link;
         }
@@ -397,6 +398,7 @@ $lightness-threshold: 70;
   }
 
   @include deprecate('3.0.0', 'Use .p-navigation__items, .p-navigation__item, .p-navigation__link classes instead.') {
+    // stylelint-disable selector-max-type
     .p-navigation__link > a {
       @extend %navigation-link-theme;
     }
@@ -408,6 +410,7 @@ $lightness-threshold: 70;
     .p-navigation__link > a::before {
       @extend %navigation-link-before;
     }
+    // stylelint-enable selector-max-type
   }
 }
 

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -262,7 +262,7 @@
 
   // Styles for markup in raw HTML docs variant
   .p-side-navigation--raw-html {
-    // stylelint-disable selector-max-type
+    // stylelint-disable selector-max-type -- we support raw HTML markup for discourse-generated side nav
     h2,
     h3,
     h4,

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -262,6 +262,7 @@
 
   // Styles for markup in raw HTML docs variant
   .p-side-navigation--raw-html {
+    // stylelint-disable selector-max-type
     h2,
     h3,
     h4,
@@ -302,6 +303,7 @@
     li li li > a {
       @include vf-side-navigation-spacing-left($multiplier: 3);
     }
+    // stylelint-enable selector-max-type
   }
 
   // Theming
@@ -542,7 +544,7 @@
   // border color of items list
   $color-sidenav-list-border
 ) {
-  // stylelint-disable selector-no-qualifying-type
+  // stylelint-disable selector-no-qualifying-type, selector-max-type
   ul::after {
     background: $color-sidenav-list-border;
   }
@@ -579,7 +581,7 @@
   h6 {
     color: $color-sidenav-text-active;
   }
-  // stylelint-enable selector-no-qualifying-type
+  // stylelint-enable selector-no-qualifying-type, selector-max-type
 }
 
 @mixin vf-side-navigation-raw-html-theme-light {

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -544,7 +544,7 @@
   // border color of items list
   $color-sidenav-list-border
 ) {
-  // stylelint-disable selector-no-qualifying-type, selector-max-type
+  // stylelint-disable selector-max-type
   ul::after {
     background: $color-sidenav-list-border;
   }
@@ -581,7 +581,7 @@
   h6 {
     color: $color-sidenav-text-active;
   }
-  // stylelint-enable selector-no-qualifying-type, selector-max-type
+  // stylelint-enable selector-max-type
 }
 
 @mixin vf-side-navigation-raw-html-theme-light {

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -104,7 +104,7 @@
   }
 
   @include deprecate('3.0.0', 'Use .p-navigation__items, .p-navigation__item, .p-navigation__link classes instead.') {
-    // stylelint-disable-next-line selector-max-type
+    // stylelint-disable-next-line selector-max-type -- this is deprecated use, will be removed
     .p-subnav > a {
       @extend %subnav-link;
     }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -104,6 +104,7 @@
   }
 
   @include deprecate('3.0.0', 'Use .p-navigation__items, .p-navigation__item, .p-navigation__link classes instead.') {
+    // stylelint-disable-next-line selector-max-type
     .p-subnav > a {
       @extend %subnav-link;
     }

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -50,6 +50,7 @@ $knob-size: $sp-unit * 3;
       width: $knob-size;
     }
 
+    // FIXME: we shouldn't be targeting span elements here
     // stylelint-disable-next-line selector-max-type
     & span {
       @extend %vf-hide-text;

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -50,6 +50,7 @@ $knob-size: $sp-unit * 3;
       width: $knob-size;
     }
 
+    // stylelint-disable-next-line selector-max-type
     & span {
       @extend %vf-hide-text;
     }

--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -6,6 +6,7 @@
     flex-flow: column nowrap;
     justify-content: space-between;
 
+    // stylelint-disable selector-max-type
     thead,
     tbody {
       display: block; // for IE we need to force display block
@@ -58,7 +59,7 @@
         display: none;
       }
     }
-    // stylelint-enable selector-no-qualifying-type
+    // stylelint-enable selector-no-qualifying-type, selector-max-type
   }
 
   @include deprecate('3.0.0', 'Use the `.p-table--expanding` instead') {

--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -27,7 +27,6 @@
       }
     }
 
-    // stylelint-disable selector-no-qualifying-type
     th,
     td {
       align-items: flex-start;
@@ -59,7 +58,7 @@
         display: none;
       }
     }
-    // stylelint-enable selector-no-qualifying-type, selector-max-type
+    // stylelint-enable selector-max-type
   }
 
   @include deprecate('3.0.0', 'Use the `.p-table--expanding` instead') {

--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -6,7 +6,7 @@
     flex-flow: column nowrap;
     justify-content: space-between;
 
-    // stylelint-disable selector-max-type
+    // stylelint-disable selector-max-type -- table elements can use selector types
     thead,
     tbody {
       display: block; // for IE we need to force display block

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -30,7 +30,6 @@
         width: calc(50% - #{0.5 * map-get($grid-gutter-widths, medium)});
       }
 
-      // stylelint-disable selector-no-qualifying-type
       td,
       tbody th {
         display: flex;
@@ -68,7 +67,7 @@
           justify-content: unset !important;
         }
       }
-      // stylelint-enable selector-no-qualifying-type, selector-max-type
+      // stylelint-enable selector-max-type
 
       // Styles contextual menus differently within mobile-card tables
       .p-contextual-menu {

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -2,7 +2,7 @@
 
 @mixin vf-p-table-mobile-card {
   .p-table--mobile-card {
-    // stylelint-disable selector-max-type
+    // stylelint-disable selector-max-type -- table elements can use selector types
     td::before,
     tbody th::before {
       @extend %muted-heading;

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -2,6 +2,7 @@
 
 @mixin vf-p-table-mobile-card {
   .p-table--mobile-card {
+    // stylelint-disable selector-max-type
     td::before,
     tbody th::before {
       @extend %muted-heading;
@@ -67,7 +68,7 @@
           justify-content: unset !important;
         }
       }
-      // stylelint-enable selector-no-qualifying-type
+      // stylelint-enable selector-no-qualifying-type, selector-max-type
 
       // Styles contextual menus differently within mobile-card tables
       .p-contextual-menu {
@@ -126,6 +127,7 @@
     }
 
     @media screen and (max-width: $breakpoint-small) {
+      // stylelint-disable-next-line selector-max-type
       tr {
         width: 100%;
       }

--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -22,7 +22,7 @@
   .p-table--sortable {
     table-layout: fixed;
 
-    // stylelint-disable selector-no-qualifying-type, selector-max-type
+    // stylelint-disable selector-max-type
     thead th {
       &[aria-sort] {
         align-items: center;
@@ -46,6 +46,6 @@
         text-decoration: underline;
       }
     }
-    // stylelint-enable selector-no-qualifying-type, selector-max-type
+    // stylelint-enable selector-max-type
   }
 }

--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -22,7 +22,7 @@
   .p-table--sortable {
     table-layout: fixed;
 
-    // stylelint-disable selector-no-qualifying-type
+    // stylelint-disable selector-no-qualifying-type, selector-max-type
     thead th {
       &[aria-sort] {
         align-items: center;
@@ -46,6 +46,6 @@
         text-decoration: underline;
       }
     }
-    // stylelint-enable selector-no-qualifying-type
+    // stylelint-enable selector-no-qualifying-type, selector-max-type
   }
 }

--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -22,7 +22,7 @@
   .p-table--sortable {
     table-layout: fixed;
 
-    // stylelint-disable selector-max-type
+    // stylelint-disable selector-max-type -- table elements can use selector types
     thead th {
       &[aria-sort] {
         align-items: center;

--- a/scss/_utilities_baseline-grid.scss
+++ b/scss/_utilities_baseline-grid.scss
@@ -24,7 +24,7 @@
   }
 
   // baseline grid on document should be in the background
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- needed for examples
   html.u-baseline-grid {
     background-color: transparentize($baseline-color, 0.95);
     position: static;

--- a/scss/_utilities_baseline-grid.scss
+++ b/scss/_utilities_baseline-grid.scss
@@ -25,7 +25,6 @@
 
   // baseline grid on document should be in the background
   // stylelint-disable selector-max-type
-  // stylelint-disable-next-line selector-no-qualifying-type
   html.u-baseline-grid {
     background-color: transparentize($baseline-color, 0.95);
     position: static;

--- a/scss/_utilities_baseline-grid.scss
+++ b/scss/_utilities_baseline-grid.scss
@@ -24,6 +24,7 @@
   }
 
   // baseline grid on document should be in the background
+  // stylelint-disable selector-max-type
   // stylelint-disable-next-line selector-no-qualifying-type
   html.u-baseline-grid {
     background-color: transparentize($baseline-color, 0.95);
@@ -33,6 +34,7 @@
       z-index: -1;
     }
   }
+  // stylelint-enable selector-max-type
 
   .u-baseline-grid__toggle {
     bottom: $spv-outer--scaleable;

--- a/scss/_utilities_hide.scss
+++ b/scss/_utilities_hide.scss
@@ -39,7 +39,7 @@
     }
   }
 
-  // stylelint-disable selector-max-type
+  // stylelint-disable selector-max-type -- table elements can use selector types
   td.u-hide,
   th.u-hide {
     @include vf-hide-table-column;

--- a/scss/_utilities_hide.scss
+++ b/scss/_utilities_hide.scss
@@ -39,7 +39,7 @@
     }
   }
 
-  // stylelint-disable selector-no-qualifying-type, selector-max-type
+  // stylelint-disable selector-max-type
   td.u-hide,
   th.u-hide {
     @include vf-hide-table-column;
@@ -62,7 +62,7 @@
       }
     }
   }
-  // stylelint-enable selector-no-qualifying-type, selector-max-type
+  // stylelint-enable selector-max-type
 
   // expanding table uses flex layout, so use standard u-hide for it
   .p-table-expanding .u-hide {

--- a/scss/_utilities_hide.scss
+++ b/scss/_utilities_hide.scss
@@ -39,7 +39,7 @@
     }
   }
 
-  // stylelint-disable selector-no-qualifying-type
+  // stylelint-disable selector-no-qualifying-type, selector-max-type
   td.u-hide,
   th.u-hide {
     @include vf-hide-table-column;
@@ -62,7 +62,7 @@
       }
     }
   }
-  // stylelint-enable selector-no-qualifying-type
+  // stylelint-enable selector-no-qualifying-type, selector-max-type
 
   // expanding table uses flex layout, so use standard u-hide for it
   .p-table-expanding .u-hide {

--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -6,6 +6,7 @@
     align-items: center !important;
     display: grid !important;
 
+    // stylelint-disable-next-line selector-max-type
     > img {
       align-self: center !important;
     }

--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -6,7 +6,7 @@
     align-items: center !important;
     display: grid !important;
 
-    // stylelint-disable-next-line selector-max-type
+    // stylelint-disable-next-line selector-max-type -- img elements should always align self
     > img {
       align-self: center !important;
     }

--- a/scss/docs/site.scss
+++ b/scss/docs/site.scss
@@ -27,6 +27,7 @@ $color-hero: #e95420;
     border: 1px solid $color-mid-x-light;
   }
 
+  // stylelint-disable-next-line selector-max-type
   iframe {
     margin: 0;
   }

--- a/scss/docs/site.scss
+++ b/scss/docs/site.scss
@@ -27,7 +27,7 @@ $color-hero: #e95420;
     border: 1px solid $color-mid-x-light;
   }
 
-  // stylelint-disable-next-line selector-max-type
+  // stylelint-disable-next-line selector-max-type -- we require an iframe here, type selector is OK
   iframe {
     margin: 0;
   }

--- a/scss/standalone/example.scss
+++ b/scss/standalone/example.scss
@@ -3,7 +3,7 @@
 @import '../utilities_baseline-grid';
 @include vf-u-baseline-grid;
 
-// stylelint-disable selector-max-type
+// stylelint-disable selector-max-type -- examples base can use type selectors
 html {
   background: $colors--light-theme--background-default;
 }

--- a/scss/standalone/example.scss
+++ b/scss/standalone/example.scss
@@ -3,6 +3,7 @@
 @import '../utilities_baseline-grid';
 @include vf-u-baseline-grid;
 
+// stylelint-disable selector-max-type
 html {
   background: $colors--light-theme--background-default;
 }
@@ -11,3 +12,4 @@ body {
   background: $colors--light-theme--background-default;
   margin: 1rem;
 }
+// stylelint-enable selector-max-type


### PR DESCRIPTION
## Done

- Added `selector-max-type` linting rule, and set it to zero.
- Added exemptions for existing styles

Fixes #2949 

## QA

- See that this PR's checks pass
- Pull down this branch
- In any scss file, break the `selector-max-type` rule by adding a naughty rule e.g. `div { display: block; }`
- Run `dotrun lint-scss`, it should fail
