### PR TITLE
Add footer to modal dialog

### DIFF
--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -82,4 +82,11 @@
       outline: $bar-thickness solid $color-focus;
     }
   }
+
+  .p-modal__footer {
+    @extend %vf-pseudo-border--top;
+
+    padding-top: 1rem;
+    text-align: right;
+  }
 }

--- a/scss/standalone/patterns_modal.scss
+++ b/scss/standalone/patterns_modal.scss
@@ -4,6 +4,10 @@
 // used in the example
 @import '../patterns_heading-icon';
 @include vf-p-heading-icon;
+@import '../patterns_buttons';
+@include vf-button-negative;
+@import '../utilities_margin-collapse';
+@include vf-u-margin-collapse;
 
 @import '../patterns_modal';
 @include vf-p-modal;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -74,7 +74,7 @@
               {{ side_nav_item("/docs/patterns/lists", "Lists") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
-              {{ side_nav_item("/docs/patterns/modal", "Modal") }}
+              {{ side_nav_item("/docs/patterns/modal", "Modal", "updated") }}
               {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
               {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
               {{ side_nav_item("/docs/patterns/notification", "Notifications") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,12 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.28 -->
     <tr>
+      <th><a href="/docs/patterns/modal">Modal footer</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.28.0</td>
+      <td>We added the optional footer to the modal pattern.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/base/tables#empty">Table - empty</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.28.0</td>

--- a/templates/docs/examples/patterns/modal/default.html
+++ b/templates/docs/examples/patterns/modal/default.html
@@ -7,7 +7,7 @@
 <button id="showModal" aria-controls="modal">Show modal&hellip;</button>
 
 <div class="p-modal" id="modal">
-  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+  <section class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">Help</h2>
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
@@ -23,7 +23,7 @@
         <p><a class="p-heading-icon__title" href="#tutorial/get-started-hadoop-spark">Hadoop Spark tutorial</a></p>
       </div>
     </div>
-  </div>
+  </section>
 </div>
 
 <script>

--- a/templates/docs/examples/patterns/modal/footer.html
+++ b/templates/docs/examples/patterns/modal/footer.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Modal / With footer{% endblock %}
+
+{% block standalone_css %}patterns_modal{% endblock %}
+
+{% block content %}
+<button id="showModal" aria-controls="modal">Show modal&hellip;</button>
+
+<div class="p-modal" id="modal">
+  <section class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="modal-title">Confirm delete</h2>
+      <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
+    </header>
+    <p>Are you sure you want to delete user "Simon"? This action is permanent and can not be undone.</p>
+    <footer class="p-modal__footer">
+      <button class="u-no-margin--bottom" aria-controls="modal">Cancel</button>
+      <button class="p-button--negative u-no-margin--bottom">Delete</button>
+    </footer>
+  </section>
+</div>
+
+<script>
+  {% include 'docs/examples/patterns/modal/_script.js' %}
+</script>
+{% endblock %}

--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -16,6 +16,12 @@ On `p-modal` set display to `display:flex` or `display:none` to toggle the visib
 View example of the modal pattern
 </a></div>
 
+Optional footer element with a `p-modal__footer` class name can be added to the modal dialog to provide additional options.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/modal/footer/" class="js-example" data-height="400">
+View example of the modal with a footer
+</a></div>
+
 ### Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

Adds styling for modal dialog footer (as per React components).
Drive-by: fix unnecessary scrollbars in modal #3674

Part of canonical-web-and-design/react-components#411
Fixes #3674

## QA

- Open [demo](https://vanilla-framework-3676.demos.haus/docs/examples/patterns/modal/footer)
- Check if modal with footer renders as expected
- Make sure scroll bars don't appear in modal when not needed
- Check if modal can be scrolled when necessary: https://vanilla-framework-3676.demos.haus/docs/examples/patterns/modal/modal-scroll
- Review updated documentation:
  - https://vanilla-framework-3676.demos.haus/docs/patterns/modal

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="816" alt="Screenshot 2021-03-31 at 08 52 26" src="https://user-images.githubusercontent.com/83575/113106298-e38a1780-9202-11eb-8829-4dafe675e6e3.png">

