### PR TITLE
Add missing labels to side navigation for 2.26

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -48,7 +48,7 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
               {{ side_nav_item("/docs/base/code", "Code") }}
-              {{ side_nav_item("/docs/base/forms", "Forms") }}
+              {{ side_nav_item("/docs/base/forms", "Forms", "updated") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
               {{ side_nav_item("/docs/base/tables", "Tables", "updated") }}
@@ -114,7 +114,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
-              {{ side_nav_item("/docs/layouts/application", "Application") }}
+              {{ side_nav_item("/docs/layouts/application", "Application", "updated") }}
               {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
               {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
               {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer", "new") }}


### PR DESCRIPTION
## Done

Add missing labels for 2.26 release (for application layout and forms)



## QA

- Open [demo](https://vanilla-framework-3630.demos.haus/docs)
- Review updated documentation:
  - check if side navigation labels are updated for release 2.26

