### PR TITLE
Update top left nav logo spacing and selected state

### DIFF
--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -108,7 +108,7 @@
   @return $value;
 }
 
-@mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false) {
+@mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false, $horizontal-padding: 0) {
   position: relative;
 
   &::before {
@@ -128,8 +128,13 @@
         right: -1px;
         z-index: 1;
       } @else {
-        left: 0;
-        right: 0;
+        left: $horizontal-padding;
+        right: $horizontal-padding;
+      }
+
+      @if $position == bottom {
+        bottom: 0;
+        top: auto;
       }
     }
   } @else if $position == left or $position == right {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -14,8 +14,8 @@ $lightness-threshold: 70;
   }
 
   %navigation-link-responsive-padding-vertical {
-    padding-bottom: $spv-inner--medium;
-    padding-top: $spv-inner--medium;
+    padding-bottom: $spv-inner--large;
+    padding-top: $spv-inner--large;
   }
 
   %navigation-link-responsive-padding-left {
@@ -57,6 +57,7 @@ $lightness-threshold: 70;
     @include vf-focus;
 
     display: block;
+    font-weight: $font-weight-bold;
     line-height: map-get($line-heights, default-text);
     margin-bottom: 0;
     overflow: hidden;
@@ -169,14 +170,14 @@ $lightness-threshold: 70;
       }
 
       @media (min-width: $breakpoint-navigation-threshold) {
-        padding-left: map-get($grid-margin-widths, large);
+        padding-left: map-get($grid-margin-widths, small);
       }
     }
 
     &__logo {
       display: flex;
       flex: 0 0 auto;
-      height: 3rem;
+      height: 3.5rem;
       margin: 0 $sph-inner 0 0;
 
       .p-navigation__item {
@@ -339,32 +340,37 @@ $lightness-threshold: 70;
 }
 
 @mixin vf-navigation-theme(
-  // color for navigation separator on small screens
+  // color for the navigation separator on small screens
   $color-navigation-separator,
-  // color for navigation background
+  // color for the navigation background
   $color-navigation-background,
-  // color for navigation text
+  // color for the navigation text
   $color-navigation-text,
-  $color-navigation-background--hover,
-  $color-navigation-text--hover
+  // color for the navigation highlight bar
+  $color-navigation-highlight,
+  $color-navigation-background--hover
 ) {
   background-color: $color-navigation-background;
 
   %navigation-link-theme {
     &,
+    &:hover,
     &:visited,
     &:focus {
       color: $color-navigation-text;
     }
 
     &:hover {
-      @extend %navigation-link-selected;
+      background-color: $color-navigation-background--hover;
     }
   }
 
   %navigation-link-selected {
-    background-color: $color-navigation-background--hover;
-    color: $color-navigation-text--hover;
+    @include vf-highlight-bar($color-navigation-highlight, left, true, $sph-inner);
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      @include vf-highlight-bar($color-navigation-highlight, bottom, false, $sph-inner);
+    }
   }
 
   %navigation-link-before {
@@ -408,10 +414,10 @@ $lightness-threshold: 70;
   @if ($override-default) {
     @include vf-navigation-theme(
       $color-navigation-background: $colors--light-theme--background-default,
+      $color-navigation-highlight: $colors--light-theme--nav-highlight,
       $color-navigation-text: $colors--light-theme--text-default,
-      $color-navigation-separator: $colors--light-theme--border-default,
       $color-navigation-background--hover: $colors--light-theme--background-alt,
-      $color-navigation-text--hover: $colors--light-theme--text-default
+      $color-navigation-separator: $colors--light-theme--border-low-contrast
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
@@ -420,10 +426,10 @@ $lightness-threshold: 70;
 
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
+      $color-navigation-highlight: $colors--light-theme--nav-highlight,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--light-theme--border-default,
       $color-navigation-background--hover: $colors--light-theme--background-alt,
-      $color-navigation-text--hover: $colors--light-theme--text-default
+      $color-navigation-separator: $colors--light-theme--border-low-contrast
     );
   }
 }
@@ -431,23 +437,23 @@ $lightness-threshold: 70;
 @mixin vf-navigation-dark-theme($override-default: false) {
   @if ($override-default) {
     @include vf-navigation-theme(
-      $color-navigation-background: $colors--dark-theme--background-alt,
+      $color-navigation-background: $colors--dark-theme--background-default,
+      $color-navigation-highlight: $colors--dark-theme--nav-highlight,
       $color-navigation-text: $colors--dark-theme--text-default,
-      $color-navigation-separator: $colors--dark-theme--border-default,
-      $color-navigation-background--hover: $colors--dark-theme--text-default,
-      $color-navigation-text--hover: $colors--dark-theme--background-default
+      $color-navigation-background--hover: $colors--dark-theme--background-alt,
+      $color-navigation-separator: $colors--dark-theme--border-low-contrast
     );
   } @else {
     // take $color-navigation-background (that can be overridden) into account
-    $color-navigation-background: $colors--dark-theme--background-alt !default;
+    $color-navigation-background: $colors--dark-theme--background-default !default;
     $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme--text-default, $colors--dark-theme--text-default) !default;
 
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
+      $color-navigation-highlight: $colors--dark-theme--nav-highlight,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-separator: $colors--dark-theme--border-default,
-      $color-navigation-background--hover: $colors--dark-theme--text-default,
-      $color-navigation-text--hover: $colors--dark-theme--background-default
+      $color-navigation-background--hover: $colors--dark-theme--background-alt,
+      $color-navigation-separator: $colors--dark-theme--border-low-contrast
     );
   }
 }

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -18,7 +18,7 @@
     position: absolute;
     right: map-get($grid-margin-widths, small);
     text-indent: calc(100% + 10rem);
-    top: $spv-inner--large;
+    top: calc(#{$spv-inner--large} + #{map-get($nudges, nudge--x-small)});
     width: map-get($icon-sizes, default);
 
     @media (min-width: $threshold-4-6-col) {
@@ -43,7 +43,8 @@
 
     @media (min-width: $breakpoint-navigation-threshold) {
       position: absolute;
-      top: $spv-inner--medium * 4;
+      // padding applied to .p-navigation__link + line-heigh of the anchor text inside
+      top: $spv-inner--large * 2 + map-get($line-heights, default-text);
     }
 
     @media (max-width: $breakpoint-navigation-threshold - 1) {

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -71,18 +71,18 @@
       // Display the highlight when focussing in modern browsers that support
       // focus-visible.
       &:focus:not(:focus-visible) {
-        @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false, $sph-inner);
       }
 
       &:active,
       &:hover,
       &[aria-selected='true'] {
-        @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false, $sph-inner);
 
         // Display the highlight when focussing (in combination with the parent
         // states) in modern browsers that support focus-visible.
         &:focus:not(:focus-visible) {
-          @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
+          @include vf-highlight-bar($color-tabs-active-bar, bottom, false, $sph-inner);
         }
 
         // Hide the highlight when focussing (in combination with the parent

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -42,6 +42,7 @@ $color-label-validated: #006b75;
 $color-code-background: rgba($color-x-dark, 0.03);
 $color-code-background-dark: rgba($color-x-light, 0.3);
 $color-code-heading-background: rgba($color-x-dark, 0.08);
+$color-navigation-highlight: #e95420;
 
 $states: (
   error: $color-negative,
@@ -87,11 +88,15 @@ $colors--light-theme--border-default: rgba($color-x-dark, 0.15) !default;
 $colors--light-theme--border-high-contrast: rgba($color-x-dark, 0.56) !default;
 $colors--light-theme--border-low-contrast: rgba($color-x-dark, 0.1) !default;
 
+$colors--light-theme--nav-highlight: $color-navigation-highlight !default;
+
 // Dark theme
 $colors--dark-theme--text-default: hsl(0, 0%, 100%) !default;
-$colors--dark-theme--text-hover: hsl(0, 0%, 56%) !default; // minimum contrast on primary that satisfies contrast checker AA
+$colors--dark-theme--nav-link-hover: $color-x-light !default;
+$colors--dark-theme--text-hover: hsl(0, 0%, 76%) !default; // minimum contrast on primary that satisfies contrast checker AA
 $colors--dark-theme--text-disabled: rgba($colors--dark-theme--text-default, 0.55) !default;
 $colors--dark-theme--text-muted: rgba($colors--dark-theme--text-default, 0.55) !default;
+$colors--dark-theme--nav-link-hover: $colors--dark-theme--text-hover !default;
 
 $colors--dark-theme--background-default: hsl(0, 0%, 15%) !default;
 $colors--dark-theme--background-alt: hsl(0, 0%, 20%) !default;
@@ -102,6 +107,8 @@ $colors--dark-theme--background-overlay: transparentize($color-dark, 0.15) !defa
 $colors--dark-theme--border-default: rgba($colors--dark-theme--text-default, 0.2) !default;
 $colors--dark-theme--border-high-contrast: rgba($colors--dark-theme--text-default, 0.4) !default;
 $colors--dark-theme--border-low-contrast: rgba($colors--dark-theme--text-default, 0.1) !default;
+
+$colors--dark-theme--nav-highlight: $color-navigation-highlight !default;
 
 // Branding colors
 $color-brand: #333 !default;

--- a/scss/_utilities_font-metrics.scss
+++ b/scss/_utilities_font-metrics.scss
@@ -1,6 +1,6 @@
 @import 'settings_font';
 
-@mixin vf-u-visualise-baseline($horisontal-bleed: 2rem) {
+@mixin vf-u-visualise-baseline($horizontal-bleed: 2rem) {
   .u-visualise-font-metrics {
     position: relative;
 
@@ -12,20 +12,20 @@
       border-width: 1px;
       content: '';
       height: calc(#{$cap-height - $x-height});
-      left: -#{$horisontal-bleed};
+      left: -#{$horizontal-bleed};
       position: absolute;
       top: calc(#{$baseline-position - $cap-height} - 1px);
-      width: calc(#{$horisontal-bleed * 2} + 100%);
+      width: calc(#{$horizontal-bleed * 2} + 100%);
     }
 
     &::after {
       background-color: transparentize($color-negative, 0.5);
       content: '';
       height: 1px;
-      left: -#{$horisontal-bleed};
+      left: -#{$horizontal-bleed};
       position: absolute;
       top: calc(#{$baseline-position} - 1px);
-      width: calc(#{$horisontal-bleed * 2} + 100%);
+      width: calc(#{$horizontal-bleed * 2} + 100%);
     }
   }
 }


### PR DESCRIPTION
## Done

- Adjusted height of top nav logo, and padding around nav items
- Added new selected/hover/active state to top nav, featuring Ubuntu orange

Fixes #3653 

## QA

- Open [default dark nav demo](https://vanilla-framework-3727.demos.haus/docs/examples/patterns/navigation/default-dark)
- Open [default nav demo](https://vanilla-framework-3727.demos.haus/docs/examples/patterns/navigation/default)
- See that the updates comply with the [design](https://app.zeplin.io/project/5ef9d96f06f00111064d6268/screen/6076f590cf53b53d0add509c)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
