### PR TITLE
Add .is-bordered to code snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js"
   },
-  "version": "2.26.0",
+  "version": "2.27.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -7,6 +7,10 @@ $code-snippet-header-v-spacing: $spv-inner--x-small--scaleable;
   .p-code-snippet {
     margin-bottom: $spv-outer--scaleable;
 
+    &.is-bordered {
+      border: 1px solid $color-mid-x-light;
+    }
+
     .p-code-snippet__block,
     .p-code-snippet__block--icon,
     .p-code-snippet__block--numbered {
@@ -106,6 +110,15 @@ $code-snippet-header-v-spacing: $spv-inner--x-small--scaleable;
       .p-code-snippet__title + .p-code-snippet__dropdowns {
         border-top: 1px solid $colors--light-theme--border-default;
       }
+    }
+
+    // stylelint-disable-next-line selector-max-type
+    iframe {
+      margin: 0;
+      // fixes a Chrome bug where, on larger screens,
+      // a .is-bordered snippet's right border would
+      // disappear at every other pixel width increment
+      width: calc(100% - 1px);
     }
   }
 }

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -8,7 +8,7 @@ $code-snippet-header-v-spacing: $spv-inner--x-small--scaleable;
     margin-bottom: $spv-outer--scaleable;
 
     &.is-bordered {
-      border: 1px solid $color-mid-x-light;
+      border: 1px solid $colors--light-theme--border-low-contrast;
     }
 
     .p-code-snippet__block,

--- a/scss/docs/site.scss
+++ b/scss/docs/site.scss
@@ -21,17 +21,5 @@ $color-hero: #e95420;
   background-position: 75% 50%;
 }
 
-// custom styling for embedded examples with code snippet
-.embedded-example {
-  .p-code-snippet {
-    border: 1px solid $color-mid-x-light;
-  }
-
-  // stylelint-disable-next-line selector-max-type -- we require an iframe here, type selector is OK
-  iframe {
-    margin: 0;
-  }
-}
-
 // import cookie policy
 @import 'node_modules/@canonical/cookie-policy/build/css/cookie-policy';

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -48,16 +48,16 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
               {{ side_nav_item("/docs/base/code", "Code", "updated") }}
-              {{ side_nav_item("/docs/base/forms", "Forms", "updated") }}
+              {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
-              {{ side_nav_item("/docs/base/tables", "Tables", "updated") }}
+              {{ side_nav_item("/docs/base/tables", "Tables") }}
               {{ side_nav_item("/docs/base/typography", "Typography") }}
             </ul>
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
-              {{ side_nav_item("/docs/patterns/accordion", "Accordion", "updated") }}
+              {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
               {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
               {{ side_nav_item("/docs/patterns/card", "Cards") }}
@@ -71,7 +71,7 @@
               {{ side_nav_item("/docs/patterns/labels", "Labels") }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists", "updated") }}
+              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}
@@ -80,7 +80,7 @@
               {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
               {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
-              {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter", "new") }}
+              {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
               {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
               {{ side_nav_item("/docs/patterns/slider", "Slider") }}
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}
@@ -114,10 +114,10 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
-              {{ side_nav_item("/docs/layouts/application", "Application", "updated") }}
+              {{ side_nav_item("/docs/layouts/application", "Application") }}
               {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
               {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
-              {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer", "new") }}
+              {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer") }}
             </ul>
 
             <ul class="p-side-navigation__list">

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -47,7 +47,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
-              {{ side_nav_item("/docs/base/code", "Code") }}
+              {{ side_nav_item("/docs/base/code", "Code", "updated") }}
               {{ side_nav_item("/docs/base/forms", "Forms", "updated") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -12,8 +12,6 @@ Vanilla gives you multiple ways to display code using the standard HTML elements
 
 ### Inline
 
-<span class="p-label--updated">Updated</span>
-
 When you refer to code inline with other text, use the <code>&lt;code></code> tag.
 
 <div class="embedded-example"><a href="/docs/examples/base/code-inline/" class="js-example">
@@ -66,8 +64,6 @@ View example of the code snippet
 
 ### Dropdowns
 
-<span class="p-label--updated">Updated</span>
-
 A select with the class `.p-code-snippet__dropdown` can be included within a `.p-code-snippet__header`, with a small amount of JS to switch between related code examples.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/dropdown" class="js-example">
@@ -105,6 +101,8 @@ View example of the code snippet with syntax highlighting
 </a></div>
 
 ### Bordered
+
+<span class="p-label--new">New</span>
 
 In some cases, such as when including an iframe as part of the code snippet to demonstrate what the code in the example outputs as, you may want a border around the entire code snippet. This can be done by adding `.is-bordered` to the `.p-code-snippet` element.
 

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -104,7 +104,7 @@ View example of the code snippet with syntax highlighting
 
 <span class="p-label--new">New</span>
 
-Add the class `.is-bordered` to the `.p-code-snippet` element to visually group the code snippet with anoter section, for instance the rendered result of the code in the snippet. ```
+Add the class `.is-bordered` to the `.p-code-snippet` element to visually group the code snippet with another section, for instance the rendered result of the code in the snippet. ```
 
 <div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/is-bordered" class="js-example">
 View example of the code snippet with a border

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -104,7 +104,7 @@ View example of the code snippet with syntax highlighting
 
 <span class="p-label--new">New</span>
 
-In some cases, such as when including an iframe as part of the code snippet to demonstrate what the code in the example outputs as, you may want a border around the entire code snippet. This can be done by adding `.is-bordered` to the `.p-code-snippet` element.
+In some cases, such as when including an `iframe` as part of the code snippet to demonstrate what the code in the example outputs as, you may want a border around the entire code snippet. This can be done by adding `.is-bordered` to the `.p-code-snippet` element.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/is-bordered" class="js-example">
 View example of the code snippet with a border

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -104,7 +104,7 @@ View example of the code snippet with syntax highlighting
 
 <span class="p-label--new">New</span>
 
-In some cases, such as when including an `iframe` as part of the code snippet to demonstrate what the code in the example outputs as, you may want a border around the entire code snippet. This can be done by adding `.is-bordered` to the `.p-code-snippet` element.
+Add the class `.is-bordered` to the `.p-code-snippet` element to visually group the code snippet with anoter section, for instance the rendered result of the code in the snippet. ```
 
 <div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/is-bordered" class="js-example">
 View example of the code snippet with a border

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -104,6 +104,14 @@ To avoid using JavaScript library for syntax highlighting you can prepare the co
 View example of the code snippet with syntax highlighting
 </a></div>
 
+### Bordered
+
+In some cases, such as when including an iframe as part of the code snippet to demonstrate what the code in the example outputs as, you may want a border around the entire code snippet. This can be done by adding `.is-bordered` to the `.p-code-snippet` element.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/code-snippet/is-bordered" class="js-example">
+View example of the code snippet with a border
+</a></div>
+
 ### Copyable
 
 <span class="p-label--deprecated">Deprecated</span>

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -38,8 +38,6 @@ Note: The attribute `readonly` disables the input but it still retains a default
 
 ### Checkbox
 
-<span class="p-label--new">New</span>
-
 Use the checkbox component to select one or more options. To provide fully featured Vanilla style and behaviour of the checkbox a specific markup structure is needed around the checkbox input (see example below).
 
 To disable the checkbox component, add the `disabled` attribute to the respective `<input type='checkbox'>` element.
@@ -66,8 +64,6 @@ View example of the heading checkbox components
 
 #### Indeterminate state checkbox
 
-<span class="p-label--new">New</span>
-
 When a checkbox requires a state between checked and unchecked, `checkbox.indeterminate = true;` can be set via JavaScript, which will cause the checkbox appear in an "indeterminate" state.
 
 In cases when JavaScript can't be used for that, set `aria-checked="mixed"` on checkbox to show "indeterminate" state. Please note that it will only change the visual look of the checkbox, it will not affect its state available to the browser via JavaScript.
@@ -87,8 +83,6 @@ This applies also to all modifier classes on checkbox elements, such as `is-h1`,
 Please refer to the [tick elements comparison example](/docs/examples/patterns/forms/tick-comparison) to find equivalent usage of new `.p-checkbox` component.
 
 ### Radio button
-
-<span class="p-label--new">New</span>
 
 Use radio buttons to select one of the given set of options. To provide fully featured Vanilla style and behaviour of the radio button a specific markup structure is needed around the radio button input (see example below).
 
@@ -139,8 +133,6 @@ View example of the base multiple selects
 </a></div>
 
 ### Range
-
-<span class="p-label--new">New</span>
 
 The `<input type="range">` allows a user to select from a specified range of values, where the precise value is not considered important.
 

--- a/templates/docs/base/separators.md
+++ b/templates/docs/base/separators.md
@@ -20,8 +20,6 @@ View example of the horizontal line
 
 #### Muted horizontal rule
 
-<span class="p-label--new">New</span>
-
 Add the `is-muted` class to an `<hr>` to make the horizontal rule lighter in colour.
 This can be useful when trying to create a more subtle partitioning within a section within a container, or between standard horizontal rules.
 
@@ -31,8 +29,6 @@ View example of the muted horizontal line
 
 #### Fixed width horizontal rule
 
-<span class="p-label--new">New</span>
-
 Often it is useful to add a rule that aligns with content placed in a grid `row` class. One way to do that is to wrap an `<hr>` in a `div` with class `row`. To avoid the need for a wrapping element, add the class `is-fixed-width` directly on the `<hr>`.
 
 <div class="embedded-example"><a href="/docs/examples/base/hr-fixed-width/" class="js-example">
@@ -40,8 +36,6 @@ View example of the fixed-width horizontal line
 </a></div>
 
 ### Separator
-
-<span class="p-label--new">New</span>
 
 To separate block sections of the page, use the separator component `<hr class="p-separator">`.
 

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -21,8 +21,6 @@ View example of the base table
 
 ### Icons
 
-<span class="p-label--new">New</span>
-
 If any of the cells in a column has an icon, all cells in the same column (including headers) should have a `.p-table__cell--icon-placeholder` to ensure proper alignment of the text values.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tables/table-icons" class="js-example">
@@ -40,8 +38,6 @@ View example of the table sortable pattern
 <span class="p-label--deprecated">Deprecated</span> We are removing the `p-table--sortable` that was previously required to enable sorting functionality in the tables. Currently any table with correctly used `aria-sort` attributes on column headers can be sorted. The `p-table--sortable` class name can be removed from HTML (any relevant JavaScript may need to be updated).
 
 ### Expanding
-
-<span class="p-label--updated">Updated</span>
 
 Using `.p-table--expanding` in conjunction with the `<table>` element will allow expanding and hidden table cells which take up the full width of the table row element.
 

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -66,8 +66,6 @@ Heading sizes are obtained by taking the ratio to a specified `power` listed in 
 
 ### Heading classes
 
-<span class="p-label--updated">Updated</span>
-
 Heading classes can be added to text elements to give them the same visual
 appearance as the base `h1`-`h6` heading elements without sacrificing correct
 heading order and semantics.
@@ -202,8 +200,6 @@ View example of the Ubuntu font weights.
 </a></div>
 
 ### Muted text
-
-<span class="p-label--new">New</span>
 
 To reduce the prominence of text, use class `u-text--muted`.
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -22,6 +22,28 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.27 -->
+    <tr>
+      <th><a href="/docs/base/code#bordered">Code snippet - bordered</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.26.0</td>
+      <td>We added the utility class <code>.is-bordered</code> to the code snippet.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 2.26 -->
     <tr>
       <th><a href="/docs/patterns/search-and-filter">Search and filter</a></th>
@@ -65,27 +87,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.26.0</td>
       <td>We deprecated the previous accordion tab patterns, <code>.p-accordion__tab</code> and <code>.p-accordion__tab--with-title .p-accordion__title</code>, in favour of a more accessible pattern. Please use <code>.p-accordion__heading .p-accordion__tab</code>.</td>
     </tr>
-    <tr>
-      <th><a href="/docs/base/code#bordered">Code snippet - bordered</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
-      <td>2.26.0</td>
-      <td>We added the utility class <code>.is-bordered</code> to the code snippet.</td>
-    </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.25 -->
     <tr>
       <th><a href="/docs/base/typography#extra-small-capitalised-text">Typography / Extra small caps</a></th>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -66,7 +66,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>We deprecated the previous accordion tab patterns, <code>.p-accordion__tab</code> and <code>.p-accordion__tab--with-title .p-accordion__title</code>, in favour of a more accessible pattern. Please use <code>.p-accordion__heading .p-accordion__tab</code>.</td>
     </tr>
     <tr>
-      <th><a href="/docs/patterns/code#bordered">Code snippet - bordered</a></th>
+      <th><a href="/docs/base/code#bordered">Code snippet - bordered</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.26.0</td>
       <td>We added the utility class <code>.is-bordered</code> to the code snippet.</td>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -65,6 +65,12 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.26.0</td>
       <td>We deprecated the previous accordion tab patterns, <code>.p-accordion__tab</code> and <code>.p-accordion__tab--with-title .p-accordion__title</code>, in favour of a more accessible pattern. Please use <code>.p-accordion__heading .p-accordion__tab</code>.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/patterns/code#bordered">Code snippet - bordered</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.26.0</td>
+      <td>We added the utility class <code>.is-bordered</code> to the code snippet.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/templates/docs/examples/patterns/code-snippet/is-bordered.html
+++ b/templates/docs/examples/patterns/code-snippet/is-bordered.html
@@ -1,0 +1,16 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Code snippet / Bordered{% endblock %}
+
+{% block standalone_css %}patterns_code-snippet{% endblock %}
+
+{% block content %}
+<div class="p-code-snippet is-bordered">
+  <div class="p-code-snippet__header">
+    <h5 class="p-code-snippet__title">Code snippet with iframe and border</h5>
+  </div>
+
+  <pre class="p-code-snippet__block"><code>&lt;button&gt;Button&lt;/button&gt;</code></pre>
+
+  <iframe src="/docs/examples/base/button"></iframe> 
+</div>
+{% endblock %}

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -48,8 +48,6 @@ The main area occupies all available space not taken by other areas of the appli
 
 #### Aside area
 
-<span class="p-label--updated">Updated</span>
-
 The aside area is used to display additional content, usually triggered from within the main content area. It is denoted with the class `l-aside`. Use `<aside class="l-aside">` tag to ensure it acts as an aside region landmark.
 
 By default, the aside area is rendered as an overlay on top of the main area. It is attached to the right edge of the screen, covering the entire height of the screen except for the status bar. The width of the aside content area is flexible and determined by the width of its contents.
@@ -105,8 +103,6 @@ View an example of the application layout demo
 
 ### Side navigation
 
-<span class="p-label--new">New</span>
-
 Use the [side navigation component](/docs/patterns/navigation#side-navigation) to build the contents of main navigation for the application layout. You can find detailed documentation in the ["Application layout" section of the Navigation page](/docs/patterns/navigation#application-layout).
 
 <div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/application" class="js-example">
@@ -135,8 +131,6 @@ On screens wider than `$application-layout--breakpoint-side-nav-expanded` (which
 
 ### Aside panel width
 
-<span class="p-label--new">New</span>
-
 Ideally, decisions about panel widths should be made once the content is known. That said, it is useful to have a few default values for prototyping purposes. The application layout provides 3 panel widths. These panel widths are derived from the static widths of 4, 8, 12 column containers as measured at window width bigger than `$grid-max-width`:
 
 - narrow: Matches the width of a 4 column container. Invoked with class `is-narrow`.
@@ -144,8 +138,6 @@ Ideally, decisions about panel widths should be made once the content is known. 
 - wide: Matches the width of a 12 column container. Invoked with class `is-wide`.
 
 ### Customizing the application layout
-
-<span class="p-label--new">New</span>
 
 The application layout can be customised. The following variables are exposed for customisation:
 

--- a/templates/docs/layouts/fluid-breakout.md
+++ b/templates/docs/layouts/fluid-breakout.md
@@ -6,8 +6,6 @@ context:
 
 ## Breaking out of the grid
 
-<span class="p-label--new">New</span>
-
 <hr>
 
 In some cases, there might be a good reason to break out of the constraints of a 12 column grid and allow content to bleed into the page margins - for example, tables with many columns that would otherwise result in heavy truncation or wrapping, charts with a lot of detail along the x axis, or card layouts that aim to impress with the abundance of available content. The fluid breakout layout allows you to do this.

--- a/templates/docs/layouts/sticky-footer.md
+++ b/templates/docs/layouts/sticky-footer.md
@@ -6,8 +6,6 @@ context:
 
 ## Sticky footer
 
-<span class="p-label--new">New</span>
-
 <hr>
 
 To implement a footer that sticks to the bottom of the viewport even when there is little content on the page use the `l-site` element (that should be a wrapper around whole contents of the page and direct child of the `<body>` element) with `l-footer--sticky` inside it.

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -6,8 +6,6 @@ context:
 
 ## Accordion
 
-<span class="p-label--updated">Updated</span>
-
 <hr>
 
 The sidebar accordion, used in listing pages or as navigation, can hold multiple navigation items or to be used as a filter for content.

--- a/templates/docs/patterns/breadcrumbs.md
+++ b/templates/docs/patterns/breadcrumbs.md
@@ -6,8 +6,6 @@ context:
 
 ## Breadcrumbs
 
-<span class="p-label--updated">Updated</span>
-
 <hr>
 
 You can use the breadcrumbs pattern to indicate where the current page sits in the site's navigation.

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -104,8 +104,6 @@ The `is-active` utility class was renamed to the more appropriate `is-processing
 
 ### Accessibility
 
-<span class="p-label--new">New</span>
-
 In some contexts, it may be necessary to indicate to the user that a button is in a pressed state, such as when a button opens a contextual menu. This can be done by adding `aria-pressed="true"` to the button with JavaScript when the button is clicked, and removed when necessary.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/pressed" class="js-example" data-height="270">

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -7,8 +7,6 @@ context:
 
 ## Contextual menu
 
-<span class="p-label--updated">Updated</span>
-
 <hr>
 
 A contextual menu can be applied to any button, link or navigation item that requires a secondary menu. To interact with the menu it will require some javascript to hide/show each pattern. This is achieved by finding the toggle element `p-contextual-menu__toggle` and what it controls `aria-controls`.
@@ -58,8 +56,6 @@ When using the `p-contextual-menu__toggle` class on a `button` element, please e
 In cases where a contextual menu is shown on click, focus should be set within the menu element, using JavaScript.
 
 ### Theming
-
-<span class="p-label--new">New</span>
 
 The contextual menu uses Vanilla's light theme by default. There are two ways to switch between the light and the dark themes:
 

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -7,8 +7,6 @@ context:
 
 ## Icons
 
-<span class="p-label--updated">Updated</span>
-
 <hr>
 
 Icons provide visual context and enhance usability, they can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -69,8 +69,6 @@ View example of the inline list pattern
 
 ### Middot
 
-<span class="p-label--updated">Updated</span>
-
 Apply the class `.p-inline-list--middot` to add a middot character between
 inline list items.
 
@@ -85,8 +83,6 @@ View example of the middot list with an is-dark class
 </a></div>
 
 ### Inline stretched
-
-<span class="p-label--new">New</span>
 
 Apply the class `.p-inline-list--stretch` to stretch the list items to fill the full width of the parent container.
 

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -63,8 +63,6 @@ View example of the sub-navigation pattern
 
 ### Side navigation
 
-<span class="p-label--updated">Updated</span>
-
 The side navigation pattern can be used to provide more detailed navigation alongside your content.
 
 It allows grouping the links into navigation sections and nesting them up to three levels.
@@ -92,8 +90,6 @@ View example of the side navigation pattern with icons
 </a></div>
 
 #### Sticky
-
-<span class="p-label--new">New</span>
 
 On pages with content significantly longer than the side navigation contents you can make the navigation sticky to keep it visible when scrolling by adding `.is-sticky` class to the root element of `.p-side-navigation`.
 
@@ -147,8 +143,6 @@ main `.p-side-navigation` element. To close the drawer (with the animation) remo
 To make sure side navigation toggle works without JavaScript the toggle button for opening the side navigation drawer should be an anchor with `href` attribute pointing to the `id` attribute of the side navigation element (for example: `<a href="#drawer" class="p-side-navigation__toggle">`).
 
 #### Application layout
-
-<span class="p-label--new">New</span>
 
 For applications built with [the application layout](/docs/layouts/application) the size and positioning of the navigation panel is handled by the layout itself, so the side navigation component doesn't need it's own drawer, overlay or toggle buttons.
 

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -91,7 +91,7 @@
 
     var codeSnippet = document.createElement('div');
 
-    codeSnippet.classList.add('p-code-snippet', 'codepen-example');
+    codeSnippet.classList.add('p-code-snippet', 'is-bordered');
 
     var header = document.createElement('div');
     header.classList.add('p-code-snippet__header');
@@ -151,11 +151,10 @@
 
   function renderIframe(container, html, height) {
     var iframe = document.createElement('iframe');
-    iframe.width = '100%';
+
     if (height) {
       iframe.height = height + 'px';
     }
-    iframe.frameBorder = 0;
     container.appendChild(iframe);
     var doc = iframe.contentWindow.document;
     doc.open();


### PR DESCRIPTION
## Done

- Added `.is-bordered` utility class to code snippet
- Removed custom styles that previously achieved the same thing in docs examples

Fixes #983 & #3590

## QA

- Open [demo](https://vanilla-framework-3632.demos.haus/docs/examples/patterns/code-snippet/is-bordered)
- See that it looks good
- Visit the updated [code docs](https://vanilla-framework-3632.demos.haus/docs/base/code#bordered), where the border is more easily visible.
- Review updated documentation:
  - [Component status](https://vanilla-framework-3632.demos.haus/docs/component-status)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in the `package.json` file  should be updated following semver:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.