### PR TITLE
Improvements to borders and box shadows

### DIFF
--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -5,7 +5,7 @@ $color-transparent: transparent !default;
 $color-x-light: #fff !default;
 $color-light: #f7f7f7 !default;
 $color-mid-x-light: #e5e5e5 !default;
-$color-mid-light: #cdcdcd !default;
+$color-mid-light: #d9d9d9 !default;
 $color-mid: #999 !default;
 $color-mid-dark: #666 !default;
 $color-dark: #111 !default;
@@ -83,7 +83,7 @@ $colors--light-theme--background-active: rgba($color-x-dark, $active-background-
 $colors--light-theme--background-hover: rgba($color-x-dark, $hover-background-opacity-amount) !default;
 $colors--light-theme--background-overlay: transparentize($color-dark, 0.15) !default;
 
-$colors--light-theme--border-default: rgba($color-x-dark, 0.2) !default;
+$colors--light-theme--border-default: rgba($color-x-dark, 0.15) !default;
 $colors--light-theme--border-high-contrast: rgba($color-x-dark, 0.56) !default;
 $colors--light-theme--border-low-contrast: rgba($color-x-dark, 0.1) !default;
 

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -6,4 +6,4 @@
 $bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
 $border-radius: $sp-unit * 0.25 !default;
 $border: 1px solid $color-mid-light !default;
-$box-shadow: 0 1px 5px 1px transparentize($color-dark, 0.8) !default;
+$box-shadow: 0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8) !default;

--- a/templates/docs/settings/placeholder-settings.md
+++ b/templates/docs/settings/placeholder-settings.md
@@ -10,12 +10,37 @@ context:
 
 Vanilla uses several global placeholders to share common styles between components. These placeholders can be edited via the following placeholder variables, assuming a `$sp-unit` of `0.5rem`.
 
-| Placeholder variable | Default value                                   | Use cases                                               |
-| -------------------- | ----------------------------------------------- | ------------------------------------------------------- |
-| `$bar-thickness`     | `3px`                                           | Navigation, notification                                |
-| `$border-radius`     | `2px`                                           | Button, Card, Code, Form, Media object, Switch, Tooltip |
-| `$border`            | `1px solid $color-mid-light`                    | Card, Code, Form, Search box                            |
-| `$box-shadow`        | `0 1px 5px 1px transparentize($color-dark, .8)` | Card (highlighted), Modal, Notification, Switch         |
+<table>
+  <thead>
+    <tr>
+      <th>Placeholder variable</th>
+      <th>Default value</th>
+      <th>Use cases</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>$bar-thickness</code></td>
+      <td><a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_settings_placeholders.scss#L6-L9"><code>0.1875rem</code></a></td>
+      <td>Navigation, notification</td>
+    </tr>
+    <tr>
+      <td><code>$border-radius</code></td>
+      <td><a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_settings_placeholders.scss#L6-L9"><code>$sp-unit * 0.25</code></a></td>
+      <td>Button, Card, Code, Form, Media object, Switch, Tooltip</td>
+    </tr>
+    <tr>
+      <td><code>$border</code></td>
+      <td><a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_settings_placeholders.scss#L6-L9"><code>1px solid $color-mid-light</code></a></td>
+      <td>Card, Code, Form, Search box</td>
+    </tr>
+    <tr>
+      <td><code>$box-shadow</code></td>
+      <td class="u-truncate"><a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_settings_placeholders.scss#L6-L9"><code>0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8)</code></a></td>
+      <td>Card (highlighted), Modal, Notification, Switch</td>
+    </tr>
+  </tbody>
+</table>
 
 ### Related
 


### PR DESCRIPTION
## Done

- Updates border color and box shadow values

Fixes #3492

## QA

- Open [demo](https://vanilla-framework-3648.demos.haus/docs)
- https://vanilla-framework-3648.demos.haus/docs/examples/patterns/card/highlighted
- https://vanilla-framework-3648.demos.haus/docs/examples/patterns/navigation/subnav
- https://vanilla-framework-3648.demos.haus/docs/examples/patterns/contextual-menu/default
- https://vanilla-framework-3648.demos.haus/docs/examples/patterns/modal/default
- https://vanilla-framework-3648.demos.haus/docs/examples/patterns/notifications/notifications
- https://vanilla-framework-3648.demos.haus/docs/examples/patterns/switch
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
