### PR TITLE
Application layout panel animations

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -63,7 +63,13 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   // Navigation panel/drawer
   // -------------------------
   .l-navigation {
-    @include vf-animation(transform, fast);
+    @include vf-animation(
+      $property: (
+        transform,
+        box-shadow,
+      ),
+      $duration: fast
+    );
 
     bottom: 0;
     box-shadow: $panel-drop-shadow;
@@ -81,10 +87,12 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     }
 
     &.is-collapsed {
+      box-shadow: $panel-drop-shadow-transparent;
       transform: translateX(-100%);
     }
 
     &.is-collapsed:focus-within {
+      box-shadow: $panel-drop-shadow;
       transform: none;
     }
   }
@@ -237,6 +245,14 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   }
 
   .l-aside {
+    @include vf-animation(
+      $property: (
+        transform,
+        box-shadow,
+      ),
+      $duration: snap
+    );
+
     box-shadow: $panel-drop-shadow;
     grid-area: main;
     justify-self: right;
@@ -257,6 +273,11 @@ $application-layout--side-nav-width-expanded: 15rem !default;
       }
     }
 
+    &.is-collapsed {
+      box-shadow: $panel-drop-shadow-transparent;
+      transform: translateX(100%);
+    }
+
     @media (min-width: $application-layout--breakpoint-side-nav-collapsed) {
       &.is-pinned {
         border-left: 1px solid $colors--light-theme--border-low-contrast;
@@ -264,6 +285,10 @@ $application-layout--side-nav-width-expanded: 15rem !default;
         grid-area: aside;
         justify-self: auto;
         max-width: $application-layout--aside-panel-max-width;
+      }
+
+      &.is-pinned.is-collapsed {
+        display: none;
       }
     }
   }

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,12 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.26 -->
     <tr>
+      <th><a href="/docs/layouts/application#aside-area">Application layout - animations</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.26.0</td>
+      <td>We added <code>is-collapsed</code> class that allows animating the application layout aside panel.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/base/tables#expanding">Tables expanding</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.26.0</td>

--- a/templates/docs/examples/layouts/application/JAAS.html
+++ b/templates/docs/examples/layouts/application/JAAS.html
@@ -89,7 +89,7 @@
       <div class="p-panel__header">
         <h4 class="p-panel__title">8 models: 3 blocked, 2 alerts, 3 running</h4>
         <div class="p-panel__controls">
-          <button class="u-no-margin--bottom js-aside-toggle">Toggle aside</button>
+          <button class="u-no-margin--bottom js-aside-open">Open aside</button>
         </div>
       </div>
       <div class="p-panel__content">

--- a/templates/docs/examples/layouts/application/_script.js
+++ b/templates/docs/examples/layouts/application/_script.js
@@ -11,16 +11,15 @@ if (document.querySelector('.js-menu-close')) {
   });
 }
 
-if (document.querySelector('.js-aside-toggle')) {
-  document.querySelector('.js-aside-toggle').addEventListener('click', function () {
-    document.querySelector('.l-aside').classList.remove('is-pinned');
-    document.querySelector('.l-aside').classList.toggle('u-hide');
+if (document.querySelector('.js-aside-open')) {
+  document.querySelector('.js-aside-open').addEventListener('click', function () {
+    document.querySelector('.l-aside').classList.remove('is-collapsed');
   });
 }
 
 if (document.querySelector('.js-aside-close')) {
   document.querySelector('.js-aside-close').addEventListener('click', function () {
-    document.querySelector('.l-aside').classList.add('u-hide');
+    document.querySelector('.l-aside').classList.add('is-collapsed');
   });
 }
 

--- a/templates/docs/examples/layouts/application/_script.js
+++ b/templates/docs/examples/layouts/application/_script.js
@@ -1,62 +1,81 @@
-if (document.querySelector('.js-menu-toggle')) {
-  document.querySelector('.js-menu-toggle').addEventListener('click', function () {
-    document.querySelector('.l-navigation').classList.toggle('is-collapsed');
-  });
-}
+/*
+  Set up event handlers for application layout examples.
+  This is for demo purposes only. Real applications should implement it within their application code.
+*/
+function setupAppLayoutExamples() {
+  var aside = document.querySelector('.l-aside');
+  var navigation = document.querySelector('.l-navigation');
 
-if (document.querySelector('.js-menu-close')) {
-  document.querySelector('.js-menu-close').addEventListener('click', function (e) {
-    document.querySelector('.l-navigation').classList.add('is-collapsed');
-    document.activeElement.blur();
-  });
-}
+  var menuToggle = document.querySelector('.js-menu-toggle');
+  var menuClose = document.querySelector('.js-menu-close');
+  var menuPin = document.querySelector('.js-menu-pin');
+  var asideOpen = document.querySelector('.js-aside-open');
+  var asideClose = document.querySelector('.js-aside-close');
+  var asideResize = document.querySelectorAll('.js-aside-resize');
+  var asidePin = document.querySelector('.js-aside-pin');
 
-if (document.querySelector('.js-aside-open')) {
-  document.querySelector('.js-aside-open').addEventListener('click', function () {
-    document.querySelector('.l-aside').classList.remove('is-collapsed');
-  });
-}
+  if (menuToggle) {
+    menuToggle.addEventListener('click', function () {
+      navigation.classList.toggle('is-collapsed');
+    });
+  }
 
-if (document.querySelector('.js-aside-close')) {
-  document.querySelector('.js-aside-close').addEventListener('click', function () {
-    document.querySelector('.l-aside').classList.add('is-collapsed');
-  });
-}
+  if (menuClose) {
+    menuClose.addEventListener('click', function (e) {
+      navigation.classList.add('is-collapsed');
+      document.activeElement.blur();
+    });
+  }
 
-[].slice.call(document.querySelectorAll('.js-aside-resize')).forEach(function (button) {
-  button.addEventListener('click', function () {
-    button.dataset.resizeClass;
-    var panel = document.getElementById(button.getAttribute('aria-controls'));
-    if (panel) {
-      panel.classList.remove('is-narrow');
-      panel.classList.remove('is-medium');
-      panel.classList.remove('is-wide');
-      if (button.dataset.resizeClass) {
-        panel.classList.add(button.dataset.resizeClass);
+  if (asideOpen) {
+    asideOpen.addEventListener('click', function () {
+      aside.classList.remove('is-collapsed');
+    });
+  }
+
+  if (asideClose) {
+    asideClose.addEventListener('click', function () {
+      aside.classList.add('is-collapsed');
+    });
+  }
+
+  [].slice.call(asideResize).forEach(function (button) {
+    button.addEventListener('click', function () {
+      button.dataset.resizeClass;
+      var panel = document.getElementById(button.getAttribute('aria-controls'));
+      if (panel) {
+        panel.classList.remove('is-narrow');
+        panel.classList.remove('is-medium');
+        panel.classList.remove('is-wide');
+        if (button.dataset.resizeClass) {
+          panel.classList.add(button.dataset.resizeClass);
+        }
       }
-    }
+    });
   });
-});
 
-if (document.querySelector('.js-menu-pin')) {
-  document.querySelector('.js-menu-pin').addEventListener('click', function () {
-    document.querySelector('.l-navigation').classList.toggle('is-pinned');
-    if (document.querySelector('.l-navigation').classList.contains('is-pinned')) {
-      document.querySelector('.js-menu-pin').querySelector('i').classList.remove('p-icon--pin');
-    } else {
-      document.querySelector('.js-menu-pin').querySelector('i').classList.add('p-icon--pin');
-    }
-    document.activeElement.blur();
-  });
+  if (menuPin) {
+    menuPin.addEventListener('click', function () {
+      navigation.classList.toggle('is-pinned');
+      if (navigation.classList.contains('is-pinned')) {
+        menuPin.querySelector('i').classList.remove('p-icon--pin');
+      } else {
+        menuPin.querySelector('i').classList.add('p-icon--pin');
+      }
+      document.activeElement.blur();
+    });
+  }
+
+  if (asidePin) {
+    asidePin.addEventListener('click', function () {
+      aside.classList.toggle('is-pinned');
+      if (aside.classList.contains('is-pinned')) {
+        asidePin.innerText = 'Unpin';
+      } else {
+        asidePin.innerText = 'Pin';
+      }
+    });
+  }
 }
 
-if (document.querySelector('.js-aside-pin')) {
-  document.querySelector('.js-aside-pin').addEventListener('click', function () {
-    document.querySelector('.l-aside').classList.toggle('is-pinned');
-    if (document.querySelector('.l-aside').classList.contains('is-pinned')) {
-      document.querySelector('.js-aside-pin').innerText = 'Unpin';
-    } else {
-      document.querySelector('.js-aside-pin').innerText = 'Pin';
-    }
-  });
-}
+setupAppLayoutExamples();

--- a/templates/docs/examples/layouts/application/default.html
+++ b/templates/docs/examples/layouts/application/default.html
@@ -49,7 +49,7 @@
       <div class="p-panel__header">
         <h4 class="p-panel__title">8 models: 3 blocked, 2 alerts, 3 running</h4>
         <div class="p-panel__controls">
-          <button class="u-no-margin--bottom js-aside-toggle">Toggle aside</button>
+          <button class="u-no-margin--bottom js-aside-open">Open aside</button>
         </div>
       </div>
       <div class="p-panel__content">

--- a/templates/docs/examples/layouts/application/structure.html
+++ b/templates/docs/examples/layouts/application/structure.html
@@ -19,7 +19,7 @@
         <button class="js-menu-pin is-dense u-no-margin u-hide--small">Pin</button>
         <button class="js-menu-close is-dense u-no-margin u-hide--medium">Close</button>
       </p>
-      
+
       <code class="is-dark">l-navigation &gt;<br> l-navigation__drawer</code>
     </div>
   </header>
@@ -27,7 +27,7 @@
   <main class="l-main">
     <p><code>l-main</code></p>
     <p class="u-clearfix">
-      <button class="js-aside-toggle">Toggle aside panel</button>
+      <button class="js-aside-open">Open aside panel</button>
     </p>
 
     <table aria-label="Table with demo content">

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -58,7 +58,7 @@ The aside content area can be detached from right, top or bottom by adding a mar
 
 It can also be pinned, similarly to the side navigation area, by adding class `is-pinned` to the `l-aside` element. Pinning the aside area transforms it from an overlay to split panel, making the main content area narrower.
 
-Toggling the `is-collapsed` class to the `l-aside` element allows to animate closing of the aside panel.
+Toggling the `is-collapsed` class on the `l-aside` element allows the animated closing of the aside panel.
 
 #### Status area
 

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -48,6 +48,8 @@ The main area occupies all available space not taken by other areas of the appli
 
 #### Aside area
 
+<span class="p-label--updated">Updated</span>
+
 The aside area is used to display additional content, usually triggered from within the main content area. It is denoted with the class `l-aside`. Use `<aside class="l-aside">` tag to ensure it acts as an aside region landmark.
 
 By default, the aside area is rendered as an overlay on top of the main area. It is attached to the right edge of the screen, covering the entire height of the screen except for the status bar. The width of the aside content area is flexible and determined by the width of its contents.
@@ -55,6 +57,8 @@ By default, the aside area is rendered as an overlay on top of the main area. It
 The aside content area can be detached from right, top or bottom by adding a margin to it with JavaScript.
 
 It can also be pinned, similarly to the side navigation area, by adding class `is-pinned` to the `l-aside` element. Pinning the aside area transforms it from an overlay to split panel, making the main content area narrower.
+
+Toggling the `is-collapsed` class to the `l-aside` element allows to animate closing of the aside panel.
 
 #### Status area
 


### PR DESCRIPTION
## Done

Fixes #3409 

## QA

- Open [demo](https://vanilla-framework-3614.demos.haus/docs/examples/layouts/application/default)
- Close/open aside panel - it should be animated
- Lower the screen size until side-nav collapses into vertical bar - hovering it should expand it with animation
- Lower the screen size to mobile view - clicking on "Menu" should open side navigation with animation
- Check if it also works as expected on other examples:
  - https://vanilla-framework-3614.demos.haus/docs/examples/layouts/application/JAAS
  - https://vanilla-framework-3614.demos.haus/docs/examples/layouts/application/structure
- Review updated documentation:
  - https://vanilla-framework-3614.demos.haus/docs/layouts/application#aside-area


## Screenshots

![aside-animation](https://user-images.githubusercontent.com/83575/110132278-48e91500-7dcb-11eb-8958-179f281b7ae0.gif)

