### PR TITLE
Add comma to hero text on marketing site homepage

### DIFF
--- a/templates/docs/examples/patterns/strips/suru.html
+++ b/templates/docs/examples/patterns/strips/suru.html
@@ -7,7 +7,7 @@
 <section class="p-strip--suru">
   <div class="row u-vertically-center">
     <div class="col-8">
-      <h1>A simple extensible CSS framework</h1>
+      <h1>A simple, extensible CSS framework</h1>
       <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>
       <button>Get started</button>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 <div id="main-content" class="p-strip--suru is-deep">
   <div class="row">
     <div class="col-12">
-      <h1>A simple extensible CSS framework</h1>
+      <h1>A simple, extensible CSS framework</h1>
       <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>
       <ul class="p-inline-list u-no-margin--bottom">
         <li class="p-inline-list__item">


### PR DESCRIPTION
## Done

Add comma to hero text on the marketing site homepage

<img width="1440" alt="Screenshot 2021-04-27 at 15 47 50" src="https://user-images.githubusercontent.com/505570/116262387-66ee4880-a770-11eb-9c11-f3c3168d87a0.png">
