### PR TITLE
Fix border when hovering disabled base button

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -126,7 +126,8 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
       $button-hover-background-color: scale-color($color-x-light, $lightness: -$hover-background-opacity-percentage),
       $button-hover-border-color: $color-transparent,
       $button-active-background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-percentage),
-      $button-active-border-color: $color-transparent
+      $button-active-border-color: $color-transparent,
+      $button-disabled-border-color: $color-transparent
     );
   }
 


### PR DESCRIPTION
## Done

- Remove border from hovered disabled base button

Fixes #3327

## QA

- Open [demo](https://vanilla-framework-3644.demos.haus/docs/examples/patterns/buttons/base)
- Make sure that hovering disabled button doesn't change anything (including border)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
