### PR TITLE
Notifications deprecations

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -80,4 +80,4 @@ specs
 dropdown
 dropdowns
 playbook
-dismissable
+timestamp

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -120,7 +120,7 @@ $notification-text-margin-bottom: 0.6rem;
     padding-right: $sph-inner;
   }
 
-  .p-notification__time {
+  .p-notification__timestamp {
     @extend %default-text;
     @extend %muted-text;
 

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -29,6 +29,18 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.33.0</td>
       <td>We added a new link variant, <code>.p-link--skip</code>, that places a link offscreen and is revealed on focus.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/patterns/notification">Notifications</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.33.0</td>
+      <td>Notifications have been updated with a new appearance, requiring a new HTML structure.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/notification#deprecated">Notifications structure</a></th>
+      <td><div class="p-label--deprecated">Deprecated</div></td>
+      <td>2.33.0</td>
+      <td>The following notification classes have been deprecated: <code>.p-notification__response</code>, <code>.p-notification__status</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/templates/docs/examples/patterns/notifications/dismissible.html
+++ b/templates/docs/examples/patterns/notifications/dismissible.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Notifications / Dismissable{% endblock %}
+{% block title %}Notifications / Dismissible{% endblock %}
 
 {% block standalone_css %}patterns_notifications{% endblock %}
 

--- a/templates/docs/examples/patterns/notifications/timestamp.html
+++ b/templates/docs/examples/patterns/notifications/timestamp.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Notifications / Time{% endblock %}
+{% block title %}Notifications / Timestamp{% endblock %}
 
 {% block standalone_css %}patterns_notifications{% endblock %}
 
@@ -11,7 +11,7 @@
     <button class="p-notification__close">Close</button>
   </div>
   <div class="p-notification__meta">
-    <span class="p-notification__time">1h ago</span>
+    <span class="p-notification__timestamp">1h ago</span>
     <div class="p-notification__actions">
       <a class="p-notification__action">Action 1</a>
     </div>

--- a/templates/docs/examples/patterns/notifications/variants.html
+++ b/templates/docs/examples/patterns/notifications/variants.html
@@ -28,7 +28,7 @@
   </div>
 </div>
 
-<h4>Dismissable</h4>
+<h4>Dismissible</h4>
 <div class="p-notification" id="notification">
   <div class="p-notification__content">
     <h4 class="p-notification__title">Title</h4>
@@ -97,7 +97,7 @@
     </p>
   </div>
   <div class="p-notification__meta">
-    <span class="p-notification__time">1h ago</span>
+    <span class="p-notification__timestamp">1h ago</span>
   </div>
 </div>
 
@@ -110,7 +110,7 @@
     </p>
   </div>
   <div class="p-notification__meta">
-    <span class="p-notification__time">1h ago</span>
+    <span class="p-notification__timestamp">1h ago</span>
     <div class="p-notification__actions">
       <button class="p-notification__action p-button">Cancel</button>
       <button class="p-notification__action p-button--positive">Confirm</button>
@@ -127,7 +127,7 @@
     </p>
   </div>
   <div class="p-notification__meta">
-    <span class="p-notification__time">1h ago</span>
+    <span class="p-notification__timestamp">1h ago</span>
     <div class="p-notification__actions">
       <a class="p-notification__action">Link 1</a>
       <a class="p-notification__action">Link 2</a>

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -14,6 +14,8 @@ Notifications are used to attract the user's attention. They offer four separate
 
 #### Information
 
+<span class="p-label--updated">Updated</span>
+
 The information severity should be used to convey an information message.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/notifications/information/" class="js-example">
@@ -21,6 +23,8 @@ View example of the information notification pattern
 </a></div>
 
 #### Caution
+
+<span class="p-label--updated">Updated</span>
 
 The caution severity should be used to convey information that is not critical but the user should be aware of.
 
@@ -30,6 +34,8 @@ View example of the caution notification pattern
 
 #### Negative
 
+<span class="p-label--updated">Updated</span>
+
 The negative severity should be used to convey information that is critical and the user should take action.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/notifications/negative/" class="js-example">
@@ -38,13 +44,19 @@ View example of the negative notification pattern
 
 #### Positive
 
+<span class="p-label--updated">Updated</span>
+
 The positive severity should be used to convey success or completion.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/notifications/positive/" class="js-example">
 View example of the positive notification pattern
 </a></div>
 
-### Borderless
+### Appearance
+
+#### Borderless
+
+<span class="p-label--new">New</span>
 
 In cases where a notification sits inside another component, such as a table cell or a card, it may be useful to remove the outer border and highlight bar.
 
@@ -52,15 +64,9 @@ In cases where a notification sits inside another component, such as a table cel
 View example of the borderless notification pattern
 </a></div>
 
-### Inline
+#### Modal
 
-When vertical space is limited, you can use the inline variant.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/notifications/inline/" class="js-example">
-View example of the inline notification pattern
-</a></div>
-
-### Modal
+<span class="p-label--new">New</span>
 
 Modal notifications should occupy the full width of the page.
 
@@ -68,7 +74,9 @@ Modal notifications should occupy the full width of the page.
 View example of the modal notification pattern
 </a></div>
 
-### Raised
+#### Raised
+
+<span class="p-label--new">New</span>
 
 Raised notifications should be used when they are overlapping another panel.
 
@@ -76,29 +84,60 @@ Raised notifications should be used when they are overlapping another panel.
 View example of the raised notification pattern
 </a></div>
 
+#### Inline
+
+<span class="p-label--new">New</span>
+
+When vertical space is limited, you can use the inline variant.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/inline/" class="js-example">
+View example of the inline notification pattern
+</a></div>
+
 ### Actions
+
+#### Buttons
+
+<span class="p-label--new">New</span>
 
 Notifications can have actions in either button or link form. These will appear below the notification message.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/notifications/action/" class="js-example">
-View example of the caution notification pattern
+View example of the notification actions.
 </a></div>
 
-#### Dismissable
+#### Dismissible
+
+<span class="p-label--updated">Updated</span>
 
 Notifications that can be dismissed can include a close button.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/notifications/dismissable/" class="js-example">
-View example of the dismissable notification pattern
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/dismissible/" class="js-example">
+View example of the dismissible notification pattern
 </a></div>
 
-### Time
+### Timestamp
+
+<span class="p-label--new">New</span>
 
 For notifications in which recency is important, you can include a section for time.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/notifications/time/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/notifications/timestamp/" class="js-example">
 View example of the time notification pattern
 </a></div>
+
+### Deprecated
+
+<span class="p-label--deprecated">Deprecated</span>
+
+The notification child classes have been replaced to support new
+variants. The following class substitutions can be used to support existing functionality:
+
+| Deprecated classes          | Replaced by                |
+| --------------------------- | -------------------------- |
+| `.p-notification__response` | `.p-notification__content` |
+| `.p-notification__status`   | `.p-notification__title`   |
+| `.p-icon--close`            | `.p-notification__close`   |
 
 ### Import
 


### PR DESCRIPTION
## Done

- Added updated and deprecated notices to the component status page.
- Added deprecated class substitutions to the notifications page.
- Reordered the notifications page.
- Renamed time to timestamp.
- Fixed spelling of `dismissible`.

Fixes: #3857.

## QA

- Open the [component status](https://vanilla-framework-3859.demos.haus/docs/component-status) page.
- Check that there are entries for notification updates and deprecations.
- Open the [notifications](https://vanilla-framework-3859.demos.haus/docs/patterns/notification) page.
- Check that there is Deprecated table near the bottom.