### PR TITLE
Deprecate neutral button

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -35,15 +35,18 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   }
 }
 
+// p-button--neutral is is exactly the same as p-button, so we are deprecating it
 @mixin vf-button-neutral {
-  %p-button--neutral {
-    @extend %vf-button-base;
+  @include deprecate('3.0.0', 'Use the `p-button` instead') {
+    %p-button--neutral {
+      @extend %vf-button-base;
 
-    @include vf-button-pattern;
-  }
+      @include vf-button-pattern;
+    }
 
-  .p-button--neutral {
-    @extend %p-button--neutral;
+    .p-button--neutral {
+      @extend %p-button--neutral;
+    }
   }
 }
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -27,7 +27,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <th><a href="/docs/patterns/buttons#neutral">Button / Neutral</a></th>
       <td><div class="p-label--deprecated">Deprecated</div></td>
       <td>2.32.0</td>
-      <td>Neutral button variant <code>p-button--neutral</code> is deprecated, please use default <code>p-button</code> instead.</td>
+      <td>The neutral button variant <code>p-button--neutral</code> is deprecated, please use default <code>p-button</code> instead.</td>
     </tr>
     <tr>
       <th><a href="/docs/base/tables#overflow">Tables / Overflow</a></th>

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -24,6 +24,12 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 2.32 -->
     <tr>
+      <th><a href="/docs/patterns/buttons#neutral">Button / Neutral</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.32.0</td>
+      <td>Neutral button variant <code>p-button--neutral</code> is deprecated, please use default <code>p-button</code> instead.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/base/tables#overflow">Tables / Overflow</a></th>
       <td><div class="p-label--updated">Updated</div></td>
       <td>2.32.0</td>

--- a/templates/docs/examples/patterns/buttons/alignment.html
+++ b/templates/docs/examples/patterns/buttons/alignment.html
@@ -10,13 +10,13 @@
 </p>
 
 <p>
-  <button class="p-button--neutral">Neutral button</button>
+  <button class="p-button">Default button</button>
   <button class="p-button--positive">Positive button</button>
   <button class="p-button--negative">Negative button</button>
 </p>
 
 <p>
-  <a href="#" class="p-button--neutral">Neutral link</a>
+  <a href="#" class="p-button">Default link</a>
   <a href="#" class="p-button--positive">Positive link</a>
   <a href="#" class="p-button--negative">Negative link</a>
 </p>
@@ -24,7 +24,7 @@
 <p>
   <button>Classless button</button>
   <button class="p-button--positive">Positive button</button>
-  <a href="#" class="p-button--neutral">Neutral link</a>
+  <a href="#" class="p-button">Default link</a>
   <button class="u-hide">Hidden button</button>
   <button class="p-button--negative">Negative button</button>
 </p>

--- a/templates/docs/examples/patterns/buttons/default.html
+++ b/templates/docs/examples/patterns/buttons/default.html
@@ -1,0 +1,9 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Buttons / Default{% endblock %}
+
+{% block standalone_css %}patterns_buttons{% endblock %}
+
+{% block content %}
+<button class="p-button">Default button</button>
+<button class="p-button" disabled>Default button disabled</button>
+{% endblock %}

--- a/templates/docs/examples/patterns/buttons/dense.html
+++ b/templates/docs/examples/patterns/buttons/dense.html
@@ -5,5 +5,5 @@
 
 {% block content %}
 <span>Everything you need to get started with Vanilla.</span>
-<button class="p-button--neutral is-dense">Dense button</button>
+<button class="p-button is-dense">Dense button</button>
 {% endblock %}

--- a/templates/docs/examples/patterns/buttons/inline.html
+++ b/templates/docs/examples/patterns/buttons/inline.html
@@ -5,5 +5,5 @@
 
 {% block content %}
 <span>Everything you need to get started with Vanilla.</span>
-<button class="p-button--neutral is-inline">Inline button</button>
+<button class="p-button is-inline">Inline button</button>
 {% endblock %}

--- a/templates/docs/examples/patterns/buttons/neutral.html
+++ b/templates/docs/examples/patterns/buttons/neutral.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Buttons / Neutral{% endblock %}
+{% block title %}Buttons / Neutral - Deprecated{% endblock %}
 
 {% block standalone_css %}patterns_buttons{% endblock %}
 

--- a/templates/docs/examples/patterns/buttons/small.html
+++ b/templates/docs/examples/patterns/buttons/small.html
@@ -4,5 +4,5 @@
 {% block standalone_css %}patterns_buttons{% endblock %}
 
 {% block content %}
-<p><small>This is small text <button class="p-button--neutral is-small is-inline">This is a small button</button><button class="p-button--neutral is-small is-dense">This is a small, dense button</button></small></p>
+<p><small>This is small text <button class="p-button is-small is-inline">This is a small button</button><button class="p-button is-small is-dense">This is a small, dense button</button></small></p>
 {% endblock %}

--- a/templates/docs/examples/templates/external-links.html
+++ b/templates/docs/examples/templates/external-links.html
@@ -24,7 +24,7 @@
       <a class="p-button"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a>
+      <a class="p-button"><span class="p-link--external">External default button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -37,7 +37,7 @@
       <a class="p-button"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a>
+      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -50,7 +50,7 @@
       <a class="p-button"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a>
+      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -63,7 +63,7 @@
       <a class="p-button"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a>
+      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -76,7 +76,7 @@
       <a class="p-button"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a>
+      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -89,7 +89,7 @@
       <a class="p-button"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a>
+      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base"><span class="p-link--external">External base button</span></a>
     </div>
   </div>

--- a/templates/docs/examples/templates/tick-element-comparison.html
+++ b/templates/docs/examples/templates/tick-element-comparison.html
@@ -20,7 +20,7 @@
         <form>
           <input type="text">
           <button>Button</button>
-          <button class="p-button--neutral">Button</button>
+          <button class="p-button">Button</button>
           <button class="p-button--negative">Button</button>
           <a class="p-button--negative">Button</a>
           <button class="p-button--positive">Button</button>

--- a/templates/docs/examples/templates/vertical-spacing.html
+++ b/templates/docs/examples/templates/vertical-spacing.html
@@ -59,7 +59,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <button class="p-button--neutral">Neutral button</button>
+      <button class="p-button">Default button</button>
     </div>
   </div>
 </section>

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -16,17 +16,21 @@ Buttons are clickable elements used to perform an action, you can apply `button`
   </p>
 </div>
 
+### Default
+
+A default button can be used to indicate a positive action that isn't necessarily the main call-to-action.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/default/" class="js-example">
+View example of the default button pattern
+</a></div>
+
 ### Neutral
 
-A neutral button can be used to indicate a positive action that isn't necessarily the main call-to-action.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/buttons/neutral/" class="js-example">
-View example of the neutral button pattern
-</a></div>
+<span class="p-label--deprecated">Deprecated</span> Neutral button style provided by `p-button--neutral` is exactly the same as default `p-button` styling, so neutral variant is deprecated and will be removed in future version 3.0 of Vanilla. Please use `p-button` instead.
 
 ### Base
 
-A base button can be used to discretely indicate a secondary action. It is often used alongside a neutral button.
+A base button can be used to discretely indicate a secondary action. It is often used alongside a default button.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/base/" class="js-example">
 View example of the base button pattern

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -26,7 +26,9 @@ View example of the default button pattern
 
 ### Neutral
 
-<span class="p-label--deprecated">Deprecated</span> Neutral button style provided by `p-button--neutral` is exactly the same as default `p-button` styling, so neutral variant is deprecated and will be removed in future version 3.0 of Vanilla. Please use `p-button` instead.
+<span class="p-label--deprecated">Deprecated</span>
+
+The neutral button style provided by `p-button--neutral` is exactly the same as default `p-button` styling, so neutral variant is deprecated and will be removed in future version 3.0 of Vanilla. Please use `p-button` instead.
 
 ### Base
 

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -84,4 +84,4 @@ We deprecated the inline images component. Please use the logo section component
 
 ### Buttons
 
-Neutral button style provided by `p-button--neutral` is exactly the same as default `p-button` styling, so neutral variant is deprecated and will be removed in future version 3.0 of Vanilla. Please use `p-button` instead.
+The neutral button style provided by `p-button--neutral` is exactly the same as default `p-button` styling, so neutral variant is deprecated and will be removed in future version 3.0 of Vanilla. Please use `p-button` instead.

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -81,3 +81,7 @@ We removed the `p-table--sortable` that was previously required to enable sortin
 ### Inline images
 
 We deprecated the inline images component. Please use the logo section component instead.
+
+### Buttons
+
+Neutral button style provided by `p-button--neutral` is exactly the same as default `p-button` styling, so neutral variant is deprecated and will be removed in future version 3.0 of Vanilla. Please use `p-button` instead.

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
           <a href="/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
         </li>
         <li class="p-inline-list__item">
-          <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download Vanilla v{{version}}</a>
+          <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button p-link--external u-no-margin--bottom">Download Vanilla v{{version}}</a>
         </li>
       </ul>
     </div>
@@ -110,7 +110,7 @@
           <h4 class="p-heading-icon__title">Vanilla Framework</h4>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button--neutral p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
         <small>See the <a class="p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
     </div>
@@ -121,7 +121,7 @@
           <h4 class="p-heading-icon__title">Vanilla Design</h4>
         </div>
         <p>Get our Sketch library of common design components.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button--neutral" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
         <small>Filesize - 2.4 MB</small>
       </div>
     </div>
@@ -135,7 +135,7 @@
   <div id="articles" class="row">
     <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
   </div>
-  <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button--neutral">View more from our blog</a></div>
+  <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button">View more from our blog</a></div>
 </div>
 
 <!-- blog snippet template -->


### PR DESCRIPTION
## Done

Deprecates the unnecessary `p-button--neutral` as it has same styling as `p-button`.

Fixes #3804 
## QA

- Open [demo](https://vanilla-framework-3806.demos.haus/docs/examples/patterns/buttons/default)
- Check if default `p-button` looks as expected (like `<button>` and `p-button--neutral` before)
- Check if deprecated neutral button still renders as expected
   - https://vanilla-framework-3806.demos.haus/docs/examples/patterns/buttons/neutral
- Check the updated documentation
  - https://vanilla-framework-3806.demos.haus/docs/patterns/buttons
  - https://vanilla-framework-3806.demos.haus/docs/component-status

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


