### PR TITLE
Add bottom margin to embedded-media, to match paragraph bottom margin

### DIFF
--- a/scss/_utilities_embedded-media.scss
+++ b/scss/_utilities_embedded-media.scss
@@ -4,6 +4,7 @@
 @mixin vf-u-embedded-media {
   .u-embedded-media {
     height: 0;
+    margin-bottom: $spv-outer--scaleable;
     margin-top: $spv-inner--small;
     max-width: 100%;
     overflow: hidden;


### PR DESCRIPTION
## Done

Added bottom margin to embedded media (which can be removed with the `u-no-margin--bottom` utility as necessary)

Fixes #3343 

## QA

- Open [demo](https://vanilla-framework-3647.demos.haus/docs/examples/utilities/embedded-media)
- Inspect the element, see that it has a bottom margin of 1.1rem

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
