### PR TITLE
add actions, modal, raised and unread notification variants

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -14,6 +14,10 @@
   %vf-has-box-shadow {
     box-shadow: $box-shadow;
   }
+  
+  %vf-has-box-shadow--deep {
+    box-shadow: $box-shadow--deep;
+  }
 
   %vf-is-bordered {
     border: $border;

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -14,7 +14,7 @@
   %vf-has-box-shadow {
     box-shadow: $box-shadow;
   }
-  
+
   %vf-has-box-shadow--deep {
     box-shadow: $box-shadow--deep;
   }

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -53,7 +53,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     width: 100vw;
   }
 
-  $panel-drop-shadow: 0 0 2rem 0 rgba($color-x-dark, $shadow-opacity);
+  $panel-drop-shadow: $box-shadow--deep;
   $panel-drop-shadow-transparent: 0 0 0 0 transparent;
 
   // Top navigation bar to toggle side navigation on small screens

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -9,6 +9,7 @@ $notification-text-margin-bottom: 0.6rem;
   // The mixin for basic notification styling
   %vf-notification {
     @extend %vf-is-bordered;
+    @extend %vf-bg--x-light;
 
     background-position: $sph-inner $notification-icon-vert-offset;
     background-repeat: no-repeat;
@@ -18,6 +19,10 @@ $notification-text-margin-bottom: 0.6rem;
     margin-top: -1px;
     padding-left: $notification-content-icon-space;
     position: relative;
+
+    &::before {
+      left: -1px !important;
+    }
 
     &.is-borderless {
       background-color: transparent;
@@ -46,7 +51,9 @@ $notification-text-margin-bottom: 0.6rem;
     }
 
     &.is-modal {
-      box-shadow: $box-shadow;
+      @extend %vf-has-box-shadow;
+
+      border-color: transparent;
 
       .p-notification__actions:only-child {
         margin-left: unset;
@@ -58,7 +65,9 @@ $notification-text-margin-bottom: 0.6rem;
     }
 
     &.is-raised {
-      box-shadow: 0 0 2rem 0 rgba($color-x-dark, $shadow-opacity);
+      @extend %vf-has-box-shadow--deep;
+
+      border-color: transparent;
     }
 
     &.is-unread {
@@ -96,23 +105,23 @@ $notification-text-margin-bottom: 0.6rem;
   .p-notification__close {
     @extend %vf-hide-text;
     @include vf-icon-close($color-mid-dark);
-    @include vf-icon-size($default-icon-size);
 
     background-color: transparent;
     background-position: center;
     background-repeat: no-repeat;
+    background-size: unset;
     border: 0;
-    margin: 0;
-    padding: $sp-unit;
+    width: $default-icon-size;
     position: absolute;
-    right: $sph-inner;
-    top: $notification-content-vert-padding + $notification-icon-vert-offset;
+    right: $sph-inner / 2;
+    top: $spv-outer--small;
   }
 
   .p-notification__meta {
     display: flex;
     justify-content: space-between;
     padding-right: $sph-inner;
+    align-items: baseline;
   }
 
   .p-notification__time {
@@ -134,10 +143,6 @@ $notification-text-margin-bottom: 0.6rem;
   .p-notification__action {
     margin: 0;
 
-    [class*='p-button'] {
-      margin-bottom: 0;
-    }
-
     & + & {
       margin-left: $sph-outer;
     }
@@ -155,7 +160,7 @@ $notification-text-margin-bottom: 0.6rem;
 @mixin vf-notifications-default {
   .p-notification {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-information, left);
+    @include vf-highlight-bar($color-information, left, true);
     @include vf-icon-info($color-mid-dark);
   }
 }
@@ -164,7 +169,7 @@ $notification-text-margin-bottom: 0.6rem;
 @mixin vf-notifications-positive {
   .p-notification--positive {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-positive, left);
+    @include vf-highlight-bar($color-positive, left, true);
     @include vf-icon-success;
   }
 }
@@ -173,7 +178,7 @@ $notification-text-margin-bottom: 0.6rem;
 @mixin vf-notifications-caution {
   .p-notification--caution {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-caution, left);
+    @include vf-highlight-bar($color-caution, left, true);
     @include vf-icon-warning;
   }
 }
@@ -182,7 +187,7 @@ $notification-text-margin-bottom: 0.6rem;
 @mixin vf-notifications-negative {
   .p-notification--negative {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-negative, left);
+    @include vf-highlight-bar($color-negative, left, true);
     @include vf-icon-error;
   }
 }
@@ -191,7 +196,7 @@ $notification-text-margin-bottom: 0.6rem;
 @mixin vf-notifications-information {
   .p-notification--information {
     @extend %vf-notification;
-    @include vf-highlight-bar($color-information, left);
+    @include vf-highlight-bar($color-information, left, true);
     @include vf-icon-info($color-mid-dark);
   }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -68,21 +68,6 @@ $notification-text-margin-bottom: 0.6rem;
 
       border-color: transparent;
     }
-
-    &.is-unread {
-      .p-notification__title {
-        position: relative;
-
-        &::after {
-          @include vf-icon-status-small($color-link);
-          @include vf-icon-size($default-icon-size);
-
-          content: '';
-          position: absolute;
-          top: $notification-icon-vert-offset + map-get($nudges, nudge--small);
-        }
-      }
-    }
   }
 
   .p-notification__content {

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -111,17 +111,17 @@ $notification-text-margin-bottom: 0.6rem;
     background-repeat: no-repeat;
     background-size: unset;
     border: 0;
-    width: $default-icon-size;
     position: absolute;
     right: $sph-inner / 2;
     top: $spv-outer--small;
+    width: $default-icon-size;
   }
 
   .p-notification__meta {
+    align-items: baseline;
     display: flex;
     justify-content: space-between;
     padding-right: $sph-inner;
-    align-items: baseline;
   }
 
   .p-notification__time {

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -1,7 +1,8 @@
 @import 'settings';
 $notification-content-vert-padding: $spv-inner--small;
 $notification-content-icon-space: 2 * $sph-inner + map-get($icon-sizes, default);
-$notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
+$notification-icon-vert-offset: 0.6rem;
+$notification-text-margin-bottom: 0.6rem;
 
 // Notification style patterns
 @mixin vf-p-notification {
@@ -9,20 +10,21 @@ $notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - ma
   %vf-notification {
     @extend %vf-is-bordered;
 
+    background-position: $sph-inner $notification-icon-vert-offset;
+    background-repeat: no-repeat;
+    background-size: map-get($icon-sizes, default);
     border-radius: 0 $border-radius $border-radius 0;
-    display: flex;
     margin-bottom: $spv-outer--scaleable;
-    overflow: hidden;
-    padding: 0;
+    margin-top: -1px;
+    padding-left: $notification-content-icon-space;
+    position: relative;
 
     &.is-borderless {
+      background-color: transparent;
+      background-position-x: 0;
       border-color: transparent;
-
-      .p-notification__content {
-        background-color: transparent;
-        background-position: 0 0.5 * (map-get($line-heights, default-text) - map-get($icon-sizes, default));
-        padding: 0 0 0 2 * $sph-inner;
-      }
+      margin-top: 0;
+      padding: 0 0 0 2 * $sph-inner;
 
       &::before {
         display: none;
@@ -30,33 +32,115 @@ $notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - ma
     }
 
     &.is-inline {
-      .p-notification__title {
-        display: inline;
+      .p-notification__content {
+        margin-bottom: $notification-text-margin-bottom;
+        padding-top: map-get($nudges, nudge--p) + map-get($browser-rounding-compensations, h5);
       }
 
+      .p-notification__title,
       .p-notification__message {
         display: inline;
+        margin: 0;
+        padding: 0;
+      }
+    }
+
+    &.is-modal {
+      box-shadow: $box-shadow;
+
+      .p-notification__actions:only-child {
+        margin-left: unset;
+      }
+
+      &::before {
+        display: none;
+      }
+    }
+
+    &.is-raised {
+      box-shadow: 0 0 2rem 0 rgba($color-x-dark, $shadow-opacity);
+    }
+
+    &.is-unread {
+      .p-notification__title {
+        position: relative;
+
+        &::after {
+          @include vf-icon-status-small($color-link);
+          @include vf-icon-size($default-icon-size);
+
+          content: '';
+          position: absolute;
+          top: $notification-icon-vert-offset + map-get($nudges, nudge--small);
+        }
       }
     }
   }
 
   .p-notification__content {
-    background-position: $sph-inner $notification-content-vert-padding + $notification-icon-vert-offset;
-    background-repeat: no-repeat;
-    background-size: map-get($icon-sizes, default);
-    margin-bottom: 0;
-    margin-top: -1px;
-    padding: $notification-content-vert-padding $sph-inner + $spv-inner--small $notification-content-vert-padding $notification-content-icon-space;
+    padding-right: 2 * $sph-inner;
   }
 
   .p-notification__title {
-    @extend %bold;
+    @extend %vf-heading-5;
 
-    display: block;
+    margin-bottom: 0.1rem;
   }
 
   .p-notification__message {
-    display: block;
+    @extend %default-text;
+
+    margin-bottom: $notification-text-margin-bottom;
+  }
+
+  .p-notification__close {
+    @extend %vf-hide-text;
+    @include vf-icon-close($color-mid-dark);
+    @include vf-icon-size($default-icon-size);
+
+    background-color: transparent;
+    background-position: center;
+    background-repeat: no-repeat;
+    border: 0;
+    margin: 0;
+    padding: $sp-unit;
+    position: absolute;
+    right: $sph-inner;
+    top: $notification-content-vert-padding + $notification-icon-vert-offset;
+  }
+
+  .p-notification__meta {
+    display: flex;
+    justify-content: space-between;
+    padding-right: $sph-inner;
+  }
+
+  .p-notification__time {
+    @extend %default-text;
+    @extend %muted-text;
+
+    margin-bottom: $notification-text-margin-bottom;
+  }
+
+  .p-notification__actions {
+    display: flex;
+    margin-bottom: $notification-text-margin-bottom;
+
+    &:only-child {
+      margin-left: auto;
+    }
+  }
+
+  .p-notification__action {
+    margin: 0;
+
+    [class*='p-button'] {
+      margin-bottom: 0;
+    }
+
+    & + & {
+      margin-left: $sph-outer;
+    }
   }
 
   @include vf-notifications-default;
@@ -72,10 +156,7 @@ $notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - ma
   .p-notification {
     @extend %vf-notification;
     @include vf-highlight-bar($color-information, left);
-
-    .p-notification__content {
-      @include vf-icon-info($color-mid-dark);
-    }
+    @include vf-icon-info($color-mid-dark);
   }
 }
 
@@ -84,10 +165,7 @@ $notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - ma
   .p-notification--positive {
     @extend %vf-notification;
     @include vf-highlight-bar($color-positive, left);
-
-    .p-notification__content {
-      @include vf-icon-success;
-    }
+    @include vf-icon-success;
   }
 }
 
@@ -96,10 +174,7 @@ $notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - ma
   .p-notification--caution {
     @extend %vf-notification;
     @include vf-highlight-bar($color-caution, left);
-
-    .p-notification__content {
-      @include vf-icon-warning;
-    }
+    @include vf-icon-warning;
   }
 }
 
@@ -108,10 +183,7 @@ $notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - ma
   .p-notification--negative {
     @extend %vf-notification;
     @include vf-highlight-bar($color-negative, left);
-
-    .p-notification__content {
-      @include vf-icon-error;
-    }
+    @include vf-icon-error;
   }
 }
 
@@ -120,22 +192,19 @@ $notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - ma
   .p-notification--information {
     @extend %vf-notification;
     @include vf-highlight-bar($color-information, left);
-
-    .p-notification__content {
-      @include vf-icon-info($color-mid-dark);
-    }
+    @include vf-icon-info($color-mid-dark);
   }
 }
 
 @mixin vf-notifications-deprecated {
   @include deprecate('3.0.0', 'Use new notification structure instead') {
-    [class^='p-notification'] {
+    [class='p-notification'],
+    [class^='p-notification--'] {
+      position: relative;
+
       .p-notification__response {
-        background-position: $sph-inner $notification-content-vert-padding + $notification-icon-vert-offset;
-        background-repeat: no-repeat;
-        background-size: map-get($icon-sizes, default);
-        margin-bottom: 0;
-        padding: $notification-content-vert-padding $sph-inner + $spv-inner--small $notification-content-vert-padding $notification-content-icon-space;
+        margin-bottom: $notification-text-margin-bottom;
+        padding-top: map-get($nudges, nudge--p) + map-get($browser-rounding-compensations, p);
       }
 
       .p-notification__status {
@@ -158,27 +227,10 @@ $notification-icon-vert-offset: 0.5 * (map-get($line-heights, default-text) - ma
         background-color: transparent;
         background-size: map-get($icon-sizes, default);
         border: 0;
-        margin: $notification-content-vert-padding + $notification-icon-vert-offset $sph-inner auto auto;
         padding: $sp-unit;
-      }
-    }
-
-    .p-notification__response {
-      .p-notification &,
-      .p-notification--information & {
-        @include vf-icon-info($color-mid-dark);
-      }
-
-      .p-notification--caution & {
-        @include vf-icon-warning;
-      }
-
-      .p-notification--negative & {
-        @include vf-icon-error;
-      }
-
-      .p-notification--positive & {
-        @include vf-icon-success;
+        position: absolute;
+        right: $sph-inner;
+        top: $notification-content-vert-padding + $notification-icon-vert-offset;
       }
     }
   }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -16,7 +16,6 @@ $notification-text-margin-bottom: 0.6rem;
     background-size: map-get($icon-sizes, default);
     border-radius: 0 $border-radius $border-radius 0;
     margin-bottom: $spv-outer--scaleable;
-    margin-top: -1px;
     padding-left: $notification-content-icon-space;
     position: relative;
 
@@ -132,6 +131,7 @@ $notification-text-margin-bottom: 0.6rem;
   }
 
   .p-notification__actions {
+    align-items: baseline;
     display: flex;
     margin-bottom: $notification-text-margin-bottom;
 
@@ -235,7 +235,7 @@ $notification-text-margin-bottom: 0.6rem;
         padding: $sp-unit;
         position: absolute;
         right: $sph-inner;
-        top: $notification-content-vert-padding + $notification-icon-vert-offset;
+        top: $notification-icon-vert-offset;
       }
     }
   }

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -7,3 +7,4 @@ $bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems s
 $border-radius: $sp-unit * 0.25 !default;
 $border: 1px solid $color-mid-light !default;
 $box-shadow: 0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8) !default;
+$box-shadow--deep: 0 0 2rem 0 rgba($color-x-dark, $shadow-opacity) !default;

--- a/templates/docs/examples/patterns/notifications/action.html
+++ b/templates/docs/examples/patterns/notifications/action.html
@@ -6,14 +6,14 @@
 {% block content %}
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</p>
     <button class="p-notification__close">Close</button>
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">
-      <a class="p-link--external" href="#">Link</a>
-      <button class="p-button--link">Action</button>
+      <a class="p-notification__action">Action 1</a>
+      <button class="p-notification__action p-button--link">Action 2</button>
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/notifications/caution.html
+++ b/templates/docs/examples/patterns/notifications/caution.html
@@ -6,8 +6,8 @@
 {% block content %}
 <div class="p-notification--caution">
   <div class="p-notification__content">
-    <div class="p-notification__title">Blocked</div>
-    <div class="p-notification__message">Custom storage configuration is only supported on Ubuntu, CentOS and RHEL.</div>
+    <h4 class="p-notification__title">Blocked</h4>
+    <p class="p-notification__message">Custom storage configuration is only supported on Ubuntu, CentOS and RHEL.</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/notifications/information.html
+++ b/templates/docs/examples/patterns/notifications/information.html
@@ -6,8 +6,8 @@
 {% block content %}
 <div class="p-notification--information">
   <div class="p-notification__content">
-    <div class="p-notification__title">Permissions changed</div>
-    <div class="p-notification__message">Anyone with access can view your invited users.</div>
+    <h4 class="p-notification__title">Permissions changed</h4>
+    <p class="p-notification__message">Anyone with access can view your invited users.</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/notifications/negative.html
+++ b/templates/docs/examples/patterns/notifications/negative.html
@@ -6,8 +6,8 @@
 {% block content %}
 <div class="p-notification--negative">
   <div class="p-notification__content">
-    <div class="p-notification__title">Error</div>
-    <div class="p-notification__message">Node must be connected to a network.</div>
+    <h4 class="p-notification__title">Error</h4>
+    <p class="p-notification__message">Node must be connected to a network.</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/notifications/notifications.html
+++ b/templates/docs/examples/patterns/notifications/notifications.html
@@ -6,8 +6,8 @@
 {% block content %}
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Cookie policy</div>
-    <div class="p-notification__message">We use cookies to improve your experience. By your continued use of this site you accept such use.</div>
+    <h4 class="p-notification__title">Cookie policy</h4>
+    <p class="p-notification__message">We use cookies to improve your experience. By your continued use of this site you accept such use.</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/notifications/positive.html
+++ b/templates/docs/examples/patterns/notifications/positive.html
@@ -6,8 +6,8 @@
 {% block content %}
 <div class="p-notification--positive">
   <div class="p-notification__content">
-    <div class="p-notification__title">Success</div>
-    <div class="p-notification__message">Code successfully reformatted.</div>
+    <h4 class="p-notification__title">Success</h4>
+    <p class="p-notification__message">Code successfully reformatted.</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/notifications/variants.html
+++ b/templates/docs/examples/patterns/notifications/variants.html
@@ -11,112 +11,139 @@
 <h4>Borderless</h4>
 <div class="p-notification--caution is-borderless">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 
 <h4>Borderless inline</h4>
 <div class="p-notification--caution is-borderless is-inline">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title:</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title:</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 
 <h4>Collapsed (not implemented)</h4>
 <div class="p-notification--caution is-collapsed">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">
-      <button class="p-button--link u-text--muted">View 9+ additional notifications</button>
+      <button class="p-notification__action p-button--link">
+        View 9+ additional notifications
+      </button>
     </div>
   </div>
   <div class="p-notification__stack--caution"></div>
   <div class="p-notification__stack"></div>
 </div>
 
-<h4>Dismissable (not implemented)</h4>
+<h4>Dismissable</h4>
 <div class="p-notification" id="notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
-    <button class="p-notification__close" aria-label="Close notification" aria-controls="notification">Close</button>
-  </div>
-  <div class="p-notification__meta">
-    <div class="p-notification__time">1h ago</div>
-    <div class="p-notification__actions">
-      <button>Action</button>
-    </div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
+    <button
+      aria-controls="notification"
+      aria-label="Close notification"
+      class="p-notification__close"
+    >
+      Close
+    </button>
   </div>
 </div>
 
 <h4>Inline</h4>
 <div class="p-notification--caution is-inline">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title:</div>
-    <div class="p-notification__message">Body copy goes here</div>
+    <h4 class="p-notification__title">Title:</h4>
+    <p class="p-notification__message">Body copy goes here</p>
   </div>
 </div>
 
 <h4>Inline multiline</h4>
 <div class="p-notification--caution is-inline" style="width: 20rem">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title:</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title:</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 
-<h4>Meta - Action buttons (not implemented)</h4>
+<h4>Meta - Action buttons</h4>
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">
-      <button class="p-button--base">Cancel</button>
-      <button class="p-button--positive">Confirm</button>
+      <button class="p-notification__action p-button">Cancel</button>
+      <button class="p-notification__action p-button--positive">Confirm</button>
     </div>
   </div>
 </div>
 
-<h4>Meta - Action links (not implemented)</h4>
+<h4>Meta - Action links</h4>
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
     <button class="p-notification__close">Close</button>
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">
-      <a href="#" class="p-link--external">Link</a>
-      <button class="p-button--link">Action</button>
+      <a class="p-notification__action">Link 1</a>
+      <a class="p-notification__action">Link 2</a>
     </div>
   </div>
 </div>
 
-<h4>Meta - Action menu (not implemented)</h4>
+<h4>Meta - Action menu (WIP)</h4>
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
     <button class="p-notification__close">Close</button>
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">
-      <span class="p-contextual-menu--left">
-        <button class="p-button--neutral p-contextual-menu__toggle has-icon" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true"><i class="p-icon--chevron-down p-contextual-menu__indicator"></i></button>
-        <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
-            <a href="#" class="p-contextual-menu__link">
-              <i class="p-icon--timed-out"></i>
+      <span class="p-notification__action p-contextual-menu">
+        <button
+          aria-controls="menu-1"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="p-button--neutral p-contextual-menu__toggle has-icon"
+        >
+          <i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
+        </button>
+        <span
+          aria-hidden="true"
+          class="p-contextual-menu__dropdown"
+          id="menu-1"
+        >
+            <a class="p-contextual-menu__link">
               Snooze
             </a>
-            <a href="#" class="p-contextual-menu__link">
-              <i class="p-icon--show"></i>
+            <a class="p-contextual-menu__link">
               Mark as read
             </a>
         </span>
@@ -125,54 +152,116 @@
   </div>
 </div>
 
-<h4>Meta - date (not implemented)</h4>
+<h4>Meta - Date</h4>
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
-    <button class="p-notification__close">Close</button>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
   <div class="p-notification__meta">
-    <div class="p-notification__time">1h ago</div>
+    <span class="p-notification__time">1h ago</span>
   </div>
 </div>
 
-<h4>Meta - date + actions (not implemented)</h4>
+<h4>Meta - Date + action buttons</h4>
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
   <div class="p-notification__meta">
-    <div class="p-notification__time">1h ago</div>
+    <span class="p-notification__time">1h ago</span>
     <div class="p-notification__actions">
-      <button class="p-button--link">Action</button>
+      <button class="p-notification__action p-button">Cancel</button>
+      <button class="p-notification__action p-button--positive">Confirm</button>
     </div>
   </div>
 </div>
 
-<h4>Modal (not implemented)</h4>
+<h4>Meta - Date + action links (WIP)</h4>
+<div class="p-notification">
+  <div class="p-notification__content">
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
+  </div>
+  <div class="p-notification__meta">
+    <span class="p-notification__time">1h ago</span>
+    <div class="p-notification__actions">
+      <a class="p-notification__action">Link 1</a>
+      <a class="p-notification__action">Link 2</a>
+    </div>
+  </div>
+</div>
+
+<h4>Meta - Date + action menu (WIP)</h4>
+<div class="p-notification">
+  <div class="p-notification__content">
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
+  </div>
+  <div class="p-notification__meta">
+    <span class="p-notification__time">1h ago</span>
+    <div class="p-notification__actions">
+      <span class="p-notification__action p-contextual-menu">
+        <button
+          aria-controls="menu-2"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="p-button--neutral p-contextual-menu__toggle has-icon"
+        >
+          <i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
+        </button>
+        <span
+          aria-hidden="true"
+          class="p-contextual-menu__dropdown"
+          id="menu-2"
+        >
+            <a class="p-contextual-menu__link">
+              Snooze
+            </a>
+            <a class="p-contextual-menu__link">
+              Mark as read
+            </a>
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+
+<h4>Modal</h4>
 <div class="p-notification--caution is-modal">
   <div class="p-notification__content">
-    <div class="p-notification__title">Signed out</div>
-    <div class="p-notification__message">Your session has expired, please sign in again.</div>
+    <h4 class="p-notification__title">Signed out</h4>
+    <p class="p-notification__message">
+      Your session has expired, please sign in again.
+    </p>
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">
-      <button class="p-button">Sign in</button>
+      <button class="p-notification__action p-button">Sign in</button>
     </div>
   </div>
 </div>
 
-<h4>Modal inline (not implemented)</h4>
+<h4>Modal inline</h4>
 <div class="p-notification--caution is-modal is-inline">
   <div class="p-notification__content">
-    <div class="p-notification__title">Signed out</div>
-    <div class="p-notification__message">Your session has expired, please sign in again.</div>
+    <h4 class="p-notification__title">Signed out:</h4>
+    <p class="p-notification__message">
+      Your session has expired, please sign in again.
+    </p>
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">
-      <button class="p-button--neutral">Sign in</button>
+      <button class="p-notification__action p-button--neutral">Sign in</button>
     </div>
   </div>
 </div>
@@ -180,65 +269,84 @@
 <h4>No title</h4>
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 
-<h4>Raised (not implemented)</h4>
+<h4>Raised</h4>
 <div class="p-notification is-raised">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 
 <h4>Snoozed (not implemented)</h4>
 <div class="p-notification is-snoozed">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
     <button class="p-notification__close">Close</button>
   </div>
   <div class="p-notification__meta">
-    <div class="p-notification__time">1h ago</div>
-    <div class="p-notification__actions">
-      <a href="#" class="p-link--external">Link</a>
-      <button class="p-button--link">Action</button>
-    </div>
+    <span class="p-notification__time">1h ago</span>
   </div>
 </div>
 
 <h4>Spacing</h4>
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 <div class="p-notification">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 <div class="p-notification is-borderless">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 <div class="p-notification is-borderless">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
   </div>
 </div>
 
-<h4>Unread (not implemented)</h4>
+<h4>Unread</h4>
 <div class="p-notification is-unread">
   <div class="p-notification__content">
-    <div class="p-notification__title">Title</div>
-    <div class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</div>
+    <h4 class="p-notification__title">Title</h4>
+    <p class="p-notification__message">
+      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+    </p>
+  </div>
+  <div class="p-notification__meta">
+    <span class="p-notification__time">3 days ago</span>
+    <div class="p-notification__actions">
+      <button class="p-notification__action p-button--link">Action 1</button>
+      <button class="p-notification__action p-button--link">Action 2</button>
+    </div>
   </div>
 </div>
 
@@ -260,7 +368,7 @@
   }
   
   // Set up all notification close buttons.
-  var closeButtons = document.querySelectorAll('.p-notification [aria-controls]');
+  var closeButtons = document.querySelectorAll('.p-notification__close');
   
   for (var i = 0, l = closeButtons.length; i < l; i++) {
     setupCloseButton(closeButtons[i]);

--- a/templates/docs/examples/patterns/notifications/variants.html
+++ b/templates/docs/examples/patterns/notifications/variants.html
@@ -28,25 +28,6 @@
   </div>
 </div>
 
-<h4>Collapsed (not implemented)</h4>
-<div class="p-notification--caution is-collapsed">
-  <div class="p-notification__content">
-    <h4 class="p-notification__title">Title</h4>
-    <p class="p-notification__message">
-      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
-    </p>
-  </div>
-  <div class="p-notification__meta">
-    <div class="p-notification__actions">
-      <button class="p-notification__action p-button--link">
-        View 9+ additional notifications
-      </button>
-    </div>
-  </div>
-  <div class="p-notification__stack--caution"></div>
-  <div class="p-notification__stack"></div>
-</div>
-
 <h4>Dismissable</h4>
 <div class="p-notification" id="notification">
   <div class="p-notification__content">
@@ -73,11 +54,11 @@
 </div>
 
 <h4>Inline multiline</h4>
-<div class="p-notification--caution is-inline" style="width: 20rem">
+<div class="p-notification--caution is-inline">
   <div class="p-notification__content">
     <h4 class="p-notification__title">Title:</h4>
     <p class="p-notification__message">
-      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum consequat pretium facilisis. Phasellus cursus neque vel elementum pharetra. Cras maximus neque non mi fermentum, vel ultrices sem rutrum. Aliquam ornare nulla et justo fermentum tincidunt. Duis in enim nec velit consequat sollicitudin ac eget arcu. Proin id leo nunc. Donec varius sem et mattis cursus. 
     </p>
   </div>
 </div>
@@ -111,43 +92,6 @@
     <div class="p-notification__actions">
       <a class="p-notification__action">Link 1</a>
       <a class="p-notification__action">Link 2</a>
-    </div>
-  </div>
-</div>
-
-<h4>Meta - Action menu (WIP)</h4>
-<div class="p-notification">
-  <div class="p-notification__content">
-    <h4 class="p-notification__title">Title</h4>
-    <p class="p-notification__message">
-      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
-    </p>
-    <button class="p-notification__close">Close</button>
-  </div>
-  <div class="p-notification__meta">
-    <div class="p-notification__actions">
-      <span class="p-notification__action p-contextual-menu">
-        <button
-          aria-controls="menu-1"
-          aria-expanded="false"
-          aria-haspopup="true"
-          class="p-button--neutral p-contextual-menu__toggle has-icon"
-        >
-          <i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
-        </button>
-        <span
-          aria-hidden="true"
-          class="p-contextual-menu__dropdown"
-          id="menu-1"
-        >
-            <a class="p-contextual-menu__link">
-              Snooze
-            </a>
-            <a class="p-contextual-menu__link">
-              Mark as read
-            </a>
-        </span>
-      </span>
     </div>
   </div>
 </div>
@@ -195,43 +139,6 @@
     <div class="p-notification__actions">
       <a class="p-notification__action">Link 1</a>
       <a class="p-notification__action">Link 2</a>
-    </div>
-  </div>
-</div>
-
-<h4>Meta - Date + action menu (WIP)</h4>
-<div class="p-notification">
-  <div class="p-notification__content">
-    <h4 class="p-notification__title">Title</h4>
-    <p class="p-notification__message">
-      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
-    </p>
-  </div>
-  <div class="p-notification__meta">
-    <span class="p-notification__time">1h ago</span>
-    <div class="p-notification__actions">
-      <span class="p-notification__action p-contextual-menu">
-        <button
-          aria-controls="menu-2"
-          aria-expanded="false"
-          aria-haspopup="true"
-          class="p-button--neutral p-contextual-menu__toggle has-icon"
-        >
-          <i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
-        </button>
-        <span
-          aria-hidden="true"
-          class="p-contextual-menu__dropdown"
-          id="menu-2"
-        >
-            <a class="p-contextual-menu__link">
-              Snooze
-            </a>
-            <a class="p-contextual-menu__link">
-              Mark as read
-            </a>
-        </span>
-      </span>
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/notifications/variants.html
+++ b/templates/docs/examples/patterns/notifications/variants.html
@@ -126,7 +126,7 @@
   </div>
 </div>
 
-<h4>Meta - Date + action links (WIP)</h4>
+<h4>Meta - Date + action links</h4>
 <div class="p-notification">
   <div class="p-notification__content">
     <h4 class="p-notification__title">Title</h4>
@@ -192,20 +192,6 @@
   </div>
 </div>
 
-<h4>Snoozed (not implemented)</h4>
-<div class="p-notification is-snoozed">
-  <div class="p-notification__content">
-    <h4 class="p-notification__title">Title</h4>
-    <p class="p-notification__message">
-      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
-    </p>
-    <button class="p-notification__close">Close</button>
-  </div>
-  <div class="p-notification__meta">
-    <span class="p-notification__time">1h ago</span>
-  </div>
-</div>
-
 <h4>Spacing</h4>
 <div class="p-notification">
   <div class="p-notification__content">
@@ -237,23 +223,6 @@
     <p class="p-notification__message">
       Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
     </p>
-  </div>
-</div>
-
-<h4>Unread</h4>
-<div class="p-notification is-unread">
-  <div class="p-notification__content">
-    <h4 class="p-notification__title">Title</h4>
-    <p class="p-notification__message">
-      Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.
-    </p>
-  </div>
-  <div class="p-notification__meta">
-    <span class="p-notification__time">3 days ago</span>
-    <div class="p-notification__actions">
-      <button class="p-notification__action p-button--link">Action 1</button>
-      <button class="p-notification__action p-button--link">Action 2</button>
-    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- Added modal, raised and unread notification variants
- Added action (links, buttons, menu) variants
- The highlight bar and padding are now applied to the root `.p-notification` element instead of the first child
- Changed the text elements `.p-notification__title`, `.p-notification__message`, `.p-notification__time` to use text tags in the examples

Fixes #3825
Fixes #3828
Fixes #3829
Fixes #3830
Fixes #3831

## QA

- Open [Notifications - Variants](https://vanilla-framework-3853.demos.haus/docs/examples/patterns/notifications/variants)
