### PR TITLE
Remove the need for `p-table--sortable` class name

### DIFF
--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -19,33 +19,29 @@
     vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $default-icon-size});
   }
 
-  .p-table--sortable {
-    table-layout: fixed;
-
-    // stylelint-disable selector-max-type -- table elements can use selector types
-    thead th {
-      &[aria-sort] {
-        align-items: center;
-        cursor: pointer;
-        white-space: nowrap;
-      }
-
-      &[aria-sort='ascending']::after {
-        @extend %heading-icon;
-      }
-
-      &[aria-sort='descending']::after {
-        @extend %heading-icon;
-
-        -webkit-transform: rotate(180deg); // stylelint-disable-line property-no-vendor-prefix
-        transform: rotate(180deg);
-      }
-
-      &[aria-sort]:hover {
-        color: $color-link;
-        text-decoration: underline;
-      }
+  // stylelint-disable selector-max-type -- table elements can use selector types
+  table th {
+    &[aria-sort] {
+      align-items: center;
+      cursor: pointer;
+      white-space: nowrap;
     }
-    // stylelint-enable selector-max-type
+
+    &[aria-sort='ascending']::after {
+      @extend %heading-icon;
+    }
+
+    &[aria-sort='descending']::after {
+      @extend %heading-icon;
+
+      -webkit-transform: rotate(180deg); // stylelint-disable-line property-no-vendor-prefix
+      transform: rotate(180deg);
+    }
+
+    &[aria-sort]:hover {
+      color: $color-link;
+      text-decoration: underline;
+    }
   }
+  // stylelint-enable selector-max-type
 }

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -31,11 +31,13 @@ View example of the base table
 
 ### Sortable
 
-Using the class `p-table--sortable` and assigning `role="columnheader"` and `aria-sort` to each `<th>` element will show each table column to be sortable. With javascript toggling between `ascending` and `descending` for the `aria-sort` attribute it will change the chevron icon in that direction.
+Assigning `aria-sort` to `<th>` elements will make given table columns sortable. With javascript toggling between `ascending` and `descending` for the `aria-sort` attribute it will change the chevron icon in that direction.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tables/table-sortable/" class="js-example">
 View example of the table sortable pattern
 </a></div>
+
+<span class="p-label--deprecated">Deprecated</span> We are removing the `p-table--sortable` that was previously required to enable sorting functionality in the tables. Currently any table with correctly used `aria-sort` attributes on column headers can be sorted. The `p-table--sortable` class name can be removed from HTML (any relevant JavaScript may need to be updated).
 
 ### Expanding
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -29,6 +29,12 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.26.0</td>
       <td>We renamed and deprecated <code>p-table-expanding</code> and <code>p-table-expanding__panel</code>. Use <code>p-table--expanding</code> and <code>p-table__expanding-panel</code> instead.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/base/tables#sortable">Tables sorting</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.26.0</td>
+      <td>We removed <code>p-table--sortable</code> class name. Sorting can be enabled on any table by adding <code>aria-sort</code> attributes.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/templates/docs/examples/patterns/tables/_script-sorting.js
+++ b/templates/docs/examples/patterns/tables/_script-sorting.js
@@ -1,0 +1,99 @@
+/**
+ * Sorts a table by the column specified.
+ * @param {HTMLElement} header Sortable header element that was clicked.
+ * @param {HTMLTableElement} table Table to sort.
+ */
+function sortTable(header, table) {
+  var SORTABLE_STATES = {
+    none: 0,
+    ascending: -1,
+    descending: 1,
+    ORDER: ['none', 'ascending', 'descending'],
+  };
+
+  // Get index of column based on position of header cell in <thead>
+  // We assume there is only one row in the table head.
+  var col = [].slice.call(table.tHead.rows[0].cells).indexOf(header);
+
+  // Based on the current aria-sort value, get the next state.
+  var newOrder = SORTABLE_STATES.ORDER.indexOf(header.getAttribute('aria-sort')) + 1;
+  newOrder = newOrder > SORTABLE_STATES.ORDER.length - 1 ? 0 : newOrder;
+  newOrder = SORTABLE_STATES.ORDER[newOrder];
+
+  // Reset all header sorts.
+  var headerSorts = table.querySelectorAll('[aria-sort]');
+
+  for (var i = 0, ii = headerSorts.length; i < ii; i += 1) {
+    headerSorts[i].setAttribute('aria-sort', 'none');
+  }
+
+  // Set the new header sort.
+  header.setAttribute('aria-sort', newOrder);
+
+  // Get the direction of the sort and assume only one tbody.
+  // For this example only assume one tbody.
+  var direction = SORTABLE_STATES[newOrder];
+  var body = table.tBodies[0];
+
+  // Convert the HTML element list to an array.
+  var newRows = Array.prototype.slice.call(body.rows, 0);
+
+  // If the direction is 0 - aria-sort="none".
+  if (direction === 0) {
+    // Reset to the default order.
+    newRows.sort(function (a, b) {
+      return a.getAttribute('data-index') - b.getAttribute('data-index');
+    });
+  } else {
+    // Sort based on a cell contents
+    newRows.sort(function (rowA, rowB) {
+      // Trim the cell contents.
+      var contentA = rowA.cells[col].textContent.trim();
+      var contentB = rowB.cells[col].textContent.trim();
+
+      // Based on the direction, do the sort.
+      //
+      // This example only sorts based on alphabetical order, to sort based on
+      // number value a more specific implementation would be needed, to provide
+      // number parsing and comparison function between text strings and numbers.
+      return contentA < contentB ? direction : -direction;
+    });
+  }
+  // Append each row into the table, replacing the current elements.
+  for (i = 0, ii = body.rows.length; i < ii; i += 1) {
+    body.appendChild(newRows[i]);
+  }
+}
+
+function setupClickableHeader(table, header) {
+  header.addEventListener('click', function () {
+    sortTable(header, table);
+  });
+}
+
+/**
+ * Initializes a sortable table by assigning event listeners to sortable column headers.
+ * @param {HTMLTableElement} table
+ */
+function setupSortableTable(table) {
+  // For this example, assume only one tbody.
+  var rows = table.tBodies[0].rows;
+  // Set an index for the default order.
+  for (var row = 0, totalRows = rows.length; row < totalRows; row += 1) {
+    rows[row].setAttribute('data-index', row);
+  }
+
+  // Select sortable column headers.
+  var clickableHeaders = table.querySelectorAll('th[aria-sort]');
+  // Attach the click event for each header.
+  for (var i = 0, ii = clickableHeaders.length; i < ii; i += 1) {
+    setupClickableHeader(table, clickableHeaders[i]);
+  }
+}
+
+// Make all tables on the page sortable.
+var tables = document.querySelectorAll('table');
+
+for (var i = 0, ii = tables.length; i < ii; i += 1) {
+  setupSortableTable(tables[i]);
+}

--- a/templates/docs/examples/patterns/tables/_script-sorting.js
+++ b/templates/docs/examples/patterns/tables/_script-sorting.js
@@ -36,7 +36,7 @@ function sortTable(header, table) {
   var body = table.tBodies[0];
 
   // Convert the HTML element list to an array.
-  var newRows = Array.prototype.slice.call(body.rows, 0);
+  var newRows = [].slice.call(body.rows, 0);
 
   // If the direction is 0 - aria-sort="none".
   if (direction === 0) {

--- a/templates/docs/examples/patterns/tables/table-expanding-deprecated.html
+++ b/templates/docs/examples/patterns/tables/table-expanding-deprecated.html
@@ -7,12 +7,12 @@
 <table class="p-table-expanding" aria-label="Example of expanding table">
     <thead>
         <tr>
-            <th id="t-name" aria-sort="none">Name</th>
-            <th id="t-users" aria-sort="none">Mac address</th>
-            <th id="t-units0" aria-sort="none">IP</th>
-            <th id="t-units1" aria-sort="none">Rack</th>
-            <th id="t-units2" aria-sort="none">Last seen</th>
-            <th id="t-revenue" aria-sort="none" class="u-align--right">Actions</th>
+            <th>Name</th>
+            <th>Mac address</th>
+            <th>IP</th>
+            <th>Rack</th>
+            <th>Last seen</th>
+            <th class="u-align--right">Actions</th>
             <th aria-hidden="true">
                 <!-- hidden empty cell required for validation -->
             </th>

--- a/templates/docs/examples/patterns/tables/table-expanding.html
+++ b/templates/docs/examples/patterns/tables/table-expanding.html
@@ -7,12 +7,12 @@
 <table class="p-table--expanding" aria-label="Example of expanding table">
     <thead>
         <tr>
-            <th id="t-name" aria-sort="none">Name</th>
-            <th id="t-users" aria-sort="none">Mac address</th>
-            <th id="t-units0" aria-sort="none">IP</th>
-            <th id="t-units1" aria-sort="none">Rack</th>
-            <th id="t-units2" aria-sort="none">Last seen</th>
-            <th id="t-revenue" aria-sort="none" class="u-align--right">Actions</th>
+            <th>Name</th>
+            <th>Mac address</th>
+            <th>IP</th>
+            <th>Rack</th>
+            <th>Last seen</th>
+            <th class="u-align--right">Actions</th>
             <th aria-hidden="true">
                 <!-- hidden empty cell required for validation -->
             </th>

--- a/templates/docs/examples/patterns/tables/table-sortable-deprecated.html
+++ b/templates/docs/examples/patterns/tables/table-sortable-deprecated.html
@@ -1,16 +1,16 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Table / Sortable{% endblock %}
+{% block title %}Table / Sortable (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_table-sortable{% endblock %}
 
 {% block content %}
-<table aria-label="Example of a sortable table">
+<table class="p-table--sortable" aria-label="Example of a sortable table">
   <thead>
     <tr>
-      <th aria-sort="none">Status</th>
-      <th aria-sort="none" class="u-align--right">Cores</th>
-      <th aria-sort="none" class="u-align--right">RAM</th>
-      <th aria-sort="none" class="u-align--right">Disks</th>
+      <th id="t-name" aria-sort="none">Status</th>
+      <th id="t-users" aria-sort="none" class="u-align--right">Cores</th>
+      <th id="t-units" aria-sort="none" class="u-align--right">RAM</th>
+      <th id="t-revenue" aria-sort="none" class="u-align--right">Disks</th>
     </tr>
   </thead>
   <tbody>

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -66,3 +66,5 @@ Use of `.col` classes outside of `.row` is deprecated. If you use `.col-X` class
 ### Tables
 
 We renamed and deprecated `p-table-expanding` and `p-table-expanding__panel`. Use `p-table--expanding` and `p-table__expanding-panel` instead.
+
+We removed the `p-table--sortable` that was previously required to enable sorting functionality in the tables. Currently any table with correctly used `aria-sort` attributes on column headers can be sorted. The `p-table--sortable` class name can be removed from HTML (any relevant JavaScript may need to be updated).


### PR DESCRIPTION
## Done

- Removes `p-table--sortable` class name
- Any table with `aria-sort` on headers can be sorted

Fixes #2948 

## QA

- Open [demo](https://vanilla-framework-3608.demos.haus/docs/examples/patterns/tables/table-sortable)
- Check new sortable example:
  - https://vanilla-framework-3608.demos.haus/docs/examples/patterns/tables/table-sortable
  - make sure it works as expected without any additional class names
- Check old deprecated sortable example:
  - https://vanilla-framework-3608.demos.haus/docs/examples/patterns/tables/table-sortable-deprecated
  - make sure it still works as expected
- Review updated documentation:
  - https://vanilla-framework-3608.demos.haus/docs/base/tables#sortable
