### PR TITLE
Add `has-overflow` utility to tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.31.0",
+  "version": "2.32.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -30,6 +30,10 @@
     text-align: left;
     text-overflow: ellipsis;
     vertical-align: top;
+
+    &.has-overflow {
+      overflow: visible;
+    }
   }
 
   thead {

--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -34,7 +34,6 @@
       flex-basis: 0;
       flex-grow: 1;
       margin: 0;
-      overflow: hidden;
       text-overflow: ellipsis;
 
       &.p-table__expanding-panel {

--- a/scss/standalone/patterns_table-overflow.scss
+++ b/scss/standalone/patterns_table-overflow.scss
@@ -1,0 +1,20 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_contextual-menu';
+@include vf-p-contextual-menu;
+
+@import '../patterns_tooltips';
+@include vf-p-tooltips;
+
+@import '../patterns_icons';
+@include vf-p-icons;
+
+@import '../utilities_content-align';
+@include vf-u-align--right;
+
+@import '../utilities_hide';
+@include vf-u-hide;
+
+@import '../utilities_margin-collapse';
+@include vf-u-margin-collapse;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -51,7 +51,7 @@
               {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
-              {{ side_nav_item("/docs/base/tables", "Tables") }}
+              {{ side_nav_item("/docs/base/tables", "Tables", "updated") }}
               {{ side_nav_item("/docs/base/typography", "Typography") }}
             </ul>
 

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -82,6 +82,14 @@ The `<thead>` element is completely hidden from view on a smaller screen and if 
 View example of the patterns table mobile card
 </a></div>
 
+### Overflow
+
+By default, all table cells have `overflow: hidden;` applied to help maintain a table's layout at reduced widths. In some cases it is necessary to allow a cell's contents to overflow, such as when using the [contextual menu](/docs/patterns/contextual-menu) or [tooltip](/docs/patterns/tooltips) patterns, and this can be achieved by applying the `.has-overflow` class to appropriate cells.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tables/table-overflow" class="js-example">
+View example of the patterns table mobile card
+</a></div>
+
 ### Import
 
 To import either or all of these components into your project, copy the snippets below and include it in your main Sass file.

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -22,18 +22,12 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-    <!-- 2.31 -->
+    <!-- 2.32 -->
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Dropdown</a></th>
       <td><div class="p-label--updated">Updated</div></td>
-      <td>2.31.0</td>
-      <td>We introduced the <code>.p-navigation__item--dropdown-toggle</code> class, as a replacement for the now deprecated <code>.p-subnav</code> class.</td>
-    </tr>
-    <tr>
-      <th><a href="/docs/patterns/navigation#dropdown">Navigation / Sub-navigation</a></th>
-      <td><div class="p-label--deprecated">Deprecated</div></td>
-      <td>2.31.0</td>
-      <td>The <code>.p-subnav</code> class previously could theoretically be used outside of the main <code>.p-navigation</code> component, which was not intended. It has been deprecated, and succeeded by the <code>.p-navigation__item--dropdown-toggle</code> class.</td>
+      <td>2.32.0</td>
+      <td>We introduced the <code>.has-overflow</code> utility for table cells, to aid with the display of components that need to overflow the cell, such as tooltips and contextual menus.</td>
     </tr>
   </tbody>
 </table>
@@ -50,6 +44,19 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.31 -->
+    <tr>
+      <th><a href="/docs/patterns/navigation#dropdown">Navigation / Dropdown</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.31.0</td>
+      <td>We introduced the <code>.p-navigation__item--dropdown-toggle</code> class, as a replacement for the now deprecated <code>.p-subnav</code> class.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/navigation#dropdown">Navigation / Sub-navigation</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.31.0</td>
+      <td>The <code>.p-subnav</code> class previously could theoretically be used outside of the main <code>.p-navigation</code> component, which was not intended. It has been deprecated, and succeeded by the <code>.p-navigation__item--dropdown-toggle</code> class.</td>
+    </tr>
     <!-- 2.30 -->
     <tr>
       <th><a href="/docs/patterns/buttons#link">Button / Link</a></th>

--- a/templates/docs/examples/patterns/tables/table-overflow.html
+++ b/templates/docs/examples/patterns/tables/table-overflow.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_table-overflow{% endblock %}
 
 {% block content %}
-<table aria-label="Example of formatting in the table">
+<table aria-label="Example of overflowing table cells">
   <thead>
     <tr>
       <th>Name</th>

--- a/templates/docs/examples/patterns/tables/table-overflow.html
+++ b/templates/docs/examples/patterns/tables/table-overflow.html
@@ -1,0 +1,71 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Table / Overflow{% endblock %}
+
+{% block standalone_css %}patterns_table-overflow{% endblock %}
+
+{% block content %}
+<table aria-label="Example of formatting in the table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Status</th>
+      <th class="u-align--right has-overflow">
+        Actions
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Machine A</th>
+      <td class="has-overflow">Pending 
+        <span class="p-tooltip--btm-center" aria-describedby="actions-tooltip">
+          <i class="p-icon--information"></i>
+          <span class="p-tooltip__message" role="tooltip" id="actions-tooltip">This machine is currently being setup</span>
+        </span>
+      </td>
+      <td class="u-align--right has-overflow">
+        <span class="p-contextual-menu--left">
+          <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-1" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
+          <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="true">
+            <button class="p-contextual-menu__link">Commission</button>
+            <button class="p-contextual-menu__link">Aquire</button>
+            <button class="p-contextual-menu__link">Deploy</button>
+          </span>
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <th class="u-truncate">Machine B</th>
+      <td>Ready</td>
+      <td class="u-align--right has-overflow">
+        <span class="p-contextual-menu--left">
+          <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-2" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
+          <span class="p-contextual-menu__dropdown" id="menu-2" aria-hidden="true">
+            <button class="p-contextual-menu__link">Commission</button>
+            <button class="p-contextual-menu__link">Aquire</button>
+            <button class="p-contextual-menu__link">Deploy</button>
+          </span>
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <th>Machine C</th>
+      <td>Ready</td>
+      <td class="u-align--right has-overflow">
+        <span class="p-contextual-menu--left">
+          <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
+          <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
+            <button class="p-contextual-menu__link">Commission</button>
+            <button class="p-contextual-menu__link">Aquire</button>
+            <button class="p-contextual-menu__link">Deploy</button>
+          </span>
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<script>
+  {% include 'docs/examples/patterns/contextual-menu/_script.js' %}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Done

Added `has-overflow` utility to tables

Fixes #3780 

## QA
- Open [demo](/docs/examples/patterns/tables/table-overflow)
- Trigger the tooltip and contextual menus, see that they're not cut off by the cell they're in
- Review updated documentation:
  - [docs](/docs/base/tables#overflow)
  - [component status](/docs/component-status)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Screenshot from 2021-06-21 14-59-33](https://user-images.githubusercontent.com/2376968/122774689-52768a00-d2a1-11eb-89a3-924a6997f831.png)
