### PR TITLE
Document figure support on images

### DIFF
--- a/templates/docs/examples/patterns/image/caption.html
+++ b/templates/docs/examples/patterns/image/caption.html
@@ -1,0 +1,11 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Image / Caption{% endblock %}
+
+{% block standalone_css %}patterns_image{% endblock %}
+
+{% block content %}
+<figure>
+  <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/584903f3-iot-drone.png" alt="">
+  <figcaption>A drone in flight</figcaption>
+</figure>
+{% endblock %}

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -26,6 +26,14 @@ Add depth using our drop shadow around your image.
 View example of image with shadow
 </a></div>
 
+### Image with caption
+
+When an image needs a caption, it can be wrapped in a `<figure>` element, along with a `<figcaption>`.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/image/caption/" class="js-example">
+View example of image with a caption
+</a></div>
+
 ### Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

Added missing documentation for image/figure caption

Fixes #2930 

## QA

- Open [demo](https://vanilla-framework-3661.demos.haus/docs/examples/patterns/image/caption)
- See that the image has an associated caption, styled in italics
- Review updated documentation:
  - [Image docs](https://vanilla-framework-3661.demos.haus/docs/patterns/images)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
