### PR TITLE
Bring search and filter height inline with other inputs

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -90,6 +90,23 @@
       @include vf-icon-success($color-x-light, $color-transparent);
     }
   }
+
+  %vf-button-has-icon {
+    width: auto;
+
+    & [class*='p-icon'] {
+      margin-left: $sph-inner--small;
+      margin-right: $sph-inner--small;
+
+      &:first-child {
+        margin-left: -#{$sph-inner--small};
+      }
+
+      &:last-child {
+        margin-right: -#{$sph-inner--small};
+      }
+    }
+  }
 }
 
 @mixin vf-button-pattern(

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -336,19 +336,6 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
 @mixin vf-button-icon {
   [class*='p-button'].has-icon {
-    width: auto;
-
-    & [class*='p-icon'] {
-      margin-left: $sph-inner--small;
-      margin-right: $sph-inner--small;
-
-      &:first-child {
-        margin-left: -#{$sph-inner--small};
-      }
-
-      &:last-child {
-        margin-right: -#{$sph-inner--small};
-      }
-    }
+    @extend %vf-button-has-icon;
   }
 }

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -7,6 +7,10 @@
 
 @mixin vf-search-and-filter {
   $search-filter-actions-width: map-get($icon-sizes, default) + $sph-inner * 2;
+  // we need to prevent the focus outline of the input element
+  // being obscured in certain situations, so this variable
+  // references the weight of that outline
+  $focus-outline-offset: $bar-thickness;
 
   .p-search-and-filter {
     border: 1px solid $colors--light-theme--border-high-contrast;
@@ -21,7 +25,7 @@
       margin: 0;
       overflow: hidden;
       padding-left: $sph-inner--small;
-      padding-right: calc(#{$search-filter-actions-width} + #{$bar-thickness});
+      padding-right: calc(#{$search-filter-actions-width} + #{$focus-outline-offset});
       position: relative;
 
       &[data-active='true'] {
@@ -37,7 +41,7 @@
         cursor: pointer;
         position: absolute;
         right: 0.5rem;
-        top: $bar-thickness;
+        top: $focus-outline-offset;
       }
 
       &[aria-expanded='true'] {
@@ -80,14 +84,15 @@
     }
 
     .p-search-and-filter__clear {
+      @extend %vf-button-has-icon;
+
       border: none;
-      bottom: $bar-thickness;
+      bottom: $focus-outline-offset;
       line-height: map-get($line-heights, small);
       margin: 0;
-      max-width: $search-filter-actions-width;
       position: absolute;
-      right: $bar-thickness;
-      top: $bar-thickness;
+      right: $focus-outline-offset;
+      top: $focus-outline-offset;
       z-index: 9999;
     }
 
@@ -108,7 +113,7 @@
       flex-grow: 1;
       margin-bottom: 0;
       margin-left: -$sph-inner--small; // compensate for the left padding of the container
-      margin-right: calc(calc(#{$search-filter-actions-width} + #{$bar-thickness}) * -1); // compensate for the space reserved for counter
+      margin-right: calc(calc(#{$search-filter-actions-width} + #{$focus-outline-offset}) * -1); // compensate for the space reserved for counter
       min-width: 6rem;
       position: relative;
     }

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -6,8 +6,10 @@
 }
 
 @mixin vf-search-and-filter {
+  $search-filter-actions-width: map-get($icon-sizes, default) + $sph-inner * 2;
+
   .p-search-and-filter {
-    border: 1px solid $color-mid-dark;
+    border: 1px solid $colors--light-theme--border-high-contrast;
     position: relative;
 
     .p-search-and-filter__search-container {
@@ -19,7 +21,7 @@
       margin: 0;
       overflow: hidden;
       padding-left: $sph-inner--small;
-      padding-right: $sp-x-large; // reserve space for selected counter
+      padding-right: calc(#{$search-filter-actions-width} + #{$bar-thickness});
       position: relative;
 
       &[data-active='true'] {
@@ -35,7 +37,7 @@
         cursor: pointer;
         position: absolute;
         right: 0.5rem;
-        top: 6px;
+        top: $bar-thickness;
       }
 
       &[aria-expanded='true'] {
@@ -79,13 +81,13 @@
 
     .p-search-and-filter__clear {
       border: none;
-      bottom: 3px;
-      line-height: 1.2rem;
+      bottom: $bar-thickness;
+      line-height: map-get($line-heights, small);
       margin: 0;
-      max-width: 48px;
+      max-width: $search-filter-actions-width;
       position: absolute;
-      right: 3px;
-      top: 3px;
+      right: $bar-thickness;
+      top: $bar-thickness;
       z-index: 9999;
     }
 
@@ -106,7 +108,7 @@
       flex-grow: 1;
       margin-bottom: 0;
       margin-left: -$sph-inner--small; // compensate for the left padding of the container
-      margin-right: -$sp-x-large; // compensate for the space reserved for counter
+      margin-right: calc(calc(#{$search-filter-actions-width} + #{$bar-thickness}) * -1); // compensate for the space reserved for counter
       min-width: 6rem;
       position: relative;
     }

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -16,6 +16,11 @@
   // and finally the width of the focus outline defined above
   $search-filter-actions-width: 2 * $sph-inner--small + map-get($icon-sizes, default) + $focus-outline-offset;
 
+  // When the search and filter is not expanded, but is overflowing with chips, we need to
+  // specify a height that matches that of a standard input element. This height is a combination
+  // of an input's line-height, its vertical padding, and a nudge.
+  $input-height: calc(#{map-get($line-heights, default-text)} + #{$input-vertical-padding} + #{$spv-nudge} - 1px);
+
   .p-search-and-filter {
     border: 1px solid $colors--light-theme--border-high-contrast;
     position: relative;
@@ -34,6 +39,11 @@
 
       &[data-active='true'] {
         height: auto;
+      }
+
+      &[data-empty='false'],
+      &[aria-expanded='false'] {
+        height: $input-height;
       }
 
       .p-chip {

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -7,8 +7,6 @@
 
 @mixin vf-search-and-filter {
   .p-search-and-filter {
-    $height: 2.5rem;
-
     border: 1px solid $color-mid-dark;
     position: relative;
 
@@ -19,7 +17,6 @@
       flex-wrap: wrap;
       height: auto;
       margin: 0;
-      min-height: $height;
       overflow: hidden;
       padding-left: $sph-inner--small;
       padding-right: $sp-x-large; // reserve space for selected counter
@@ -29,13 +26,8 @@
         height: auto;
       }
 
-      &[data-empty='false'],
-      &[aria-expanded='false'] {
-        height: $height;
-      }
-
       .p-chip {
-        margin-bottom: $spv-outer--small;
+        margin-top: 0;
       }
 
       .p-search-and-filter__selected-count {
@@ -87,7 +79,8 @@
 
     .p-search-and-filter__clear {
       border: none;
-      height: 2rem;
+      bottom: 3px;
+      line-height: 1.2rem;
       margin: 0;
       max-width: 48px;
       position: absolute;
@@ -103,7 +96,7 @@
     .p-search-and-filter__box {
       display: inline-flex;
       flex: 1;
-      margin: -6px 0 0;
+      margin: 0;
       position: relative;
     }
 
@@ -114,11 +107,8 @@
       margin-bottom: 0;
       margin-left: -$sph-inner--small; // compensate for the left padding of the container
       margin-right: -$sp-x-large; // compensate for the space reserved for counter
-      min-height: 2.25rem;
       min-width: 6rem;
-      padding: $spv-inner--small;
       position: relative;
-      top: 3px;
     }
 
     .p-chip + .p-search-and-filter__box {

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -6,11 +6,15 @@
 }
 
 @mixin vf-search-and-filter {
-  $search-filter-actions-width: map-get($icon-sizes, default) + $sph-inner * 2;
   // we need to prevent the focus outline of the input element
   // being obscured in certain situations, so this variable
   // references the weight of that outline
   $focus-outline-offset: $bar-thickness;
+
+  // this is the total width occupied by the search input clear button:
+  // the buttons left and right padding, plus the width of the icon,
+  // and finally the width of the focus outline defined above
+  $search-filter-actions-width: 2 * $sph-inner--small + map-get($icon-sizes, default) + $focus-outline-offset;
 
   .p-search-and-filter {
     border: 1px solid $colors--light-theme--border-high-contrast;
@@ -25,7 +29,7 @@
       margin: 0;
       overflow: hidden;
       padding-left: $sph-inner--small;
-      padding-right: calc(#{$search-filter-actions-width} + #{$focus-outline-offset});
+      padding-right: $search-filter-actions-width;
       position: relative;
 
       &[data-active='true'] {
@@ -114,7 +118,7 @@
       flex-grow: 1;
       margin-bottom: 0;
       margin-left: -$sph-inner--small; // compensate for the left padding of the container
-      margin-right: calc(calc(#{$search-filter-actions-width} + #{$focus-outline-offset}) * -1); // compensate for the space reserved for counter
+      margin-right: -$search-filter-actions-width; // compensate for the space reserved for counter
       min-width: 6rem;
       position: relative;
     }

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -33,7 +33,8 @@
       }
 
       .p-chip {
-        margin-top: 0;
+        margin-bottom: $sp-x-small;
+        margin-top: $sp-x-small;
       }
 
       .p-search-and-filter__selected-count {

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 300000,
+      threshold: 310000,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

Adjusted the height of the search and filter input to match standard inputs
- this includes tweaking the position of the clear CTA, and the margin on chips in the input

Fixes #3808

## QA

- Open:
  - [chip overflow demo](https://vanilla-framework-3864.demos.haus/docs/examples/patterns/search-and-filter/chip-overflow)
  - [default demo](https://vanilla-framework-3864.demos.haus/docs/examples/patterns/search-and-filter/default)
  - [with chips demo](https://vanilla-framework-3864.demos.haus/docs/examples/patterns/search-and-filter/with-chips)
  - [with search prompt demo](https://vanilla-framework-3864.demos.haus/docs/examples/patterns/search-and-filter/with-search-prompt)
- Open dev tools and inspect the height of the div with class `.p-search-and-filter`
- See that it matches the height of the text inputs shown here: https://vanilla-framework-3864.demos.haus/docs/examples/templates/tick-element-comparison

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
