### PR TITLE
Add Vanilla-branded Suru to the website

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -84,25 +84,37 @@
   }
 }
 
+// gradient of the main suru slant
 $color-suru-start: lighten($color-brand, 10%) !default;
 $color-suru-middle: $color-brand !default;
 $color-suru-end: darken($color-brand, 10%) !default;
+
+// page background
+$color-suru-background: $color-x-light !default;
+
+// colors of suru slants on left right (for blend mode multiply)
+$color-suru-slant-right: rgba(205, 205, 205, 0.55) !default;
+$color-suru-slant-left: rgba(205, 205, 205, 0.55) !default;
+
+// fallback colors of suru slants (when blend mode multiply is not supported)
+$color-suru-slant-right-fallback: rgba(205, 205, 205, 0.14) !default;
+$color-suru-slant-left-fallback: rgba(205, 205, 205, 0.14) !default;
 
 @mixin vf-p-strip-suru {
   .p-strip--suru {
     @extend %vf-strip;
 
-    background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
-      linear-gradient(to bottom left, rgba(205, 205, 205, 0.14) 0%, rgba(205, 205, 205, 0.14) 49.8%, transparent 50%, transparent 100%),
+    background-image: linear-gradient(to bottom right, $color-suru-slant-left-fallback 0%, $color-suru-slant-left-fallback 49.8%, transparent 50%, transparent 100%),
+      linear-gradient(to bottom left, $color-suru-slant-right-fallback 0%, $color-suru-slant-right-fallback 49.8%, transparent 50%, transparent 100%),
       linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(to top right, #fff 0%, #fff 100%),
       linear-gradient(111deg, $color-suru-start 10%, $color-suru-middle 37%, $color-suru-end 100%);
 
     @supports (background-blend-mode: multiply) {
       background-blend-mode: multiply, multiply, normal, normal, normal;
-      background-image: linear-gradient(to bottom right, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),
-        linear-gradient(to bottom left, rgba(205, 205, 205, 0.55) 0%, rgba(205, 205, 205, 0.55) 49.8%, transparent 50%, transparent 100%),
-        linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%, transparent 100%), linear-gradient(#fff 0%, #fff 100%),
-        linear-gradient(111deg, $color-suru-start 10%, $color-suru-middle 37%, $color-suru-end 100%);
+      background-image: linear-gradient(to bottom right, $color-suru-slant-left 0%, $color-suru-slant-left 49.8%, transparent 50%, transparent 100%),
+        linear-gradient(to bottom left, $color-suru-slant-right 0%, $color-suru-slant-right 49.8%, transparent 50%, transparent 100%),
+        linear-gradient(to top right, $color-suru-background 0%, $color-suru-background 49%, transparent 50%, transparent 100%),
+        linear-gradient($color-suru-background 0%, $color-suru-background 100%), linear-gradient(111deg, $color-suru-start 10%, $color-suru-middle 37%, $color-suru-end 100%);
     }
 
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;

--- a/scss/docs/site.scss
+++ b/scss/docs/site.scss
@@ -3,6 +3,17 @@
 // settings
 $breakpoint-navigation-threshold: 900px;
 
+// colors for Vanilla-branded suru strips
+$color-brand: #d94b14;
+
+$color-suru-start: $color-brand;
+$color-suru-middle: $color-brand;
+$color-suru-end: $color-brand;
+
+$color-suru-slant-right: rgba(229, 229, 229, 0.5);
+$color-suru-slant-left: rgba(233, 84, 32, 0.2);
+$color-suru-slant-left-fallback: $color-suru-slant-left;
+
 // import vanilla
 @import '../build';
 


### PR DESCRIPTION
## Done

- Updates Vanilla website suru to use new colors
- Exposes more variables needed to customize Suru slant colors

Fixes canonical-web-and-design/vanilla-squad#995

## QA

- Open [demo](https://vanilla-framework-3660.demos.haus/)
- Check if the suru matches the design:
  - https://app.zeplin.io/project/605b80ed1c5bbb06d5c10fcf/screen/605b8131a94abf41743257c0
- Also check small suru on other pages:
  - https://vanilla-framework-3660.demos.haus//accessibility
 
### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1803" alt="Screenshot 2021-03-25 at 13 43 04" src="https://user-images.githubusercontent.com/83575/112474535-0c785b80-8d70-11eb-979e-4e2098f19028.png">

