### PR TITLE
Fix backround of buttons in contextual menu

### DIFF
--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -138,6 +138,7 @@
     &:active,
     &:hover,
     &:visited {
+      background-color: transparent;
       color: $color-contextual-menu-text;
     }
 

--- a/templates/docs/examples/patterns/contextual-menu/dark.html
+++ b/templates/docs/examples/patterns/contextual-menu/dark.html
@@ -5,19 +5,19 @@
 
 {% block content %}
 <span class="p-contextual-menu--left is-dark">
-    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
-    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
-        <span class="p-contextual-menu__group">
-            <a href="#" class="p-contextual-menu__link">Commission</a>
-            <a href="#" class="p-contextual-menu__link">Aquire</a>
-            <a href="#" class="p-contextual-menu__link">Deploy</a>
-        </span>
-        <span class="p-contextual-menu__group">
-            <a href="#" class="p-contextual-menu__link">Test harware</a>
-            <a href="#" class="p-contextual-menu__link">Rescue mode</a>
-            <a href="#" class="p-contextual-menu__link">Mark broken</a>
-        </span>
+  <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
+  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
+    <span class="p-contextual-menu__group">
+      <button class="p-contextual-menu__link">Commission</button>
+      <button class="p-contextual-menu__link">Aquire</button>
+      <button class="p-contextual-menu__link">Deploy</button>
     </span>
+    <span class="p-contextual-menu__group">
+      <button class="p-contextual-menu__link">Test harware</button>
+      <button class="p-contextual-menu__link">Rescue mode</button>
+      <button class="p-contextual-menu__link">Mark broken</button>
+    </span>
+  </span>
 </span>
 
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left is-dark">

--- a/templates/docs/examples/patterns/contextual-menu/default.html
+++ b/templates/docs/examples/patterns/contextual-menu/default.html
@@ -5,19 +5,19 @@
 
 {% block content %}
 <span class="p-contextual-menu--left">
-    <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
-    <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
-        <span class="p-contextual-menu__group">
-            <a href="#" class="p-contextual-menu__link">Commission</a>
-            <a href="#" class="p-contextual-menu__link">Aquire</a>
-            <a href="#" class="p-contextual-menu__link">Deploy</a>
-        </span>
-        <span class="p-contextual-menu__group">
-            <a href="#" class="p-contextual-menu__link">Test harware</a>
-            <a href="#" class="p-contextual-menu__link">Rescue mode</a>
-            <a href="#" class="p-contextual-menu__link">Mark broken</a>
-        </span>
+  <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
+  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
+    <span class="p-contextual-menu__group">
+      <button class="p-contextual-menu__link">Commission</button>
+      <button class="p-contextual-menu__link">Aquire</button>
+      <button class="p-contextual-menu__link">Deploy</button>
     </span>
+    <span class="p-contextual-menu__group">
+      <button class="p-contextual-menu__link">Test harware</button>
+      <button class="p-contextual-menu__link">Rescue mode</button>
+      <button class="p-contextual-menu__link">Mark broken</button>
+    </span>
+  </span>
 </span>
 
 <p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left">


### PR DESCRIPTION
## Done

Make sure buttons render correctly in contextual menu

Fixes #3705 

## QA

- Open [demo](https://vanilla-framework-3706.demos.haus/docs/examples/patterns/contextual-menu/dark)
- Open menu using "Take action" button, make sure that the items are buttons and look the same as in standard menu with links
- check the light theme as well:
  - https://vanilla-framework-3706.demos.haus/docs/examples/patterns/contextual-menu/default

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


