### PR TITLE
Print size of build file in CI logs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,8 @@ jobs:
       - run: yarn test
       - name: Check if import test file exists but is empty
         run: test -f build/css/standalone/import.css -a ! -s build/css/standalone/import.css
+      - name: Show size of the build file
+        run: stat -c '%s' build/css/build.css
 
   dart:
     name: Test build with dart-sass

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -20,6 +20,8 @@ jobs:
       - run: yarn install
       - run: yarn build
       - run: yarn test
+      - name: Show size of the build file
+        run: stat -c '%s' build/css/build.css
       - run: cp VANILLA_VERSION build/css
       - uses: actions/upload-artifact@v2
         with:
@@ -48,7 +50,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: css
-          path: css 
+          path: css
       - name: Install upload-assets snap
         run: sudo snap install upload-assets
       - name: Upload to assets server


### PR DESCRIPTION
## Done

Before we implement better automated ways of doing this we can at least print the size of the CSS file in CI logs, so they are easier to check.



## QA

- Check the 'Test' CI job, it should print build.css file size in logs

<img width="592" alt="Screenshot 2021-04-08 at 14 43 41" src="https://user-images.githubusercontent.com/83575/114028506-d6ab9a80-9878-11eb-8990-6f8355cc1d34.png">
