### PR TITLE
Update existing notification pattern with new styling

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -78,8 +78,6 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 
     .p-notification__response {
       @include vf-icon-success;
-
-      padding-left: $response-icon-space;
     }
   }
 }
@@ -92,8 +90,6 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 
     .p-notification__response {
       @include vf-icon-warning;
-
-      padding-left: $response-icon-space;
     }
   }
 }
@@ -106,8 +102,6 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 
     .p-notification__response {
       @include vf-icon-error;
-
-      padding-left: $response-icon-space;
     }
   }
 }
@@ -116,5 +110,10 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-notifications-information {
   .p-notification--information {
     @extend %vf-notification;
+    @include vf-highlight-bar($color-information, left);
+
+    .p-notification__response {
+      @include vf-icon-info($color-mid-dark);
+    }
   }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -6,10 +6,10 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-p-notification {
   // The mixin for basic notification styling
   %vf-notification {
-    @extend %vf-has-round-corners;
-    @extend %vf-has-box-shadow;
     @extend %vf-card;
+    @extend %vf-is-bordered;
 
+    border-radius: 0 $border-radius $border-radius 0;
     display: flex;
     overflow: hidden;
     padding: 0;
@@ -34,7 +34,6 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-notifications-default {
   .p-notification {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-mid-dark);
 
     & + & {
       margin-top: $spv-outer--scaleable; // negate bottom margin
@@ -51,6 +50,8 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 
   .p-notification__status {
     @extend %bold;
+
+    display: block;
   }
 
   .p-notification__status::after,
@@ -68,7 +69,7 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-notifications-positive {
   .p-notification--positive {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-positive);
+    @include vf-highlight-bar($color-positive, left);
 
     .p-notification__response {
       @include vf-icon-success;
@@ -82,7 +83,7 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-notifications-caution {
   .p-notification--caution {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-caution);
+    @include vf-highlight-bar($color-caution, left);
 
     .p-notification__response {
       @include vf-icon-warning;
@@ -96,7 +97,7 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-notifications-negative {
   .p-notification--negative {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-negative);
+    @include vf-highlight-bar($color-negative, left);
 
     .p-notification__response {
       @include vf-icon-error;
@@ -110,6 +111,12 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-notifications-information {
   .p-notification--information {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-information);
+    @include vf-highlight-bar($color-information, left);
+
+    .p-notification__response {
+      @include vf-icon-info($color-mid-dark);
+
+      padding-left: $response-icon-space;
+    }
   }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -1,5 +1,5 @@
 @import 'settings';
-$response-top-padding: $spv-nudge + $spv-inner--small;
+$response-top-padding: $spv-inner--small;
 $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 
 // Notification style patterns
@@ -34,6 +34,11 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-notifications-default {
   .p-notification {
     @extend %vf-notification;
+    @include vf-highlight-bar($color-information, left);
+
+    .p-notification__response {
+      @include vf-icon-info($color-mid-dark);
+    }
 
     & + & {
       margin-top: $spv-outer--scaleable; // negate bottom margin
@@ -45,7 +50,7 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
     margin-bottom: 0;
-    padding: $response-top-padding $sph-inner $spv-nudge-compensation + $spv-inner--small;
+    padding: $response-top-padding $sph-inner + $spv-inner--small $response-top-padding $response-icon-space;
   }
 
   .p-notification__status {
@@ -111,12 +116,5 @@ $response-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
 @mixin vf-notifications-information {
   .p-notification--information {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-information, left);
-
-    .p-notification__response {
-      @include vf-icon-info($color-mid-dark);
-
-      padding-left: $response-icon-space;
-    }
   }
 }


### PR DESCRIPTION
## Done

- Updated existing notification pattern to use new styling

Fixes #3822 

## QA

- Open [demo](https://vanilla-framework-3844.demos.haus/docs/examples/patterns/notifications/caution)
- Check that it matches the new [design](https://app.zeplin.io/project/5fac06865cfff51271b72cc6/screen/60353ac1f130133007d40217)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![2021-07-05_12-06](https://user-images.githubusercontent.com/25733845/124408392-7ea60680-dd89-11eb-9aa0-54ccc03ed7a7.png)


## Questions
- Is this pattern meant for a minor or major release?
- Should we update the documentation immediately or when the pattern is finished?
- What should the default style be that would show if someone updated Vanilla without changing the markup at all? Should it be full-width?
- Is the notification icon always linked to the highlight bar, or should they be able to be changed independently?
- Is the default notification supposed to use the warning icon?
- Is the "date" section of the new notification only allowed to be dates? Or should it be able to be any supplementary text (in other words, can it potentially be really long)?
- The design shows that the bottom-right can contain action "links", action "buttons", a contextual menu or a "view more notifications" text. Are they mutually-exclusive? If not, how should they display when there are multiple? Also, what are the circumstances in which you'd use an action "link" over an action "button"?
- Are the stacked notifications maxed out at three with the extras hidden?
- Can a stacked notification also have the overlapping or full-width styles?
- When expanding the stacked notifications, do they just all show one on top of the other? Is there animation?
- Do we want to show each stacked notification with the real highlight colour? Or can we "fake" it to just show the same as the top notification if we're assuming stacked notifications will only ever be grouped by type.
