### PR TITLE
Remove right arrow from tabs component

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.28.0",
+  "version": "2.28.1",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -10,27 +10,6 @@
     padding: 0;
     position: relative;
 
-    &::after {
-      background: linear-gradient(to right, $color-transparent 0%, $color-x-light 45%, $color-x-light 100%);
-      color: $color-mid-dark;
-      content: '\203A';
-      display: block;
-      font-size: 2rem;
-      line-height: calc(100% + 1rem - #{$bar-thickness});
-      padding-left: 1.5rem;
-      padding-right: $sp-large;
-      pointer-events: none;
-      position: absolute;
-      right: 0;
-      text-align: right;
-      top: 0;
-      width: 1rem;
-
-      @media (min-width: $breakpoint-medium) {
-        display: none;
-      }
-    }
-
     &__list {
       @extend %vf-pseudo-border--bottom;
 


### PR DESCRIPTION
## Done

- Removed the right arrow on the tabs component, based on [the conclusion](https://github.com/canonical-web-and-design/vanilla-framework/issues/3602#issuecomment-818564147) of a UX battle royale.
- Bumped version to 2.28.1

Fixes #3602 

## QA

- Open [demo](https://vanilla-framework-3702.demos.haus/docs/examples/patterns/tabs)
- Reduce the width of your browser so that the tabs overflow horizontally
- Scroll the tabs to the right, see that there is no right arrow obscuring the last tab (compare to [live](https://vanillaframework.io/docs/examples/patterns/tabs))

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
