### PR TITLE
Fix focus highlight states for tabs and side nav

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -40,7 +40,7 @@ Once the server is running, you can visit <http://0.0.0.0:8101/> in your browser
 
 The documentation for the latest version of Vanilla framework is hosted at <https://vanillaframework.io/docs>, and the documentation markdown files live in the [`docs` folder](/docs).
 
-The [examples directory](/docs/examples) contains example markup for each component of the framework, and these examples can be viewed in the browser at <http://0.0.0.0:8101/examples/>.
+The [examples directory](/docs/examples) contains example markup for each component of the framework, and these examples can be viewed in the browser at <http://0.0.0.0:8101/docs/examples/>.
 
 ## Adding new icons
 

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -202,7 +202,7 @@
 
     // vf-highlight-bar is rendered above focus outline
     // so we need to hide it on focus
-    &:focus::before {
+    &:focus-visible::before {
       display: none;
     }
 

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -202,8 +202,14 @@
 
     // vf-highlight-bar is rendered above focus outline
     // so we need to hide it on focus
-    &:focus-visible::before {
+    &:focus::before {
       display: none;
+    }
+
+    // Display the highlight when focussing in modern browsers that support
+    // focus-visible.
+    &:focus:not(:focus-visible)::before {
+      display: block;
     }
 
     &:hover {

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -77,7 +77,7 @@
       }
 
       // make sure tab strip border doesn't overlap focus outline
-      &:focus {
+      &:focus-visible {
         z-index: 1;
 
         &::before,
@@ -86,12 +86,14 @@
         }
       }
 
+      &:active,
+      &:focus,
       &:hover,
       &[aria-selected='true'] {
         @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
 
-        &:focus::before,
-        &:focus::after {
+        &:focus-visible::before,
+        &:focus-visible::after {
           content: none;
         }
       }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -77,7 +77,7 @@
       }
 
       // make sure tab strip border doesn't overlap focus outline
-      &:focus-visible {
+      &:focus {
         z-index: 1;
 
         &::before,
@@ -86,14 +86,27 @@
         }
       }
 
+      // Display the highlight when focussing in modern browsers that support
+      // focus-visible.
+      &:focus:not(:focus-visible) {
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
+      }
+
       &:active,
-      &:focus,
       &:hover,
       &[aria-selected='true'] {
         @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
 
-        &:focus-visible::before,
-        &:focus-visible::after {
+        // Display the highlight when focussing (in combination with the parent
+        // states) in modern browsers that support focus-visible.
+        &:focus:not(:focus-visible) {
+          @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
+        }
+
+        // Hide the highlight when focussing (in combination with the parent
+        // states) in browsers that don't support focus-visible.
+        &:focus::before,
+        &:focus::after {
           content: none;
         }
       }


### PR DESCRIPTION
## Done

- Fix tab highlights for focus and active so that the underline appears.
- Fix side nav highlights when focusing on the active link so that the left border appears.
- Drive-by update so the examples URL is correct in the hacking doc.

Fixes #3686.

## QA

- Go to https://vanilla-framework-3698.demos.haus/docs/examples/patterns/tabs
- Click on the active tab (Machine summary) and the underline should not disappear.
- Click on another tab, the underline should be visible for focus and active states.
- Use your keyboard to tab to the active tab, it should show the blue border and the underline should not be visible.
- Go to https://vanilla-framework-3698.demos.haus/docs/examples/patterns/side-navigation/docs
- Click on the active link (Commissioning and hardware testing scripts) and the border on the left should not disappear.
- Use your keyboard to tab to the active link, it should show the blue border and the left border should not be visible.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.

