### PR TITLE
Consolidate media queries

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -25,6 +25,7 @@
     padding: calc(#{$spv-nudge} - 1px) $sph-inner;
     text-align: center;
     text-decoration: none;
+    width: 100%;
 
     &:active,
     &:focus,
@@ -38,11 +39,7 @@
       opacity: $disabled-element-opacity;
     }
 
-    @media only screen and (max-width: $breakpoint-x-small) {
-      width: 100%;
-    }
-
-    @media only screen and (min-width: $breakpoint-x-small + 1) {
+    @media (min-width: $breakpoint-x-small) {
       margin-right: $sph-outer;
       width: auto;
 
@@ -80,7 +77,7 @@
       margin-top: $spv-outer--small - $spv-nudge;
     }
 
-    @media only screen and (max-width: $breakpoint-x-small) {
+    @media (max-width: $breakpoint-x-small) {
       p & + & {
         margin-top: $spv-outer--small + $spv-nudge-compensation;
       }

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -67,7 +67,7 @@
       padding-top: calc(#{$spv-nudge - $sp-unit * 0.5} - 1px);
     }
 
-    // The following three rules address buttons nested in <p>'s;
+    // The following rules address buttons nested in <p>'s;
     p & {
       margin-bottom: $spv-outer--small-scaleable - $spv-nudge;
       margin-top: -#{$spv-nudge};
@@ -77,7 +77,7 @@
       margin-top: $spv-outer--small - $spv-nudge;
     }
 
-    @media (max-width: $breakpoint-x-small) {
+    @media (max-width: $breakpoint-x-small - 1) {
       p & + & {
         margin-top: $spv-outer--small + $spv-nudge-compensation;
       }

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -145,47 +145,45 @@ $box-offsets-top: (
       @extend %vf-pseudo-tick-box;
 
       // Align with different text styles
-      @media (max-width: $breakpoint-heading-threshold) {
-        &:not(.is-h1)::before,
-        &:not(.is-h2)::before,
-        &:not(.is-h3)::before,
-        &:not(.is-h4)::before,
-        &:not(.is-muted-heading)::before,
-        &:not(.is-inline-label)::before {
-          top: #{$sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
-        }
+      &:not(.is-h1)::before,
+      &:not(.is-h2)::before,
+      &:not(.is-h3)::before,
+      &:not(.is-h4)::before,
+      &:not(.is-muted-heading)::before,
+      &:not(.is-inline-label)::before {
+        top: #{$sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
+      }
 
-        &.is-h1::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
-        }
+      &.is-h1::before {
+        top: #{$sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h2::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
-        }
+      &.is-h2::before {
+        top: #{$sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h3::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
-        }
+      &.is-h3::before {
+        top: #{$sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h4::before {
-          top: #{$sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
-        }
+      &.is-h4::before {
+        top: #{$sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-inline-label::before {
-          top: #{$sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
-        }
+      &.is-inline-label::before {
+        top: #{$sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
+      }
 
-        &.is-muted-heading::before {
-          top: #{$sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
-        }
+      &.is-muted-heading::before {
+        top: #{$sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
+      }
 
-        &.is-muted-inline-heading::before {
-          top: #{$sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
-        }
+      &.is-muted-inline-heading::before {
+        top: #{$sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
+      }
 
-        &.is-table-header::before {
-          top: #{$sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
-        }
+      &.is-table-header::before {
+        top: #{$sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
       }
 
       @media (min-width: $breakpoint-heading-threshold) {
@@ -294,47 +292,45 @@ $box-offsets-top: (
       @extend %vf-pseudo-checkbox;
 
       // Align with different text styles
-      @media (max-width: $breakpoint-heading-threshold) {
-        &:not(.is-h1)::after,
-        &:not(.is-h2)::after,
-        &:not(.is-h3)::after,
-        &:not(.is-h4)::after,
-        &:not(.is-muted-heading)::after,
-        &:not(.is-inline-label)::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
-        }
+      &:not(.is-h1)::after,
+      &:not(.is-h2)::after,
+      &:not(.is-h3)::after,
+      &:not(.is-h4)::after,
+      &:not(.is-muted-heading)::after,
+      &:not(.is-inline-label)::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
+      }
 
-        &.is-h1::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
-        }
+      &.is-h1::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h2::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
-        }
+      &.is-h2::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h3::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
-        }
+      &.is-h3::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h4::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
-        }
+      &.is-h4::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-inline-label::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
-        }
+      &.is-inline-label::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
+      }
 
-        &.is-muted-heading::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
-        }
+      &.is-muted-heading::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
+      }
 
-        &.is-muted-inline-heading::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
-        }
+      &.is-muted-inline-heading::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
+      }
 
-        &.is-table-header::after {
-          top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
-        }
+      &.is-table-header::after {
+        top: #{$form-tick-offset-top + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
       }
 
       @media (min-width: $breakpoint-heading-threshold) {
@@ -392,47 +388,45 @@ $box-offsets-top: (
       @extend %vf-pseudo-radio;
 
       // Align with different text styles
-      @media (max-width: $breakpoint-heading-threshold) {
-        &:not(.is-h1)::after,
-        &:not(.is-h2)::after,
-        &:not(.is-h3)::after,
-        &:not(.is-h4)::after,
-        &:not(.is-muted-heading)::after,
-        &:not(.is-inline-label)::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
-        }
+      &:not(.is-h1)::after,
+      &:not(.is-h2)::after,
+      &:not(.is-h3)::after,
+      &:not(.is-h4)::after,
+      &:not(.is-muted-heading)::after,
+      &:not(.is-inline-label)::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, default-text) - $form-tick-box-size};
+      }
 
-        &.is-h1::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
-        }
+      &.is-h1::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h1-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h2::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
-        }
+      &.is-h2::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h2-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h3::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
-        }
+      &.is-h3::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h3-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-h4::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
-        }
+      &.is-h4::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, h4-small-screens) - $form-tick-box-size};
+      }
 
-        &.is-inline-label::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
-        }
+      &.is-inline-label::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, unpadded-text) - $form-tick-box-size};
+      }
 
-        &.is-muted-heading::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
-        }
+      &.is-muted-heading::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, muted-heading) - $form-tick-box-size};
+      }
 
-        &.is-muted-inline-heading::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
-        }
+      &.is-muted-inline-heading::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, muted-inline-heading) - $form-tick-box-size};
+      }
 
-        &.is-table-header::after {
-          top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
-        }
+      &.is-table-header::after {
+        top: #{$form-radio-circle-offset + $sp-unit * map-get($box-offsets-top, table-header) - $form-tick-box-size};
       }
 
       @media (min-width: $breakpoint-heading-threshold) {

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -58,26 +58,23 @@
 
     @supports (display: grid) {
       display: grid;
+      grid-gap: 0 map-get($grid-gutter-widths, small);
+      grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
       grid-template-rows: auto;
       margin-left: auto;
       margin-right: auto;
       max-width: $grid-max-width;
+
+      & > * {
+        grid-column-end: span $grid-columns-small;
+      }
 
       [class*='#{$grid-column-prefix}'] {
         grid-column-start: auto;
       }
 
       // set static gutter width per breakpoint
-      @media (max-width: $threshold-4-6-col) {
-        grid-gap: 0 map-get($grid-gutter-widths, small);
-        grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
-
-        & > * {
-          grid-column-end: span $grid-columns-small;
-        }
-      }
-
-      @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+      @media (min-width: $threshold-4-6-col) {
         grid-gap: 0 map-get($grid-gutter-widths, medium);
         grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
 
@@ -99,12 +96,10 @@
 
   %vf-grid-container-padding {
     // set static outside padding per breakpoint
-    @media (max-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, small);
-      padding-right: map-get($grid-margin-widths, small);
-    }
+    padding-left: map-get($grid-margin-widths, small);
+    padding-right: map-get($grid-margin-widths, small);
 
-    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+    @media (min-width: $threshold-4-6-col) {
       padding-left: map-get($grid-margin-widths, medium);
       padding-right: map-get($grid-margin-widths, medium);
     }

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -20,13 +20,10 @@
     &.is-fixed-width {
       margin-left: auto;
       margin-right: auto;
+      max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, small)});
+      width: calc(100% - #{2 * map-get($grid-margin-widths, small)});
 
-      @media (max-width: $threshold-4-6-col) {
-        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, small)});
-        width: calc(100% - #{2 * map-get($grid-margin-widths, small)});
-      }
-
-      @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+      @media (min-width: $threshold-4-6-col) {
         max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, medium)});
         width: calc(100% - #{2 * map-get($grid-margin-widths, medium)});
       }

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -90,33 +90,29 @@
 
   // Spacing
   %section-padding--shallow {
-    @media only screen and (max-width: $breakpoint-large) {
-      padding-bottom: $spv-outer--shallow-scaleable * 0.5;
-      padding-top: $spv-outer--shallow-scaleable * 0.5;
-    }
-    @media only screen and (min-width: $breakpoint-large) {
+    padding-bottom: $spv-outer--shallow-scaleable * 0.5;
+    padding-top: $spv-outer--shallow-scaleable * 0.5;
+
+    @media (min-width: $breakpoint-large) {
       padding-bottom: $spv-outer--shallow-scaleable;
       padding-top: $spv-outer--shallow-scaleable;
     }
   }
 
   %section-padding--default {
-    @media only screen and (max-width: $breakpoint-large) {
-      padding-bottom: $spv-outer--regular-scaleable * 0.5;
-      padding-top: $spv-outer--regular-scaleable * 0.5;
-    }
-    @media only screen and (min-width: $breakpoint-large) {
+    padding-bottom: $spv-outer--regular-scaleable * 0.5;
+    padding-top: $spv-outer--regular-scaleable * 0.5;
+
+    @media (min-width: $breakpoint-large) {
       padding-bottom: $spv-outer--regular-scaleable;
       padding-top: $spv-outer--regular-scaleable;
     }
   }
 
   %section-padding--deep {
-    @media only screen and (max-width: $breakpoint-large) {
-      padding: $spv-outer--deep-scaleable * 0.5 0 $spv-outer--deep-scaleable * 0.5;
-    }
+    padding: $spv-outer--deep-scaleable * 0.5 0 $spv-outer--deep-scaleable * 0.5;
 
-    @media only screen and (min-width: $breakpoint-large) {
+    @media (min-width: $breakpoint-large) {
       padding: $spv-outer--deep-scaleable 0;
     }
   }
@@ -145,9 +141,7 @@
   }
 
   %u-no-margin--bottom--h1 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h1-mobile)} !important;
-    }
+    margin-bottom: -#{map-get($nudges, nudge--h1-mobile)} !important;
 
     @media (min-width: $breakpoint-heading-threshold) {
       margin-bottom: -#{map-get($nudges, nudge--h1)} !important;
@@ -161,9 +155,7 @@
   }
 
   %u-no-margin--bottom--h2 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-bottom: -#{map-get($nudges, nudge--h2-mobile)} !important;
-    }
+    margin-bottom: -#{map-get($nudges, nudge--h2-mobile)} !important;
 
     @media (min-width: $breakpoint-heading-threshold) {
       margin-bottom: -#{map-get($nudges, nudge--h2)} !important;
@@ -171,9 +163,7 @@
   }
 
   %u-no-margin--bottom--h3 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-bottom: #{$sp-unit - map-get($nudges, nudge--h3-mobile)} !important;
-    }
+    margin-bottom: #{$sp-unit - map-get($nudges, nudge--h3-mobile)} !important;
 
     @media (min-width: $breakpoint-heading-threshold) {
       margin-bottom: -#{map-get($nudges, nudge--h3)} !important;
@@ -181,9 +171,7 @@
   }
 
   %u-no-margin--bottom--h4 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-bottom: #{$sp-unit - map-get($nudges, nudge--h4-mobile)} !important;
-    }
+    margin-bottom: #{$sp-unit - map-get($nudges, nudge--h4-mobile)} !important;
 
     @media (min-width: $breakpoint-heading-threshold) {
       margin-bottom: -#{map-get($nudges, nudge--h4)} !important;

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -5,16 +5,13 @@
   %vf-heading-1 {
     @include heading-max-width--short;
 
+    font-size: #{map-get($font-sizes, h1-mobile)}rem;
     font-style: normal;
     font-weight: 100;
+    line-height: map-get($line-heights, h1-mobile);
+    margin-bottom: map-get($sp-after, h1-mobile) - map-get($nudges, nudge--h1-mobile);
     margin-top: 0;
-
-    @media (max-width: $breakpoint-heading-threshold) {
-      font-size: #{map-get($font-sizes, h1-mobile)}rem;
-      line-height: map-get($line-heights, h1-mobile);
-      margin-bottom: map-get($sp-after, h1-mobile) - map-get($nudges, nudge--h1-mobile);
-      padding-top: map-get($nudges, nudge--h1-mobile) + map-get($browser-rounding-compensations, h1);
-    }
+    padding-top: map-get($nudges, nudge--h1-mobile) + map-get($browser-rounding-compensations, h1);
 
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h1)}rem;
@@ -38,16 +35,13 @@
   %vf-heading-2 {
     @include heading-max-width--short;
 
+    font-size: #{map-get($font-sizes, h2-mobile)}rem;
     font-style: normal;
     font-weight: 100;
+    line-height: map-get($line-heights, h2-mobile);
+    margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, nudge--h2-mobile);
     margin-top: 0;
-
-    @media (max-width: $breakpoint-heading-threshold) {
-      font-size: #{map-get($font-sizes, h2-mobile)}rem;
-      line-height: map-get($line-heights, h2-mobile);
-      margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, nudge--h2-mobile);
-      padding-top: map-get($nudges, nudge--h2-mobile) + map-get($browser-rounding-compensations, h2);
-    }
+    padding-top: map-get($nudges, nudge--h2-mobile) + map-get($browser-rounding-compensations, h2);
 
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h2)}rem;
@@ -64,16 +58,13 @@
   %vf-heading-3 {
     @include heading-max-width--long;
 
+    font-size: #{map-get($font-sizes, h3-mobile)}rem;
     font-style: normal;
     font-weight: 100;
+    line-height: map-get($line-heights, h3-mobile);
+    margin-bottom: map-get($sp-after, h3-mobile) - map-get($nudges, nudge--h3-mobile);
     margin-top: 0;
-
-    @media (max-width: $breakpoint-heading-threshold) {
-      font-size: #{map-get($font-sizes, h3-mobile)}rem;
-      line-height: map-get($line-heights, h3-mobile);
-      margin-bottom: map-get($sp-after, h3-mobile) - map-get($nudges, nudge--h3-mobile);
-      padding-top: map-get($nudges, nudge--h3-mobile);
-    }
+    padding-top: map-get($nudges, nudge--h3-mobile);
 
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h3)}rem;
@@ -90,16 +81,13 @@
   %vf-heading-4 {
     @include heading-max-width--long;
 
+    font-size: #{map-get($font-sizes, h4-mobile)}rem;
     font-style: normal;
     font-weight: $font-weight-regular-text;
+    line-height: map-get($line-heights, h4-mobile);
+    margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, nudge--h4-mobile);
     margin-top: 0;
-
-    @media (max-width: $breakpoint-heading-threshold) {
-      font-size: #{map-get($font-sizes, h4-mobile)}rem;
-      line-height: map-get($line-heights, h4-mobile);
-      margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, nudge--h4-mobile);
-      padding-top: map-get($nudges, nudge--h4-mobile) + map-get($browser-rounding-compensations, h4);
-    }
+    padding-top: map-get($nudges, nudge--h4-mobile) + map-get($browser-rounding-compensations, h4);
 
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, h4)}rem;
@@ -251,25 +239,23 @@
   // Placeholder naming: $sp + -- + {preceding element} + {following element}, e.g. for p + h1: $sp--ph1
 
   %sp--ph1 {
-    padding-top: map-get($nudges, nudge--h1) + $spv-outer--scaleable;
+    padding-top: map-get($nudges, nudge--h1-mobile) + $spv-outer--scaleable;
 
-    @media (max-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h1-mobile) + $spv-outer--scaleable;
+    @media (min-width: $breakpoint-heading-threshold) {
+      padding-top: map-get($nudges, nudge--h1) + $spv-outer--scaleable;
     }
   }
 
   %sp--ph2 {
-    padding-top: map-get($nudges, nudge--h2) + $spv-outer--scaleable;
+    padding-top: map-get($nudges, nudge--h2-mobile) + $spv-outer--scaleable;
 
-    @media (max-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h2-mobile) + $spv-outer--scaleable;
+    @media (min-width: $breakpoint-heading-threshold) {
+      padding-top: map-get($nudges, nudge--h2) + $spv-outer--scaleable;
     }
   }
 
   %sp--ph3 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h3-mobile) + $spv-outer--scaleable;
-    }
+    padding-top: map-get($nudges, nudge--h3-mobile) + $spv-outer--scaleable;
 
     @media (min-width: $breakpoint-heading-threshold) {
       padding-top: map-get($nudges, nudge--h3) + $spv-outer--scaleable;
@@ -277,9 +263,7 @@
   }
 
   %sp--ph4 {
-    @media (max-width: $breakpoint-heading-threshold) {
-      padding-top: map-get($nudges, nudge--h4-mobile) + $spv-outer--scaleable;
-    }
+    padding-top: map-get($nudges, nudge--h4-mobile) + $spv-outer--scaleable;
 
     @media (min-width: $breakpoint-heading-threshold) {
       padding-top: map-get($nudges, nudge--h4) + $spv-outer--scaleable;

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -23,11 +23,9 @@
     line-height: map-get($line-heights, default-text);
 
     @if ($increase-font-size-on-larger-screens) {
-      @media screen and (max-width: $breakpoint-x-large) {
-        font-size: map-get($base-font-sizes, base);
-      }
+      font-size: map-get($base-font-sizes, base);
 
-      @media screen and (min-width: $breakpoint-x-large) {
+      @media (min-width: $breakpoint-x-large) {
         font-size: map-get($base-font-sizes, large);
         //the rem value is not affected by the change in font-size; it needs to be multiplied by the ratio new font-size/default font-size
         line-height: map-get($line-heights, default-text) * $font-size-ratio--largescreen;

--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -56,6 +56,9 @@
   .l-fluid-breakout#{$suffix} {
     @extend %l-fluid-breakout-ie11-fallback#{$suffix};
 
+    padding-left: map-get($grid-margin-widths, small);
+    padding-right: map-get($grid-margin-widths, small);
+
     @supports (display: grid) {
       display: block;
       grid-gap: 0 0;
@@ -76,17 +79,12 @@
       }
     }
 
-    @media (max-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, small);
-      padding-right: map-get($grid-margin-widths, small);
-    }
-
-    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+    @media (min-width: $threshold-4-6-col) {
       padding-left: map-get($grid-margin-widths, medium);
       padding-right: map-get($grid-margin-widths, medium);
     }
 
-    @media (min-width: $threshold-6-12-col) and (max-width: $l-fluid-breakout-3-col-threshold) {
+    @media (min-width: $threshold-6-12-col) {
       padding-left: map-get($grid-margin-widths, large);
       padding-right: map-get($grid-margin-widths, large);
     }
@@ -177,7 +175,7 @@
       @extend %l-fluid-breakout__aside--right-ie-11-fallback#{$suffix};
       @extend %l-fluid-breakout__aside-common-properties#{$suffix};
 
-      @media (min-width: $breakpoint-large) and (max-width: $l-fluid-breakout-3-col-threshold) {
+      @media (min-width: $breakpoint-large) {
         padding-right: map-get($grid-margin-widths, large);
       }
 
@@ -191,7 +189,7 @@
       @extend %l-fluid-breakout__aside--left-ie-11-fallback#{$suffix};
       @extend %l-fluid-breakout__aside-common-properties#{$suffix};
 
-      @media (min-width: $breakpoint-large) and (max-width: $l-fluid-breakout-3-col-threshold) {
+      @media (min-width: $breakpoint-large) {
         padding-left: map-get($grid-margin-widths, large);
         padding-right: 0;
       }

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -85,7 +85,7 @@
       position: relative;
       top: 0.05rem;
 
-      @media only screen and (max-width: $breakpoint-x-small) {
+      @media (max-width: $breakpoint-x-small) {
         width: auto;
       }
 

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -17,7 +17,7 @@
     width: 100%;
 
     .p-form__group {
-      @media screen and (min-width: $breakpoint-medium) {
+      @media (min-width: $breakpoint-medium) {
         align-items: baseline;
 
         + .p-form__group {
@@ -30,7 +30,7 @@
 
 @mixin vf-p-forms-inline {
   .p-form--inline {
-    @media screen and (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
       align-items: baseline;
       display: inline-flex;
       flex-direction: row;
@@ -42,7 +42,7 @@
     }
 
     .p-form__group {
-      @media screen and (min-width: $breakpoint-medium) {
+      @media (min-width: $breakpoint-medium) {
         display: flex;
         flex-shrink: 1;
         width: auto;

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -137,13 +137,10 @@
       background: $color-mid-light;
       content: '';
       height: 1px;
+      left: map-get($grid-margin-widths, small);
       margin-bottom: calc(#{$spv-inner--scaleable} - 1px);
       position: absolute;
-
-      @media (max-width: $threshold-4-6-col) {
-        left: map-get($grid-margin-widths, small);
-        right: map-get($grid-margin-widths, small);
-      }
+      right: map-get($grid-margin-widths, small);
 
       @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
         left: map-get($grid-margin-widths, medium);

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -22,11 +22,8 @@
     height: map-get($icon-sizes, heading-icon--small);
     margin-bottom: 0;
     margin-right: $sph-inner;
+    margin-top: map-get($nudges, nudge--h3-mobile);
     width: map-get($icon-sizes, heading-icon--small);
-
-    @media (max-width: $breakpoint-medium) {
-      margin-top: map-get($nudges, nudge--h3-mobile);
-    }
 
     @media (min-width: $breakpoint-medium) {
       height: map-get($icon-sizes, heading-icon);
@@ -38,11 +35,8 @@
   .p-heading-icon--small {
     .p-heading-icon__img {
       height: map-get($icon-sizes, heading-icon--x-small);
+      margin-top: $spv-inner--x-small;
       width: map-get($icon-sizes, heading-icon--x-small);
-
-      @media (max-width: $breakpoint-medium) {
-        margin-top: $spv-inner--x-small;
-      }
 
       @media (min-width: $breakpoint-medium) {
         height: map-get($icon-sizes, heading-icon--small);

--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -19,7 +19,7 @@
     text-align: center;
     vertical-align: middle;
 
-    @media only screen and (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
       margin: 1.875rem;
     }
   }
@@ -29,7 +29,7 @@
     max-width: 7rem;
     width: auto;
 
-    @media screen and (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
       max-height: 5.5rem;
       max-width: 9rem;
     }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -263,10 +263,7 @@ $spv-list-item--inner: null;
       &::before {
         flex-shrink: 0;
         margin-right: $sph-inner;
-
-        @media (max-width: $breakpoint-heading-threshold) {
-          width: $bullet-width-mobile;
-        }
+        width: $bullet-width-mobile;
 
         @media (min-width: $breakpoint-heading-threshold) {
           width: $bullet-width;
@@ -275,9 +272,7 @@ $spv-list-item--inner: null;
     }
 
     h#{$i}.p-stepped-list__title + .p-stepped-list__content {
-      @media (max-width: $breakpoint-heading-threshold) {
-        margin-left: $bullet-width-mobile + $sph-inner;
-      }
+      margin-left: $bullet-width-mobile + $sph-inner;
 
       @media (min-width: $breakpoint-heading-threshold) {
         margin-left: $bullet-width + $sph-inner;

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -92,11 +92,8 @@
     height: auto;
     margin-bottom: $spv-inner--small;
     margin-right: $matrix-img-gutter;
+    margin-top: 0;
     width: $matrix-img-width;
-
-    @media (max-width: $breakpoint-heading-threshold) {
-      margin-top: 0;
-    }
 
     @media (min-width: $breakpoint-heading-threshold) {
       margin-top: -#{map-get($nudges, nudge--h4)};

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -31,6 +31,13 @@
       width: 33.333%;
     }
 
+    @media (min-width: $breakpoint-small) and (max-width: $breakpoint-medium) {
+      &:nth-child(2),
+      &:nth-child(3) {
+        border-top: none;
+      }
+    }
+
     @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
       flex-direction: column;
     }

--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -34,7 +34,7 @@
     top: $spv-inner--large;
     width: auto;
 
-    @media screen and (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
       bottom: initial;
       left: initial;
       position: relative;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -20,11 +20,9 @@ $lightness-threshold: 70;
 
   %navigation-link-responsive-padding-left {
     // follows grid padding to ensure nav items on small breakpoints align with grid padding
-    @media (max-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, small);
-    }
+    padding-left: map-get($grid-margin-widths, small);
 
-    @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+    @media (min-width: $threshold-4-6-col) {
       padding-left: map-get($grid-margin-widths, medium);
     }
 
@@ -35,11 +33,9 @@ $lightness-threshold: 70;
 
   %navigation-link-responsive-padding-right {
     // follows grid padding to ensure nav items on small breakpoints align with grid padding
-    @media (max-width: $threshold-4-6-col) {
-      padding-right: map-get($grid-margin-widths, small);
-    }
+    padding-right: map-get($grid-margin-widths, small);
 
-    @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+    @media (min-width: $threshold-4-6-col) {
       padding-right: map-get($grid-margin-widths, medium);
     }
 
@@ -166,12 +162,9 @@ $lightness-threshold: 70;
       display: flex;
       flex: 0 0 auto;
       justify-content: space-between;
+      padding-right: 0;
 
-      @media (max-width: $threshold-4-6-col) {
-        padding-right: 0;
-      }
-
-      @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+      @media (min-width: $threshold-4-6-col) {
         padding-right: 0;
       }
 
@@ -239,16 +232,13 @@ $lightness-threshold: 70;
     // p-search-box overrides
     .p-search-box {
       flex: 1 0 auto;
+      margin-left: map-get($grid-margin-widths, small);
+      margin-right: map-get($grid-margin-widths, small);
       margin-top: -1px;
       min-width: 10em;
       order: -1;
 
-      @media (max-width: $threshold-4-6-col) {
-        margin-left: map-get($grid-margin-widths, small);
-        margin-right: map-get($grid-margin-widths, small);
-      }
-
-      @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+      @media (min-width: $threshold-4-6-col) {
         margin-left: map-get($grid-margin-widths, medium);
         margin-right: map-get($grid-margin-widths, medium);
       }

--- a/scss/_patterns_separator.scss
+++ b/scss/_patterns_separator.scss
@@ -1,11 +1,10 @@
 @mixin vf-p-separator {
   .p-separator {
     // spacing based on %section-padding--default, but using margins on <hr>
-    @media only screen and (max-width: $breakpoint-large) {
-      margin-bottom: $spv-outer--regular-scaleable * 0.5;
-      margin-top: $spv-outer--regular-scaleable * 0.5;
-    }
-    @media only screen and (min-width: $breakpoint-large) {
+    margin-bottom: $spv-outer--regular-scaleable * 0.5;
+    margin-top: $spv-outer--regular-scaleable * 0.5;
+
+    @media (min-width: $breakpoint-large) {
       margin-bottom: $spv-outer--regular-scaleable;
       margin-top: $spv-outer--regular-scaleable;
     }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -356,11 +356,9 @@
   // offset to use for additional spacing (for icons)
   $offset: 0
 ) {
-  @media (max-width: $threshold-4-6-col) {
-    #{$prop}: $multiplier * map-get($grid-margin-widths, small) + $offset;
-  }
+  #{$prop}: $multiplier * map-get($grid-margin-widths, small) + $offset;
 
-  @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+  @media (min-width: $threshold-4-6-col) {
     #{$prop}: $multiplier * map-get($grid-margin-widths, medium) + $offset;
   }
 

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -46,7 +46,7 @@
       top: $spv-inner--medium * 4;
     }
 
-    @media (max-width: $breakpoint-navigation-threshold) {
+    @media (max-width: $breakpoint-navigation-threshold - 1) {
       box-shadow: none;
     }
   }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -16,19 +16,16 @@
     height: $spv-inner--large;
     pointer-events: none;
     position: absolute;
+    right: map-get($grid-margin-widths, small);
     text-indent: calc(100% + 10rem);
     top: $spv-inner--large;
     width: map-get($icon-sizes, default);
 
-    @media (max-width: $threshold-4-6-col) {
-      right: map-get($grid-margin-widths, small);
-    }
-
-    @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-navigation-threshold) {
+    @media (min-width: $threshold-4-6-col) {
       right: map-get($grid-margin-widths, medium);
     }
 
-    @media (min-width: $breakpoint-navigation-threshold + 1) {
+    @media (min-width: $breakpoint-navigation-threshold) {
       right: calc(#{$sph-inner--small} + 1px); // 1px for the border on selects. this aligns it with any selects underneath
     }
   }
@@ -44,7 +41,7 @@
     padding: 0;
     z-index: 5;
 
-    @media (min-width: $breakpoint-navigation-threshold + 1) {
+    @media (min-width: $breakpoint-navigation-threshold) {
       position: absolute;
       top: $spv-inner--medium * 4;
     }
@@ -77,12 +74,9 @@
     @extend %navigation-link-responsive-padding-horizontal;
 
     display: block;
+    padding-bottom: $spv-inner--small;
+    padding-top: $spv-inner--small;
     white-space: nowrap;
-
-    @media (max-width: $breakpoint-navigation-threshold) {
-      padding-bottom: $spv-inner--small;
-      padding-top: $spv-inner--small;
-    }
 
     @media (min-width: $breakpoint-navigation-threshold) {
       padding-bottom: $spv-inner--medium;

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -8,7 +8,7 @@
       @extend %muted-heading;
     }
 
-    @media screen and (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-medium) {
       thead {
         display: none;
       }
@@ -125,7 +125,7 @@
       }
     }
 
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
       // stylelint-disable-next-line selector-max-type
       tr {
         width: 100%;

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -26,7 +26,7 @@
       top: 0;
       width: 1rem;
 
-      @media screen and (min-width: $breakpoint-medium) {
+      @media (min-width: $breakpoint-medium) {
         display: none;
       }
     }

--- a/scss/_utilities_equal-height.scss
+++ b/scss/_utilities_equal-height.scss
@@ -4,7 +4,7 @@
 @mixin vf-u-equal-height {
   // Default equal-height pattern styles
   .u-equal-height {
-    @media only screen and (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
       display: flex;
 
       &.row {

--- a/scss/_utilities_hide.scss
+++ b/scss/_utilities_hide.scss
@@ -21,7 +21,7 @@
     display: none !important;
 
     &--small {
-      @media screen and (max-width: $breakpoint-medium - 1) {
+      @media (max-width: $breakpoint-medium - 1) {
         display: none !important;
       }
     }
@@ -33,7 +33,7 @@
     }
 
     &--large {
-      @media screen and (min-width: $breakpoint-large) {
+      @media (min-width: $breakpoint-large) {
         display: none !important;
       }
     }
@@ -45,7 +45,7 @@
     @include vf-hide-table-column;
 
     &--small {
-      @media screen and (max-width: $breakpoint-medium - 1) {
+      @media (max-width: $breakpoint-medium - 1) {
         @include vf-hide-table-column;
       }
     }
@@ -57,7 +57,7 @@
     }
 
     &--large {
-      @media screen and (min-width: $breakpoint-large) {
+      @media (min-width: $breakpoint-large) {
         @include vf-hide-table-column;
       }
     }
@@ -69,7 +69,7 @@
     display: none !important;
 
     &--small {
-      @media screen and (max-width: $breakpoint-medium - 1) {
+      @media (max-width: $breakpoint-medium - 1) {
         display: none !important;
       }
     }
@@ -81,7 +81,7 @@
     }
 
     &--large {
-      @media screen and (min-width: $breakpoint-large) {
+      @media (min-width: $breakpoint-large) {
         display: none !important;
       }
     }

--- a/scss/_utilities_show.scss
+++ b/scss/_utilities_show.scss
@@ -10,7 +10,7 @@
     display: initial !important;
 
     &--small {
-      @media screen and (max-width: $breakpoint-medium) {
+      @media (max-width: $breakpoint-medium) {
         display: inherit !important;
         display: initial !important;
       }
@@ -24,7 +24,7 @@
     }
 
     &--large {
-      @media screen and (min-width: $breakpoint-large) {
+      @media (min-width: $breakpoint-large) {
         display: inherit !important;
         display: initial !important;
       }


### PR DESCRIPTION
## Done

- Removed any instances of `only screen` and `screen` media queries
- Removed media queries that _seem_ to be unnecessary - in each instance there was a `max-width` media query that set styles overridden in a subsequent `min-width` media query set to the same breakpoint.
- Reduced number of unique media queries reported by Parker in the project from 31 to 18:

| Before: | After: |
| ---- | ---- |
| (min-width: 460px) | (max-width: 459px) |
| (max-width: 460px) | (max-width: 460px) |
| only screen and (max-width: 460px) | (min-width: 460px) |
| only screen and (min-width: 461px) | (max-width: 620px) |
| (max-width: 620px) | (min-width: 620px) |
| (min-width: 620px) | (min-width: 620px) and (max-width: 772px) |
| (min-width: 620px) and (max-width: 772px) | (min-width: 620px) and (max-width: 1036px) |
| (min-width: 620px) and (max-width: 1036px) | (max-width: 771px) |
| screen and (max-width: 620px) | (max-width: 772px) |
| screen and (max-width: 771px) | (min-width: 772px) |
| (min-width: 772px) and (max-width: 1035px) | (min-width: 772px) and (max-width: 1035px) |
| (min-width: 772px) and (max-width: 1036px) | (min-width: 772px) and (max-width: 1036px) |
| (min-width: 772px) and (max-width: calc(72rem + 14rem)) | (min-width: 1036px) |
| (max-width: 772px) | (min-width: 1681px) |
| (min-width: 772px) | (min-width: calc(72rem + 14rem)) |
| only screen and (min-width: 772px) | (max-width: calc(72rem + 14rem)) |
| screen and (max-width: 772px) | (prefers-reduced-motion: reduce) |
| screen and (min-width: 772px)  | print |
| (min-width: 773px) 
| (min-width: 1036px) 
| (min-width: 1036px) and (max-width: calc(72rem + 14rem)) 
| only screen and (max-width: 1036px) 
| only screen and (min-width: 1036px) 
| screen and (min-width: 1036px) 
| (min-width: 1681px) 
| screen and (max-width: 1681px) 
| screen and (min-width: 1681px) 
| (min-width: calc(72rem + 14rem)) 
| (max-width: calc(72rem + 14rem)) 
| (prefers-reduced-motion: reduce) 
| print 

Partly addresses #1862 

## QA

- Open [demo](https://vanilla-framework-3625.demos.haus/docs/examples)
- Check a number of examples, particularly (but not exclusively) the [grid](https://vanilla-framework-3625.demos.haus/docs/examples/patterns/grid/default), and check that each example responds at different breakpoints in the same way the [current live examples](https://vanillaframework.io/docs/examples) do
- Verify that there are no issues in Percy

### Components to QA around breakpoints

- [x] button (**BUG!**)
- [x] checkboxes
- [x] grid
- [x] grid bordered row
- [x] hr
- [x] section paddings (strip shallow/deep/etc)
- [x] no margin on headings
- [x] headings
- [x] fluid breakout layout
- [x] chips
- [x] forms
- [x] heading icons
- [x] lists
- [x] matrix (**BUG**, unrelated to the PR, happens on live vanilla too)
- [x] modal
- [x] navigation
- [x] sub nav (**BUG**, unrelated to the PR, happens on live vanilla too)
- [x] separator
- [x] side navigation
- [x] mobile card
- [x] tabs
- [x] hide/show