### PR TITLE
Add toolbar to the fluid-breakout layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.28.1",
+  "version": "2.29.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -9,6 +9,7 @@
   %l-fluid-breakout-ie11-fallback#{$suffix} {
     @media (min-width: $breakpoint-large) {
       display: flex;
+      flex-wrap: wrap;
     }
   }
 
@@ -23,6 +24,7 @@
 
   %l-fluid-breakout__main-ie11-fallback#{$suffix} {
     display: flex;
+    flex: 1 1 80%;
     flex-wrap: wrap;
     width: 100%;
 
@@ -36,7 +38,7 @@
     justify-content: flex-start;
 
     @media (min-width: $breakpoint-large) {
-      flex: 1 1 auto;
+      flex: 1 1 13%;
       width: $l-fluid-breakout-aside-width;
     }
   }
@@ -50,6 +52,20 @@
 
     @media (max-width: $l-fluid-breakout-3-col-threshold) {
       padding-left: 0;
+    }
+  }
+
+  %l-fluid-breakout__toolbar-ie-11-fallback#{$suffix} {
+    @media (min-width: $breakpoint-large) {
+      flex: 1 1 100%;
+    }
+  }
+
+  %l-fluid-breakout__toolbar-items-ie-11-fallback#{$suffix} {
+    @media (min-width: $breakpoint-large) {
+      display: flex;
+      flex: 1 1 100%;
+      justify-content: space-between;
     }
   }
 
@@ -203,7 +219,7 @@
     }
 
     .l-fluid-breakout__toolbar {
-      @extend %l-fluid-breakout-ie11-fallback#{$suffix};
+      @extend %l-fluid-breakout__toolbar-ie-11-fallback#{$suffix};
 
       margin-block-end: $spv-outer--medium;
 
@@ -230,6 +246,8 @@
     }
 
     .l-fluid-breakout__toolbar-items {
+      @extend %l-fluid-breakout__toolbar-items-ie-11-fallback#{$suffix};
+
       @supports (display: grid) {
         display: grid;
         grid-column: 2 / -1;

--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -104,7 +104,7 @@
       @supports (display: grid) {
         display: grid;
         grid-gap: 0 $grid-gap;
-        grid-row: 1;
+        grid-row: 2;
         grid-template-columns: repeat(auto-fit, minmax($l-fluid-breakout-main-child-width, 1fr));
         width: 100%;
       }
@@ -167,7 +167,7 @@
       @supports (display: grid) {
         grid-column-end: span 1;
         grid-column-start: auto;
-        grid-row: 1 / 100;
+        grid-row: 2 / 100;
       }
     }
 
@@ -200,6 +200,64 @@
       }
 
       @extend %l-fluid-breakout__aside-common-properties#{$suffix};
+    }
+
+    .l-fluid-breakout__toolbar {
+      @extend %l-fluid-breakout-ie11-fallback#{$suffix};
+
+      margin-block-end: $spv-outer--medium;
+
+      @media (min-width: $breakpoint-large) {
+        margin-left: auto;
+        margin-right: auto;
+        max-width: calc(2 * #{$l-fluid-breakout-aside-width} + #{$l-fluid-breakout-max-width});
+
+        @supports (display: grid) {
+          display: grid;
+          grid-column: 1 / -1;
+          grid-template-columns:
+            minmax($l-fluid-breakout-aside-width, 1fr)
+            minmax(0, $l-fluid-breakout-max-width)
+            minmax($l-fluid-breakout-aside-width, 1fr);
+          grid-template-rows: auto;
+        }
+      }
+
+      @media (min-width: $l-fluid-breakout-3-col-threshold) {
+        margin-left: map-get($grid-margin-widths, large);
+        margin-right: map-get($grid-margin-widths, large);
+      }
+    }
+
+    .l-fluid-breakout__toolbar-items {
+      @supports (display: grid) {
+        display: grid;
+        grid-column: 2 / -1;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+
+        @media (max-width: $threshold-4-6-col) {
+          flex: 1 1 auto;
+          grid-template-columns: repeat(1, minmax(0, 1fr));
+          width: $l-fluid-breakout-main-child-width;
+        }
+      }
+    }
+
+    .l-fluid-breakout__toolbar-item {
+      align-items: center;
+      display: flex;
+
+      @supports (display: grid) {
+        grid-column-end: span 1;
+      }
+
+      &:nth-child(2) {
+        justify-content: flex-end;
+
+        @media (max-width: $threshold-4-6-col) {
+          justify-content: flex-start;
+        }
+      }
     }
   }
 }

--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -58,6 +58,7 @@
   %l-fluid-breakout__toolbar-ie-11-fallback#{$suffix} {
     @media (min-width: $breakpoint-large) {
       flex: 1 1 100%;
+      margin-left: $l-fluid-breakout-aside-width;
     }
   }
 
@@ -224,7 +225,6 @@
       margin-block-end: $spv-outer--medium;
 
       @media (min-width: $breakpoint-large) {
-        margin-left: auto;
         margin-right: auto;
         max-width: calc(2 * #{$l-fluid-breakout-aside-width} + #{$l-fluid-breakout-max-width});
 
@@ -236,6 +236,7 @@
             minmax(0, $l-fluid-breakout-max-width)
             minmax($l-fluid-breakout-aside-width, 1fr);
           grid-template-rows: auto;
+          margin-left: auto;
         }
       }
 

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -51,7 +51,7 @@
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
-              {{ side_nav_item("/docs/base/tables", "Tables", "updated") }}
+              {{ side_nav_item("/docs/base/tables", "Tables") }}
               {{ side_nav_item("/docs/base/typography", "Typography") }}
             </ul>
 
@@ -72,10 +72,10 @@
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
               {{ side_nav_item("/docs/patterns/lists", "Lists") }}
-              {{ side_nav_item("/docs/patterns/logo-section", "Logo section", "new") }}
+              {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
-              {{ side_nav_item("/docs/patterns/modal", "Modal", "updated") }}
+              {{ side_nav_item("/docs/patterns/modal", "Modal") }}
               {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
               {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
               {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
@@ -88,7 +88,7 @@
               {{ side_nav_item("/docs/patterns/switch", "Switch") }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
               {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}
-              {{ side_nav_item("/docs/patterns/tooltips", "Tooltips", "updated") }}
+              {{ side_nav_item("/docs/patterns/tooltips", "Tooltips") }}
             </ul>
 
             <ul class="p-side-navigation__list">
@@ -117,7 +117,7 @@
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
               {{ side_nav_item("/docs/layouts/application", "Application") }}
               {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
-              {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout", 'Updated') }}
+              {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout", "updated") }}
               {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer") }}
             </ul>
 

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -117,7 +117,7 @@
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
               {{ side_nav_item("/docs/layouts/application", "Application") }}
               {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
-              {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
+              {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout", 'Updated') }}
               {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer") }}
             </ul>
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,8 +24,8 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.29 -->
     <tr>
-      <th><a href="/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar">Fluid breakout - toolbar</a></th>
-      <td><div class="p-label--new">Updated</div></td>
+      <th><a href="/docs/layouts/fluid-breakout#toolbar">Fluid breakout - toolbar</a></th>
+      <td><div class="p-label--new">New</div></td>
       <td>2.29.0</td>
       <td>We added support for a toolbar within the fluid-breakout layout.</td>
     </tr>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -22,19 +22,41 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.29 -->
+    <tr>
+      <th><a href="/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar">Fluid breakout - toolbar</a></th>
+      <td><div class="p-label--new">Updated</div></td>
+      <td>2.29.0</td>
+      <td>We added support for a toolbar within the fluid-breakout layout.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 2.28 -->
     <tr>
       <th><a href="/docs/patterns/modal">Modal footer</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.28.0</td>
       <td>We added the optional footer to the modal pattern.</td>
+    </tr>
     <tr>
       <th><a href="/docs/patterns/logo-section">Logo section</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.28.0</td>
       <td>A new logo section</td>
     </tr>
-    <tr>
     <tr>
       <th><a href="/docs/patterns/logo-section">Inline images</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
@@ -53,21 +75,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.28.0</td>
       <td>We added the <code>.is-detached</code> utility, providing a way for tooltips to exist separately from their associated element.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.27 -->
     <tr>
       <th><a href="/docs/patterns/icons#social">GitHub icon</a></th>

--- a/templates/docs/examples/layouts/fluid-breakout/_toolbar.html
+++ b/templates/docs/examples/layouts/fluid-breakout/_toolbar.html
@@ -1,0 +1,18 @@
+<div class="l-fluid-breakout__toolbar-item">
+  43 Items
+</div>
+<div class="l-fluid-breakout__toolbar-item">
+  <form class="p-form p-form--inline">
+    <div class="p-form__group u-no-margin--right">
+      <label for="exampleSelect" class="p-form__label u-no-margin--bottom">Ubuntu releases</label>
+      <div class="p-form__control">
+        <select name="exampleSelect" id="exampleSelect" class="u-no-margin--bottom">
+          <option value="" disabled="disabled" selected="">Select an option</option>
+          <option value="1">Cosmic Cuttlefish</option>
+          <option value="2">Bionic Beaver</option>
+          <option value="3">Xenial Xerus</option>
+        </select>
+      </div>
+    </div>
+  </form>
+</div>

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Fluid breakout - cards and aside{% endblock %}
+{% block title %}Fluid breakout - cards with aside and toolbar{% endblock %}
 
 {% block standalone_css %}layouts_fluid-breakout{% endblock %}
 
@@ -23,8 +23,13 @@
 </div>
 
   <div class="l-fluid-breakout">
+    <div class="l-fluid-breakout__toolbar">
+      <div class="l-fluid-breakout__toolbar-items">
+        {% include "docs/examples/layouts/fluid-breakout/_toolbar.html" %}
+      </div>
+    </div>
     <div class="l-fluid-breakout__aside">
-        {% include "docs/examples/layouts/fluid-breakout/_aside.html" %}
+      {% include "docs/examples/layouts/fluid-breakout/_aside.html" %}
     </div>
     <div class="l-fluid-breakout__main">
       {% for i in range(14) %}

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar.html
@@ -1,0 +1,76 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Fluid breakout - aside on the left and toolbar{% endblock %}
+
+{% block standalone_css %}layouts_fluid-breakout{% endblock %}
+
+{% block style %}
+<style>
+{% include "docs/examples/layouts/fluid-breakout/visualize-grid.css" %}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="p-strip is-shallow grid-demo u-no-padding-top">
+  <div class="row">
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+    <div class="col-1">
+      <span>.col-1</span>
+    </div>
+  </div>
+</div>
+
+<div class="l-fluid-breakout">
+  <div class="l-fluid-breakout__toolbar viz-grid-item">
+    <div class=l-fluid-breakout__toolbar-items>
+      <div class="l-fluid-breakout__toolbar-item">
+        Toolbar item left
+      </div>
+      <div class="l-fluid-breakout__toolbar-item">
+        Toolbar item right
+      </div>
+    </div>
+  </div>
+  <div class="l-fluid-breakout__aside">
+    <div class="viz-aside">Aside</div>
+  </div>
+  <div class="l-fluid-breakout__main">
+    {% for i in range(14) %}
+    {% with index = i + 1 %}
+    <div class="viz-grid-item l-fluid-breakout__item">item #{{index}}</div>
+    {% endwith %}
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/templates/docs/layouts/fluid-breakout.md
+++ b/templates/docs/layouts/fluid-breakout.md
@@ -23,6 +23,8 @@ The wrapper aims to align as much as possible with the 12 column grid. On smalle
 
 #### Toolbar
 
+<span class="p-label--new">New</span>
+
 The toolbar is optional. When present, the toolbar will be positioned above the aside and main area elements. The toolbar is split in 2 columns, with the second column being aligned to the right on large screens.
 
 <div class="embedded-example"><a href="/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar/" class="js-example">

--- a/templates/docs/layouts/fluid-breakout.md
+++ b/templates/docs/layouts/fluid-breakout.md
@@ -21,6 +21,14 @@ The wrapper aims to align as much as possible with the 12 column grid. On smalle
 - the central area's width needs to match the 12 column grid's width (we achieve this by setting the central area's max-width to the same value as the 12 column grid's max-width)
 - The window width is larger than the combined width of the 3 columns of the layout (`$l-fluid-breakout-max-width + 2 * $l-fluid-breakout-aside-width`)
 
+#### Toolbar
+
+The toolbar is optional. When present, the toolbar will be positioned above the aside and main area elements. The toolbar is split in 2 columns, with the second column being aligned to the right on large screens.
+
+<div class="embedded-example"><a href="/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar/" class="js-example">
+View example of the fluid breakout layout with a left aside and a toolbar
+</a></div>
+
 #### Aside
 
 The aside is optional. When present, the order of the aside can be changed from before to after the main area by re-arranging the markup. Depending on the screen width, that would place it above / below (on screens smaller than `$breakpoint--large`) or to the left / right on larger screens.

--- a/templates/docs/layouts/fluid-breakout.md
+++ b/templates/docs/layouts/fluid-breakout.md
@@ -73,7 +73,7 @@ A couple of examples of where this layout might be useful. Both examples include
 
 A card layout where the goal is to fit more cards than the 12 column grid would allow. This what the default arguments to the `layouts_fluid-breakout` mixin provide out of the box:
 
-<div class="embedded-example"><a href="/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-and-aside/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar/" class="js-example">
 View example of the fluid breakout layout with an aside and a series of cards
 </a></div>
 


### PR DESCRIPTION
## Done

- Add toolbar to the fluid-breakout layout

Fixes [list issues/bugs if needed]

## QA

- Open [demo](insert-demo-url)
- Go to /docs/layouts/fluid-breakout and see the `toolbar` information makes sense
- Go to /docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar and see the toolbar example works fine on all screen sizes
- Go to /docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar and see the layout works fine on all screen sizes
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
