### PR TITLE
Document icon color customisation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -38,6 +38,7 @@ vanilla-framework
 LGPLv3
 Easings
 mixin
+mixins
 dialog
 javascript
 autoprefixer

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -737,6 +737,26 @@ If you use a limited set of icons you may want to include them individually to r
 @include vf-p-icon-warning-grey;
 ```
 
+### Customisation
+
+Should you wish to change the colour of an icon, this can be achieved by using an icon mixin and passing a color as an argument to the mixin.
+
+In the below example, the `.p-icon--share` class includes the `vf-icon-share` mixin, and overrides the icon's default `$color-mid-dark` with `$color-dark`:
+
+```scss
+@import 'vanilla-framework/scss/vanilla';
+@import 'vanilla-framework/scss/base_placeholders';
+@import 'vanilla-framework/scss/patterns_icons';
+@include vf-p-icons;
+@include vf-b-placeholders;
+
+.p-icon--share {
+  @include vf-icon-share($color-dark);
+}
+```
+
+You can find all of the available icon mixins listed [here](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_base_icon-definitions.scss).
+
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
 ### React


### PR DESCRIPTION
## Done

Added note on customising icon color to icon docs

Fixes #3858 

## QA

- Open [demo](https://vanilla-framework-3880.demos.haus/docs/patterns/icons#customisation)
- Check that it makes sense and reads well

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
