### PR TITLE
Fix spacing around chips in search and filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.28.0-rc1",
+  "version": "2.28.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -21,6 +21,8 @@
       margin: 0;
       min-height: $height;
       overflow: hidden;
+      padding-left: $spv-outer--small;
+      padding-right: $sp-x-large; // reserve space for selected counter
       position: relative;
 
       &[data-active='true'] {
@@ -51,10 +53,6 @@
         .p-search-and-filter__selected-count {
           display: none;
         }
-      }
-
-      .p-search-and-filter__box {
-        flex-grow: 1;
       }
     }
 
@@ -112,8 +110,10 @@
     .p-search-and-filter__input {
       border: 0;
       box-shadow: none;
+      flex-grow: 1;
       margin-bottom: 0;
-      margin-right: -$spv-outer--shallow-scaleable;
+      margin-left: -$spv-outer--small; // compensate for the left padding of the container
+      margin-right: -$sp-x-large; // compensate for the space reserved for counter
       min-height: 2.25rem;
       min-width: 6rem;
       padding: $spv-inner--small;


### PR DESCRIPTION
## Done

Fix spacing around chips in the search and filter component.

Fixes #3680

## QA

- Open [demo](https://vanilla-framework-3687.demos.haus/docs/examples/patterns/search-and-filter/chip-overflow)
  - check if there is a small padding on the left between the border and first chip
  - make sure there is enough right padding for the "+2" counter not to overflow the last chip visible
- Open example without chips in search field: https://vanilla-framework-3687.demos.haus/docs/examples/patterns/search-and-filter/default
  - make sure the left/right padding doesn't affect the search field (focus should be around whole field)
- compare with current react component: https://canonical-web-and-design.github.io/react-components/?path=/story/search-and-filter--default-story

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1018" alt="Screenshot 2021-04-06 at 14 34 30" src="https://user-images.githubusercontent.com/83575/113711493-4b4dd000-96e5-11eb-89d0-d384f9aeb7dd.png">
<img width="1025" alt="Screenshot 2021-04-06 at 14 34 46" src="https://user-images.githubusercontent.com/83575/113711492-4ab53980-96e5-11eb-9485-6cda7437ede0.png">

<img width="1030" alt="Screenshot 2021-04-06 at 14 34 54" src="https://user-images.githubusercontent.com/83575/113711485-48eb7600-96e5-11eb-946a-1d8553615412.png">

