### PR TITLE
Modal focus accessibility improvements

### DIFF
--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -59,11 +59,11 @@
   }
 
   /**
-  Toggles visibility of modal dialog.
-  @param {HTMLElement} modal Modal dialog to show or hide.
-  @param {HTMLElement} sourceEl Element that triggered toggling modal
-  @param {Boolean} open If defined as `true` modal will be opened, if `false` modal will be closed, undefined toggles current visibility.
-*/
+    Toggles visibility of modal dialog.
+    @param {HTMLElement} modal Modal dialog to show or hide.
+    @param {HTMLElement} sourceEl Element that triggered toggling modal
+    @param {Boolean} open If defined as `true` modal will be opened, if `false` modal will be closed, undefined toggles current visibility.
+  */
   function toggleModal(modal, sourceEl, open) {
     if (modal && modal.classList.contains('p-modal')) {
       if (typeof open === 'undefined') {
@@ -113,4 +113,7 @@
       closeModals();
     }
   });
+
+  // init the dialog that is initially opened in the example
+  toggleModal(document.querySelector('#modal'), document.querySelector('[aria-controls=modal]'), true);
 })();

--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -13,10 +13,29 @@ function toggleModal(modal) {
   }
 }
 
+// Find and hide all modals on the page
+function closeModals() {
+  var modals = [].slice.apply(document.querySelectorAll('.p-modal'));
+  modals.forEach(function (modal) {
+    modal.style.display = 'none';
+  });
+}
+
 // Add click handler for clicks on elements with aria-controls
 document.addEventListener('click', function (event) {
   var targetControls = event.target.getAttribute('aria-controls');
   if (targetControls) {
     toggleModal(document.getElementById(targetControls));
+  }
+});
+
+// Add handler for closing modals using ESC key.
+document.addEventListener('keydown', function (e) {
+  e = e || window.event;
+
+  if (e.code === 'Escape') {
+    closeModals();
+  } else if (e.keyCode === 27) {
+    closeModals();
   }
 });

--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -91,7 +91,7 @@
   function closeModals() {
     var modals = [].slice.apply(document.querySelectorAll('.p-modal'));
     modals.forEach(function (modal) {
-      toggleModal(modal, false);
+      toggleModal(modal, false, false);
     });
   }
 

--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -1,41 +1,116 @@
-/**
-  Toggles visibility of modal dialog.
-  @param {HTMLElement} modal Modal dialog to show or hide.
-*/
-function toggleModal(modal) {
-  if (modal && modal.classList.contains('p-modal')) {
-    if (modal.style.display === 'none') {
-      modal.style.display = 'flex';
-      modal.focus();
+// This is an example modal implementation inspired by
+// https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html
+
+(function () {
+  // This is not a production ready code, just serves as an example
+  // of how the focus should be controlled within the modal dialog.
+  var currentDialog = null;
+  var lastFocus = null;
+  var ignoreFocusChanges = false;
+  var focusAfterClose = null;
+
+  // Traps the focus within the currently open modal dialog
+  function trapFocus(event) {
+    if (ignoreFocusChanges) return;
+
+    if (currentDialog.contains(event.target)) {
+      lastFocus = event.target;
     } else {
-      modal.style.display = 'none';
+      focusFirstDescendant(currentDialog);
+      if (lastFocus == document.activeElement) {
+        focusLastDescendant(currentDialog);
+      }
+      lastFocus = document.activeElement;
     }
   }
-}
 
-// Find and hide all modals on the page
-function closeModals() {
-  var modals = [].slice.apply(document.querySelectorAll('.p-modal'));
-  modals.forEach(function (modal) {
-    modal.style.display = 'none';
+  // Attempts to focus given element
+  function attemptFocus(child) {
+    if (child.focus) {
+      ignoreFocusChanges = true;
+      child.focus();
+      ignoreFocusChanges = false;
+      return document.activeElement === child;
+    }
+
+    return false;
+  }
+
+  // Focuses first child element
+  function focusFirstDescendant(element) {
+    for (var i = 0; i < element.childNodes.length; i++) {
+      var child = element.childNodes[i];
+      if (attemptFocus(child) || focusFirstDescendant(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Focuses last child element
+  function focusLastDescendant(element) {
+    for (var i = element.childNodes.length - 1; i >= 0; i--) {
+      var child = element.childNodes[i];
+      if (attemptFocus(child) || focusLastDescendant(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+  Toggles visibility of modal dialog.
+  @param {HTMLElement} modal Modal dialog to show or hide.
+  @param {HTMLElement} sourceEl Element that triggered toggling modal
+  @param {Boolean} open If defined as `true` modal will be opened, if `false` modal will be closed, undefined toggles current visibility.
+*/
+  function toggleModal(modal, sourceEl, open) {
+    if (modal && modal.classList.contains('p-modal')) {
+      if (typeof open === 'undefined') {
+        open = modal.style.display === 'none';
+      }
+
+      if (open) {
+        currentDialog = modal;
+        modal.style.display = 'flex';
+        focusFirstDescendant(modal);
+        focusAfterClose = sourceEl;
+        document.addEventListener('focus', trapFocus, true);
+      } else {
+        modal.style.display = 'none';
+        if (focusAfterClose && focusAfterClose.focus) {
+          focusAfterClose.focus();
+        }
+        document.removeEventListener('focus', trapFocus, true);
+        currentDialog = null;
+      }
+    }
+  }
+
+  // Find and hide all modals on the page
+  function closeModals() {
+    var modals = [].slice.apply(document.querySelectorAll('.p-modal'));
+    modals.forEach(function (modal) {
+      toggleModal(modal, false);
+    });
+  }
+
+  // Add click handler for clicks on elements with aria-controls
+  document.addEventListener('click', function (event) {
+    var targetControls = event.target.getAttribute('aria-controls');
+    if (targetControls) {
+      toggleModal(document.getElementById(targetControls), event.target);
+    }
   });
-}
 
-// Add click handler for clicks on elements with aria-controls
-document.addEventListener('click', function (event) {
-  var targetControls = event.target.getAttribute('aria-controls');
-  if (targetControls) {
-    toggleModal(document.getElementById(targetControls));
-  }
-});
+  // Add handler for closing modals using ESC key.
+  document.addEventListener('keydown', function (e) {
+    e = e || window.event;
 
-// Add handler for closing modals using ESC key.
-document.addEventListener('keydown', function (e) {
-  e = e || window.event;
-
-  if (e.code === 'Escape') {
-    closeModals();
-  } else if (e.keyCode === 27) {
-    closeModals();
-  }
-});
+    if (e.code === 'Escape') {
+      closeModals();
+    } else if (e.keyCode === 27) {
+      closeModals();
+    }
+  });
+})();

--- a/templates/docs/examples/patterns/modal/default.html
+++ b/templates/docs/examples/patterns/modal/default.html
@@ -7,7 +7,7 @@
 <button id="showModal" aria-controls="modal">Show modal&hellip;</button>
 
 <div class="p-modal" id="modal">
-  <section class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+  <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">Help</h2>
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>

--- a/templates/docs/examples/patterns/modal/footer.html
+++ b/templates/docs/examples/patterns/modal/footer.html
@@ -7,7 +7,7 @@
 <button id="showModal" aria-controls="modal">Show modal&hellip;</button>
 
 <div class="p-modal" id="modal">
-  <section class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+  <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">Confirm delete</h2>
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>

--- a/templates/docs/examples/patterns/modal/modal-scroll.html
+++ b/templates/docs/examples/patterns/modal/modal-scroll.html
@@ -45,7 +45,7 @@
 
 
 <div class="p-modal" id="modal">
-  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+  <div class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">Help</h2>
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>

--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -37,7 +37,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 For any elements that launch a modal, please ensure that the label contains a trailing ellipsis `…`, e.g. "Launch modal&hellip;". This is a convention used to indicate that the element launches a dialog.
 
-When a modal is launched, focus should be set within the modal element, using JavaScript.
+When a modal is launched, focus should be set and contained within the modal dialog, using JavaScript. When the modal is closed, focus should be set back to the element that opened it.
 
 ### Design
 


### PR DESCRIPTION
## Done

- Added aria-modal to modal dialogs
- Added example of closing modal on ESC key
- Added example of trapping focus inside the modal, and returning focus to element that triggered modal
- Updated relevant docs

Fixes #3223

## QA

- Open [demo](https://vanilla-framework-3712.demos.haus/docs/examples/patterns/modal/default)
- Make sure focus stays in modal when using tab key
- Make sure focus returns to button when modal is closed
- Check other modal examples as well:
  - https://vanilla-framework-3712.demos.haus/docs/examples/patterns/modal/footer
  - https://vanilla-framework-3712.demos.haus/docs/examples/patterns/modal/modal-scroll
- Review updated documentation:
  - https://vanilla-framework-3712.demos.haus/docs/patterns/modal#accessibility

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.

