### PR TITLE
Clarify base button role

### DIFF
--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -16,20 +16,20 @@ Buttons are clickable elements used to perform an action, you can apply `button`
   </p>
 </div>
 
-### Base
-
-A base button is usually used alongside a neutral button.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/buttons/base/" class="js-example">
-View example of the base button pattern
-</a></div>
-
 ### Neutral
 
 A neutral button can be used to indicate a positive action that isn't necessarily the main call-to-action.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/neutral/" class="js-example">
 View example of the neutral button pattern
+</a></div>
+
+### Base
+
+A base button can be used to discretely indicate a secondary action. It is often used alongside a neutral button.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/base/" class="js-example">
+View example of the base button pattern
 </a></div>
 
 ### Positive


### PR DESCRIPTION
## Done

- Moved base button below neutral button in docs page order
- Reworded the description of the base button to make its purpose clearer

Fixes #2660 

## QA

- Open [button docs](https://vanilla-framework-3645.demos.haus/docs/patterns/buttons#base)
- See that the documentation makes sense and clears up the confusion identified in #2660

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
