### PR TITLE
Document formatting in table cells

### DIFF
--- a/scss/standalone/patterns_table-sortable.scss
+++ b/scss/standalone/patterns_table-sortable.scss
@@ -5,5 +5,9 @@
 @import '../utilities_content-align';
 @include vf-u-align--right;
 
+// for truncating
+@import '../utilities_truncate';
+@include vf-u-truncate;
+
 @import '../patterns_table-sortable';
 @include vf-p-table-sortable;

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -10,14 +10,26 @@ context:
 
 Data tables are used to organize and display all information from a data set.
 
+<div class="embedded-example"><a href="/docs/examples/base/table/" class="js-example">
+View example of the base table
+</a></div>
+
+### Formatting
+
 We recommend that you align the text in table columns that contain only digits
 to the right by adding the class `.u-align--right` to each individual cell,
 as in the example that follows. This is considered good practice when formatting
 data tables as it makes it easier to scan and compare the values quickly.
 
-<div class="embedded-example"><a href="/docs/examples/base/table/" class="js-example">
-View example of the base table
+By default long text in the cells will wrap on word breaks. To prevent that and
+truncate long values add the `.u-truncate` class to the cell.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tables/table-formatting" class="js-example">
+View example of formatting in the table
 </a></div>
+
+You can find out more about the [truncation](/docs/utilities/truncate) and
+[alignment](/docs/utilities/align) utilities on their respective documentation pages.
 
 ### Icons
 

--- a/templates/docs/examples/patterns/tables/table-formatting.html
+++ b/templates/docs/examples/patterns/tables/table-formatting.html
@@ -1,0 +1,41 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Table / Formatting{% endblock %}
+
+{% block standalone_css %}patterns_table-sortable{% endblock %}
+
+{% block content %}
+<table aria-label="Example of formatting in the table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Status</th>
+      <th class="u-align--right">Cores</th>
+      <th class="u-align--right">RAM</th>
+      <th class="u-align--right">Disks</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Example</th>
+      <td>Ready</td>
+      <td class="u-align--right">1</td>
+      <td class="u-align--right">1 GiB</td>
+      <td class="u-align--right">2</td>
+    </tr>
+    <tr>
+      <th>Very long long long example name that should wrap</th>
+      <td>Ready</td>
+      <td class="u-align--right">1</td>
+      <td class="u-align--right">1 GiB</td>
+      <td class="u-align--right">2</td>
+    </tr>
+    <tr>
+      <th class="u-truncate">Truncated very long long long example name</th>
+      <td>Ready</td>
+      <td class="u-align--right">8</td>
+      <td class="u-align--right">3.9 GiB</td>
+      <td class="u-align--right">3</td>
+    </tr>
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Done

- adds new table example to show how to use utils to format text in cells
- adds documentation about formatting

Fixes #2963

## QA

- Open [demo](https://vanilla-framework-3646.demos.haus/docs/examples/patterns/tables/table-formatting)
- Make sure cell text is aligned and truncated as expected
- Review updated documentation:
  - https://vanilla-framework-3646.demos.haus/docs/base/tables#formatting

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="934" alt="Screenshot 2021-03-23 at 12 38 42" src="https://user-images.githubusercontent.com/83575/112140759-b7eca900-8bd4-11eb-85dc-767163252c8c.png">

