### PR TITLE
WIP: Link from Vanilla to React docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,9 +1,11 @@
 utils
+codesnippet
 color
 colors
 center
 centered
 clearfix
+dialogs
 textarea
 fieldset
 middot

--- a/scss/docs/site.scss
+++ b/scss/docs/site.scss
@@ -17,5 +17,7 @@ $color-suru-slant-left-fallback: $color-suru-slant-left;
 // import vanilla
 @import '../build';
 
+@include vf-p-icon-task-outstanding;
+
 // import cookie policy
 @import 'node_modules/@canonical/cookie-policy/build/css/cookie-policy';

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -128,6 +128,6 @@ It is being replaced by the new [code snippet pattern](/docs/base/code#code-snip
 
 ### React
 
-You can use code snippet in React by installing our react-component library and importing `CodeSnippet` component.
+You can use code snippet in React by installing our react-component library and importing code snippet component.
 
 [See the documentation for our React `CodeSnippet` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/codesnippet--default-story#code-snippet)

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -126,6 +126,8 @@ The code numbered pattern is now deprecated and will be removed in a future vers
 
 It is being replaced by the new [code snippet pattern](/docs/base/code#code-snippet).
 
-### Design
+### React
 
-For more information [view the code design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Code), which includes the specification in markdown format and a PNG image.
+You can use code snippet in React by installing our react-component library and importing `CodeSnippet` component.
+
+[See the documentation for our React `CodeSnippet` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/codesnippet--default-story#code-snippet)

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -224,6 +224,10 @@ To add form help text or validation into your project, copy either or both snipp
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the forms design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Forms), which includes the specification in markdown format and a PNG image.
+You can use forms in React by installing our react-component library and importing `Form` and `Input` component.
+
+[See the documentation for our React `Form` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/form--default-story#form)
+
+[See the documentation for our React `Input` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/input--text-input#input)

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -100,6 +100,10 @@ To import either or all of these components into your project, copy the snippets
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information view the [table](https://github.com/ubuntudesign/vanilla-design/tree/master/Table), [sortable](https://github.com/ubuntudesign/vanilla-design/tree/master/Table%20sortable), [expanding](https://github.com/ubuntudesign/vanilla-design/tree/master/Table) or [mobile card design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Table) which includes the specification in markdown format and a PNG image.
+You can use tables in React by installing our react-component library and importing `MainTable` or `ModularTable` component.
+
+[See the documentation for our React `MainTable` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/maintable--default-story#maintable)
+
+[See the documentation for our React `ModularTable` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/modulartable--default-story)

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -59,6 +59,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the accordion design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Accordion), which includes the specification in markdown format and a PNG image.
+You can use accordion in React by installing our react-component library and importing `Accordion` component.
+
+[See the documentation for our React `Accordion` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/accordion--default-story#accordion)

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -6,6 +6,12 @@ context:
 
 ## Accordion
 
+<ul class="p-inline-list">
+  <li class="p-inline-list__item"><span class="p-muted-heading">Availability:</span></li>
+  <li class="p-inline-list__item"><i class="p-icon--task-outstanding"></i> CSS</li>
+  <li class="p-inline-list__item"><i class="p-icon--minus"></i> React</li>
+</ul>
+
 <hr>
 
 The sidebar accordion, used in listing pages or as navigation, can hold multiple navigation items or to be used as a filter for content.

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -127,6 +127,10 @@ If you only need a small subset of the icons consider [including them individual
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information view the [buttons design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Buttons) which includes the specification in markdown format and a PNG image.
+You can use buttons in React by installing our react-component library and importing `Button` or `ActionButton` component.
+
+[See the documentation for our React `Button` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/button--base#button)
+
+[See the documentation for our React `ActionButton` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/actionbutton--default-story#actionbutton)

--- a/templates/docs/patterns/card.md
+++ b/templates/docs/patterns/card.md
@@ -53,6 +53,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the cards design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Cards), which includes the specification in markdown format and a PNG image.
+You can use cards in React by installing our react-component library and importing `Card` component.
+
+[See the documentation for our React `Card` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/card--default-story)

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -25,6 +25,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-Unfortunately there are no design specs available for this component.
+You can use chips in React by installing our react-component library and importing `Chip` component.
+
+[See the documentation for our React `Chip` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/chip--default-story#chip)

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -85,9 +85,11 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the contextual menu design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Contextual%20menu), which includes the specification in markdown format and a PNG image.
+You can use contextual menu in React by installing our react-component library and importing `ContextualMenu` component.
+
+[See the documentation for our React `ContextualMenu` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/contextualmenu--default-story#contextual-menu)
 
 ### Related
 

--- a/templates/docs/patterns/grid.md
+++ b/templates/docs/patterns/grid.md
@@ -106,6 +106,10 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the grid design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Grid), which includes the specification in markdown format and a PNG image.
+You can use grid in React by installing our react-component library and importing `Row` and `Col` components.
+
+[See the documentation for our React `Row` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/row--default-story#row)
+
+[See the documentation for our React `Col` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/col--default-story#col)

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -46,7 +46,6 @@ Our icons have two predefined color styles: light and dark. The light variant is
         <p><i class="p-icon--expand" style="margin-right: 1rem;"></i>p-icon--expand</p>
       </div>
     </div>
-
     <div class="row u-equal-height">
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--collapse" style="margin-right: 1rem;"></i>p-icon--collapse</p>
@@ -58,7 +57,6 @@ Our icons have two predefined color styles: light and dark. The light variant is
         <p><i class="p-icon--drag" style="margin-right: 1rem;"></i>p-icon--drag</p>
       </div>
     </div>
-
     <div class="row u-equal-height">
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--close" style="margin-right: 1rem;"></i>p-icon--close</p>
@@ -69,8 +67,7 @@ Our icons have two predefined color styles: light and dark. The light variant is
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--information" style="margin-right: 1rem;"></i>p-icon--information</p>
       </div>
-      </div>
-
+    </div>
     <div class="row u-equal-height">
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--delete" style="margin-right: 1rem;"></i>p-icon--delete</p>
@@ -82,7 +79,6 @@ Our icons have two predefined color styles: light and dark. The light variant is
         <p><i class="p-icon--chevron-down" style="margin-right: 1rem;"></i>p-icon--chevron-down</p>
       </div>
     </div>
-
     <div class="row u-equal-height">
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--chevron-up" style="margin-right: 1rem;"></i>p-icon--chevron-up</p>
@@ -94,7 +90,6 @@ Our icons have two predefined color styles: light and dark. The light variant is
         <p><i class="p-icon--code" style="margin-right: 1rem;"></i>p-icon--code</p>
       </div>
     </div>
-
     <div class="row u-equal-height">
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--copy" style="margin-right: 1rem;"></i>p-icon--copy</p>
@@ -106,7 +101,6 @@ Our icons have two predefined color styles: light and dark. The light variant is
         <p><i class="p-icon--share" style="margin-right: 1rem;"></i>p-icon--share</p>
       </div>
     </div>
-
     <div class="row u-equal-height">
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--user" style="margin-right: 1rem;"></i>p-icon--user</p>
@@ -115,7 +109,6 @@ Our icons have two predefined color styles: light and dark. The light variant is
         <p><i class="p-icon--anchor" style="margin-right: 1rem;"></i>p-icon--anchor</p>
       </div>
     </div>
-
   </div>
 </section>
 
@@ -180,7 +173,6 @@ Outside of the standard set, additional icons are available for use, and need to
         <i class="p-icon--fullscreen" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--fullscreen
       </div>
     </div>
-
     <div class="row">
       <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--models" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--models
@@ -192,7 +184,6 @@ Outside of the standard set, additional icons are available for use, and need to
         <i class="p-icon--pin" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--pin
       </div>
     </div>
-
     <div class="row">
       <div class="p-card col-3 u-vertically-center" style="display:flex; align-items:center;">
         <i class="p-icon--units" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--units
@@ -204,7 +195,6 @@ Outside of the standard set, additional icons are available for use, and need to
         <i class="p-icon--priority-high" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--priority-high
       </div>
     </div>
-
     <div class="row">
       <div class="p-card col-3 u-vertically-center" style="display: flex; align-item: center;">
         <i class="p-icon--priority-low" style="margin-right: 1rem; flex-shrink: 0;"></i>p-icon--priority-low
@@ -749,6 +739,8 @@ If you use a limited set of icons you may want to include them individually to r
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information view the [icons design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Icons) which includes the specification in markdown format and a PNG image.
+You can use icons in React by installing our react-component library and importing `Icon` component.
+
+[See the documentation for our React `Icon` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/icon--default-story#icon)

--- a/templates/docs/patterns/links.md
+++ b/templates/docs/patterns/links.md
@@ -69,6 +69,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information view the [links design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Links) which includes the specification in markdown format and a PNG image.
+You can use links in React by installing our react-component library and importing `Link` component.
+
+[See the documentation for our React `Link` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/link--default-story#link)

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -163,9 +163,11 @@ To include individual list patterns you need to include the `vf-p-list-placehold
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the lists design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Lists), which includes the specification in markdown format and a PNG image.
+You can use lists in React by installing our react-component library and importing `List` component.
+
+[See the documentation for our React `List` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/list--default-story#list)
 
 ### Related
 

--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -39,6 +39,8 @@ For any elements that launch a modal, please ensure that the label contains a tr
 
 When a modal is launched, focus should be set and contained within the modal dialog, using JavaScript. When the modal is closed, focus should be set back to the element that opened it.
 
-### Design
+### React
 
-For more information view the [modal design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Modal) which includes the specification in markdown format and a PNG image.
+You can use modal dialogs in React by installing our react-component library and importing `Modal` component.
+
+[See the documentation for our React `Modal` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/modal--default-story#modal)

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -77,6 +77,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information view the [notification design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Notifications) which includes the specification in markdown format and a PNG image.
+You can use notifications in React by installing our react-component library and importing `Notification` component.
+
+[See the documentation for our React `Notification` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/notification--default-story#notification)

--- a/templates/docs/patterns/pagination.md
+++ b/templates/docs/patterns/pagination.md
@@ -72,3 +72,11 @@ To import the article pagination component into your project, copy the snippet b
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+
+### React
+
+You can use pagination in React by installing our react-component library and importing `Pagination` or `ArticlePagination` component.
+
+[See the documentation for our React `Pagination` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/pagination--default-story#pagination)
+
+[See the documentation for our React `ArticlePagination` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/articlepagination--default-story#articlepagination)

--- a/templates/docs/patterns/search-and-filter.md
+++ b/templates/docs/patterns/search-and-filter.md
@@ -84,12 +84,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-## React
+### React
 
-For use of the React component you can do that by installing our react-component page and importing.
+You can use search and filter in React by installing our react-component library and importing `SearchAndFilter` component.
 
-[See the documentation for our React `SearchAndFilter` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/search-and-filter--default-story)
-
-### Design
-
-No design specs available yet.
+[See the documentation for our React `SearchAndFilter` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/search-and-filter--default-story#search-and-filter)

--- a/templates/docs/patterns/search-box.md
+++ b/templates/docs/patterns/search-box.md
@@ -45,9 +45,11 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the search design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Search), which includes the specification in markdown format and a PNG image.
+You can use search box in React by installing our react-component library and importing `SearchBox` component.
+
+[See the documentation for our React `SearchBox` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/searchbox--default-story#searchbox)
 
 ### Related
 

--- a/templates/docs/patterns/slider.md
+++ b/templates/docs/patterns/slider.md
@@ -29,6 +29,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the slider design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Slider), which includes the specification in markdown format and a PNG image.
+You can use slider in React by installing our react-component library and importing `Slider` component.
+
+[See the documentation for our React `Slider` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/slider--default-story#slider)

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -107,6 +107,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the strip design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Strip), which includes the specification in markdown format and a PNG image.
+You can use strip in React by installing our react-component library and importing `Strip` component.
+
+[See the documentation for our React `Strip` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/strip--light-strip#strip)

--- a/templates/docs/patterns/tabs.md
+++ b/templates/docs/patterns/tabs.md
@@ -47,6 +47,8 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the tabs design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Tabs), which includes the specification in markdown format and a PNG image.
+You can use tabs in React by installing our react-component library and importing `Tab` component.
+
+[See the documentation for our React `Tab` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/tabs--default-story#tabs)

--- a/templates/docs/patterns/tooltips.md
+++ b/templates/docs/patterns/tooltips.md
@@ -47,9 +47,11 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-### Design
+### React
 
-For more information [view the tooltips design spec](https://github.com/ubuntudesign/vanilla-design/tree/master/Tooltips), which includes the specification in markdown format and a PNG image.
+You can use tooltips in React by installing our react-component library and importing `Tooltip` component.
+
+[See the documentation for our React `Tooltip` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/tooltip--default-story)
 
 ### Related
 


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

Fixes #1003

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
