### PR TITLE
Update p-stepped-list__title to allow child elements

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -17,10 +17,8 @@ $spv-list-item--inner: null;
   }
 
   %numbered-step-title {
-    display: flex;
     list-style: none;
     margin-left: 0;
-    padding-left: 0;
 
     &::before {
       align-self: start;
@@ -30,6 +28,8 @@ $spv-list-item--inner: null;
       counter-increment: li;
       direction: rtl;
       display: block;
+      left: 0;
+      position: absolute;
       text-align: center;
     }
   }
@@ -260,8 +260,13 @@ $spv-list-item--inner: null;
     }
 
     h#{$i}.p-stepped-list__title {
+      padding-left: $bullet-width-mobile + $sph-inner;
+
+      @media (min-width: $breakpoint-heading-threshold) {
+        padding-left: $bullet-width + $sph-inner;
+      }
+
       &::before {
-        flex-shrink: 0;
         margin-right: $sph-inner;
         width: $bullet-width-mobile;
 

--- a/templates/docs/examples/patterns/lists/lists-stepped-detailed.html
+++ b/templates/docs/examples/patterns/lists/lists-stepped-detailed.html
@@ -25,4 +25,11 @@
     </h3>
     <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
   </li>
+
+  <li class="p-stepped-list__item">
+    <h3 class="p-stepped-list__title">
+      Design and&nbsp;<strong>build</strong>
+    </h3>
+    <p class="p-stepped-list__content">Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. We'll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we'll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
+  </li>
 {% endblock %}

--- a/templates/docs/examples/patterns/lists/lists-stepped.html
+++ b/templates/docs/examples/patterns/lists/lists-stepped.html
@@ -25,6 +25,13 @@
     </h3>
     <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
   </li>
+
+  <li class="p-stepped-list__item">
+    <h3 class="p-stepped-list__title">
+      Design and&nbsp;<strong>build</strong>
+    </h3>
+    <p class="p-stepped-list__content">Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. We'll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we'll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
+  </li>
 </ol>
 
 <ol class="p-stepped-list">
@@ -47,6 +54,13 @@
       Credentials and SSH keys
     </h4>
     <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
+  </li>
+
+  <li class="p-stepped-list__item">
+    <h4 class="p-stepped-list__title">
+      Design and&nbsp;<strong>build</strong>
+    </h4>
+    <p class="p-stepped-list__content">Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. We'll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we'll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
   </li>
 </ol>
 {% endblock %}


### PR DESCRIPTION
## Done

Changed p-stepped-list__title to not use `display: flex;` so child elements don't cause layout problems

Fixes #2518 

## QA

- Open [demo](https://vanilla-framework-3694.demos.haus/docs/examples/patterns/lists/lists-stepped)
- Reduce the width of your browser until the fourth item "Design and Build" begins to wrap. It should wrap as expected, unlike https://codepen.io/sowasred2012/pen/xxgXvQg

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
