### PR TITLE
Increase small text line height

### DIFF
--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -15,6 +15,7 @@
         thead {
           display: none;
         }
+
         tbody {
           display: grid;
           grid-gap: 0 map-get($grid-gutter-widths, small);

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -55,7 +55,7 @@ $nudges: (
   nudge--h4-mobile: 0.3rem,
   nudge--p: 0.4rem,
   nudge--p-ubuntumono: 0.45rem,
-  nudge--small: 0.2rem,
+  nudge--small: 0.05rem,
   nudge--x-small: 0.25rem,
 ) !default;
 

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -35,8 +35,8 @@ $line-heights: (
   h3-mobile: 4 * $sp-unit,
   h4-mobile: 3 * $sp-unit,
   default-text: 3 * $sp-unit,
-  small: $sp-unit * 2.5,
-  x-small: $sp-unit * 2,
+  small: 2.5 * $sp-unit,
+  x-small: 2 * $sp-unit,
 ) !default;
 
 // baseline nudges for type scale ratio of (16/14)^2

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -35,7 +35,7 @@ $line-heights: (
   h3-mobile: 4 * $sp-unit,
   h4-mobile: 3 * $sp-unit,
   default-text: 3 * $sp-unit,
-  small: $sp-unit * 2,
+  small: $sp-unit * 2.5,
   x-small: $sp-unit * 2,
 ) !default;
 

--- a/templates/docs/examples/base/small.html
+++ b/templates/docs/examples/base/small.html
@@ -5,4 +5,6 @@
 
 {% block content %}
 <small>This is some &lt;small&gt; text with a font size of 14 pixels.</small>
+
+<p class="p-text--small">This is a p.p-text--small with a font size of 14 pixels.</p>
 {% endblock %}


### PR DESCRIPTION
## Done

- Increased line height of %small-text placeholder to 1.25rem
- Added example of `p-text--small` to "small" example

Fixes #3482 
## QA

- Open [demo](https://vanilla-framework-3697.demos.haus/docs/examples/base/small)
- Reduce the width of your browser until the text wraps, see that the line height in the example is reasonable, and not too small.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
