### PR TITLE
correct typo in the positive green hex code

### DIFF
--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -15,7 +15,7 @@ $color-input-shadow: rgba($color-x-dark, 0.12) !default;
 // SEMANTIC COLOURS
 $color-negative: #c7162b !default;
 $color-caution: #f99b11 !default;
-$color-positive: #0e8620 !default;
+$color-positive: #0e8420 !default;
 $color-information: #24598f !default;
 
 // STATE VARIABLES


### PR DESCRIPTION
## Done

Looking at the git blame of the color-positive, it was accidentally converted from hex to hsl and back, introducing a change in one of the digits  form 4 to 6. This pr corrects it back to whatch the colour settings doc page specifies.
