### PR TITLE
Simplify external link icon example

### DIFF
--- a/templates/docs/examples/patterns/links/links-external-typography.html
+++ b/templates/docs/examples/patterns/links/links-external-typography.html
@@ -1,0 +1,27 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Links / External - Typography{% endblock %}
+
+{% block standalone_css %}patterns_links{% endblock %}
+
+{% block content %}
+<h1>
+    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</h1>
+<h2>
+    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+            NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</h2>
+<h3>
+    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+    NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</h3>
+<h4>
+    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</h4>
+<p>
+    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
+        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
+</p>
+{% endblock %}

--- a/templates/docs/examples/patterns/links/links-external.html
+++ b/templates/docs/examples/patterns/links/links-external.html
@@ -4,24 +4,5 @@
 {% block standalone_css %}patterns_links{% endblock %}
 
 {% block content %}
-<h1>
-    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</h1>
-<h2>
-    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-            NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</h2>
-<h3>
-    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-    NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</h3>
-<h4>
-    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</h4>
-<p>
-    <a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s
-        NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
-</p>
+<a href="#www.youtube.com/watch?v=Sv3Z_gbRVgQ" class="p-link--external">Listen to Nathan Rader – Canonical’s NFV Strategy Director – talking about OSM at the SDN NFV World Congress 2017</a>
 {% endblock %}


### PR DESCRIPTION
## Done

- Added simpler external link icon example in place of the existing one
- Renamed existing example to "Icons / External - Typography" so it's still being tracked by Percy

Fixes #3619 

## QA

- Open [external link docs](https://vanilla-framework-3657.demos.haus/docs/patterns/links#external)
- See that there is now just one link in the example
- Open [new example](https://vanilla-framework-3657.demos.haus/docs/examples/patterns/links/links-external-typography), see that it contains external links on heading elements

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels
