### PR TITLE
Split align utlity examples to better describe their uses

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -93,7 +93,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Utilities</span></li>
-              {{ side_nav_item("/docs/utilities/align", "Alignment") }}
+              {{ side_nav_item("/docs/utilities/align", "Align") }}
               {{ side_nav_item("/docs/utilities/baseline-grid", "Baseline grid") }}
               {{ side_nav_item("/docs/utilities/clearfix", "Clearfix") }}
               {{ side_nav_item("/docs/utilities/embedded-media", "Embedded media") }}

--- a/templates/docs/examples/utilities/align/content.html
+++ b/templates/docs/examples/utilities/align/content.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Align{% endblock %}
+{% block title %}Align / Content{% endblock %}
 
 {% block content %}
 <div>
@@ -12,8 +12,5 @@
   <div class="u-align--right">
     <img src="https://assets.ubuntu.com/v1/de9722f5-align-right.png" alt=""/>
   </div>
-  <p class="u-align-text--center">Centered text</p>
-  <p class="u-align-text--left">Left-aligned text</p>
-  <p class="u-align-text--right">Right-aligned text</p>
 </div>
 {% endblock %}

--- a/templates/docs/examples/utilities/align/text.html
+++ b/templates/docs/examples/utilities/align/text.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Align / Text{% endblock %}
+
+{% block content %}
+<p class="u-align-text--center">Centered text</p>
+<p class="u-align-text--left">Left-aligned text</p>
+<p class="u-align-text--right">Right-aligned text</p>
+{% endblock %}
+
+

--- a/templates/docs/utilities/align.md
+++ b/templates/docs/utilities/align.md
@@ -8,10 +8,20 @@ context:
 
 <hr>
 
-You can use these utilities to force the content inside an element to align center, left or right.
+### Content
 
-<div class="embedded-example"><a href="/docs/examples/utilities/align/" class="js-example">
+When you need to align elements within a container, you can use the `u-align` utilities to force them to align center, left or right.
+
+<div class="embedded-example"><a href="/docs/examples/utilities/align/content" class="js-example">
 View example of the content align utility
+</a></div>
+
+### Text
+
+If you only need text to be aligned, you can use the `u-align-text` utilities.
+
+<div class="embedded-example"><a href="/docs/examples/utilities/align/text" class="js-example">
+View example of the text align utility
 </a></div>
 
 ### Import


### PR DESCRIPTION
## Done

Split the `u-align` example into two, one for `u-align` and another for `u-align-text`

Fixes #2448 

## QA

- Open [demo](https://vanilla-framework-3737.demos.haus/docs/utilities/align)
- See that it's clear that there are two different utility classes, each with their own example

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
