### PR TITLE
Remove hardcoded color from stroke in error icon

### DIFF
--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -45,7 +45,7 @@
 }
 
 @mixin vf-icon-error($color: $color-negative) {
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='%23C7162B' stroke-width='1.5' fill='#{vf-url-friendly-color($color)}' cx='8' cy='8' r='6.25'/%3E%3Cpath fill='%23FFF' fill-rule='nonzero' d='M10.282 4.638l1.06 1.06L9.05 7.99l2.293 2.292-1.06 1.06L7.99 9.05 5.7 11.343l-1.06-1.06 2.29-2.293L4.64 5.7l1.06-1.06 2.291 2.29z'/%3E%3C/g%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='#{vf-url-friendly-color($color)}' stroke-width='1.5' fill='#{vf-url-friendly-color($color)}' cx='8' cy='8' r='6.25'/%3E%3Cpath fill='%23FFF' fill-rule='nonzero' d='M10.282 4.638l1.06 1.06L9.05 7.99l2.293 2.292-1.06 1.06L7.99 9.05 5.7 11.343l-1.06-1.06 2.29-2.293L4.64 5.7l1.06-1.06 2.291 2.29z'/%3E%3C/g%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-warning($color: $color-caution) {


### PR DESCRIPTION
## Done

Removed hardcoded red color from error icon svg outline

Fixes #3725 

## QA

- Check out this branch
- Locally, update the color variable on [line 233 of _patterns_icons.scss](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_patterns_icons.scss#L233) to any color value.
- `dotrun` the project
- Visit [icons example](/docs/examples/patterns/icons/icons-dark)
- See that error icon does not have a red outline, and that the circle part of the icon is the color you set (the `x` should remain white).

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

For purposes of these screenshots only, the default red has been replaced with blue:

### Before
![Screenshot from 2021-05-04 15-59-45](https://user-images.githubusercontent.com/2376968/117024512-f86e3500-acf1-11eb-8053-89f9b3f9cd86.png)

### After
![Screenshot from 2021-05-04 16-00-10](https://user-images.githubusercontent.com/2376968/117024541-fe641600-acf1-11eb-9cbf-70908bd8d6c7.png)


