### PR TITLE
Add right padding to modal header to accommodate close button

### DIFF
--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -1,6 +1,8 @@
 @import 'settings';
 
 @mixin vf-p-modal {
+  $icon-size: map-get($icon-sizes, default);
+
   .p-modal {
     align-items: center;
     background: transparentize($color-dark, 0.15);
@@ -49,6 +51,8 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: $spv-inner--small;
+    // add padding to accommodate the width of p-modal__close
+    padding-right: $icon-size + $sph-inner--small * 2;
   }
 
   .p-modal__title {
@@ -58,8 +62,6 @@
   }
 
   .p-modal__close {
-    $icon-size: map-get($icon-sizes, default);
-
     background: {
       image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='90' width='90'%3E%3Cg color='%23000'%3E%3Cpath fill='none' d='M0 0h90v90H0z'/%3E%3Cpath d='M14.52 6L6 14.52 36.48 45 6 75.49 14.52 84 45 53.52 75.48 84 84 75.49 53.52 45 84 14.52 75.48 6 45 36.49z' fill='%23888'/%3E%3C/g%3E%3C/svg%3E");
       position: center;


### PR DESCRIPTION
## Done

Added right padding to `p-modal__header` to prevent the `p-modal__close` element overlapping the heading.

Fixes #3639 

## QA

- Open [demo](https://vanilla-framework-3691.demos.haus/docs/examples/patterns/modal/footer)
- Reduce the width of the browser window, see that the title of the modal is never obscured by the close button
  - Compare to [staging](https://staging.vanillaframework.io/docs/examples/patterns/modal/footer)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
