### PR TITLE
Fix title of `has-overflow` item in component status page

### DIFF
--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,7 +24,7 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.32 -->
     <tr>
-      <th><a href="/docs/patterns/navigation#dropdown">Navigation / Dropdown</a></th>
+      <th><a href="/docs/base/tables#overflow">Tables / Overflow</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.32.0</td>
       <td>We introduced the <code>.has-overflow</code> utility for table cells, to aid with the display of components that need to overflow the cell, such as tooltips and contextual menus.</td>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -34,7 +34,7 @@ TEAM_MEMBERS = [
     {"login": "bartaz", "role": "Senior Web Engineer"},
     {"login": "lyubomir-popov", "role": "Lead Visual Designer"},
     {"login": "ziheliu214", "role": "UX Designer"},
-    {"login": "sowasred2012", "role": "Web Developer"},
+    {"login": "sowasred2012", "role": "Web Engineer"},
 ]
 
 


### PR DESCRIPTION
## Done

- Fixed a mislabelled item in component status
- Drive by: updated a role on the contribute page

## QA

- Open [demo](https://vanilla-framework-3799.demos.haus/docs/component-status)
- Check that the item in "What's new in Vanilla 2.32" table is "Tables / Overflow" and links to the correct page

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
