### PR TITLE
Add latest Vanilla version to home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
         <a href="/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
       </li>
       <li class="p-inline-list__item">
-        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download Vanilla</a>
+        <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download Vanilla v{{version}}</a>
       </li>
     </ul>
   </div>
@@ -108,7 +108,7 @@
           <h4 class="p-heading-icon__title">Vanilla Framework</h4>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Download latest release</a></p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
         <small>See the <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
     </div>


### PR DESCRIPTION
## Done

Adds latest Vanilla version to download buttons on the home page.

Fixes #3032 

## QA

- Open [demo](https://vanilla-framework-3641.demos.haus)
- Make sure download buttons (in hero and download section) have latest version in the label

## Screenshots

<img width="1301" alt="Screenshot 2021-03-22 at 14 25 28" src="https://user-images.githubusercontent.com/83575/111996610-7f889480-8b1a-11eb-9f68-968aaf44d293.png">
<img width="1281" alt="Screenshot 2021-03-22 at 14 25 37" src="https://user-images.githubusercontent.com/83575/111996609-7eeffe00-8b1a-11eb-9083-9e7b5bf28274.png">
