### PR TITLE
Make nav highlight colour overrideable

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -414,7 +414,7 @@ $lightness-threshold: 70;
   @if ($override-default) {
     @include vf-navigation-theme(
       $color-navigation-background: $colors--light-theme--background-default,
-      $color-navigation-highlight: $colors--light-theme--nav-highlight,
+      $color-navigation-highlight: $color-accent,
       $color-navigation-text: $colors--light-theme--text-default,
       $color-navigation-background--hover: $colors--light-theme--background-alt,
       $color-navigation-separator: $colors--light-theme--border-low-contrast
@@ -426,7 +426,7 @@ $lightness-threshold: 70;
 
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
-      $color-navigation-highlight: $colors--light-theme--nav-highlight,
+      $color-navigation-highlight: $color-accent,
       $color-navigation-text: $color-navigation-text,
       $color-navigation-background--hover: $colors--light-theme--background-alt,
       $color-navigation-separator: $colors--light-theme--border-low-contrast
@@ -438,7 +438,7 @@ $lightness-threshold: 70;
   @if ($override-default) {
     @include vf-navigation-theme(
       $color-navigation-background: $colors--dark-theme--background-default,
-      $color-navigation-highlight: $colors--dark-theme--nav-highlight,
+      $color-navigation-highlight: $color-accent,
       $color-navigation-text: $colors--dark-theme--text-default,
       $color-navigation-background--hover: $colors--dark-theme--background-alt,
       $color-navigation-separator: $colors--dark-theme--border-low-contrast
@@ -450,7 +450,7 @@ $lightness-threshold: 70;
 
     @include vf-navigation-theme(
       $color-navigation-background: $color-navigation-background,
-      $color-navigation-highlight: $colors--dark-theme--nav-highlight,
+      $color-navigation-highlight: $color-accent,
       $color-navigation-text: $color-navigation-text,
       $color-navigation-background--hover: $colors--dark-theme--background-alt,
       $color-navigation-separator: $colors--dark-theme--border-low-contrast

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -109,4 +109,4 @@ $colors--dark-theme--border-low-contrast: rgba($colors--dark-theme--text-default
 $color-brand: #333 !default;
 $color-brand-background: $colors--dark-theme--background-default;
 $color-accent: #e95420 !default;
-$color-accent-background: $color-accent !default;
+$color-accent-background: $color-brand !default;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -42,7 +42,7 @@ $color-label-validated: #006b75;
 $color-code-background: rgba($color-x-dark, 0.03);
 $color-code-background-dark: rgba($color-x-light, 0.3);
 $color-code-heading-background: rgba($color-x-dark, 0.08);
-$color-navigation-highlight: #e95420;
+$color-navigation-highlight: #e95420 !default;
 
 $states: (
   error: $color-negative,

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -42,7 +42,6 @@ $color-label-validated: #006b75;
 $color-code-background: rgba($color-x-dark, 0.03);
 $color-code-background-dark: rgba($color-x-light, 0.3);
 $color-code-heading-background: rgba($color-x-dark, 0.08);
-$color-navigation-highlight: #e95420 !default;
 
 $states: (
   error: $color-negative,
@@ -88,8 +87,6 @@ $colors--light-theme--border-default: rgba($color-x-dark, 0.15) !default;
 $colors--light-theme--border-high-contrast: rgba($color-x-dark, 0.56) !default;
 $colors--light-theme--border-low-contrast: rgba($color-x-dark, 0.1) !default;
 
-$colors--light-theme--nav-highlight: $color-navigation-highlight !default;
-
 // Dark theme
 $colors--dark-theme--text-default: hsl(0, 0%, 100%) !default;
 $colors--dark-theme--nav-link-hover: $color-x-light !default;
@@ -108,10 +105,8 @@ $colors--dark-theme--border-default: rgba($colors--dark-theme--text-default, 0.2
 $colors--dark-theme--border-high-contrast: rgba($colors--dark-theme--text-default, 0.4) !default;
 $colors--dark-theme--border-low-contrast: rgba($colors--dark-theme--text-default, 0.1) !default;
 
-$colors--dark-theme--nav-highlight: $color-navigation-highlight !default;
-
 // Branding colors
 $color-brand: #333 !default;
 $color-brand-background: $colors--dark-theme--background-default;
-$color-accent: $color-brand !default;
+$color-accent: #e95420 !default;
 $color-accent-background: $color-accent !default;

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -97,9 +97,9 @@ These guidelines are the framework upon which we have built our system for how c
       </p>
     </div>
     <div class="col-2 p-card u-no-padding">
-      <div class="p-strip is-shallow is-bordered" style="background-color: #333"></div>
+      <div class="p-strip is-shallow is-bordered" style="background-color: #e95420"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
-        $color-accent<br><span class="p-muted-heading">#333</span>
+        $color-accent<br><span class="p-muted-heading">#e95420</span>
       </p>
     </div>
     <div class="col-2 p-card u-no-padding">


### PR DESCRIPTION
## Done

Add !default to the recently introduced $colors--light-theme--nav-highlight so it can be overriden

## QA
- Look ast diff
- Verify the $colors--light-theme--nav-highlight ha sa !default at the end