### PR TITLE
Add documentation on notification accessibility

### DIFF
--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -106,6 +106,10 @@ For notifications in which recency is important, you can include a section for t
 View example of the time notification pattern
 </a></div>
 
+### Accessibility
+
+When adding notifications dynamically, it's important that the content of the notification is announced to users using assistive technology. If the notification is urgent, add `aria-live="assertive"` to the element, which will prompt assistive technology to announce it immediately, or use `aria-live="polite"`, which will cause assistive technology to wait for a pause before announcing the information.
+
 ### Deprecated
 
 <span class="p-label--deprecated">Deprecated</span>


### PR DESCRIPTION
## Done

Added documentation on improving notification accessibility

Fixes #3832 
## QA

- Open [demo](https://vanilla-framework-3879.demos.haus/)
- Review updated documentation:
  - [Notification docs](https://vanilla-framework-3879.demos.haus/docs/patterns/notification#accessibility)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.