### PR TITLE
Fix small typo in navigation examples

### DIFF
--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -29,7 +29,7 @@
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Docs</a>
         </li>
-        <li class="p-navigation__link">
+        <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">About</a>
         </li>
       </ul>

--- a/templates/docs/examples/patterns/navigation/default-dark.html
+++ b/templates/docs/examples/patterns/navigation/default-dark.html
@@ -29,7 +29,7 @@
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">Partners</a>
         </li>
-        <li class="p-navigation__link">
+        <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">About</a>
         </li>
       </ul>

--- a/templates/docs/examples/patterns/navigation/default.html
+++ b/templates/docs/examples/patterns/navigation/default.html
@@ -29,7 +29,7 @@
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">Partners</a>
         </li>
-        <li class="p-navigation__link">
+        <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">About</a>
         </li>
       </ul>

--- a/templates/docs/examples/patterns/navigation/full-width.html
+++ b/templates/docs/examples/patterns/navigation/full-width.html
@@ -29,7 +29,7 @@
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">Partners</a>
         </li>
-        <li class="p-navigation__link">
+        <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">About</a>
         </li>
       </ul>


### PR DESCRIPTION
## Done
Fix small typo in navigation examples

## QA
Check code and visit the navigation examples.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3788
