### PR TITLE
Set z-index of hr.u-no-margin--bottom

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.33.0",
+  "version": "2.33.1",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -199,6 +199,9 @@
   %u-no-margin--bottom--hr {
     // compensate for hr thickness, to make sure it doesn't drift from baseline grid
     margin-bottom: -1px !important;
+    // then lift it up on the z axis, so the negative margin doesn't cause it to be
+    // obscured by neighbouring elements with color backgrounds
+    z-index: 1;
   }
 
   %icon {

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -142,7 +142,9 @@
       </span>
     </span>
     vel eu.
-  </p>
+  </p> 
+
+  <hr class="u-no-margin--bottom" />
 
   <nav class="p-tabs" aria-label="Example tabs navigation">
     <ul class="p-tabs__list" role="tablist">


### PR DESCRIPTION
## Done

- Set z-index of hr.u-no-margin--bottom
- bumped Vanilla version to 2.33.1

Fixes #3878 

## QA

- Open [demo](https://vanilla-framework-3880.demos.haus/docs/examples/templates/z-index)
- See that the hr above the tabs is visible, and not obscured in any way

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
