### PR TITLE
Standardize hover and active states across components

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -9,7 +9,7 @@
   }
 
   %vf-button-base {
-    @include vf-animation(#{background-color, border-color}, fast, in);
+    @include vf-animation(#{background-color, border-color}, snap, in);
     @include vf-focus;
 
     border-radius: $border-radius;
@@ -92,18 +92,15 @@
   }
 }
 
-/// mixin for all the buttons
-/// there are sensible defaults, but you can
-/// override colors as desired
 @mixin vf-button-pattern(
   $button-background-color: $color-x-light,
   $button-text-color: $color-dark,
   $button-disabled-background-color: $color-transparent,
   $button-disabled-border-color: $colors--light-theme--border-high-contrast,
   $button-border-color: $colors--light-theme--border-high-contrast,
-  $button-hover-background-color: scale-color($color-x-light, $lightness: -$hover-background-opacity-amount * 100%),
+  $button-hover-background-color: $colors--light-theme--background-hover,
   $button-hover-border-color: $colors--light-theme--border-high-contrast,
-  $button-active-background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-amount * 100%),
+  $button-active-background-color: $colors--light-theme--background-active,
   $button-active-border-color: $colors--light-theme--border-high-contrast
 ) {
   background-color: $button-background-color;

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -108,7 +108,7 @@
   @return $value;
 }
 
-@mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false, $horizontal-padding: 0) {
+@mixin vf-highlight-bar($bg-color: $color-mid-dark, $position: top, $over-border: false) {
   position: relative;
 
   &::before {
@@ -127,9 +127,6 @@
         left: -1px;
         right: -1px;
         z-index: 1;
-      } @else {
-        left: $horizontal-padding;
-        right: $horizontal-padding;
       }
 
       @if $position == bottom {

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -127,6 +127,9 @@
         left: -1px;
         right: -1px;
         z-index: 1;
+      } @else {
+        left: 0;
+        right: 0;
       }
 
       @if $position == bottom {

--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -35,15 +35,18 @@
   }
 
   %p-article-pagination__link {
+    @extend %vf-button-base;
+    @include vf-button-pattern(
+      $button-border-color: $color-transparent,
+      $button-hover-border-color: $color-transparent,
+      $button-active-border-color: $color-transparent,
+      $button-disabled-border-color: $color-transparent
+    );
+
     margin-top: 0;
     padding: $sp-medium;
     position: relative;
     width: 50%;
-
-    &:hover {
-      background: $color-light;
-      text-decoration: none;
-    }
   }
 
   .p-article-pagination__link {

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -27,7 +27,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   %p-button {
     @extend %vf-button-base;
 
-    @include vf-button-pattern($button-disabled-background-color: $color-x-light, $button-disabled-border-color: $color-x-light, $button-active-border-color: $color-x-light);
+    @include vf-button-pattern($button-disabled-background-color: transparent, $button-disabled-border-color: transparent);
   }
 
   .p-button {
@@ -53,13 +53,14 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
     @include vf-button-pattern(
       $button-background-color: $color-brand,
-      $button-border-color: $color-brand,
-      $button-text-color: vf-contrast-text-color($color-brand),
-      $button-hover-background-color: scale-color($color-brand, $lightness: -$hover-background-opacity-percentage),
+      $button-hover-background-color: adjust-color($color-brand, $lightness: -$hover-background-opacity-percentage),
+      $button-active-background-color: adjust-color($color-brand, $lightness: -$active-background-opacity-percentage),
       $button-disabled-background-color: $color-brand,
+      $button-border-color: $color-brand,
+      $button-hover-border-color: adjust-color($color-brand, $lightness: -$hover-background-opacity-percentage),
+      $button-active-border-color: adjust-color($color-brand, $lightness: -$active-background-opacity-percentage),
       $button-disabled-border-color: $color-brand,
-      $button-active-background-color: scale-color($color-brand, $lightness: -$active-background-opacity-percentage),
-      $button-active-border-color: scale-color($color-brand, $lightness: -$active-background-opacity-percentage)
+      $button-text-color: vf-contrast-text-color($color-brand)
     );
   }
 
@@ -75,12 +76,14 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
     @include vf-button-pattern(
       $button-background-color: $color-positive,
-      $button-border-color: $color-positive,
-      $button-text-color: $color-x-light,
-      $button-hover-background-color: scale-color($color-positive, $lightness: -$hover-background-opacity-percentage),
+      $button-hover-background-color: adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage),
+      $button-active-background-color: adjust-color($color-positive, $lightness: -$active-background-opacity-percentage),
       $button-disabled-background-color: $color-positive,
+      $button-border-color: $color-positive,
+      $button-hover-border-color: adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage),
+      $button-active-border-color: adjust-color($color-positive, $lightness: -$active-background-opacity-percentage),
       $button-disabled-border-color: $color-positive,
-      $button-active-background-color: scale-color($color-positive, $lightness: -$active-background-opacity-percentage)
+      $button-text-color: vf-contrast-text-color($color-positive)
     );
 
     @include vf-focus($color-focus-positive);
@@ -98,13 +101,14 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
     @include vf-button-pattern(
       $button-background-color: $color-negative,
-      $button-border-color: $color-negative,
-      $button-text-color: $color-x-light,
-      $button-hover-background-color: scale-color($color-negative, $lightness: -$hover-background-opacity-percentage),
+      $button-hover-background-color: adjust-color($color-negative, $lightness: -$hover-background-opacity-percentage),
+      $button-active-background-color: adjust-color($color-negative, $lightness: -$active-background-opacity-percentage),
       $button-disabled-background-color: $color-negative,
+      $button-border-color: $color-negative,
+      $button-hover-border-color: adjust-color($color-negative, $lightness: -$hover-background-opacity-percentage),
+      $button-active-border-color: adjust-color($color-negative, $lightness: -$active-background-opacity-percentage),
       $button-disabled-border-color: $color-negative,
-      $button-active-background-color: scale-color($color-negative, $lightness: -$active-background-opacity-percentage),
-      $button-active-border-color: scale-color($color-negative, $lightness: -$active-background-opacity-percentage)
+      $button-text-color: vf-contrast-text-color($color-negative)
     );
 
     @include vf-focus($color-focus-negative);
@@ -121,12 +125,8 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
     @extend %vf-button-base;
 
     @include vf-button-pattern(
-      $button-background-color: $color-transparent,
       $button-border-color: $color-transparent,
-      $button-text-color: $color-dark,
-      $button-hover-background-color: scale-color($color-x-light, $lightness: -$hover-background-opacity-percentage),
       $button-hover-border-color: $color-transparent,
-      $button-active-background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-percentage),
       $button-active-border-color: $color-transparent,
       $button-disabled-border-color: $color-transparent
     );

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -2,11 +2,14 @@
 
 @mixin vf-p-chip {
   $chip-line-height: 1rem;
+  $base-background-opacity-amount: 0.05;
+  $color-background-base: adjust-color($color-x-dark, $lightness: 100% * (1 - $base-background-opacity-amount));
+  $color-background-hover: adjust-color($color-x-dark, $lightness: 100% * (1 - ($base-background-opacity-amount + $hover-background-opacity-amount)));
 
   .p-chip {
     @extend %small-text;
 
-    background-color: rgba($color-x-dark, 0.05);
+    background-color: $color-background-base;
     border-radius: $chip-line-height;
     display: inline-flex;
     line-height: $chip-line-height;
@@ -20,19 +23,12 @@
     white-space: nowrap;
 
     &:hover {
-      background-color: rgba($color-x-dark, 0.08);
+      background-color: $color-background-hover;
     }
 
-    &.is-selected {
-      background-color: rgba($color-x-dark, 0.15);
-
-      &:hover {
-        background-color: rgba($color-x-dark, 0.18);
-      }
-    }
-
+    &.is-selected,
     &:active {
-      background-color: rgba($color-x-dark, 0.15);
+      background-color: $colors--light-theme--background-active;
     }
 
     .p-chip__lead,

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -120,7 +120,7 @@
   $color-contextual-menu-border,
   // color of the contextual menu item link text
   $color-contextual-menu-text,
-  // color of the contextual menu item link hover background
+  // color of the contextual menu item link active background
   $color-contextual-menu-active-background,
   // color of the contextual menu item link hover background
   $color-contextual-menu-hover-background
@@ -148,6 +148,7 @@
 
     &:active {
       background-color: $color-contextual-menu-active-background;
+      cursor: default;
     }
   }
 }
@@ -155,19 +156,19 @@
 @mixin vf-contextual-menu-light-theme {
   @include vf-contextual-menu-theme(
     $color-contextual-menu-background: $colors--light-theme--background-default,
-    $color-contextual-menu-border: $colors--light-theme--border-default,
-    $color-contextual-menu-text: $colors--light-theme--text-default,
+    $color-contextual-menu-hover-background: $colors--light-theme--background-hover,
     $color-contextual-menu-active-background: $colors--light-theme--background-active,
-    $color-contextual-menu-hover-background: $colors--light-theme--background-hover
+    $color-contextual-menu-border: $colors--light-theme--border-default,
+    $color-contextual-menu-text: $colors--light-theme--text-default
   );
 }
 
 @mixin vf-contextual-menu-dark-theme {
   @include vf-contextual-menu-theme(
     $color-contextual-menu-background: $colors--dark-theme--background-default,
-    $color-contextual-menu-border: $colors--dark-theme--border-default,
-    $color-contextual-menu-text: $colors--dark-theme--text-default,
+    $color-contextual-menu-hover-background: $colors--dark-theme--background-hover,
     $color-contextual-menu-active-background: $colors--dark-theme--background-active,
-    $color-contextual-menu-hover-background: $colors--dark-theme--background-hover
+    $color-contextual-menu-border: $colors--dark-theme--border-default,
+    $color-contextual-menu-text: $colors--dark-theme--text-default
   );
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -382,10 +382,10 @@ $lightness-threshold: 70;
   %navigation-link-selected {
     @extend %navigation-link-hover;
 
-    @include vf-highlight-bar($color-navigation-highlight, left, true, 0);
+    @include vf-highlight-bar($color-navigation-highlight, left, true);
 
     @media (min-width: $breakpoint-navigation-threshold) {
-      @include vf-highlight-bar($color-navigation-highlight, bottom, false, 0);
+      @include vf-highlight-bar($color-navigation-highlight, bottom, false);
     }
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -246,7 +246,7 @@ $lightness-threshold: 70;
 
       @media (min-width: $breakpoint-navigation-threshold) {
         // align baselines of menu items and input text
-        $input-gap-top: $spv-inner--medium - $spv-nudge;
+        $input-gap-top: $spv-inner--large - $spv-nudge;
 
         display: flex;
         flex: 1 1 auto;
@@ -345,12 +345,23 @@ $lightness-threshold: 70;
   // color for the navigation background
   $color-navigation-background,
   // color for the navigation text
+  $color-navigation-background--hover,
+  $color-navigation-background--active,
   $color-navigation-text,
   // color for the navigation highlight bar
   $color-navigation-highlight,
   $color-navigation-background--hover
 ) {
   background-color: $color-navigation-background;
+
+  %navigation-link-before {
+    // separator color on small screens
+    background: $color-navigation-separator;
+  }
+
+  %navigation-link-hover {
+    background-color: $color-navigation-background--hover;
+  }
 
   %navigation-link-theme {
     &,
@@ -361,21 +372,22 @@ $lightness-threshold: 70;
     }
 
     &:hover {
-      background-color: $color-navigation-background--hover;
+      @extend %navigation-link-hover;
+    }
+
+    &:active {
+      background-color: $color-navigation-background--active;
     }
   }
 
   %navigation-link-selected {
-    @include vf-highlight-bar($color-navigation-highlight, left, true, $sph-inner);
+    @extend %navigation-link-hover;
+
+    @include vf-highlight-bar($color-navigation-highlight, left, true, 0);
 
     @media (min-width: $breakpoint-navigation-threshold) {
-      @include vf-highlight-bar($color-navigation-highlight, bottom, false, $sph-inner);
+      @include vf-highlight-bar($color-navigation-highlight, bottom, false, 0);
     }
-  }
-
-  %navigation-link-before {
-    // separator color on small screens
-    background: $color-navigation-separator;
   }
 
   .p-navigation__item > .p-navigation__link, // remove nesting in 3.0 when deprecated __link styles are removed
@@ -413,10 +425,11 @@ $lightness-threshold: 70;
 @mixin vf-navigation-light-theme($override-default: false) {
   @if ($override-default) {
     @include vf-navigation-theme(
-      $color-navigation-background: $colors--light-theme--background-default,
-      $color-navigation-highlight: $color-accent,
       $color-navigation-text: $colors--light-theme--text-default,
+      $color-navigation-background: $colors--light-theme--background-default,
       $color-navigation-background--hover: $colors--light-theme--background-alt,
+      $color-navigation-background--active: $colors--light-theme--background-active,
+      $color-navigation-highlight: $colors-accent,
       $color-navigation-separator: $colors--light-theme--border-low-contrast
     );
   } @else {
@@ -425,10 +438,11 @@ $lightness-threshold: 70;
     $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme--text-default, $colors--dark-theme--text-default) !default;
 
     @include vf-navigation-theme(
-      $color-navigation-background: $color-navigation-background,
-      $color-navigation-highlight: $color-accent,
       $color-navigation-text: $color-navigation-text,
+      $color-navigation-background: $color-navigation-background,
       $color-navigation-background--hover: $colors--light-theme--background-alt,
+      $color-navigation-background--active: $colors--light-theme--background-active,
+      $color-navigation-highlight: $color-accent,
       $color-navigation-separator: $colors--light-theme--border-low-contrast
     );
   }
@@ -437,10 +451,11 @@ $lightness-threshold: 70;
 @mixin vf-navigation-dark-theme($override-default: false) {
   @if ($override-default) {
     @include vf-navigation-theme(
-      $color-navigation-background: $colors--dark-theme--background-default,
-      $color-navigation-highlight: $color-accent,
       $color-navigation-text: $colors--dark-theme--text-default,
-      $color-navigation-background--hover: $colors--dark-theme--background-alt,
+      $color-navigation-background: $colors--dark-theme--background-default,
+      $color-navigation-background--hover: $colors--dark-theme--background-hover,
+      $color-navigation-background--active: $colors--dark-theme--background-active,
+      $color-navigation-highlight: $color-accent,
       $color-navigation-separator: $colors--dark-theme--border-low-contrast
     );
   } @else {
@@ -449,10 +464,11 @@ $lightness-threshold: 70;
     $color-navigation-text: if(lightness($color-navigation-background) > $lightness-threshold, $colors--light-theme--text-default, $colors--dark-theme--text-default) !default;
 
     @include vf-navigation-theme(
-      $color-navigation-background: $color-navigation-background,
-      $color-navigation-highlight: $color-accent,
       $color-navigation-text: $color-navigation-text,
-      $color-navigation-background--hover: $colors--dark-theme--background-alt,
+      $color-navigation-background: $color-navigation-background,
+      $color-navigation-background--hover: $colors--dark-theme--background-hover,
+      $color-navigation-background--active: $colors--dark-theme--background-active,
+      $color-navigation-highlight: $color-accent,
       $color-navigation-separator: $colors--dark-theme--border-low-contrast
     );
   }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -344,13 +344,12 @@ $lightness-threshold: 70;
   $color-navigation-separator,
   // color for the navigation background
   $color-navigation-background,
-  // color for the navigation text
-  $color-navigation-background--hover,
   $color-navigation-background--active,
+  // color for the navigation text
   $color-navigation-text,
+  $color-navigation-background--hover,
   // color for the navigation highlight bar
-  $color-navigation-highlight,
-  $color-navigation-background--hover
+  $color-navigation-highlight
 ) {
   background-color: $color-navigation-background;
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -429,7 +429,7 @@ $lightness-threshold: 70;
       $color-navigation-background: $colors--light-theme--background-default,
       $color-navigation-background--hover: $colors--light-theme--background-alt,
       $color-navigation-background--active: $colors--light-theme--background-active,
-      $color-navigation-highlight: $colors-accent,
+      $color-navigation-highlight: $color-accent,
       $color-navigation-separator: $colors--light-theme--border-low-contrast
     );
   } @else {

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -452,17 +452,19 @@
       color: $color-sidenav-text-active;
     }
 
-    &:active {
+    &:active,
+    &.is-active,
+    &[aria-current='page'],
+    &[aria-current='true'] {
       background: $color-sidenav-item-background-active;
+      color: $color-sidenav-text-active;
+      cursor: default;
     }
 
     &.is-active,
     &[aria-current='page'],
     &[aria-current='true'] {
       @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
-
-      background: $color-sidenav-item-background-hover;
-      color: $color-sidenav-text-active;
     }
   }
 
@@ -503,7 +505,7 @@
 
 @mixin vf-side-navigation-theme-light {
   @include vf-side-navigation-theme(
-    $color-sidenav-text-default: $colors--light-theme--text-muted,
+    $color-sidenav-text-default: $colors--light-theme--text-inactive,
     $color-sidenav-background-default: $colors--light-theme--background-default,
     $color-sidenav-background-overlay: $colors--light-theme--background-overlay,
     $color-sidenav-text-active: $colors--light-theme--text-default,
@@ -511,7 +513,7 @@
     $color-sidenav-item-background-hover: $colors--light-theme--background-hover,
     $color-sidenav-item-border-highlight: $colors--light-theme--text-default,
     $color-sidenav-list-border: $colors--light-theme--border-low-contrast,
-    $color-sidenav-toggle-icon: $colors--light-theme--text-muted
+    $color-sidenav-toggle-icon: $colors--light-theme--text-inactive
   );
 }
 
@@ -521,7 +523,7 @@
   // but vf-url-friendly-color doesn't support rgba(),
   // so we are using #999 as fallback for now
   @include vf-side-navigation-theme(
-    $color-sidenav-text-default: $colors--dark-theme--text-muted,
+    $color-sidenav-text-default: $colors--dark-theme--text-inactive,
     $color-sidenav-background-default: $colors--dark-theme--background-default,
     $color-sidenav-background-overlay: $colors--dark-theme--background-overlay,
     $color-sidenav-text-active: $colors--dark-theme--text-default,
@@ -564,16 +566,13 @@
       color: $color-sidenav-text-active;
     }
 
-    &:active {
-      background: $color-sidenav-item-background-active;
-    }
-
+    &:active,
     &.is-active,
     &[aria-current='page'],
     &[aria-current='true'] {
       @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
 
-      background: $color-sidenav-item-background-hover;
+      background: $color-sidenav-item-background-active;
       color: $color-sidenav-text-active;
     }
   }
@@ -590,7 +589,7 @@
 
 @mixin vf-side-navigation-raw-html-theme-light {
   @include vf-side-navigation-raw-html-theme(
-    $color-sidenav-text-default: $colors--light-theme--text-muted,
+    $color-sidenav-text-default: $colors--light-theme--text-inactive,
     $color-sidenav-text-active: $colors--light-theme--text-default,
     $color-sidenav-item-background-active: $colors--light-theme--background-active,
     $color-sidenav-item-background-hover: $colors--light-theme--background-hover,
@@ -601,7 +600,7 @@
 
 @mixin vf-side-navigation-raw-html-theme-dark {
   @include vf-side-navigation-raw-html-theme(
-    $color-sidenav-text-default: $colors--dark-theme--text-muted,
+    $color-sidenav-text-default: $colors--dark-theme--text-inactive,
     $color-sidenav-text-active: $colors--dark-theme--text-default,
     $color-sidenav-item-background-active: $colors--dark-theme--background-active,
     $color-sidenav-item-background-hover: $colors--dark-theme--background-hover,

--- a/scss/_patterns_subnav.scss
+++ b/scss/_patterns_subnav.scss
@@ -136,6 +136,8 @@
   $color-subnav-text,
   // color of the subnav items background on hover
   $color-subnav-background-hover,
+  // color of the subnav items background on active
+  $color-subnav-background-active,
   // color of the subnav items text on hover
   $color-subnav-text-hover,
   // color of the subnav items separator on small screens
@@ -143,6 +145,10 @@
 ) {
   &::after {
     @include vf-icon-chevron($color-subnav-icon);
+  }
+
+  .p-subnav__items {
+    background-color: $color-subnav-background;
   }
 
   .p-subnav__item {
@@ -159,16 +165,22 @@
       background-color: $color-subnav-background-hover;
       color: $color-subnav-text-hover;
     }
+
+    &:active {
+      background: $color-subnav-background-active;
+      color: $color-subnav-text-hover;
+    }
   }
 }
 
 @mixin vf-subnav-light-theme {
   @include vf-subnav-theme(
-    $color-subnav-icon: $colors--light-theme--text-muted,
     $color-subnav-background: $colors--light-theme--background-default,
-    $color-subnav-text: $colors--light-theme--text-default,
     $color-subnav-background-hover: $colors--light-theme--background-alt,
+    $color-subnav-background-active: $colors--light-theme--background-active,
+    $color-subnav-text: $colors--light-theme--text-default,
     $color-subnav-text-hover: $colors--light-theme--text-default,
+    $color-subnav-icon: $color-mid-dark,
     $color-subnav-separator: $colors--light-theme--border-default
   );
 }
@@ -179,11 +191,12 @@
   // but vf-url-friendly-color doesn't support rgba(),
   // so we are using #999 as fallback for now
   @include vf-subnav-theme(
-    $color-subnav-icon: #999,
     $color-subnav-background: $colors--dark-theme--background-alt,
+    $color-subnav-background-hover: $colors--dark-theme--background-hover,
+    $color-subnav-background-active: $colors--dark-theme--background-active,
     $color-subnav-text: $colors--dark-theme--text-default,
-    $color-subnav-text-hover: $colors--dark-theme--background-default,
-    $color-subnav-background-hover: $colors--dark-theme--text-default,
+    $color-subnav-text-hover: $colors--dark-theme--text-default,
+    $color-subnav-icon: $color-mid-x-light,
     $color-subnav-separator: $colors--dark-theme--border-default
   );
 }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -71,17 +71,17 @@
       // Display the highlight when focussing in modern browsers that support
       // focus-visible.
       &:focus:not(:focus-visible) {
-        @include vf-highlight-bar($color-tabs-active-bar, bottom, false, 0);
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
       }
 
       &:active,
       &[aria-selected='true'] {
-        @include vf-highlight-bar($color-tabs-active-bar, bottom, false, 0);
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
 
         // Display the highlight when focussing (in combination with the parent
         // states) in modern browsers that support focus-visible.
         &:focus:not(:focus-visible) {
-          @include vf-highlight-bar($color-tabs-active-bar, bottom, false, 0);
+          @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
         }
 
         // Hide the highlight when focussing (in combination with the parent

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -2,7 +2,7 @@
 
 @mixin vf-p-tabs {
   // for _patterns_tabs.scss
-  $color-tabs-active-bar: $color-mid-dark !default;
+  $color-tabs-active-bar: $colors--light-theme--text-default !default;
 
   .p-tabs {
     border-radius: 0;
@@ -33,9 +33,16 @@
     }
 
     &__link {
-      @include vf-focus;
+      @extend %vf-button-base;
+      @include vf-button-pattern(
+        $button-border-color: $color-transparent,
+        $button-hover-border-color: $color-transparent,
+        $button-active-border-color: $color-transparent,
+        $button-disabled-border-color: $color-transparent
+      );
+      @include vf-highlight-bar(transparent, bottom, false);
 
-      border: 0;
+      border: none;
       color: $color-dark;
       display: block;
       line-height: map-get($line-heights, default-text);
@@ -43,16 +50,9 @@
       padding: $spv-inner--medium $sph-inner;
       position: relative;
 
-      &:active,
-      &:hover,
-      &:visited {
-        background: none;
-        color: $color-dark;
-        text-decoration: none;
-      }
-
       &::before {
         @extend %vf-pseudo-border;
+        @include vf-animation(#{background-color, border-color}, snap, in);
 
         bottom: 0;
         z-index: 1;
@@ -71,18 +71,17 @@
       // Display the highlight when focussing in modern browsers that support
       // focus-visible.
       &:focus:not(:focus-visible) {
-        @include vf-highlight-bar($color-tabs-active-bar, bottom, false, $sph-inner);
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false, 0);
       }
 
       &:active,
-      &:hover,
       &[aria-selected='true'] {
-        @include vf-highlight-bar($color-tabs-active-bar, bottom, false, $sph-inner);
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false, 0);
 
         // Display the highlight when focussing (in combination with the parent
         // states) in modern browsers that support focus-visible.
         &:focus:not(:focus-visible) {
-          @include vf-highlight-bar($color-tabs-active-bar, bottom, false, $sph-inner);
+          @include vf-highlight-bar($color-tabs-active-bar, bottom, false, 0);
         }
 
         // Hide the highlight when focussing (in combination with the parent

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -35,7 +35,9 @@ $color-focus-negative: #3b0006 !default;
 
 // Button background color changes
 $hover-background-opacity-amount: 0.05;
-$active-background-opacity-amount: 0.15;
+$active-background-opacity-amount: 0.08;
+$muted-text-opacity-amount: 0.6;
+$inactive-text-opacity-amount: 0.75;
 
 // NON-SEMANTIC COLOURS
 $color-label-validated: #006b75;
@@ -73,14 +75,14 @@ $states: (
 
 // Light theme
 $colors--light-theme--text-default: #111 !default;
-$colors--light-theme--text-hover: #757575 !default;
 $colors--light-theme--text-disabled: #666 !default;
-$colors--light-theme--text-muted: #666 !default;
+$colors--light-theme--text-muted: rgba($color-x-dark, $muted-text-opacity-amount) !default;
+$colors--light-theme--text-inactive: rgba($color-x-dark, $inactive-text-opacity-amount) !default;
 
 $colors--light-theme--background-default: #fff !default;
 $colors--light-theme--background-alt: #f7f7f7 !default;
-$colors--light-theme--background-active: rgba($color-x-dark, $active-background-opacity-amount) !default;
-$colors--light-theme--background-hover: rgba($color-x-dark, $hover-background-opacity-amount) !default;
+$colors--light-theme--background-active: adjust-color($color-x-dark, $lightness: 100% * (1 - $active-background-opacity-amount)) !default;
+$colors--light-theme--background-hover: adjust-color($color-x-dark, $lightness: 100% * (1 - $hover-background-opacity-amount)) !default;
 $colors--light-theme--background-overlay: transparentize($color-dark, 0.15) !default;
 
 $colors--light-theme--border-default: rgba($color-x-dark, 0.15) !default;
@@ -92,7 +94,8 @@ $colors--dark-theme--text-default: hsl(0, 0%, 100%) !default;
 $colors--dark-theme--nav-link-hover: $color-x-light !default;
 $colors--dark-theme--text-hover: hsl(0, 0%, 76%) !default; // minimum contrast on primary that satisfies contrast checker AA
 $colors--dark-theme--text-disabled: rgba($colors--dark-theme--text-default, 0.55) !default;
-$colors--dark-theme--text-muted: rgba($colors--dark-theme--text-default, 0.55) !default;
+$colors--dark-theme--text-muted: rgba($colors--dark-theme--text-default, $muted-text-opacity-amount) !default;
+$colors--dark-theme--text-inactive: rgba($colors--dark-theme--text-default, $inactive-text-opacity-amount) !default;
 $colors--dark-theme--nav-link-hover: $colors--dark-theme--text-hover !default;
 
 $colors--dark-theme--background-default: hsl(0, 0%, 15%) !default;

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -3,7 +3,7 @@
 
 // Global placeholder settings
 
-$bar-thickness: 0.1875rem !default; // 4px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
+$bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
 $border-radius: $sp-unit * 0.25 !default;
 $border: 1px solid $color-mid-light !default;
 $box-shadow: 0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8) !default;

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -3,7 +3,7 @@
 
 // Global placeholder settings
 
-$bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
+$bar-thickness: 0.1875rem !default; // 4px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
 $border-radius: $sp-unit * 0.25 !default;
 $border: 1px solid $color-mid-light !default;
 $box-shadow: 0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8) !default;

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 280000,
+      threshold: 285000,
       result: results['total-stylesheet-size'],
     },
     {

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 270000,
+      threshold: 280000,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3665

## QA

- Inspect side navigation, chips, buttons (all flavours), accordion
- Verify states are consistent

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
