### PR TITLE
Update table mobile card design

### DIFF
--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -259,6 +259,11 @@ $box-offsets-top: (
 
         display: inline;
         padding-top: 0;
+
+        .p-checkbox__label {
+          // color: $colors--light-theme--text-muted !important;
+          color: pink !important;
+        }
       }
 
       &.is-table-header {
@@ -472,6 +477,10 @@ $box-offsets-top: (
         }
       }
     }
+  }
+
+  .p-muted-heading .p-checkbox__label {
+    color: $colors--light-theme--text-muted;
   }
 
   // Theming

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -259,11 +259,6 @@ $box-offsets-top: (
 
         display: inline;
         padding-top: 0;
-
-        .p-checkbox__label {
-          // color: $colors--light-theme--text-muted !important;
-          color: pink !important;
-        }
       }
 
       &.is-table-header {

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -36,10 +36,8 @@
     th {
       @extend %table-header-label;
 
-      line-height: map-get($line-heights, x-small);
       padding-bottom: $spv-inner--large - map-get($nudges, nudge--x-small);
       padding-top: map-get($nudges, nudge--x-small) + map-get($browser-rounding-compensations, small) + $sp-unit;
-      text-transform: uppercase;
     }
 
     tr {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -191,6 +191,7 @@
 
   %x-small-text {
     font-size: #{map-get($font-sizes, x-small)}rem;
+    font-weight: $font-weight-bold;
     line-height: map-get($line-heights, x-small);
     margin-bottom: map-get($sp-after, x-small) - map-get($nudges, nudge--x-small);
     padding-top: map-get($nudges, nudge--x-small) + map-get($browser-rounding-compensations, small);
@@ -213,18 +214,12 @@
   %table-header-label {
     @extend %x-small-text;
 
-    font-weight: $font-weight-bold;
+    text-transform: uppercase;
   }
 
   %muted-heading {
-    @extend %small-text;
     @extend %muted-text;
-
-    font-weight: $font-weight-regular-text;
-    margin-bottom: map-get($sp-after, small) - map-get($nudges, nudge--small);
-    margin-top: 0;
-    padding-top: map-get($nudges, nudge--small);
-    text-transform: uppercase;
+    @extend %table-header-label;
 
     &.u-no-margin--bottom {
       @extend %u-no-margin--bottom--small;

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -44,6 +44,7 @@
 
     .p-chip__lead {
       $space-between-lead-and-value: 0.25rem;
+      @extend %muted-text;
       @extend %x-small-text;
 
       line-height: $chip-line-height;

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -11,76 +11,65 @@
     }
 
     @media (max-width: $breakpoint-medium) {
-      thead {
-        display: none;
-      }
-
-      tbody {
-        display: flex;
-        flex-wrap: wrap;
-        margin-left: -#{map-get($grid-gutter-widths, small)};
-
-        @supports (display: grid) {
+      @supports (display: grid) {
+        thead {
+          display: none;
+        }
+        tbody {
           display: grid;
-          flex-wrap: unset;
           grid-gap: 0 map-get($grid-gutter-widths, small);
           grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
           grid-template-rows: auto;
-          margin-left: 0;
-        }
-      }
-
-      tr {
-        border: $border;
-        border-radius: $border-radius;
-        display: flex;
-        flex: 1 1 auto;
-        flex-direction: column;
-        margin-bottom: $spv-outer--scaleable;
-        margin-left: #{map-get($grid-gutter-widths, small)};
-        min-width: 12rem;
-        overflow: auto; // prevent overflow of child margins
-        padding: 0 $sph-inner;
-
-        @supports (display: grid) {
-          flex: unset;
-          margin-left: 0;
-        }
-      }
-
-      td,
-      tbody th {
-        padding-left: 0;
-        padding-right: 0;
-        position: relative;
-        text-overflow: ellipsis;
-        width: 100%;
-        word-break: break-word;
-
-        &.u-align--right {
-          justify-content: unset !important;
-          text-align: left !important;
-        }
-
-        &[aria-label]::before {
-          content: attr(aria-label);
-          display: block;
-          margin-bottom: map-get($sp-after, x-small) - map-get($nudges, nudge--x-small) - $sp-unit;
-          overflow: hidden;
-          padding-left: 0;
-          padding-right: 0;
-          text-overflow: ellipsis;
           width: 100%;
         }
 
-        &:not(:first-child)::after {
-          background-color: $color-mid-light;
-          content: '';
-          height: 1px;
-          left: 0;
-          position: absolute;
-          right: 0;
-          top: 0;
+        tr {
+          border: $border;
+          border-radius: $border-radius;
+          display: grid;
+          grid-gap: 0 map-get($grid-gutter-widths, small);
+          grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+          grid-template-rows: auto;
+          margin-bottom: $spv-outer--scaleable;
+          padding: 0 $sph-inner;
+        }
+
+        td,
+        tbody th {
+          overflow: hidden;
+          padding-left: 0;
+          padding-right: 0;
+          position: relative;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          width: 100%;
+          word-break: break-word;
+          // stylelint-disable-next-line max-nesting-depth
+          &.u-align--right {
+            justify-content: unset !important;
+            text-align: left !important;
+          }
+          // stylelint-disable-next-line max-nesting-depth
+          &[aria-label]::before {
+            content: attr(aria-label);
+            display: block;
+            margin-bottom: map-get($sp-after, x-small) - map-get($nudges, nudge--x-small) - $sp-unit;
+            overflow: hidden;
+            padding-left: 0;
+            padding-right: 0;
+            text-overflow: ellipsis;
+            width: 100%;
+          }
+          // stylelint-disable-next-line max-nesting-depth
+          &:not(:first-child)::after {
+            background-color: $color-mid-light;
+            content: '';
+            height: 1px;
+            left: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+          }
         }
       }
 

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -6,6 +6,8 @@
     td::before,
     tbody th::before {
       @extend %table-header-label;
+
+      text-align: left;
     }
 
     @media (max-width: $breakpoint-medium) {
@@ -64,6 +66,7 @@
           top: 0;
         }
       }
+
       // stylelint-enable selector-max-type
 
       // Styles contextual menus differently within mobile-card tables

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -14,9 +14,11 @@
       }
 
       tbody {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-between;
+        display: grid;
+        grid-gap: 0 map-get($grid-gutter-widths, small);
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-rows: auto;
+        padding: 0 $sph-inner--large calc(#{$spv-inner--large} - 1px);
       }
 
       tr {
@@ -26,45 +28,41 @@
         flex-direction: column;
         margin-bottom: $spv-outer--scaleable;
         overflow: auto; // prevent overflow of child margins
-        padding: 0 $sph-inner--large calc(#{$spv-inner--large} - 1px);
         width: calc(50% - #{0.5 * map-get($grid-gutter-widths, medium)});
       }
 
       td,
       tbody th {
-        display: flex;
-        min-width: 100%;
-        overflow: hidden;
-        padding-bottom: $spv-nudge-compensation;
-        padding-left: calc(50% + #{0.5 * $sph-inner});
+        padding-left: 0;
         padding-right: 0;
-        padding-top: $spv-nudge;
         position: relative;
-        text-align: left !important;
         text-overflow: ellipsis;
         width: 100%;
         word-break: break-word;
 
-        &[aria-label] {
-          text-align: right;
-        }
-
         &[aria-label]::before {
           content: attr(aria-label);
           display: block;
-          flex: 0 0 auto;
-          margin-bottom: $spv-inner--small - map-get($nudges, nudge--small);
-          margin-left: -100%;
+          margin-bottom: map-get($sp-after, x-small) - map-get($nudges, nudge--x-small) - $sp-unit;
           overflow: hidden;
-          padding-right: #{$sph-inner};
-          padding-top: $sp-unit - map-get($nudges, nudge--small);
-          text-align: right;
+          padding-left: 0;
+          padding-right: 0;
           text-overflow: ellipsis;
           width: 100%;
         }
 
         &.u-align--right {
           justify-content: unset !important;
+        }
+
+        &:not(:first-child)::after {
+          background-color: $color-mid-light;
+          content: '';
+          height: 1px;
+          left: 0;
+          position: absolute;
+          right: 0;
+          top: 0;
         }
       }
       // stylelint-enable selector-max-type

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -16,20 +16,36 @@
       }
 
       tbody {
-        display: grid;
-        grid-gap: 0 map-get($grid-gutter-widths, small);
-        grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-        grid-template-rows: auto;
+        display: flex;
+        flex-wrap: wrap;
+        margin-left: -#{map-get($grid-gutter-widths, small)};
+
+        @supports (display: grid) {
+          display: grid;
+          flex-wrap: unset;
+          grid-gap: 0 map-get($grid-gutter-widths, small);
+          grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+          grid-template-rows: auto;
+          margin-left: 0;
+        }
       }
 
       tr {
         border: $border;
         border-radius: $border-radius;
         display: flex;
+        flex: 1 1 auto;
         flex-direction: column;
         margin-bottom: $spv-outer--scaleable;
+        margin-left: #{map-get($grid-gutter-widths, small)};
+        min-width: 12rem;
         overflow: auto; // prevent overflow of child margins
         padding: 0 $sph-inner;
+
+        @supports (display: grid) {
+          flex: unset;
+          margin-left: 0;
+        }
       }
 
       td,

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -28,7 +28,6 @@
         margin-bottom: $spv-outer--scaleable;
         overflow: auto; // prevent overflow of child margins
         padding: 0 $sph-inner;
-        // width: calc(50% - #{0.5 * map-get($grid-gutter-widths, medium)});
       }
 
       td,

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -41,6 +41,11 @@
         width: 100%;
         word-break: break-word;
 
+        &.u-align--right {
+          justify-content: unset !important;
+          text-align: left !important;
+        }
+
         &[aria-label]::before {
           content: attr(aria-label);
           display: block;
@@ -50,10 +55,6 @@
           padding-right: 0;
           text-overflow: ellipsis;
           width: 100%;
-        }
-
-        &.u-align--right {
-          justify-content: unset !important;
         }
 
         &:not(:first-child)::after {

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -5,7 +5,7 @@
     // stylelint-disable selector-max-type -- table elements can use selector types
     td::before,
     tbody th::before {
-      @extend %muted-heading;
+      @extend %table-header-label;
     }
 
     @media (max-width: $breakpoint-medium) {
@@ -16,9 +16,8 @@
       tbody {
         display: grid;
         grid-gap: 0 map-get($grid-gutter-widths, small);
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
         grid-template-rows: auto;
-        padding: 0 $sph-inner--large calc(#{$spv-inner--large} - 1px);
       }
 
       tr {
@@ -28,7 +27,8 @@
         flex-direction: column;
         margin-bottom: $spv-outer--scaleable;
         overflow: auto; // prevent overflow of child margins
-        width: calc(50% - #{0.5 * map-get($grid-gutter-widths, medium)});
+        padding: 0 $sph-inner;
+        // width: calc(50% - #{0.5 * map-get($grid-gutter-widths, medium)});
       }
 
       td,

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_table-mobile-card{% endblock %}
 
 {% block content %}
-<table class="p-table--mobile-card" aria-label="Example of table transforming into mobile cards on small screens">
+<table class="p-table--mobile-card is-split" aria-label="Example of table transforming into mobile cards on small screens">
   <thead>
     <tr>
       <th>FQDN</th>

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_table-mobile-card{% endblock %}
 
 {% block content %}
-<table class="p-table--mobile-cards" aria-label="Example of table transforming into mobile cards on small screens">
+<table class="p-table--mobile-card" aria-label="Example of table transforming into mobile cards on small screens">
   <thead>
     <tr>
       <th>FQDN</th>

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_table-mobile-card{% endblock %}
 
 {% block content %}
-<table class="p-table--mobile-card is-split" aria-label="Example of table transforming into mobile cards on small screens">
+<table class="p-table--mobile-cards" aria-label="Example of table transforming into mobile cards on small screens">
   <thead>
     <tr>
       <th>FQDN</th>


### PR DESCRIPTION
## Done

Update table mobile card design to match what was agreed in https://github.com/canonical-web-and-design/vanilla-framework/issues/2817

Fixes #2817

-Drive by: makes muted heading same style as table headers, they are close but slightly different which Ithink is unnecesary.

## QA

- Open docs/examples/patterns/tables/table-mobile-card
- QA

## Screenshots
It is responsive, min column width 12rem, feel free to suggest another value if you think this isn't optimal. Opted for this rather than modifier classes as it is simpler to use.

![image](https://user-images.githubusercontent.com/2741678/115009427-30791980-9ea4-11eb-8402-7d7d3521706c.png)
![image](https://user-images.githubusercontent.com/2741678/115009385-28b97500-9ea4-11eb-8297-600e1c51918c.png)
![image](https://user-images.githubusercontent.com/2741678/115009460-3838be00-9ea4-11eb-870d-dd9c03877b5c.png)


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.

