### PR TITLE
Add p-label

### DIFF
--- a/scss/_patterns_label.scss
+++ b/scss/_patterns_label.scss
@@ -18,7 +18,7 @@
   .p-label {
     @extend %vf-label;
 
-    background-color: $colors--light-theme--text-disabled;
+    background-color: $color-mid-dark;
     color: $color-x-light;
   }
 

--- a/scss/_patterns_label.scss
+++ b/scss/_patterns_label.scss
@@ -15,6 +15,13 @@
     white-space: nowrap;
   }
 
+  .p-label {
+    @extend %vf-label;
+
+    background-color: $colors--light-theme--text-disabled;
+    color: $color-x-light;
+  }
+
   @include vf-p-label-validated;
   @include vf-p-label-in-progress;
   @include vf-p-label-new;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -75,7 +75,6 @@ $states: (
 
 // Light theme
 $colors--light-theme--text-default: #111 !default;
-$colors--light-theme--text-disabled: #666 !default;
 $colors--light-theme--text-muted: rgba($color-x-dark, $muted-text-opacity-amount) !default;
 $colors--light-theme--text-inactive: rgba($color-x-dark, $inactive-text-opacity-amount) !default;
 
@@ -93,7 +92,6 @@ $colors--light-theme--border-low-contrast: rgba($color-x-dark, 0.1) !default;
 $colors--dark-theme--text-default: hsl(0, 0%, 100%) !default;
 $colors--dark-theme--nav-link-hover: $color-x-light !default;
 $colors--dark-theme--text-hover: hsl(0, 0%, 76%) !default; // minimum contrast on primary that satisfies contrast checker AA
-$colors--dark-theme--text-disabled: rgba($colors--dark-theme--text-default, 0.55) !default;
 $colors--dark-theme--text-muted: rgba($colors--dark-theme--text-default, $muted-text-opacity-amount) !default;
 $colors--dark-theme--text-inactive: rgba($colors--dark-theme--text-default, $inactive-text-opacity-amount) !default;
 $colors--dark-theme--nav-link-hover: $colors--dark-theme--text-hover !default;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -68,7 +68,7 @@
               {{ side_nav_item("/docs/patterns/icons", "Icons") }}
               {{ side_nav_item("/docs/patterns/images", "Images") }}
               {{ side_nav_item("/docs/patterns/inline-images", "Inline images") }}
-              {{ side_nav_item("/docs/patterns/labels", "Labels") }}
+              {{ side_nav_item("/docs/patterns/labels", "Labels", 'new') }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
               {{ side_nav_item("/docs/patterns/lists", "Lists", "updated") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,7 +24,7 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.32 -->
     <tr>
-      <th><a href="/docs/patterns/buttons#neutral">Labels / Default</a></th>
+      <th><a href="/docs/patterns/labels#default">Labels / Default</a></th>
       <td><div class="p-label--new">New</div></td>
       <td>2.32.0</td>
       <td>We've added a default label <code>p-label</code></td>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -25,7 +25,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <!-- 2.32 -->
     <tr>
       <th><a href="/docs/patterns/buttons#neutral">Labels / Default</a></th>
-      <td><div class="p-label--new">Deprecated</div></td>
+      <td><div class="p-label--new">New</div></td>
       <td>2.32.0</td>
       <td>We've added a default label <code>p-label</code></td>
     </tr>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,12 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.32 -->
     <tr>
+      <th><a href="/docs/patterns/buttons#neutral">Labels / Default</a></th>
+      <td><div class="p-label--new">Deprecated</div></td>
+      <td>2.32.0</td>
+      <td>We've added a default label <code>p-label</code></td>
+    </tr>
+     <tr>
       <th><a href="/docs/patterns/buttons#neutral">Button / Neutral</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.32.0</td>

--- a/templates/docs/examples/patterns/labels/default.html
+++ b/templates/docs/examples/patterns/labels/default.html
@@ -1,0 +1,8 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Labels / Default{% endblock %}
+
+{% block standalone_css %}patterns_label{% endblock %}
+
+{% block content %}
+<div class="p-label">Default</div>
+{% endblock %}

--- a/templates/docs/patterns/labels.md
+++ b/templates/docs/patterns/labels.md
@@ -16,6 +16,14 @@ Labels are static elements which you can apply to signify status, tags or any ot
   </p>
 </div>
 
+### Default
+
+Generic label that carries no semantic meaning.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/labels/default/" class="js-example">
+View example of the default label pattern
+</a></div>
+
 ### New
 
 Label to be used on newly released components, utilities or settings that are safe to use in projects.


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3201

## QA

- Open docs/patterns/labels
- Review the The "Default" section at the top

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![image](https://user-images.githubusercontent.com/2741678/123668703-45264600-d833-11eb-8756-ab61f3a17d13.png)
