### PR TITLE
Increase z-index on tooltips

### DIFF
--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -20,14 +20,18 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
         text-decoration: initial;
       }
     }
+
+    &.is-detached {
+      display: inline;
+      position: absolute;
+    }
   }
 
   .p-tooltip {
     @extend %tooltip;
   }
 
-  .p-tooltip__message,
-  .p-tooltip--detached {
+  .p-tooltip__message {
     @extend %small-text;
 
     background-color: $color-dark;
@@ -46,6 +50,10 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
     transform: translateX(0%) translateY(13px);
     white-space: pre;
     z-index: 11; // one step above p-navigation's z-index
+
+    .is-detached & {
+      display: block;
+    }
 
     // tooltip
     &::before {
@@ -74,10 +82,6 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
       right: 0;
       top: -2 * $triangle-height;
     }
-  }
-
-  .p-tooltip--detached {
-    display: block;
   }
 
   // Bottom center tooltip

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -45,7 +45,7 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
     -webkit-transform: translateX(0%) translateY(13px); // stylelint-disable-line property-no-vendor-prefix
     transform: translateX(0%) translateY(13px);
     white-space: pre;
-    z-index: 1;
+    z-index: 11; // one step above p-navigation's z-index
 
     // tooltip
     &::before {

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -22,7 +22,7 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
     }
 
     &.is-detached {
-      display: inline;
+      display: block;
       position: absolute;
     }
   }

--- a/scss/standalone/patterns_tooltips.scss
+++ b/scss/standalone/patterns_tooltips.scss
@@ -3,3 +3,6 @@
 
 @import '../patterns_tooltips';
 @include vf-p-tooltips;
+
+@import '../utilities_hide';
+@include vf-u-hide;

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -39,7 +39,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <th><a href="/docs/patterns/tooltips#detached">Tooltips - detached</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.28.0</td>
-      <td>We added the <code>.p-tooltip--detached</code> variant, providing a way for tooltips to exist separately from their associated element.</td>
+      <td>We added the <code>.is-detached</code> utility, providing a way for tooltips to exist separately from their associated element.</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/examples/patterns/tooltips/_tooltips_script.js
+++ b/templates/docs/examples/patterns/tooltips/_tooltips_script.js
@@ -1,15 +1,39 @@
-function setTooltipPosition(tooltip, x, y) {
-  // offset the tooltip so it
-  // isn't obscured by the cursor
-  var offset = 20;
+function getTooltipPlacement(tooltip) {
+  var placement = 'btm-left';
 
-  tooltip.style.left = x - offset + 'px';
-  tooltip.style.top = y + offset + 'px';
+  tooltip.classList.forEach(function (className) {
+    if (className.startsWith('p-tooltip--')) {
+      placement = className.replace('p-tooltip--', '');
+    }
+  });
+
+  return placement;
 }
 
-function handleTooltipEvents(tooltip) {
-  var trigger = document.querySelector('[aria-describedby="' + tooltip.getAttribute('id') + '"]');
+function setTooltipPosition(tooltip, cursorX, cursorY) {
+  var placement = getTooltipPlacement(tooltip);
 
+  // FOR VANILLA EXAMPLE ONLY:
+  // this example only covers two tooltip positions
+
+  // offset the tooltip x and y position
+  // so it isn't obscured by the cursor
+  switch (placement) {
+    case 'btm-center':
+      tooltipX = cursorX + 8;
+      tooltipY = cursorY + 20;
+      break;
+    default:
+      tooltipX = cursorX - 12;
+      tooltipY = cursorY + 20;
+      break;
+  }
+
+  tooltip.style.left = tooltipX + 'px';
+  tooltip.style.top = tooltipY + 'px';
+}
+
+function handleTooltipEvents(tooltip, trigger) {
   trigger.addEventListener('mouseenter', function (e) {
     // remove this class on mouseenter,
     // rather than unnecessarily on mousemove
@@ -21,19 +45,22 @@ function handleTooltipEvents(tooltip) {
     setTooltipPosition(tooltip, e.x, e.y);
   });
 
-  trigger.addEventListener('mouseout', function () {
-    tooltip.classList.add('u-hide');
+  trigger.addEventListener('mouseout', function (e) {
+    if (e.target.parentNode !== trigger) {
+      tooltip.classList.add('u-hide');
+    }
   });
 }
 
 function initTooltips(selector) {
-  var tooltips = [].slice.call(document.querySelectorAll(selector));
+  var tooltipContainers = [].slice.call(document.querySelectorAll(selector));
 
-  tooltips.forEach(function (tooltip) {
-    handleTooltipEvents(tooltip);
+  tooltipContainers.forEach(function (container) {
+    var trigger = document.querySelector("[aria-describedby='" + container.getAttribute('id') + "']");
+    handleTooltipEvents(container, trigger);
   });
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  initTooltips('.p-tooltip--detached');
+  initTooltips('.is-detached');
 });

--- a/templates/docs/examples/patterns/tooltips/_tooltips_script.js
+++ b/templates/docs/examples/patterns/tooltips/_tooltips_script.js
@@ -1,32 +1,15 @@
-function getTooltipPlacement(tooltip) {
-  var placement = 'btm-left';
-
-  tooltip.classList.forEach(function (className) {
-    if (className.startsWith('p-tooltip--')) {
-      placement = className.replace('p-tooltip--', '');
-    }
-  });
-
-  return placement;
-}
-
 function setTooltipPosition(tooltip, cursorX, cursorY) {
-  var placement = getTooltipPlacement(tooltip);
-
   // FOR VANILLA EXAMPLE ONLY:
   // this example only covers two tooltip positions
 
   // offset the tooltip x and y position
   // so it isn't obscured by the cursor
-  switch (placement) {
-    case 'btm-center':
-      tooltipX = cursorX + 8;
-      tooltipY = cursorY + 20;
-      break;
-    default:
-      tooltipX = cursorX - 12;
-      tooltipY = cursorY + 20;
-      break;
+  if (tooltip.classList.contains('p-tooltip--btm-center')) {
+    tooltipX = cursorX + 8;
+    tooltipY = cursorY + 20;
+  } else {
+    tooltipX = cursorX - 12;
+    tooltipY = cursorY + 20;
   }
 
   tooltip.style.left = tooltipX + 'px';
@@ -62,5 +45,5 @@ function initTooltips(selector) {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  initTooltips('.is-detached');
+  initTooltips('[class*="p-tooltip"].is-detached');
 });

--- a/templates/docs/examples/patterns/tooltips/detached.html
+++ b/templates/docs/examples/patterns/tooltips/detached.html
@@ -4,11 +4,21 @@
 {% block standalone_css %}patterns_tooltips{% endblock %}
 
 {% block content %}
-<button aria-describedby="default-tooltip">
-  Moves with cursor
+<button aria-describedby="tooltip1">
+  UA Infrastructure - Standard
 </button>
 
-<span class="p-tooltip--detached u-hide" role="tooltip" id="default-tooltip">Product name to be displayed on the storefront.</span>
+<div class="p-tooltip is-detached u-hide" id="tooltip1">
+  <span class="p-tooltip__message" role="tooltip">Support level: 24 hours, 5 days a week</span>
+</div>
+
+<button aria-describedby="tooltip2">
+  UA Infrastructure - Advanced
+</button>
+
+<div class="p-tooltip--btm-center is-detached u-hide" id="tooltip2">
+  <span class="p-tooltip__message" role="tooltip">Support level: 24 hours, 7 days a week</span>
+</div>
 
 <script>
   {% include 'docs/examples/patterns/tooltips/_tooltips_script.js' %}

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -83,6 +83,11 @@
 <div class="p-stripe is-shallow">
   <button id="showModal" aria-controls="modal">Show modal&hellip;</button>
 
+  <button class="p-tooltip--top-left" aria-describedby="zindex-tooltip">
+    Tooltip
+    <span class="p-tooltip__message" role="tooltip" id="zindex-tooltip">This tooltip appears above other elements.</span>
+  </button>
+
   <p>
     Lorem ipsum dolor sit amet consectetur adipiscing elit
     <span class="p-contextual-menu--left">

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -83,10 +83,14 @@
 <div class="p-stripe is-shallow">
   <button id="showModal" aria-controls="modal">Show modal&hellip;</button>
 
-  <button class="p-tooltip--top-left" aria-describedby="zindex-tooltip">
+  <button aria-describedby="zindex-tooltip">
     Tooltip
-    <span class="p-tooltip__message" role="tooltip" id="zindex-tooltip">This tooltip appears above other elements.</span>
   </button>
+
+  <!-- make visible and hardcode the initial position of the tooltip so Percy can snapshot it -->
+  <div class="p-tooltip is-detached" id="zindex-tooltip" style="left: 212px; top: 140px;">
+    <span class="p-tooltip__message" role="tooltip">This excessively long tooltip appears above other elements.</span>
+  </div>
 
   <p>
     Lorem ipsum dolor sit amet consectetur adipiscing elit
@@ -192,5 +196,8 @@
 
 <script>
   {% include 'docs/examples/patterns/modal/_script.js' %}
+</script>
+<script>
+  {% include 'docs/examples/patterns/tooltips/_tooltips_script.js' %}
 </script>
 {% endblock %}

--- a/templates/docs/patterns/tooltips.md
+++ b/templates/docs/patterns/tooltips.md
@@ -25,7 +25,7 @@ View example of the tooltips pattern
 
 ### Detached
 
-In some cases you may need the tooltip element to exist outside of the element it is a tooltip for, in which case you can use the `p-tooltip--detached` class with the `u-hide` utility, and JavaScript to set the desired position of the tooltip.
+In some cases you may need the tooltip element to exist outside of the element it is a tooltip for, in which case you can use the `is-detached` utility with the `u-hide` utility, and JavaScript to set the desired position of the tooltip.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tooltips/detached"  data-height="120" class="js-example">
 View example of the detached tooltips pattern

--- a/templates/docs/patterns/tooltips.md
+++ b/templates/docs/patterns/tooltips.md
@@ -25,7 +25,7 @@ View example of the tooltips pattern
 
 ### Detached
 
-In some cases you may need the tooltip element to exist outside of the element it is a tooltip for, in which case you can use the `is-detached` utility with the `u-hide` utility, and JavaScript to set the desired position of the tooltip.
+In some cases you may need the tooltip element to exist outside of the element it is a tooltip for, in which case you can use the `is-detached` class with the `u-hide` utility, and JavaScript to set the desired position of the tooltip.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tooltips/detached"  data-height="120" class="js-example">
 View example of the detached tooltips pattern


### PR DESCRIPTION
## Done

Increased z-index on tooltips, so that they sit above most other elements.
Drive by: changed the `p-tooltip--detached` modifier class to a `is-detached` utility, so that detached tooltips are able to support positioning the tooltip arrow using existing classes i.e. `p-tooltip--top-center`

Fixes #3668 

## QA

- Open [demo](https://vanilla-framework-3679.demos.haus/docs/examples/templates/z-index)
- Hover over the "Tooltip" button, see that the tooltip is visible on top of neighboring elements.
- Open [detached example](https://vanilla-framework-3679.demos.haus/docs/examples/patterns/tooltips/detached)
- Hover over the buttons, see that the tooltips appear.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Screenshot from 2021-03-31 14-25-06](https://user-images.githubusercontent.com/2376968/113151379-eb5eb180-922c-11eb-8565-247aa4e104cc.png)

