### PR TITLE
Update search box examples with JS to handle cancel event

### DIFF
--- a/templates/docs/examples/patterns/search-box/_script.js
+++ b/templates/docs/examples/patterns/search-box/_script.js
@@ -1,0 +1,15 @@
+function initSearchResetButtons(selector) {
+  var resetButtons = [].slice.call(document.querySelectorAll(selector));
+
+  resetButtons.forEach(function (button) {
+    button.addEventListener('click', function () {
+      var input = button.parentNode.querySelector('input');
+
+      input.focus();
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  initSearchResetButtons('.p-search-box__reset');
+});

--- a/templates/docs/examples/patterns/search-box/default-dark.html
+++ b/templates/docs/examples/patterns/search-box/default-dark.html
@@ -14,4 +14,8 @@
   <button type="reset" class="p-search-box__reset" disabled><i class="p-icon--close"></i></button>
   <button type="submit" class="p-search-box__button" disabled><i class="p-icon--search"></i></button>
 </form>
+
+<script>
+  {% include 'docs/examples/patterns/search-box/_script.js' %}
+</script>
 {% endblock %}

--- a/templates/docs/examples/patterns/search-box/default.html
+++ b/templates/docs/examples/patterns/search-box/default.html
@@ -14,4 +14,8 @@
   <button type="reset" class="p-search-box__reset" disabled><i class="p-icon--close"></i></button>
   <button type="submit" class="p-search-box__button" disabled><i class="p-icon--search"></i></button>
 </form>
+
+<script>
+  {% include 'docs/examples/patterns/search-box/_script.js' %}
+</script>
 {% endblock %}

--- a/templates/docs/examples/patterns/search-box/navigation-dark.html
+++ b/templates/docs/examples/patterns/search-box/navigation-dark.html
@@ -34,4 +34,8 @@
     </nav>
   </div>
 </header>
+
+<script>
+  {% include 'docs/examples/patterns/search-box/_script.js' %}
+</script>
 {% endblock %}

--- a/templates/docs/examples/patterns/search-box/navigation.html
+++ b/templates/docs/examples/patterns/search-box/navigation.html
@@ -34,4 +34,8 @@
     </nav>
   </div>
 </header>
+
+<script>
+  {% include 'docs/examples/patterns/search-box/_script.js' %}
+</script>
 {% endblock %}

--- a/templates/docs/patterns/search-box.md
+++ b/templates/docs/patterns/search-box.md
@@ -14,6 +14,8 @@ Search boxes enable search functionality on a page and are typically used in a n
 
 The component expands to the full width of its container by default.
 
+A cancel button is shown when the input has content, and a small amount of JavaScript is required to ensure that focus is returned to the relevant input field when the cancel button is clicked.
+
 <div class="embedded-example"><a href="/docs/examples/patterns/search-box/default/" class="js-example">
 View examples of search box patterns
 </a></div>


### PR DESCRIPTION
## Done

Added example JS to search box pattern to demonstrate how to return focus to the input field when the cancel/clear input button is clicked.

Fixes #2866 

## QA

- Open [demo](https://vanilla-framework-3642.demos.haus/docs/examples/patterns/search-box/default)
- Type something into the search field, see that the cancel button becomes visible
- Click the cancel button, see that browser focus is restored to the input field
- Review updated documentation:
  - [Search box docs](https://vanilla-framework-3642.demos.haus/docs/patterns/search-box)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
