### PR TITLE
Use calc for computations with grid-max-width

### DIFF
--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -22,17 +22,17 @@
       margin-right: auto;
 
       @media (max-width: $threshold-4-6-col) {
-        max-width: #{$grid-max-width - 2 * map-get($grid-margin-widths, small)};
+        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, small)});
         width: calc(100% - #{2 * map-get($grid-margin-widths, small)});
       }
 
       @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
-        max-width: #{$grid-max-width - 2 * map-get($grid-margin-widths, medium)};
+        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, medium)});
         width: calc(100% - #{2 * map-get($grid-margin-widths, medium)});
       }
 
       @media (min-width: $threshold-6-12-col) {
-        max-width: #{$grid-max-width - 2 * map-get($grid-margin-widths, large)};
+        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, large)});
         width: calc(100% - #{2 * map-get($grid-margin-widths, large)});
       }
 

--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -64,7 +64,7 @@
     @media (min-width: $breakpoint-large) {
       margin-left: auto;
       margin-right: auto;
-      max-width: 2 * $l-fluid-breakout-aside-width + $l-fluid-breakout-max-width;
+      max-width: calc(2 * #{$l-fluid-breakout-aside-width} + #{$l-fluid-breakout-max-width});
 
       @supports (display: grid) {
         display: grid;

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -32,4 +32,4 @@ $grid-margin-width: $sph-outer--large !default;
 $l-fluid-breakout-max-width: $grid-max-width !default;
 $l-fluid-breakout-aside-width: 14rem !default;
 $l-fluid-breakout-main-child-width: 13rem !default;
-$l-fluid-breakout-3-col-threshold: $grid-max-width + $l-fluid-breakout-aside-width;
+$l-fluid-breakout-3-col-threshold: calc(#{$grid-max-width} + #{$l-fluid-breakout-aside-width});

--- a/scss/standalone/custom.scss
+++ b/scss/standalone/custom.scss
@@ -1,0 +1,7 @@
+// we are testing building Vanilla with custom settings
+
+// using 100% grid to make sure it works if it's not in rem units
+$grid-max-width: 100%;
+
+@import '../vanilla';
+@include vanilla;


### PR DESCRIPTION
## Done

- Uses `calc` in `<hr>` is-fixed-width to make it valid with grid max width is 100%
- Uses `calc` in fluid breakout variables

Fixes #3610

## QA

- Open [demo](https://vanilla-framework-3620.demos.haus)
- There should be no visual differences
- Verify that affected patterns work as expected:
  - horizontal rule: https://vanilla-framework-3620.demos.haus/docs/examples/base/hr-fixed-width
  - breakout layout: https://vanilla-framework-3620.demos.haus/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-and-aside
- Check the build:
  - pull this branch
  - somewhere in SCSS code try to do a calculation with $grid-max-width (`width: $grid-max-width + $sp-small;`)
  - Vanilla should build fine, but `custom.scss` test file should fail, because it uses 100% instead of rem
