### PR TITLE
update homepage URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/canonical-web-and-design/vanilla-framework/issues"
   },
   "description": "A simple, extendable CSS framework.",
-  "homepage": "http://canonical-web-and-design.github.io/vanilla-framework/",
+  "homepage": "https://vanillaframework.io/",
   "keywords": [
     "ubuntu",
     "vanilla",


### PR DESCRIPTION
## Done

Fixed the homepage link in package.json

Fixes #3734

## QA

- Check the `homepage` value in package.json, see that the URL takes you the Vanilla homepage

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
