### PR TITLE
Update docs with guidance on using tooltips with disabled elements

### DIFF
--- a/templates/docs/patterns/tooltips.md
+++ b/templates/docs/patterns/tooltips.md
@@ -10,12 +10,17 @@ context:
 
 Tooltips are text labels that appear when the user hovers over, focuses on, or touches an element on the screen.
 
-- They can be used to provide information about concepts/terms/actions that are not self-explanatory or well known.
-- An alternative use of tooltips is to provide information on a disabled actionable element, e.g. for disabled buttons, providing information about why they are disabled.
+They can be used to provide information about concepts/terms/actions that are not self-explanatory or well known.
 
 <div class="p-notification--caution">
   <p class="p-notification__response">
     <span class="p-notification__status">Avoid:</span>Using tooltips to provide instructions or guidance. They shouldn't be used to show rich information including images and formatted text and avoid placing over plain text or other places where they are not discoverable.
+  </p>
+</div>
+
+<div class="p-notification--caution">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Avoid:</span>Tooltips shouldn't be used on disabled elements, such as buttons. It should be clear to the user why the button is disabled, without the tooltip needing to be revealed first.
   </p>
 </div>
 


### PR DESCRIPTION
## Done

- Updated tooltips documentation to advise against using tooltips on disabled elements
- Added a follow up issue regarding potentially creating a new pattern to inform users why an element is disabled https://github.com/canonical-web-and-design/vanilla-framework/issues/3690

Fixes #2180 

## QA

- Open [demo](https://vanilla-framework-3689.demos.haus/docs/patterns/tooltips)
- Read the second caution notification, see that it makes sense

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
