### PR TITLE
Add skip link pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.32.0",
+  "version": "2.33.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -39,10 +39,10 @@
     top: -999px;
 
     &:focus {
-      background: $color-x-light;
-      border: 1px solid $color-link;
+      @include vf-focus;
+
       left: 0;
-      padding: 3px;
+      padding: $spv-inner--x-small;
       position: relative;
       top: 0;
       z-index: 999999;

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -31,6 +31,24 @@
     }
   }
 
+  .p-link--skip {
+    color: $color-link;
+    display: block;
+    left: -999px;
+    position: absolute;
+    top: -999px;
+
+    &:focus {
+      background: $color-x-light;
+      border: 1px solid $color-link;
+      left: 0;
+      padding: 3px;
+      position: relative;
+      top: 0;
+      z-index: 999999;
+    }
+  }
+
   // include external link styles only if CSS mask is supported
   @supports (mask-size: 1em) or (-webkit-mask-size: 1em) {
     @include vf-mask-supported;

--- a/scss/standalone/patterns_navigation.scss
+++ b/scss/standalone/patterns_navigation.scss
@@ -1,9 +1,5 @@
 @import '../base';
 @include vf-base;
 
-// used by navigation for accessibility links
-@import '../utilities_off-screen';
-@include vf-u-off-screen;
-
 @import '../patterns_navigation';
 @include vf-p-navigation;

--- a/scss/standalone/patterns_skip-link.scss
+++ b/scss/standalone/patterns_skip-link.scss
@@ -1,0 +1,8 @@
+@import '../base';
+@include vf-base;
+
+@import '../patterns_links';
+@include vf-p-links;
+
+@import '../patterns_navigation';
+@include vf-p-navigation;

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -1,3 +1,5 @@
+<a href="#main-content" class="p-link--skip">Jump to main content</a>
+
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
@@ -10,9 +12,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Main navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items">
         <li class="p-navigation__item {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
         <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -69,7 +69,7 @@
               {{ side_nav_item("/docs/patterns/images", "Images") }}
               {{ side_nav_item("/docs/patterns/inline-images", "Inline images") }}
               {{ side_nav_item("/docs/patterns/labels", "Labels", 'new') }}
-              {{ side_nav_item("/docs/patterns/links", "Links") }}
+              {{ side_nav_item("/docs/patterns/links", "Links", "updated") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
               {{ side_nav_item("/docs/patterns/lists", "Lists", "updated") }}
               {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -22,6 +22,28 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.33 -->
+    <tr>
+      <th><a href="/docs/patterns/links#skip-link">Links / Skip Link</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.33.0</td>
+      <td>We added a new link variant, <code>.p-link--skip</code>, that places a link offscreen and is revealed on focus.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Previously in Vanilla
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 2.32 -->
     <tr>
       <th><a href="/docs/patterns/labels#default">Labels / Default</a></th>
@@ -53,21 +75,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.32.0</td>
       <td>The <code>.p-table--mobile-card</code> previously contained style overrides for the <a href="https://vanillaframework.io/docs/examples/patterns/contextual-menu/default">contextual menu pattern</a>, these have been removed so that contextual menus within responsive tables look and behave the same as they do elsewhere.</td>
     </tr>
-  </tbody>
-</table>
-
-#### Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.31 -->
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Dropdown</a></th>

--- a/templates/docs/examples/patterns/links/links-skip.html
+++ b/templates/docs/examples/patterns/links/links-skip.html
@@ -36,4 +36,10 @@
     </nav>
   </div>
 </header>
+
+<main id="main" class="p-strip">
+  <div class="u-fixed-width">
+    <h1>A simple, extensible CSS framework</h1>
+  </div>
+</main>
 {% endblock %}

--- a/templates/docs/examples/patterns/links/links-skip.html
+++ b/templates/docs/examples/patterns/links/links-skip.html
@@ -1,0 +1,39 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Links / Skip Link{% endblock %}
+
+{% block standalone_css %}patterns_skip-link{% endblock %}
+
+{% block content %}
+<a href="#main" class="p-link--skip">Jump to main content</a>
+
+<header id="navigation" class="p-navigation">
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__item" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+
+    <nav class="p-navigation__nav" aria-label="Example main navigation">
+      <ul class="p-navigation__items">
+        <li class="p-navigation__item is-selected">
+          <a class="p-navigation__link" href="#">Products</a>
+        </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">Services</a>
+        </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">Partners</a>
+        </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">About</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+{% endblock %}

--- a/templates/docs/examples/patterns/navigation/default-dark.html
+++ b/templates/docs/examples/patterns/navigation/default-dark.html
@@ -16,9 +16,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Example main navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/default.html
+++ b/templates/docs/examples/patterns/navigation/default.html
@@ -15,10 +15,8 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
+
     <nav class="p-navigation__nav" aria-label="Example main navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/deprecated-dark.html
+++ b/templates/docs/examples/patterns/navigation/deprecated-dark.html
@@ -16,9 +16,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Example main navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__links">
         <li class="p-navigation__link is-selected" >
           <a href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/deprecated-subnav-dark.html
+++ b/templates/docs/examples/patterns/navigation/deprecated-subnav-dark.html
@@ -16,9 +16,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Example main navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items">
         <li class="p-navigation__item p-subnav" id="link-1">
           <a href="#link-1-menu" aria-controls="link-1-menu" class="p-subnav__toggle p-navigation__link">LXC</a>

--- a/templates/docs/examples/patterns/navigation/deprecated-subnav.html
+++ b/templates/docs/examples/patterns/navigation/deprecated-subnav.html
@@ -16,9 +16,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Example sub navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items">
         <li class="p-navigation__item p-subnav" id="link-1">
           <a href="#link-1-menu" aria-controls="link-1-menu" class="p-subnav__toggle p-navigation__link">LXC</a>

--- a/templates/docs/examples/patterns/navigation/deprecated.html
+++ b/templates/docs/examples/patterns/navigation/deprecated.html
@@ -16,9 +16,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Example main navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__links">
         <li class="p-navigation__link is-selected" >
           <a href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/dropdown-dark.html
+++ b/templates/docs/examples/patterns/navigation/dropdown-dark.html
@@ -16,9 +16,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Example main navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items">
         <li class="p-navigation__item--dropdown-toggle" id="link-1">
           <a href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">LXC</a>

--- a/templates/docs/examples/patterns/navigation/dropdown.html
+++ b/templates/docs/examples/patterns/navigation/dropdown.html
@@ -16,9 +16,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Example sub navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items">
         <li class="p-navigation__item--dropdown-toggle" id="link-1">
           <a href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">LXC</a>

--- a/templates/docs/examples/patterns/navigation/full-width.html
+++ b/templates/docs/examples/patterns/navigation/full-width.html
@@ -16,9 +16,6 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav" aria-label="Example of full-width main navigation">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/patterns/links.md
+++ b/templates/docs/patterns/links.md
@@ -62,7 +62,7 @@ View example of the back to top pattern
 
 <span class="p-label--new">New</span>
 
-The `.p-skip-link` link is used to help keyboard users navigate quickly to the main content of a page. It should be the first element that can be tabbed to on any page, and should reference either the `<main>` landmark region element, or the ID of an element that contains the main content of the page.
+The `.p-link--skip` link is used to help keyboard users navigate quickly to the main content of a page. It should be the first element that can be tabbed to on any page, and should reference either the `<main>` landmark region element, or the ID of an element that contains the main content of the page.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/links/links-skip/" class="js-example">
 View example of the back to skip link pattern

--- a/templates/docs/patterns/links.md
+++ b/templates/docs/patterns/links.md
@@ -58,6 +58,16 @@ The `.p-top` link can be used to make it easier to go back to the top on long pa
 View example of the back to top pattern
 </a></div>
 
+### Skip link
+
+<span class="p-label--new">New</span>
+
+The `.p-skip-link` link is used to help keyboard users navigate quickly to the main content of a page. It should be the first element that can be tabbed to on any page, and should reference either the `<main>` landmark region element, or the ID of an element that contains the main content of the page.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/links/links-skip/" class="js-example">
+View example of the back to skip link pattern
+</a></div>
+
 ### Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Added `p-link--skip` pattern
  - styles were taken from [global-nav](https://github.com/canonical-web-and-design/global-nav/blob/master/src/sass/global-nav.scss#L400)
- Removed skip links nested within navigation components
  - skip links should be the first thing that can be tabbed to, and should become visible on focus (see: [WCAG guidance](https://www.w3.org/TR/WCAG20-TECHS/G1.html))
- Added skip link to vf.io

Fixes #3662 

## QA

- Open [demo](https://vanilla-framework-3851.demos.haus/docs/examples/patterns/links/links-skip)
- Press tab, see that the skip link appears
- Open [vf.io homepage](https://vanilla-framework-3851.demos.haus/)
- Review updated documentation:
  - [Link docs](https://vanilla-framework-3851.demos.haus/docs/patterns/links#skip-link)
  - [Component status](https://vanilla-framework-3851.demos.haus/docs/component-status)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots
![Screenshot from 2021-07-06 12-34-58](https://user-images.githubusercontent.com/2376968/124593483-9c8d6d00-de56-11eb-9d92-760c67f71bfc.png)

