### PR TITLE
Add the definition of done to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,19 @@ Fixes [list issues/bugs if needed]
 - Review updated documentation:
   - [List any updated documentation for review]
 
-Make sure PR has one of the following labels to automatically categorise it in release notes:
-`Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
+### Check if PR is ready for release
+
+If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:
+
+- [ ] PR should have one of the following labels to automatically categorise it in release notes:
+  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
+- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
+  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
+  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
+  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
+- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
+- [ ] Documentation side navigation should be updated with the relevant labels.
+
 
 ## Screenshots
 


### PR DESCRIPTION
## Done

To make sure the main branch is always releasable we add 'definition of done' to PR template to make sure during review/QA we don't miss anything.

Fixes #3001

## QA

- check if the updated PR template doesn't have errors
### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in the `package.json` file  should be updated following semver:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
