### PR TITLE
Fix blog links on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -215,6 +215,7 @@
     articlesContainerSelector: "#articles",
     articleTemplateSelector: "#template",
     gtmEventLabel: "Vanilla homepage",
+    hostname: "ubuntu.com",
     limit: "4",
     tagId: "2962",
   })


### PR DESCRIPTION
## Done

Added `hostname` param to latest-news call, so links are absolute and not relative

## QA

- Open [demo](https://vanilla-framework-3735.demos.haus)
- Scroll to the blog section, click any of the blog links, see that you are taken to the ubuntu.com blog

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
