### PR TITLE
Change modal dialog overflow to auto

### DIFF
--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -28,7 +28,7 @@
     margin-bottom: 0;
     max-height: calc(100% - #{2 * $spv-inner--large});
     max-width: $grid-max-width;
-    overflow: scroll;
+    overflow: auto;
     position: absolute;
     right: $sph-inner--large;
     top: $spv-inner--large;


### PR DESCRIPTION
## Done

Set `overflow: auto` on `p-modal__dialog`, previously it was set to `scroll`, and would show empty scrollbars on some browser/OS combos.

Fixes #3674 

## QA

- Open each of the modal examples in Vanilla:
  - [default modal](https://vanilla-framework-3678.demos.haus/docs/examples/patterns/modal/default)
  - [scrollable modal](https://vanilla-framework-3678.demos.haus/docs/examples/patterns/modal/modal-scroll)
  - [z-index template](https://vanilla-framework-3678.demos.haus/docs/examples/templates/z-index)
- See that each of them only show scroll bars when there is content that needs to scroll

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
