### PR TITLE
Merge PR with master before running Percy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  build-tools: circleci/build-tools@2.9.0
 
 defaults: &defaults
   docker:
@@ -11,6 +14,14 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: Set up testing git repository
+          command: |
+            git config --global user.email "circleci@example.com"
+            git config --global user.name "CircleCI"
+            git checkout -b percy
+      - build-tools/merge-with-parent:
+          parent: master
       - run:
           # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
           name: Install puppeteer dependencies


### PR DESCRIPTION
## Done

Updates the CircleCI Percy job to run snapshots on PR merged to master branch, not a source branch.
This means we test the final result of merging.

## QA

- Check Percy for this PR
- It should only contain expected changes (Firefox bug)
- It should not contain any other changes (even though the PR branch is made from an old master)