### PR TITLE
Enable source maps

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
       - run: yarn install
       - run: yarn build
       - run: yarn test
+      - name: Build import.css test file without sourcemaps
+        run: npx node-sass scss/standalone/import.scss --functions sass-functions.js --output-style compressed --output build/css/standalone
       - name: Check if import test file exists but is empty
         run: test -f build/css/standalone/import.css -a ! -s build/css/standalone/import.css
       - name: Show size of the build file

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "start": "yarn build && yarn serve",
     "build": "yarn build-scss && yarn build-js",
-    "build-scss": "yarn run build-js && node-sass scss --functions sass-functions.js --output-style compressed --output build/css && postcss --use autoprefixer --replace 'build/css/**/*.css' --no-map",
+    "build-scss": "yarn run build-js && node-sass scss --functions sass-functions.js --output-style compressed --source-map true --source-map-contents true --output build/css && postcss --use autoprefixer --replace 'build/css/**/*.css' --map",
     "build-js": "mkdir -p build/js/modules && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js build/js/modules && cp node_modules/@canonical/latest-news/dist/latest-news.js build/js/modules",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "test-scss": "node -e 'require(\"./tests/parker\").parkerTest()'",
@@ -36,7 +36,7 @@
     "test": "yarn lint-scss && yarn lint-prettier &&  yarn test-spelling && yarn test-scss",
     "lint-prettier": "prettier -c .",
     "lint-scss": "stylelint 'scss/**/*.scss'",
-    "watch:scss": "node-sass scss --functions sass-functions.js --output-style compressed --output build/css --watch",
+    "watch:scss": "node-sass scss --functions sass-functions.js --output-style compressed --source-map true --source-map-contents true --output build/css --watch",
     "watch:scss:skip-standalone": "node-sass  scss/docs --functions sass-functions.js --output-style compressed --output build/css/docs --watch",
     "watch": "yarn build && yarn watch:scss",
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",


### PR DESCRIPTION
## Done

Adds source maps to build step

## QA

- Open [demo](https://vanilla-framework-3709.demos.haus)
- Inspect any element on page, check if inspector shows original scss source

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.

