### PR TITLE
Remove background from link button.

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -141,6 +141,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   .p-button--link {
     @extend %vf-link-base;
 
+    background-color: transparent;
     border: none;
     border-radius: 0;
     margin-right: 0;


### PR DESCRIPTION
## Done

Removes default white background from link button.

Fixes #3771 

## QA

- Open [demo](https://vanilla-framework-3772.demos.haus/docs/examples/patterns/buttons/link)
- Make sure link button looks well when background is not white

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.

