### PR TITLE
add 410 template for deleted content

### DIFF
--- a/deleted.yaml
+++ b/deleted.yaml
@@ -1,0 +1,1 @@
+/showcase:

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -6,4 +6,3 @@
 /css/(?P<path>.*): /static/css/{path}
 /js/(?P<path>.*): /static/js/{path}
 /docs/patterns/article-pagination: /docs/patterns/pagination
-/showcase: /

--- a/templates/410.html
+++ b/templates/410.html
@@ -1,0 +1,19 @@
+{% extends "_layouts/site.html" %}
+
+{% block content %}
+<div id="main-content" class="p-strip--suru-topped">
+  <div class="row">
+    <div class="col 12">
+      <h1 class="u-no-margin--bottom">410 - Page deleted</h1>
+    </div>
+  </div>  
+</div>
+
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div class="col 12">
+      <p>{{ message or "This page has been removed" }}</p>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Done

- added a 410 template
- added `deleted.yaml` and removed the recently added redirect for the [recently removed showcase page](https://github.com/canonical-web-and-design/vanilla-framework/pull/3810) 

## QA

- Open [demo](https://vanilla-framework-3812.demos.haus/showcase)
- See that you're presented with a message informing you that the content has been deleted

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
