### PR TITLE
Remove contextual menu styles from p-table--mobile-card

### DIFF
--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -51,6 +51,10 @@
             justify-content: unset !important;
             text-align: left !important;
           }
+
+          &.has-overflow {
+            overflow: visible;
+          }
           // stylelint-disable-next-line max-nesting-depth
           &[aria-label]::before {
             content: attr(aria-label);
@@ -76,61 +80,6 @@
       }
 
       // stylelint-enable selector-max-type
-
-      // Styles contextual menus differently within mobile-card tables
-      .p-contextual-menu {
-        width: 100%;
-
-        // Initial menu item for actions should be hidden
-        [role='menuitem'] {
-          display: none;
-        }
-      }
-
-      .p-contextual-menu__dropdown {
-        box-shadow: none;
-        display: block;
-        max-width: 100%;
-        position: relative;
-
-        &::before {
-          display: none;
-        }
-      }
-
-      .p-contextual-menu__group {
-        padding: 0;
-
-        + .p-contextual-menu__group {
-          margin-top: $sp-small;
-          padding-top: $sp-small;
-        }
-      }
-
-      // Any link items should be styled as a button element
-      .p-contextual-menu__link {
-        border: {
-          color: $color-mid-light;
-          radius: 0.125rem;
-          style: solid;
-          width: 1px;
-        }
-
-        box-sizing: border-box;
-        color: $color-x-dark;
-        cursor: pointer;
-        display: block;
-        line-height: $sp-medium;
-        outline: none;
-        padding: $sp-small $sp-large;
-        text-align: center;
-        text-decoration: none;
-        width: 100%;
-
-        + .p-contextual-menu__link {
-          margin-top: $sp-x-small;
-        }
-      }
     }
 
     @media (max-width: $breakpoint-small) {

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -46,7 +46,7 @@
           white-space: nowrap;
           width: 100%;
           word-break: break-word;
-          // stylelint-disable-next-line max-nesting-depth
+          // stylelint-disable max-nesting-depth
           &.u-align--right {
             justify-content: unset !important;
             text-align: left !important;
@@ -55,7 +55,7 @@
           &.has-overflow {
             overflow: visible;
           }
-          // stylelint-disable-next-line max-nesting-depth
+
           &[aria-label]::before {
             content: attr(aria-label);
             display: block;
@@ -66,7 +66,7 @@
             text-overflow: ellipsis;
             width: 100%;
           }
-          // stylelint-disable-next-line max-nesting-depth
+
           &:not(:first-child)::after {
             background-color: $color-mid-light;
             content: '';
@@ -76,6 +76,7 @@
             right: 0;
             top: 0;
           }
+          // stylelint-enable max-nesting-depth
         }
       }
 

--- a/scss/standalone/patterns_table-mobile-card.scss
+++ b/scss/standalone/patterns_table-mobile-card.scss
@@ -7,3 +7,9 @@
 
 @import '../patterns_table-mobile-card';
 @include vf-p-table-mobile-card;
+
+@import '../patterns_contextual-menu';
+@include vf-p-contextual-menu;
+
+@import '../utilities_margin-collapse';
+@include vf-u-margin-collapse;

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -47,6 +47,12 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.32.0</td>
       <td>We introduced the <code>.has-overflow</code> utility for table cells, to aid with the display of components that need to overflow the cell, such as tooltips and contextual menus.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/base/tables#responsive">Tables / Responsive</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.32.0</td>
+      <td>The <code>.p-table--mobile-card</code> previously contained style overrides for the <a href="https://vanillaframework.io/docs/examples/patterns/contextual-menu/default">contextual menu pattern</a>, these have been removed so that contextual menus within responsive tables look and behave the same as they do elsewhere.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -32,8 +32,8 @@
       <td class="u-align--right"  aria-label="Storagelongenoughtocauseellipsis">2TB</td>
       <td class="has-overflow" aria-label="Actions">
         <span class="p-contextual-menu--left">
-          <button class="p-contextual-menu__toggle" aria-controls="menu-1" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
-          <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="true">
+          <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-1" aria-expanded="true" aria-haspopup="true">Actions&hellip;</button>
+          <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="false">
             <span class="p-contextual-menu__group">
               <button class="p-contextual-menu__link">Commission</button>
               <button class="p-contextual-menu__link">Aquire</button>
@@ -60,7 +60,7 @@
       <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">500GB</td>
       <td class="has-overflow" aria-label="Actions">
         <span class="p-contextual-menu--left">
-          <button class="p-contextual-menu__toggle" aria-controls="menu-2" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
+          <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-2" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
           <span class="p-contextual-menu__dropdown" id="menu-2" aria-hidden="true">
             <span class="p-contextual-menu__group">
               <button class="p-contextual-menu__link">Commission</button>
@@ -88,7 +88,7 @@
       <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">6TB</td>
       <td class="has-overflow" aria-label="Actions">
         <span class="p-contextual-menu--left">
-          <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
+          <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
           <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
             <span class="p-contextual-menu__group">
               <button class="p-contextual-menu__link">Commission</button>
@@ -116,7 +116,7 @@
       <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">240GB</td>
       <td class="has-overflow" aria-label="Actions">
         <span class="p-contextual-menu--left">
-          <button class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
+          <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
           <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true">
             <span class="p-contextual-menu__group">
               <button class="p-contextual-menu__link">Commission</button>

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -16,6 +16,7 @@
       <th class="u-align--right">RAM</th>
       <th class="u-align--right">Disks</th>
       <th class="u-align--right">Storage</th>
+      <th>Actions</th>
     </tr>
   </thead>
   <tbody>
@@ -29,6 +30,23 @@
       <td class="u-align--right"  aria-label="RAM">2 GiB</td>
       <td class="u-align--right"  aria-label="Disks">1</td>
       <td class="u-align--right"  aria-label="Storagelongenoughtocauseellipsis">2TB</td>
+      <td class="has-overflow" aria-label="Actions">
+        <span class="p-contextual-menu--left">
+          <button class="p-contextual-menu__toggle" aria-controls="menu-1" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
+          <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="true">
+            <span class="p-contextual-menu__group">
+              <button class="p-contextual-menu__link">Commission</button>
+              <button class="p-contextual-menu__link">Aquire</button>
+              <button class="p-contextual-menu__link">Deploy</button>
+            </span>
+            <span class="p-contextual-menu__group">
+              <button class="p-contextual-menu__link">Test harware</button>
+              <button class="p-contextual-menu__link">Rescue mode</button>
+              <button class="p-contextual-menu__link">Mark broken</button>
+            </span>
+          </span>
+        </span>
+      </td>
     </tr>
     <tr>
       <td aria-label="FQDN">upward-muskox</td>
@@ -40,6 +58,23 @@
       <td class="u-align--right"  aria-label="RAM">4 GiB</td>
       <td class="u-align--right"  aria-label="Disks">1</td>
       <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">500GB</td>
+      <td class="has-overflow" aria-label="Actions">
+        <span class="p-contextual-menu--left">
+          <button class="p-contextual-menu__toggle" aria-controls="menu-2" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
+          <span class="p-contextual-menu__dropdown" id="menu-2" aria-hidden="true">
+            <span class="p-contextual-menu__group">
+              <button class="p-contextual-menu__link">Commission</button>
+              <button class="p-contextual-menu__link">Aquire</button>
+              <button class="p-contextual-menu__link">Deploy</button>
+            </span>
+            <span class="p-contextual-menu__group">
+              <button class="p-contextual-menu__link">Test harware</button>
+              <button class="p-contextual-menu__link">Rescue mode</button>
+              <button class="p-contextual-menu__link">Mark broken</button>
+            </span>
+          </span>
+        </span>
+      </td>
     </tr>
     <tr>
       <td aria-label="FQDN">first-cattle</td>
@@ -51,6 +86,23 @@
       <td class="u-align--right"  aria-label="RAM">16 GiB</td>
       <td class="u-align--right"  aria-label="Disks">3</td>
       <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">6TB</td>
+      <td class="has-overflow" aria-label="Actions">
+        <span class="p-contextual-menu--left">
+          <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
+          <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
+            <span class="p-contextual-menu__group">
+              <button class="p-contextual-menu__link">Commission</button>
+              <button class="p-contextual-menu__link">Aquire</button>
+              <button class="p-contextual-menu__link">Deploy</button>
+            </span>
+            <span class="p-contextual-menu__group">
+              <button class="p-contextual-menu__link">Test harware</button>
+              <button class="p-contextual-menu__link">Rescue mode</button>
+              <button class="p-contextual-menu__link">Mark broken</button>
+            </span>
+          </span>
+        </span>
+      </td>
     </tr>
     <tr>
       <td aria-label="FQDN">golden-rodent</td>
@@ -62,7 +114,28 @@
       <td class="u-align--right"  aria-label="RAM">1 GiB</td>
       <td class="u-align--right"  aria-label="Disks">1</td>
       <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">240GB</td>
+      <td class="has-overflow" aria-label="Actions">
+        <span class="p-contextual-menu--left">
+          <button class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
+          <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true">
+            <span class="p-contextual-menu__group">
+              <button class="p-contextual-menu__link">Commission</button>
+              <button class="p-contextual-menu__link">Aquire</button>
+              <button class="p-contextual-menu__link">Deploy</button>
+            </span>
+            <span class="p-contextual-menu__group">
+              <button class="p-contextual-menu__link">Test harware</button>
+              <button class="p-contextual-menu__link">Rescue mode</button>
+              <button class="p-contextual-menu__link">Mark broken</button>
+            </span>
+          </span>
+        </span>
+      </td>
     </tr>
   </tbody>
 </table>
+
+<script>
+  {% include 'docs/examples/patterns/contextual-menu/_script.js' %}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Done

Removed contextual menu styles from p-table--mobile-card pattern

Fixes #3835 

## QA

- Open [demo](https://vanilla-framework-3843.demos.haus/docs/examples/patterns/tables/table-mobile-card)
- Reduce the width of the browser to a small enough breakpoint to see the table turn into its card form
- Click any of the "Actions" buttons, see that the contextual menu behaves as normal
- Review updated documentation:
  - [Component status](https://vanilla-framework-3843.demos.haus/docs/component-status)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
