### PR TITLE
Remove aliceOS logo from home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -151,24 +151,20 @@
     <h2 class="p-muted-heading u-align-text--center">Who&rsquo;s using Vanilla</h2>
   </div>
   <div class="row">
-    <div class="col-small-2 col-medium-2 col-2">
+    <div class="col-small-2 col-medium-3 col-2 col-start-large-3 u-align--center">
       <a href="https://ubuntu.com">
         <img class="b-lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/5a8a0172-2018-logo-ubuntu.svg" alt="Ubuntu" /></a>
     </div>
-    <div class="col-small-2 col-medium-2 col-2">
+    <div class="col-small-2 col-medium-3 col-2 u-align--center">
       <a href="https://jaas.ai">
         <img class="b-lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg" alt="JAAS" />
       </a>
     </div>
-    <div class="col-small-2 col-medium-2 col-2">
-      <a href="https://docs.aliceos.app/master/index.html">
-        <img class="b-lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/07efa0fc-2019-alice-os-logo.svg" alt="AliceOS" /></a>
-    </div>
-    <div class="col-small-2 col-medium-2 col-2">
+    <div class="col-small-2 col-medium-3 col-2 u-align--center">
       <a href="https://stmargarets.london/">
         <img class="b-lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/b7c9c8ce-2019-st-margarets-logo.svg" alt="St Margarets" /></a>
     </div>
-    <div class="col-small-2 col-medium-2 col-2">
+    <div class="col-small-2 col-medium-3 col-2 u-align--center">
       <a href="https://snapcraft.io">
         <img class="b-lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/35cbab33-2018-logo-snapcraft.svg" alt="Snapcraft" /></a>
     </div>


### PR DESCRIPTION
## Done

Removes aliceOS logo from home page (as they don't use Vanilla anymore).

## QA

- Open [demo](https://vanilla-framework-3672.demos.haus)
- Check "Who is using Vanilla" logos. AliceOS should not be there. Logos should be centered and look well on all screen widths.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1185" alt="Screenshot 2021-03-29 at 12 11 47" src="https://user-images.githubusercontent.com/83575/112822272-0512c400-9088-11eb-87d2-e1cffedbb5ce.png">

