### PR TITLE
Add min width to mobile card columns

### DIFF
--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -37,6 +37,7 @@
 
         td,
         tbody th {
+          min-width: 100%;
           overflow: hidden;
           padding-left: 0;
           padding-right: 0;


### PR DESCRIPTION
## Done

Adds a min-width to `p-mobile--card` columns to help enforce their correct display.

Partially fixes #3754 (doesn't address the text overflow issue)

## QA

(it's easier to QA this one line fix where the problem was first encountered)
- Go to https://ubuntu.com/cube/microcerts
- Login
- Reduce the width of the browser so it hits the mobile breakpoint, see that the width of the columns is unbearably narrow
- In dev tools, set the min-width of `.p-table--mobile-card td` to 100%
- See that the columns fit the width of the card

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![width](https://user-images.githubusercontent.com/2376968/119353766-34fed200-bc9b-11eb-9b9d-d56810d58dc4.gif)

