### PR TITLE
Fix bottom margin on last p element in p-matrix__desc

### DIFF
--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -12,10 +12,6 @@
     margin-bottom: $spv-outer--scaleable;
     margin-left: 0;
     padding-left: 0;
-
-    > p:last-child {
-      margin-bottom: $spv-nudge-compensation;
-    }
   }
 
   .p-matrix__item {
@@ -139,8 +135,14 @@
   }
 
   .p-matrix__desc {
+    margin-bottom: $spv-nudge-compensation;
+
     @media (max-width: $breakpoint-heading-threshold) {
       margin-top: -#{$sp-unit};
+    }
+
+    > :last-child {
+      margin: 0;
     }
   }
 }


### PR DESCRIPTION
## Done

Fixed a bug introduced in the [2.0 refactor](https://github.com/canonical-web-and-design/vanilla-framework/pull/2138/files#diff-02b46287dfcdad2bcacdccc1da64b1f474cb5cfd855d1e604567e68da4ba8df3R108)* where last-child  `p` elements within `.p-matrix__desc` no longer had their bottom margin reduced.

*noticed while working on https://github.com/canonical-web-and-design/vanilla-framework/pull/3607

## QA

- Open [demo](https://vanilla-framework-3609.demos.haus/docs/patterns/matrix)
- See that the margin below the last paragraph in each matrix item has been reduced, compared to [live version](https://vanillaframework.io/docs/examples/patterns/matrix)

## Screenshots

Before:
![Screenshot from 2021-03-03 15-13-23](https://user-images.githubusercontent.com/2376968/109829395-61272b80-7c35-11eb-9fc3-1761aa3e30b6.png)

After:
![Screenshot from 2021-03-03 15-13-53](https://user-images.githubusercontent.com/2376968/109829407-65534900-7c35-11eb-931a-18d376753a52.png)

