### PR TITLE
Change width of medium application panel

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -262,7 +262,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
 
     @media (min-width: $breakpoint-x-small) {
       max-width: 100%;
-      width: 45.3rem; // ~col-8
+      width: 33.5rem; // ~col-6
 
       &.is-wide {
         width: $grid-max-width; // full grid width: ~col-12


### PR DESCRIPTION
## Done

Adjust the width of medium app panel to be 6 cols not 8.

Fixes #3655

## QA

- Open [demo](https://vanilla-framework-3656.demos.haus/docs/examples/layouts/application/structure)
- Make sure medium panel width is around 6 columns wide instead of 8

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
