### PR TITLE
Remove unnecessary p-slider class from the example

### DIFF
--- a/templates/docs/examples/patterns/slider/slider-input.html
+++ b/templates/docs/examples/patterns/slider/slider-input.html
@@ -6,7 +6,7 @@
 {% block content %}
 
 <div class="p-slider__wrapper">
-  <input class="p-slider"
+  <input
     type="range"
     min="0"
     max="100"
@@ -21,7 +21,7 @@
   tabindex="0">
 </div>
 <div class="p-slider__wrapper">
-  <input class="p-slider"
+  <input
     type="range"
     min="0"
     max="100"
@@ -97,7 +97,7 @@ function initSlider(slider) {
 }
 
 // Setup all sliders on the page.
-var sliders = document.querySelectorAll('.p-slider');
+var sliders = document.querySelectorAll('input[type=range]');
 
 for (var i = 0, l = sliders.length; i < l; i++) {
   initSlider(sliders[i]);


### PR DESCRIPTION
## Done

Remove unnecessary `p-slider` class from the example

Fixes #413

## QA

- Open [demo](https://vanilla-framework-3704.demos.haus/docs/examples/patterns/slider/slider-input)
- Check if slider renders correctly and doesn't have `p-slider` class on the input
- Check if JS works (slider and input should update together without errors)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


