### PR TITLE
Remove unnecessary example styling for app layout

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -294,38 +294,4 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   }
 
   @include vf-l-application-panels;
-
-  // minimal demo styling
-  // FIXME: this should be removed from framework SCSS
-  // (see https://github.com/canonical-web-and-design/vanilla-framework/issues/3199)
-  .l-application.app-demo {
-    & > .l-navigation-bar,
-    & > .l-navigation .l-navigation__drawer,
-    & > .l-main,
-    & > .l-aside,
-    & > .l-status {
-      padding: $spv-inner--large;
-    }
-
-    & > .l-navigation-bar,
-    & > .l-navigation .l-navigation__drawer {
-      background: $color-dark;
-      color: $colors--dark-theme--text-default;
-    }
-
-    & > .l-navigation-bar {
-      padding-bottom: $spv-inner--x-small;
-      padding-top: $spv-inner--x-small;
-    }
-
-    & > .l-aside {
-      background: $color-x-light;
-    }
-
-    & > .l-status {
-      background: $color-light;
-      padding-bottom: $spv-inner--small;
-      padding-top: $spv-inner--small;
-    }
-  }
 }

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -49,6 +49,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     grid-template-columns: min-content minmax(0, 1fr) minmax(0, min-content);
     grid-template-rows: min-content 1fr min-content;
     height: 100vh;
+    overflow: hidden; // make sure panels transformed off-screen don't make the layout scroll
     width: 100vw;
   }
 

--- a/templates/docs/examples/layouts/application/structure.html
+++ b/templates/docs/examples/layouts/application/structure.html
@@ -4,6 +4,17 @@
 {% block style %}
 <style>
   body { margin: 0; }
+
+  /* example structure styling to make panels visible */
+  .app-demo > .l-navigation-bar,
+  .app-demo > .l-main,
+  .app-demo > .l-navigation .l-navigation__drawer,
+  .app-demo > .l-aside,
+  .app-demo > .l-status {
+    padding: 0.5rem;
+    background-color: #fff;
+    border: 1px solid #d9d9d9;
+  }
 </style>
 {% endblock %}
 
@@ -20,7 +31,7 @@
         <button class="js-menu-close is-dense u-no-margin u-hide--medium">Close</button>
       </p>
 
-      <code class="is-dark">l-navigation &gt;<br> l-navigation__drawer</code>
+      <code>l-navigation &gt;<br> l-navigation__drawer</code>
     </div>
   </header>
 

--- a/templates/docs/examples/layouts/application/structure.html
+++ b/templates/docs/examples/layouts/application/structure.html
@@ -11,9 +11,9 @@
   .app-demo > .l-navigation .l-navigation__drawer,
   .app-demo > .l-aside,
   .app-demo > .l-status {
-    padding: 0.5rem;
     background-color: #fff;
     border: 1px solid #d9d9d9;
+    padding: 0.5rem;
   }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Done

Remove unnecessary example styling for app layout

Fixes #3575 

## QA

- Open [demo](https://vanilla-framework-3669.demos.haus/docs/examples/layouts/application/structure)
- Verify that app layout structure example looks ok on various screen sizes

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1293" alt="Screenshot 2021-03-26 at 13 50 38" src="https://user-images.githubusercontent.com/83575/112633951-47df5c80-8e3a-11eb-8de6-4c7a918ffd6b.png">

