### PR TITLE
Update the style of back to top link

### DIFF
--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -39,7 +39,6 @@
   .p-top {
     align-items: center;
     display: flex;
-    margin-top: -$spv-outer--scaleable;
 
     &::before {
       border-bottom: 1px solid $colors--light-theme--border-default;
@@ -59,7 +58,7 @@
 
   .p-top__link {
     color: $color-dark;
-    padding: 0 $sph-inner--small;
+    padding: 0 $sph-inner--small 0 $sph-inner;
     text-decoration: none;
   }
 }

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -37,20 +37,30 @@
   }
 
   .p-top {
-    border-bottom: 1px dotted $color-mid-light;
-    clear: both;
-    margin: 20px 0;
+    align-items: center;
+    display: flex;
+    margin-top: -$spv-outer--scaleable;
+
+    &::before {
+      border-bottom: 1px solid $colors--light-theme--border-default;
+      content: '';
+      flex-grow: 1;
+      margin: $spv-outer--scaleable 0 calc(#{$spv-outer--scaleable} - 1px) 0;
+    }
+
+    &::after {
+      @extend %icon;
+      @include vf-icon-back-to-top($color-mid-dark);
+
+      content: '';
+      margin-right: $sph-inner--small;
+    }
   }
 
   .p-top__link {
-    background: $color-x-light;
     color: $color-dark;
-    float: right;
-    margin-right: 5px;
-    padding: 0 5px;
-    position: relative;
+    padding: 0 $sph-inner--small;
     text-decoration: none;
-    top: -0.725rem;
   }
 }
 


### PR DESCRIPTION
## Done

Updates the style of back to top link to make sure it doesn't imply white background.

Fixes #3667

## QA

- Open [demo](https://vanilla-framework-3696.demos.haus/docs/examples/patterns/links/links-back-to-top)
- Make sure the updated link looks as expected (as per design in https://github.com/canonical-web-and-design/vanilla-framework/issues/3667#issuecomment-814931499)
- Change the body background to make sure it's not covered

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1061" alt="Screenshot 2021-04-08 at 16 01 14" src="https://user-images.githubusercontent.com/83575/114040194-ab7a7880-9883-11eb-8a48-2f8783e34a4c.png">

