### PR TITLE
Use the correct color code for the $color-information example

### DIFF
--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -83,9 +83,9 @@ These guidelines are the framework upon which we have built our system for how c
       </p>
     </div>
     <div class="col-2 p-card u-no-padding">
-      <div class="p-strip is-shallow is-bordered" style="background-color: #06c"></div>
+      <div class="p-strip is-shallow is-bordered" style="background-color: #24598f"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
-        $color-information<br><span class="p-muted-heading">#06c</span>
+        $color-information<br><span class="p-muted-heading">#24598f</span>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Fixes the color code for $color-information in the color settings docs. 

Fixes #3633 

## QA

- Open [demo](https://vanilla-framework-3634.demos.haus/docs/settings/color-settings) and view the color settings to ensure it has the correct color.

## Screenshots

![Screen Shot 2021-03-17 at 7 54 45 PM](https://user-images.githubusercontent.com/532033/111561795-aa5d9c00-875a-11eb-955f-f839db25166b.png)
