### PR TITLE
Document ability to add icon classes to anchor tags

### DIFF
--- a/templates/docs/examples/patterns/icons/icons-links.html
+++ b/templates/docs/examples/patterns/icons/icons-links.html
@@ -1,0 +1,9 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Icons / Links{% endblock %}
+
+{% block standalone_css %}patterns_icons{% endblock %}
+
+{% block content %}
+<a class="p-icon--github" href="https://github.com/canonical-web-and-design/vanilla-framework/">GitHub</a>
+<a class="p-icon--twitter" href="https://twitter.com/vanillaframewrk">Twitter</a>
+{% endblock %}

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -11,6 +11,10 @@ context:
 
 Icons provide visual context and enhance usability, they can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`.
 
+<div class="embedded-example"><a href="/docs/examples/patterns/icons/icons-light" class="js-example">
+View example of icons
+</a></div>
+
 ### Icons as links
 
 If an icon needs to act as a link, `p-icon--` classes can instead be applied to `<a>` elements:

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -9,7 +9,15 @@ context:
 
 <hr>
 
-Icons provide visual context and enhance usability, they can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`
+Icons provide visual context and enhance usability, they can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`.
+
+### Icons as links
+
+If an icon needs to act as a link, `p-icon--` classes can instead be applied to `<a>` elements:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/icons/icons-links" class="js-example">
+View example of icons as links
+</a></div>
 
 ### Accessibility
 


### PR DESCRIPTION
## Done

- Documented ability to set `p-icon--` classes on `a` elements

Fixes #3033 

## QA

- Open [demo](https://vanilla-framework-3650.demos.haus/docs/examples/patterns/icons/icons-links)
- Hover over the icons, see that no underline/text-decoration appears
- Review updated documentation:
  - [Icons docs](https://vanilla-framework-3650.demos.haus/docs/patterns/icons#icons-as-links)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
