### PR TITLE
Website accessibility fixes

### DIFF
--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -25,10 +25,9 @@
       </ul>
       {% if path.startswith('/docs') %}
       <form class="p-search-box" action="/docs/search">
-        <label class="u-off-screen" for="search-docs">Search the docs</label>
-        <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" required />
-        <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close"></i><span class="u-off-screen">Clear input</span></button>
-        <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search"></i><span class="u-off-screen">Submit</span></button>
+        <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" aria-label="Search the docs" required />
+        <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close">Clear input</i></button>
+        <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search">Submit</i></button>
       </form>
       {% endif %}
     </nav>

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -25,9 +25,10 @@
       </ul>
       {% if path.startswith('/docs') %}
       <form class="p-search-box" action="/docs/search">
-        <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation" autocomplete="on" required />
-        <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close"></i></button>
-        <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search"></i></button>
+        <label class="u-off-screen" for="search-docs">Search the docs</label>
+        <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" required />
+        <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close"></i><span class="u-off-screen">Clear input</span></button>
+        <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search"></i><span class="u-off-screen">Submit</span></button>
       </form>
       {% endif %}
     </nav>

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -21,7 +21,7 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-6">
-      <h2 class="p-heading--2">Ensuring conformance</h2>
+      <h2>Ensuring conformance</h2>
       <p>We use the following tools to continually audit the framework:</p>
     </div>
     <div class="col-6">

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -21,7 +21,7 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-6">
-      <h3 class="p-heading--2">Ensuring conformance</h3>
+      <h2 class="p-heading--2">Ensuring conformance</h2>
       <p>We use the following tools to continually audit the framework:</p>
     </div>
     <div class="col-6">
@@ -34,13 +34,15 @@
     </div>
   </div>
 </div>
+
 <div class="u-fixed-width">
   <hr class="u-no-margin--bottom">
 </div>
+
 <div class="p-strip">
-<div class="row">
-  <div class="col-6">
-      <h2 class="">Curated criteria checklist</h2>
+  <div class="row">
+    <div class="col-6">
+      <h2>Curated criteria checklist</h2>
       <p class="u-no-padding--bottom">The scope of the WCAG spec can be overwhelming. We find the following checklist a good starting point if you're new to accessibility:</p>
     </div>
     <div class="col-6">

--- a/templates/browser-support.html
+++ b/templates/browser-support.html
@@ -45,7 +45,7 @@
         <li class="p-list__item">
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/09a6a50e-vf.io-chrome.png" />
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/09a6a50e-vf.io-chrome.png" alt="" />
               <p class="p-heading-icon__title">Chrome 62 or greater</p>
             </div>
           </div>
@@ -53,7 +53,7 @@
         <li class="p-list__item">
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/a45d30aa-vf.io-firefox.svg" class="p-heading-icon__img" />
+              <img src="https://assets.ubuntu.com/v1/a45d30aa-vf.io-firefox.svg" class="p-heading-icon__img" alt="" />
               <p class="p-heading-icon__title">Firefox 56 or greater</p>
             </div>
           </div>
@@ -61,7 +61,7 @@
         <li class="p-list__item">
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/a030d872-vf.io-safari.svg" class="p-heading-icon__img" />
+              <img src="https://assets.ubuntu.com/v1/a030d872-vf.io-safari.svg" class="p-heading-icon__img" alt="" />
               <p class="p-heading-icon__title">Safari 11 or greater</p>
             </div>
           </div>
@@ -69,7 +69,7 @@
         <li class="p-list__item">
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/165a2220-vf.io-ie.svg" class="p-heading-icon__img" />
+              <img src="https://assets.ubuntu.com/v1/165a2220-vf.io-ie.svg" class="p-heading-icon__img" alt="" />
               <p class="p-heading-icon__title">IE 11 or greater</p>
             </div>
           </div>
@@ -77,7 +77,7 @@
         <li class="p-list__item">
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/de0673bb-vf.io-edge.svg" class="p-heading-icon__img" />
+              <img src="https://assets.ubuntu.com/v1/de0673bb-vf.io-edge.svg" class="p-heading-icon__img" alt="" />
               <p class="p-heading-icon__title">Edge 16 or greater</p>
             </div>
           </div>
@@ -85,7 +85,7 @@
         <li class="p-list__item">
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/74738acc-vf.io-opera.svg" class="p-heading-icon__img" />
+              <img src="https://assets.ubuntu.com/v1/74738acc-vf.io-opera.svg" class="p-heading-icon__img" alt="" />
               <p class="p-heading-icon__title">Opera 48 or greater</p>
             </div>
           </div>

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -7,15 +7,15 @@
 {% block title %}Component examples{% endblock %}
 
 {% block body %}
-<div class="p-strip is-bordered">
+<main id="main-content" class="p-strip is-bordered">
   <div class="u-fixed-width">
-    <h2>Component examples</h2>
+    <h1 class="p-heading--2">Component examples</h1>
     <hr>
   </div>
 
   <div class="row">
     <div class="col-3">
-      <h3>Base elements</h3>
+      <h2 class="p-heading--3">Base elements</h2>
       <nav aria-label="Documentation: base elements">
         <ul class="p-list">
           {% for example in examples.base %}
@@ -27,7 +27,7 @@
       </nav>
     </div>
     <div class="col-3">
-      <h3>Components</h3>
+      <h2 class="p-heading--3">Components</h2>
       <nav aria-label="Documentation: components">
         <ul class="p-list">
           {% for example in examples.patterns %}
@@ -39,7 +39,7 @@
       </nav>
     </div>
     <div class="col-3">
-      <h3>Utilities</h3>
+      <h2 class="p-heading--3">Utilities</h2>
       <nav aria-label="Documentation: utilities">
         <ul class="p-list">
           {% for example in examples.utilities %}
@@ -51,7 +51,7 @@
       </nav>
     </div>
     <div class="col-3">
-      <h3>Layouts</h3>
+      <h2 class="p-heading--3">Layouts</h2>
       <nav aria-label="Documentation: layouts">
         <ul class="p-list">
           {% for example in examples.layouts %}
@@ -61,7 +61,7 @@
           {% endfor %}
         </ul>
       </nav>
-      <h3>Templates</h3>
+      <h2 class="p-heading--3">Templates</h2>
       <nav aria-label="Documentation: templates">
         <ul class="p-list">
           {% for example in examples.templates %}
@@ -77,5 +77,5 @@
   <div class="u-fixed-width">
     <p><a href="/docs/examples/standalone">Examples using standalone component CSS for testing/debugging</a></p>
   </div>
-</div>
+</main>
 {% endblock %}

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -9,13 +9,13 @@
 {% block body %}
 <main id="main-content" class="p-strip is-bordered">
   <div class="u-fixed-width">
-    <h1 class="p-heading--2">Component examples</h1>
+    <h1>Component examples</h1>
     <hr>
   </div>
 
   <div class="row">
     <div class="col-3">
-      <h2 class="p-heading--3">Base elements</h2>
+      <h2>Base elements</h2>
       <nav aria-label="Documentation: base elements">
         <ul class="p-list">
           {% for example in examples.base %}
@@ -27,7 +27,7 @@
       </nav>
     </div>
     <div class="col-3">
-      <h2 class="p-heading--3">Components</h2>
+      <h2>Components</h2>
       <nav aria-label="Documentation: components">
         <ul class="p-list">
           {% for example in examples.patterns %}
@@ -39,7 +39,7 @@
       </nav>
     </div>
     <div class="col-3">
-      <h2 class="p-heading--3">Utilities</h2>
+      <h2>Utilities</h2>
       <nav aria-label="Documentation: utilities">
         <ul class="p-list">
           {% for example in examples.utilities %}
@@ -51,7 +51,7 @@
       </nav>
     </div>
     <div class="col-3">
-      <h2 class="p-heading--3">Layouts</h2>
+      <h2>Layouts</h2>
       <nav aria-label="Documentation: layouts">
         <ul class="p-list">
           {% for example in examples.layouts %}
@@ -61,7 +61,7 @@
           {% endfor %}
         </ul>
       </nav>
-      <h2 class="p-heading--3">Templates</h2>
+      <h2>Templates</h2>
       <nav aria-label="Documentation: templates">
         <ul class="p-list">
           {% for example in examples.templates %}

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -7,17 +7,17 @@
 {% block title %}Standalone component examples{% endblock %}
 
 {% block body %}
-<div class="p-strip is-bordered">
+<main id="main-content" class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2>Standalone component examples</h2>
+      <h1 class="p-heading--2">Standalone component examples</h1>
       <hr>
       <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
     </div>
   </div>
   <div class="row">
     <div class="col-3">
-      <h3>Base elements</h3>
+      <h2 class="p-heading--3">Base elements</h2>
       <nav aria-label="Documentation: base elements">
         <ul class="p-list">
           {% for example in examples.base %}
@@ -29,7 +29,7 @@
       </nav>
     </div>
     <div class="col-3">
-      <h3>Components</h3>
+      <h2 class="p-heading--3">Components</h2>
       <nav aria-label="Documentation: components">
         <ul class="p-list">
           {% for example in examples.patterns %}
@@ -41,5 +41,5 @@
       </nav>
     </div>
   </div>
-</div>
+</main>
 {% endblock %}

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -10,14 +10,14 @@
 <main id="main-content" class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
-      <h1 class="p-heading--2">Standalone component examples</h1>
+      <h1>Standalone component examples</h1>
       <hr>
       <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
     </div>
   </div>
   <div class="row">
     <div class="col-3">
-      <h2 class="p-heading--3">Base elements</h2>
+      <h2>Base elements</h2>
       <nav aria-label="Documentation: base elements">
         <ul class="p-list">
           {% for example in examples.base %}
@@ -29,7 +29,7 @@
       </nav>
     </div>
     <div class="col-3">
-      <h2 class="p-heading--3">Components</h2>
+      <h2>Components</h2>
       <nav aria-label="Documentation: components">
         <ul class="p-list">
           {% for example in examples.patterns %}

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -3,13 +3,13 @@
 {% block title %}Get started{% endblock %}
 
 {% block content %}
-<h1 class="p-heading--2">Get started</h1>
+<h1>Get started</h1>
 
 <hr>
 
 <p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
 
-<h2 class="p-heading--3">Install</h2>
+<h2>Install</h2>
 
 <p>The recommended way to get Vanilla is with <a href="https://www.yarnpkg.com/" class="p-link--external">yarn</a>:</p>
 <pre><code>yarn add vanilla-framework</code></pre>
@@ -26,16 +26,16 @@
 
 <p><em>For information on overriding settings and importing only parts of Vanilla, see <a href="/docs/customising-vanilla">Customising Vanilla</a>.</em></p>
 
-<h2 class="p-heading--3">Hotlink</h2>
+<h2>Hotlink</h2>
 <p>You can add Vanilla directly to your markup:</p>
 <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-{{ version }}.min.css" /&gt;</code></pre>
 
-<h2 class="p-heading--3">Download</h2>
+<h2>Download</h2>
 <p>Download the latest version of Vanilla from GitHub.</p>
 <p><a class="p-button--positive" href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v{{ version }}.zip">Download v{{ version }}</a></p>
 <p>See the <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest updates.</p>
 
-<h2 class="p-heading--3">Local development</h2>
+<h2>Local development</h2>
 <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-framework" class="p-link--external">README.md</a>.</p>
 <ul class="p-inline-list">
   <li class="p-inline-list__item"><i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Join our channel</a></li>

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -3,13 +3,13 @@
 {% block title %}Get started{% endblock %}
 
 {% block content %}
-<h2>Get started</h2>
+<h1 class="p-heading--2">Get started</h1>
 
 <hr>
 
 <p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
 
-<h3>Install</h3>
+<h2 class="p-heading--3">Install</h2>
 
 <p>The recommended way to get Vanilla is with <a href="https://www.yarnpkg.com/" class="p-link--external">yarn</a>:</p>
 <pre><code>yarn add vanilla-framework</code></pre>
@@ -26,16 +26,16 @@
 
 <p><em>For information on overriding settings and importing only parts of Vanilla, see <a href="/docs/customising-vanilla">Customising Vanilla</a>.</em></p>
 
-<h3>Hotlink</h3>
+<h2 class="p-heading--3">Hotlink</h2>
 <p>You can add Vanilla directly to your markup:</p>
 <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-{{ version }}.min.css" /&gt;</code></pre>
 
-<h3>Download</h3>
+<h2 class="p-heading--3">Download</h2>
 <p>Download the latest version of Vanilla from GitHub.</p>
 <p><a class="p-button--positive" href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v{{ version }}.zip">Download v{{ version }}</a></p>
 <p>See the <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest updates.</p>
 
-<h3>Local development</h3>
+<h2 class="p-heading--3">Local development</h2>
 <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-framework" class="p-link--external">README.md</a>.</p>
 <ul class="p-inline-list">
   <li class="p-inline-list__item"><i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Join our channel</a></li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           <img class="b-lazy p-heading-icon__img" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt=""/>
-          <h3 class="p-heading-icon__title">Lightweight</h3>
+          <h2 class="p-heading--3 p-heading-icon__title">Lightweight</h2>
         </div>
         <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
       </div>
@@ -38,7 +38,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           <img class="b-lazy p-heading-icon__img" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt=""/>
-          <h3 class="p-heading-icon__title">Composable</h3>
+          <h2 class="p-heading--3 p-heading-icon__title">Composable</h2>
         </div>
         <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
       </div>
@@ -47,7 +47,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           <img class="b-lazy p-heading-icon__img" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt=""/>
-          <h3 class="p-heading-icon__title">Open source</h3>
+          <h2 class="p-heading--3 p-heading-icon__title">Open source</h2>
         </div>
         <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
       </div>
@@ -107,7 +107,7 @@
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub repo:" />
-          <h4 class="p-heading-icon__title">Vanilla Framework</h4>
+          <h3 class="p-heading--4 p-heading-icon__title">Vanilla Framework</h3>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
         <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
@@ -118,7 +118,7 @@
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />
-          <h4 class="p-heading-icon__title">Vanilla Design</h4>
+          <h3 class="p-heading--4 p-heading-icon__title">Vanilla Design</h3>
         </div>
         <p>Get our Sketch library of common design components.</p>
         <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
@@ -140,10 +140,10 @@
 
 <!-- blog snippet template -->
 <template style="display:none" id="template">
-  <div class="col-3">
-    <h4><a  class="article-link article-title"></a></h4>
-    <p class="p-heading--6 article-time"></p>
-  </div>
+  <article class="col-3">
+    <h3 class="p-heading--4"><a  class="article-link article-title"></a></h3>
+    <time class="p-heading--6 article-time"></time>
+  </article>
 </template>
 
 <div class="p-strip is-bordered">
@@ -198,7 +198,7 @@
         <div class="p-form__group">
           <label for="mce-EMAIL">Email address</label>
           <input type="email" value="" name="EMAIL" placeholder="vanilla@example.com" id="mce-EMAIL" aria-label="Email address" autocomplete="email" required />
-          <input class="u-off-screen" aria-hidden="true" type="text" name="b_56dac47c206ba0f58ec25f314_36f7d8394e" tabindex="-1" value="" />
+          <input class="u-off-screen" aria-hidden="true" type="hidden" name="b_56dac47c206ba0f58ec25f314_36f7d8394e" tabindex="-1" value="" />
           <p class="p-form-help-text">Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.</p>
         </div>
         <button name="subscribe" type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button--positive">Subscribe</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -193,7 +193,7 @@
       </ul>
     </div>
     <div class="col-6">
-      <h3>Subscribe to Vanilla updates</h3>
+      <h2>Subscribe to Vanilla updates</h2>
       <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="p-form">
         <div class="p-form__group">
           <label for="mce-EMAIL">Email address</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           <img class="b-lazy p-heading-icon__img" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg" alt=""/>
-          <h2 class="p-heading--3 p-heading-icon__title">Lightweight</h2>
+          <h2 class="p-heading-icon__title">Lightweight</h2>
         </div>
         <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
       </div>
@@ -38,7 +38,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           <img class="b-lazy p-heading-icon__img" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg" alt=""/>
-          <h2 class="p-heading--3 p-heading-icon__title">Composable</h2>
+          <h2 class="p-heading-icon__title">Composable</h2>
         </div>
         <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
       </div>
@@ -47,7 +47,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           <img class="b-lazy p-heading-icon__img" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg" alt=""/>
-          <h2 class="p-heading--3 p-heading-icon__title">Open source</h2>
+          <h2 class="p-heading-icon__title">Open source</h2>
         </div>
         <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
       </div>
@@ -107,7 +107,7 @@
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub repo:" />
-          <h3 class="p-heading--4 p-heading-icon__title">Vanilla Framework</h3>
+          <h3 class="p-heading-icon__title">Vanilla Framework</h3>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
         <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button p-link--external" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
@@ -118,7 +118,7 @@
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />
-          <h3 class="p-heading--4 p-heading-icon__title">Vanilla Design</h3>
+          <h3 class="p-heading-icon__title">Vanilla Design</h3>
         </div>
         <p>Get our Sketch library of common design components.</p>
         <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
@@ -141,7 +141,7 @@
 <!-- blog snippet template -->
 <template style="display:none" id="template">
   <article class="col-3">
-    <h3 class="p-heading--4"><a  class="article-link article-title"></a></h3>
+    <h3><a class="article-link article-title"></a></h3>
     <time class="p-heading--6 article-time"></time>
   </article>
 </template>
@@ -174,12 +174,12 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-3">
-      <h2 class="p-heading--3">Contribute</h2>
+      <h2>Contribute</h2>
       <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
       <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
     </div>
     <div class="col-3">
-      <h2 class="p-heading--3">Get involved</h2>
+      <h2>Get involved</h2>
       <ul class="p-list--divided">
         <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg'); background-size: 1rem;">
           <a href="https://vanillaframework.slack.com" class="p-link--soft">Slack&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

Fixed a number of accessibility errors on top level pages that were highlighted by the WAVE extension

## QA

- Open:
  - [homepage](https://vanilla-framework-3811.demos.haus)
  - [docs index](https://vanilla-framework-3811.demos.haus/docs)
  - [examples index](https://vanilla-framework-3811.demos.haus/docs/examples)
  - [standalone examples index](https://vanilla-framework-3811.demos.haus/docs/examples/standalone)
  - [/accessibility](https://vanilla-framework-3811.demos.haus/accessibility)
  - [/browser-support](https://vanilla-framework-3811.demos.haus/browser-support)
  - [/contribute](https://vanilla-framework-3811.demos.haus/contribute)
- Open the [WAVE browser extension](https://wave.webaim.org/extension/) on each page
  - See that there are zero errors, and fewer alerts compared to the live site.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
