### PR TITLE
Increase the transparency on the background of the modal

### DIFF
--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -3,7 +3,7 @@
 @mixin vf-p-modal {
   .p-modal {
     align-items: center;
-    background: transparentize($color-dark, 0.15);
+    background: transparentize($color-dark, 0.5);
     bottom: 0;
     display: flex;
     height: 100vh;


### PR DESCRIPTION
## Done

Increased the transparency of the background of the modal. This is done as sometimes it's important to see the context below the modal as per the screenshot below and 0.85 was too dark. 

## QA

- Open [demo](insert-demo-url)
- View the modal, is the background lighter now?

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

## Screenshots

![III  App - Unit - Panel Action - Confirm action](https://user-images.githubusercontent.com/532033/112875522-89ae1400-9081-11eb-95c7-816701b5bfef.png)
