### PR TITLE
Update import guidance in docs

### DIFF
--- a/scss/standalone/base.scss
+++ b/scss/standalone/base.scss
@@ -1,2 +1,2 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;

--- a/scss/standalone/example.scss
+++ b/scss/standalone/example.scss
@@ -1,6 +1,6 @@
 // styles specific for the example pages
 
-@import '../utilities_baseline-grid';
+@import '../vanilla';
 @include vf-u-baseline-grid;
 
 // stylelint-disable selector-max-type -- examples base can use type selectors

--- a/scss/standalone/layouts_fluid-breakout-full.scss
+++ b/scss/standalone/layouts_fluid-breakout-full.scss
@@ -1,7 +1,8 @@
 @import '../vanilla';
-
 @include vf-base;
+
+@include vf-l-fluid-breakout(14rem, 13rem, 0, '--single-main');
+
 @include vf-p-grid;
 @include vf-p-lists;
-@include vf-l-fluid-breakout(14rem, 13rem, 0, '--single-main');
 @include vf-p-strip;

--- a/scss/standalone/layouts_fluid-breakout-full.scss
+++ b/scss/standalone/layouts_fluid-breakout-full.scss
@@ -1,11 +1,6 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
-
-@import '../patterns_grid';
-@import '../patterns_lists';
-@import '../layouts_fluid-breakout';
-@import '../patterns_strip';
-
 @include vf-p-grid;
 @include vf-p-lists;
 @include vf-l-fluid-breakout(14rem, 13rem, 0, '--single-main');

--- a/scss/standalone/layouts_fluid-breakout.scss
+++ b/scss/standalone/layouts_fluid-breakout.scss
@@ -1,9 +1,8 @@
 @import '../vanilla';
 @include vf-base;
 
-@include vf-p-grid;
-@include vf-p-lists;
 @include vf-l-fluid-breakout;
 
-// other patterns used in the examples
 @include vf-p-card;
+@include vf-p-grid;
+@include vf-p-lists;

--- a/scss/standalone/layouts_fluid-breakout.scss
+++ b/scss/standalone/layouts_fluid-breakout.scss
@@ -1,13 +1,9 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_grid';
-@import '../patterns_lists';
-@import '../layouts_fluid-breakout';
 @include vf-p-grid;
 @include vf-p-lists;
 @include vf-l-fluid-breakout;
 
 // other patterns used in the examples
-@import '../patterns_card';
 @include vf-p-card;

--- a/scss/standalone/patterns_accordion.scss
+++ b/scss/standalone/patterns_accordion.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-accordion;

--- a/scss/standalone/patterns_accordion.scss
+++ b/scss/standalone/patterns_accordion.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_accordion';
+@include vf-base;
 @include vf-p-accordion;

--- a/scss/standalone/patterns_article-pagination.scss
+++ b/scss/standalone/patterns_article-pagination.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_article-pagination';
+@include vf-base;
 @include vf-p-article-pagination;

--- a/scss/standalone/patterns_article-pagination.scss
+++ b/scss/standalone/patterns_article-pagination.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-article-pagination;

--- a/scss/standalone/patterns_breadcrumbs.scss
+++ b/scss/standalone/patterns_breadcrumbs.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_breadcrumbs';
+@include vf-base;
 @include vf-p-breadcrumbs;

--- a/scss/standalone/patterns_breadcrumbs.scss
+++ b/scss/standalone/patterns_breadcrumbs.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-breadcrumbs;

--- a/scss/standalone/patterns_buttons.scss
+++ b/scss/standalone/patterns_buttons.scss
@@ -1,5 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
 
 // needed in buttons icon example

--- a/scss/standalone/patterns_buttons.scss
+++ b/scss/standalone/patterns_buttons.scss
@@ -1,13 +1,10 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
 // needed in buttons icon example
-@import '../patterns_icons';
 @include vf-p-icons;
 
 // needed in aria-pressed example
-@import '../patterns_contextual-menu';
 @include vf-p-contextual-menu;
-
-@import '../patterns_buttons';
 @include vf-p-buttons;

--- a/scss/standalone/patterns_card.scss
+++ b/scss/standalone/patterns_card.scss
@@ -1,9 +1,8 @@
 @import '../vanilla';
-
 @include vf-base;
 
-// needed by card overlay example
-@include vf-p-strip;
-@include vf-p-grid;
-@include vf-u-vertical-spacing;
 @include vf-p-card;
+@include vf-p-grid;
+@include vf-p-strip;
+
+@include vf-u-vertical-spacing;

--- a/scss/standalone/patterns_card.scss
+++ b/scss/standalone/patterns_card.scss
@@ -1,13 +1,9 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
 // needed by card overlay example
-@import '../patterns_strip';
 @include vf-p-strip;
-@import '../patterns_grid';
 @include vf-p-grid;
-@import '../utilities_vertical-spacing';
 @include vf-u-vertical-spacing;
-
-@import '../patterns_card';
 @include vf-p-card;

--- a/scss/standalone/patterns_chip.scss
+++ b/scss/standalone/patterns_chip.scss
@@ -1,9 +1,6 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
-
-@import '../patterns_chip';
 @include vf-p-chip;
-
-@import '../patterns_icons';
 @include vf-p-icons-common;
 @include vf-p-icon-close;

--- a/scss/standalone/patterns_chip.scss
+++ b/scss/standalone/patterns_chip.scss
@@ -1,6 +1,6 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-chip;
 @include vf-p-icons-common;
 @include vf-p-icon-close;

--- a/scss/standalone/patterns_code-copyable.scss
+++ b/scss/standalone/patterns_code-copyable.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-code-copyable;

--- a/scss/standalone/patterns_code-copyable.scss
+++ b/scss/standalone/patterns_code-copyable.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_code-copyable';
+@include vf-base;
 @include vf-p-code-copyable;

--- a/scss/standalone/patterns_code-numbered.scss
+++ b/scss/standalone/patterns_code-numbered.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_code-numbered';
+@include vf-base;
 @include vf-p-code-numbered;

--- a/scss/standalone/patterns_code-numbered.scss
+++ b/scss/standalone/patterns_code-numbered.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-code-numbered;

--- a/scss/standalone/patterns_code-snippet.scss
+++ b/scss/standalone/patterns_code-snippet.scss
@@ -1,5 +1,6 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-code-snippet;
+
 @include vf-u-hide;

--- a/scss/standalone/patterns_code-snippet.scss
+++ b/scss/standalone/patterns_code-snippet.scss
@@ -1,8 +1,5 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
-
-@import '../patterns_code-snippet';
 @include vf-p-code-snippet;
-
-@import '../utilities_hide';
 @include vf-u-hide;

--- a/scss/standalone/patterns_contextual-menu.scss
+++ b/scss/standalone/patterns_contextual-menu.scss
@@ -1,5 +1,6 @@
 @import '../vanilla';
 @include vf-base;
+
 @include vf-p-buttons;
 
 // icons are needed for indicator variant

--- a/scss/standalone/patterns_contextual-menu.scss
+++ b/scss/standalone/patterns_contextual-menu.scss
@@ -1,13 +1,8 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
-
-@import '../patterns_buttons';
 @include vf-p-buttons;
 
 // icons are needed for indicator variant
-@import '../patterns_icons';
 @include vf-p-icons-common;
 @include vf-p-icon-chevron;
-
-@import '../patterns_contextual-menu';
 @include vf-p-contextual-menu;

--- a/scss/standalone/patterns_divider.scss
+++ b/scss/standalone/patterns_divider.scss
@@ -1,6 +1,7 @@
 @import '../vanilla';
 @include vf-base;
 
+@include vf-p-divider;
+
 // grid classes (col-X) needed for divider pattern
 @include vf-p-grid;
-@include vf-p-divider;

--- a/scss/standalone/patterns_divider.scss
+++ b/scss/standalone/patterns_divider.scss
@@ -1,9 +1,6 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // grid classes (col-X) needed for divider pattern
-@import '../patterns_grid';
 @include vf-p-grid;
-
-@import '../patterns_divider';
 @include vf-p-divider;

--- a/scss/standalone/patterns_form-tick-elements.scss
+++ b/scss/standalone/patterns_form-tick-elements.scss
@@ -1,19 +1,12 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
 // grid required by stacked form example
-@import '../patterns_grid';
 @include vf-p-grid;
-
-@import '../utilities_layout';
 @include vf-u-layout;
 
 // button styles used in some form examples
-@import '../patterns_buttons';
 @include vf-p-buttons;
-
-@import '../patterns_muted-heading';
 @include vf-p-muted-heading;
-
-@import '../patterns_form-tick-elements';
 @include vf-p-form-tick-elements;

--- a/scss/standalone/patterns_form-tick-elements.scss
+++ b/scss/standalone/patterns_form-tick-elements.scss
@@ -1,12 +1,12 @@
 @import '../vanilla';
-
 @include vf-base;
 
 // grid required by stacked form example
 @include vf-p-grid;
-@include vf-u-layout;
 
 // button styles used in some form examples
 @include vf-p-buttons;
 @include vf-p-muted-heading;
 @include vf-p-form-tick-elements;
+
+@include vf-u-layout;

--- a/scss/standalone/patterns_forms.scss
+++ b/scss/standalone/patterns_forms.scss
@@ -1,5 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
 
 // grid required by stacked form example
@@ -8,10 +7,10 @@
 // button styles used in some form examples
 @include vf-p-buttons;
 
-// float utilities used to position buttons in some examples
-@include vf-u-floats;
-
 // importing forms and related patterns as they are all used in various examples
 @include vf-p-forms;
 @include vf-p-form-help-text;
 @include vf-p-form-validation;
+
+// float utilities used to position buttons in some examples
+@include vf-u-floats;

--- a/scss/standalone/patterns_forms.scss
+++ b/scss/standalone/patterns_forms.scss
@@ -1,24 +1,17 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
 // grid required by stacked form example
-@import '../patterns_grid';
 @include vf-p-grid;
 
 // button styles used in some form examples
-@import '../patterns_buttons';
 @include vf-p-buttons;
 
 // float utilities used to position buttons in some examples
-@import '../utilities_floats';
 @include vf-u-floats;
 
 // importing forms and related patterns as they are all used in various examples
-@import '../patterns_forms';
 @include vf-p-forms;
-
-@import '../patterns_form-help-text';
 @include vf-p-form-help-text;
-
-@import '../patterns_form-validation';
 @include vf-p-form-validation;

--- a/scss/standalone/patterns_grid.scss
+++ b/scss/standalone/patterns_grid.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_grid';
+@include vf-base;
 @include vf-p-grid;

--- a/scss/standalone/patterns_grid.scss
+++ b/scss/standalone/patterns_grid.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-grid;

--- a/scss/standalone/patterns_heading-icon.scss
+++ b/scss/standalone/patterns_heading-icon.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-heading-icon;

--- a/scss/standalone/patterns_heading-icon.scss
+++ b/scss/standalone/patterns_heading-icon.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_heading-icon';
+@include vf-base;
 @include vf-p-heading-icon;

--- a/scss/standalone/patterns_headings.scss
+++ b/scss/standalone/patterns_headings.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_headings';
+@include vf-base;
 @include vf-p-headings;

--- a/scss/standalone/patterns_headings.scss
+++ b/scss/standalone/patterns_headings.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-headings;

--- a/scss/standalone/patterns_icons-additional.scss
+++ b/scss/standalone/patterns_icons-additional.scss
@@ -4,8 +4,8 @@
 // our examples.
 
 @import '../vanilla';
+@include vf-base;
 
-@include vf-b-placeholders;
 @include vf-p-icons-common;
 
 @include vf-p-icon-applications;

--- a/scss/standalone/patterns_icons-additional.scss
+++ b/scss/standalone/patterns_icons-additional.scss
@@ -4,7 +4,7 @@
 // our examples.
 
 @import '../vanilla';
-@include vf-base;
+@include vf-b-placeholders;
 
 @include vf-p-icons-common;
 

--- a/scss/standalone/patterns_icons-additional.scss
+++ b/scss/standalone/patterns_icons-additional.scss
@@ -3,10 +3,7 @@
 // pattern, but is needed to display this icon set in
 // our examples.
 
-@import '../settings';
-@import '../base_icon-definitions';
-@import '../base_placeholders';
-@import '../patterns_icons';
+@import '../vanilla';
 
 @include vf-b-placeholders;
 @include vf-p-icons-common;

--- a/scss/standalone/patterns_icons.scss
+++ b/scss/standalone/patterns_icons.scss
@@ -1,7 +1,7 @@
 @import '../vanilla';
-
 @include vf-base;
+
+@include vf-p-icons;
 
 // for spin animation on the spinner icon
 @include vf-u-animations;
-@include vf-p-icons;

--- a/scss/standalone/patterns_icons.scss
+++ b/scss/standalone/patterns_icons.scss
@@ -1,9 +1,7 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
 // for spin animation on the spinner icon
-@import '../utilities_animations';
 @include vf-u-animations;
-
-@import '../patterns_icons';
 @include vf-p-icons;

--- a/scss/standalone/patterns_image.scss
+++ b/scss/standalone/patterns_image.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-image;

--- a/scss/standalone/patterns_image.scss
+++ b/scss/standalone/patterns_image.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_image';
+@include vf-base;
 @include vf-p-image;

--- a/scss/standalone/patterns_inline-images.scss
+++ b/scss/standalone/patterns_inline-images.scss
@@ -1,5 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
 
 @include vf-p-inline-images;

--- a/scss/standalone/patterns_inline-images.scss
+++ b/scss/standalone/patterns_inline-images.scss
@@ -1,5 +1,5 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
-@import '../patterns_inline-images';
 @include vf-p-inline-images;

--- a/scss/standalone/patterns_label.scss
+++ b/scss/standalone/patterns_label.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_label';
+@include vf-base;
 @include vf-p-label;

--- a/scss/standalone/patterns_label.scss
+++ b/scss/standalone/patterns_label.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-label;

--- a/scss/standalone/patterns_links.scss
+++ b/scss/standalone/patterns_links.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_links';
+@include vf-base;
 @include vf-p-links;

--- a/scss/standalone/patterns_links.scss
+++ b/scss/standalone/patterns_links.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-links;

--- a/scss/standalone/patterns_list-tree.scss
+++ b/scss/standalone/patterns_list-tree.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-list-tree;

--- a/scss/standalone/patterns_list-tree.scss
+++ b/scss/standalone/patterns_list-tree.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_list-tree';
+@include vf-base;
 @include vf-p-list-tree;

--- a/scss/standalone/patterns_lists.scss
+++ b/scss/standalone/patterns_lists.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-lists;

--- a/scss/standalone/patterns_lists.scss
+++ b/scss/standalone/patterns_lists.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_lists';
+@include vf-base;
 @include vf-p-lists;

--- a/scss/standalone/patterns_logo-section.scss
+++ b/scss/standalone/patterns_logo-section.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_logo-section';
+@include vf-base;
 @include vf-p-logo-section;

--- a/scss/standalone/patterns_logo-section.scss
+++ b/scss/standalone/patterns_logo-section.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-logo-section;

--- a/scss/standalone/patterns_matrix.scss
+++ b/scss/standalone/patterns_matrix.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-matrix;

--- a/scss/standalone/patterns_matrix.scss
+++ b/scss/standalone/patterns_matrix.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_matrix';
+@include vf-base;
 @include vf-p-matrix;

--- a/scss/standalone/patterns_media-object.scss
+++ b/scss/standalone/patterns_media-object.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-media-object;

--- a/scss/standalone/patterns_media-object.scss
+++ b/scss/standalone/patterns_media-object.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_media-object';
+@include vf-base;
 @include vf-p-media-object;

--- a/scss/standalone/patterns_modal.scss
+++ b/scss/standalone/patterns_modal.scss
@@ -1,9 +1,9 @@
 @import '../vanilla';
-
 @include vf-base;
 
 // used in the example
 @include vf-p-heading-icon;
-@include vf-button-negative;
-@include vf-u-margin-collapse;
 @include vf-p-modal;
+@include vf-button-negative;
+
+@include vf-u-margin-collapse;

--- a/scss/standalone/patterns_modal.scss
+++ b/scss/standalone/patterns_modal.scss
@@ -1,13 +1,9 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
 // used in the example
-@import '../patterns_heading-icon';
 @include vf-p-heading-icon;
-@import '../patterns_buttons';
 @include vf-button-negative;
-@import '../utilities_margin-collapse';
 @include vf-u-margin-collapse;
-
-@import '../patterns_modal';
 @include vf-p-modal;

--- a/scss/standalone/patterns_muted-heading.scss
+++ b/scss/standalone/patterns_muted-heading.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-muted-heading;

--- a/scss/standalone/patterns_muted-heading.scss
+++ b/scss/standalone/patterns_muted-heading.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_muted-heading';
+@include vf-base;
 @include vf-p-muted-heading;

--- a/scss/standalone/patterns_navigation.scss
+++ b/scss/standalone/patterns_navigation.scss
@@ -1,5 +1,4 @@
-@import '../base';
-@include vf-base;
+@import '../vanilla';
 
-@import '../patterns_navigation';
+@include vf-base;
 @include vf-p-navigation;

--- a/scss/standalone/patterns_navigation.scss
+++ b/scss/standalone/patterns_navigation.scss
@@ -1,4 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
+
 @include vf-p-navigation;

--- a/scss/standalone/patterns_notifications.scss
+++ b/scss/standalone/patterns_notifications.scss
@@ -1,9 +1,7 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
 // needed in borderless demo
-@import '../utilities_margin-collapse';
 @include vf-u-margin-collapse;
-
-@import '../patterns_notifications';
 @include vf-p-notification;

--- a/scss/standalone/patterns_notifications.scss
+++ b/scss/standalone/patterns_notifications.scss
@@ -1,7 +1,7 @@
 @import '../vanilla';
-
 @include vf-base;
+
+@include vf-p-notification;
 
 // needed in borderless demo
 @include vf-u-margin-collapse;
-@include vf-p-notification;

--- a/scss/standalone/patterns_pagination.scss
+++ b/scss/standalone/patterns_pagination.scss
@@ -1,10 +1,7 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // p-icon--chevron-down needed as next/prev icon
-@import '../patterns_icons';
 @include vf-p-icons-common;
 @include vf-p-icon-chevron;
-
-@import '../patterns_pagination';
 @include vf-p-pagination;

--- a/scss/standalone/patterns_pull-quotes.scss
+++ b/scss/standalone/patterns_pull-quotes.scss
@@ -1,5 +1,5 @@
-@import '../base';
+@import '../vanilla';
+
 @include vf-base;
 
-@import '../patterns_pull-quotes';
 @include vf-p-pull-quotes;

--- a/scss/standalone/patterns_pull-quotes.scss
+++ b/scss/standalone/patterns_pull-quotes.scss
@@ -1,5 +1,4 @@
 @import '../vanilla';
-
 @include vf-base;
 
 @include vf-p-pull-quotes;

--- a/scss/standalone/patterns_search-and-filter.scss
+++ b/scss/standalone/patterns_search-and-filter.scss
@@ -1,10 +1,6 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_chip';
-@import '../patterns_icons';
-@import '../patterns_search-and-filter';
-@import '../utilities_off-screen';
 @include vf-p-chip;
 @include vf-p-icon-close;
 @include vf-p-search-and-filter;

--- a/scss/standalone/patterns_search-and-filter.scss
+++ b/scss/standalone/patterns_search-and-filter.scss
@@ -4,4 +4,5 @@
 @include vf-p-chip;
 @include vf-p-icon-close;
 @include vf-p-search-and-filter;
+
 @include vf-u-off-screen;

--- a/scss/standalone/patterns_search-box.scss
+++ b/scss/standalone/patterns_search-box.scss
@@ -1,19 +1,15 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // navigation is used in some examples
-@import '../patterns_navigation';
 @include vf-p-navigation;
 
 // used by navigation
-@import '../utilities_off-screen';
 @include vf-u-off-screen;
 
 // icons are needed for search box buttons
-@import '../patterns_icons';
 @include vf-p-icons-common;
 @include vf-p-icon-close;
 @include vf-p-icon-search;
 
-@import '../patterns_search-box';
 @include vf-p-search-box;

--- a/scss/standalone/patterns_search-box.scss
+++ b/scss/standalone/patterns_search-box.scss
@@ -1,15 +1,15 @@
 @import '../vanilla';
 @include vf-base;
 
-// navigation is used in some examples
-@include vf-p-navigation;
-
-// used by navigation
-@include vf-u-off-screen;
+@include vf-p-search-box;
 
 // icons are needed for search box buttons
 @include vf-p-icons-common;
 @include vf-p-icon-close;
 @include vf-p-icon-search;
 
-@include vf-p-search-box;
+// navigation is used in some examples
+@include vf-p-navigation;
+
+// used by navigation
+@include vf-u-off-screen;

--- a/scss/standalone/patterns_separator.scss
+++ b/scss/standalone/patterns_separator.scss
@@ -1,5 +1,4 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_separator';
 @include vf-p-separator;

--- a/scss/standalone/patterns_side-navigation.scss
+++ b/scss/standalone/patterns_side-navigation.scss
@@ -1,11 +1,11 @@
 @import '../vanilla';
 @include vf-base;
 
+@include vf-p-side-navigation;
+
 // labels and icons for navigation statuses
 @include vf-p-label;
 @include vf-p-icons;
 
 // grid is used in group example with differents side nav variants
 @include vf-p-grid;
-
-@include vf-p-side-navigation;

--- a/scss/standalone/patterns_side-navigation.scss
+++ b/scss/standalone/patterns_side-navigation.scss
@@ -1,16 +1,11 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // labels and icons for navigation statuses
-@import '../patterns_label';
 @include vf-p-label;
-
-@import '../patterns_icons';
 @include vf-p-icons;
 
 // grid is used in group example with differents side nav variants
-@import '../patterns_grid';
 @include vf-p-grid;
 
-@import '../patterns_side-navigation';
 @include vf-p-side-navigation;

--- a/scss/standalone/patterns_skip-link.scss
+++ b/scss/standalone/patterns_skip-link.scss
@@ -1,14 +1,8 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_links';
 @include vf-p-links;
-
-@import '../patterns_navigation';
 @include vf-p-navigation;
-
-@import '../patterns_strip';
 @include vf-p-strip;
 
-@import '../utilities_layout';
 @include vf-u-layout;

--- a/scss/standalone/patterns_slider.scss
+++ b/scss/standalone/patterns_slider.scss
@@ -1,5 +1,4 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_slider';
 @include vf-p-slider;

--- a/scss/standalone/patterns_strip.scss
+++ b/scss/standalone/patterns_strip.scss
@@ -3,7 +3,8 @@
 
 // needed by some of the examples
 @include vf-p-grid;
+@include vf-p-strip;
+
 @include vf-u-vertically-center;
 @include vf-u-align;
 @include vf-u-hide;
-@include vf-p-strip;

--- a/scss/standalone/patterns_strip.scss
+++ b/scss/standalone/patterns_strip.scss
@@ -1,15 +1,9 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // needed by some of the examples
-@import '../patterns_grid';
 @include vf-p-grid;
-@import '../utilities_vertically-center';
 @include vf-u-vertically-center;
-@import '../utilities_content-align';
 @include vf-u-align;
-@import '../utilities_hide';
 @include vf-u-hide;
-
-@import '../patterns_strip';
 @include vf-p-strip;

--- a/scss/standalone/patterns_subnav.scss
+++ b/scss/standalone/patterns_subnav.scss
@@ -1,10 +1,10 @@
 @import '../vanilla';
 @include vf-base;
 
+@include vf-p-subnav;
+
 // subnav is part of navigation
 @include vf-p-navigation;
 
 // used by navigation for accessibility links
 @include vf-u-off-screen;
-
-@include vf-p-subnav;

--- a/scss/standalone/patterns_subnav.scss
+++ b/scss/standalone/patterns_subnav.scss
@@ -1,13 +1,10 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // subnav is part of navigation
-@import '../patterns_navigation';
 @include vf-p-navigation;
 
 // used by navigation for accessibility links
-@import '../utilities_off-screen';
 @include vf-u-off-screen;
 
-@import '../patterns_subnav';
 @include vf-p-subnav;

--- a/scss/standalone/patterns_subnav.scss
+++ b/scss/standalone/patterns_subnav.scss
@@ -1,10 +1,9 @@
 @import '../vanilla';
 @include vf-base;
 
-@include vf-p-subnav;
-
 // subnav is part of navigation
 @include vf-p-navigation;
+@include vf-p-subnav;
 
 // used by navigation for accessibility links
 @include vf-u-off-screen;

--- a/scss/standalone/patterns_switch.scss
+++ b/scss/standalone/patterns_switch.scss
@@ -1,5 +1,4 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_switch';
 @include vf-p-switch;

--- a/scss/standalone/patterns_table-expanding.scss
+++ b/scss/standalone/patterns_table-expanding.scss
@@ -1,10 +1,10 @@
 @import '../vanilla';
 @include vf-base;
 
-// for right aligning headings and content of cells
-@include vf-u-align--right;
+@include vf-p-table-expanding;
 
 // needed to hide cells
 @include vf-u-hide;
 
-@include vf-p-table-expanding;
+// for right aligning headings and content of cells
+@include vf-u-align--right;

--- a/scss/standalone/patterns_table-expanding.scss
+++ b/scss/standalone/patterns_table-expanding.scss
@@ -1,13 +1,10 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // for right aligning headings and content of cells
-@import '../utilities_content-align';
 @include vf-u-align--right;
 
 // needed to hide cells
-@import '../utilities_hide';
 @include vf-u-hide;
 
-@import '../patterns_table-expanding';
 @include vf-p-table-expanding;

--- a/scss/standalone/patterns_table-mobile-card.scss
+++ b/scss/standalone/patterns_table-mobile-card.scss
@@ -1,11 +1,10 @@
 @import '../vanilla';
 @include vf-base;
 
-// for right aligning headings and content of cells
-@include vf-u-align--right;
-
 @include vf-p-table-mobile-card;
-
 @include vf-p-contextual-menu;
 
 @include vf-u-margin-collapse;
+
+// for right aligning headings and content of cells
+@include vf-u-align--right;

--- a/scss/standalone/patterns_table-mobile-card.scss
+++ b/scss/standalone/patterns_table-mobile-card.scss
@@ -1,15 +1,11 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // for right aligning headings and content of cells
-@import '../utilities_content-align';
 @include vf-u-align--right;
 
-@import '../patterns_table-mobile-card';
 @include vf-p-table-mobile-card;
 
-@import '../patterns_contextual-menu';
 @include vf-p-contextual-menu;
 
-@import '../utilities_margin-collapse';
 @include vf-u-margin-collapse;

--- a/scss/standalone/patterns_table-of-contents.scss
+++ b/scss/standalone/patterns_table-of-contents.scss
@@ -1,9 +1,7 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // required by table of contents HTML
-@import '../patterns_lists';
 @include vf-p-lists;
 
-@import '../patterns_table-of-contents';
 @include vf-p-table-of-contents;

--- a/scss/standalone/patterns_table-of-contents.scss
+++ b/scss/standalone/patterns_table-of-contents.scss
@@ -1,7 +1,7 @@
 @import '../vanilla';
 @include vf-base;
 
+@include vf-p-table-of-contents;
+
 // required by table of contents HTML
 @include vf-p-lists;
-
-@include vf-p-table-of-contents;

--- a/scss/standalone/patterns_table-overflow.scss
+++ b/scss/standalone/patterns_table-overflow.scss
@@ -1,20 +1,14 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_contextual-menu';
 @include vf-p-contextual-menu;
 
-@import '../patterns_tooltips';
 @include vf-p-tooltips;
 
-@import '../patterns_icons';
 @include vf-p-icons;
 
-@import '../utilities_content-align';
 @include vf-u-align--right;
 
-@import '../utilities_hide';
 @include vf-u-hide;
 
-@import '../utilities_margin-collapse';
 @include vf-u-margin-collapse;

--- a/scss/standalone/patterns_table-overflow.scss
+++ b/scss/standalone/patterns_table-overflow.scss
@@ -2,13 +2,9 @@
 @include vf-base;
 
 @include vf-p-contextual-menu;
-
 @include vf-p-tooltips;
-
 @include vf-p-icons;
 
 @include vf-u-align--right;
-
 @include vf-u-hide;
-
 @include vf-u-margin-collapse;

--- a/scss/standalone/patterns_table-sortable.scss
+++ b/scss/standalone/patterns_table-sortable.scss
@@ -1,13 +1,10 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
 // for right aligning headings and content of cells
-@import '../utilities_content-align';
 @include vf-u-align--right;
 
 // for truncating
-@import '../utilities_truncate';
 @include vf-u-truncate;
 
-@import '../patterns_table-sortable';
 @include vf-p-table-sortable;

--- a/scss/standalone/patterns_table-sortable.scss
+++ b/scss/standalone/patterns_table-sortable.scss
@@ -1,10 +1,10 @@
 @import '../vanilla';
 @include vf-base;
 
+@include vf-p-table-sortable;
+
 // for right aligning headings and content of cells
 @include vf-u-align--right;
 
 // for truncating
 @include vf-u-truncate;
-
-@include vf-p-table-sortable;

--- a/scss/standalone/patterns_tabs.scss
+++ b/scss/standalone/patterns_tabs.scss
@@ -1,5 +1,4 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_tabs';
 @include vf-p-tabs;

--- a/scss/standalone/patterns_tooltips.scss
+++ b/scss/standalone/patterns_tooltips.scss
@@ -1,8 +1,6 @@
-@import '../base';
+@import '../vanilla';
 @include vf-base;
 
-@import '../patterns_tooltips';
 @include vf-p-tooltips;
 
-@import '../utilities_hide';
 @include vf-u-hide;

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -53,7 +53,11 @@ Please ensure the `aria-control` attribute matches an ID of an element. If `aria
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_accordion';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-accordion;
 ```
 

--- a/templates/docs/patterns/breadcrumbs.md
+++ b/templates/docs/patterns/breadcrumbs.md
@@ -29,7 +29,11 @@ The breadcrumb markup has been updated for accessibility reasons. Support for th
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_breadcrumbs';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-breadcrumbs;
 ```
 

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -142,11 +142,14 @@ View example of the contextual menu pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_buttons';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-buttons;
 
 // when using icons within buttons you need to include icons as well
-@import 'patterns_icons';
 @include vf-p-icons;
 ```
 

--- a/templates/docs/patterns/card.md
+++ b/templates/docs/patterns/card.md
@@ -47,7 +47,11 @@ View example of the patterns card overlay
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_card';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-card;
 ```
 

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -19,7 +19,11 @@ View example of the default chip pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_chip';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-chip;
 ```
 

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -71,14 +71,14 @@ View example of the contextual menu with an is-dark class
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_contextual-menu';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
 @include vf-p-contextual-menu;
 
 // when using the menu with dropdown button you need to include buttons and icon as well
-@import 'patterns_buttons';
 @include vf-p-buttons;
-
-@import 'patterns_icons';
 @include vf-p-icons-common;
 @include vf-p-icon-chevron;
 ```

--- a/templates/docs/patterns/grid.md
+++ b/templates/docs/patterns/grid.md
@@ -100,7 +100,11 @@ In some cases, there might be a good reason to break out of the constraints of a
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_grid';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-grid;
 ```
 

--- a/templates/docs/patterns/heading-icon.md
+++ b/templates/docs/patterns/heading-icon.md
@@ -36,7 +36,11 @@ View example of the pattern heading icon small
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_heading-icon';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-heading-icon;
 ```
 

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -744,11 +744,12 @@ Should you wish to change the colour of an icon, this can be achieved by using a
 In the below example, the `.p-icon--share` class includes the `vf-icon-share` mixin, and overrides the icon's default `$color-mid-dark` with `$color-dark`:
 
 ```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
 @import 'vanilla-framework/scss/vanilla';
-@import 'vanilla-framework/scss/base_placeholders';
-@import 'vanilla-framework/scss/patterns_icons';
+@include vf-base;
+
 @include vf-p-icons;
-@include vf-b-placeholders;
 
 .p-icon--share {
   @include vf-icon-share($color-dark);

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -39,7 +39,11 @@ View example of image with a caption
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_image';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-image;
 ```
 

--- a/templates/docs/patterns/inline-images.md
+++ b/templates/docs/patterns/inline-images.md
@@ -21,7 +21,11 @@ View example of the inline images pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_inline-images';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-inline-images;
 ```
 

--- a/templates/docs/patterns/labels.md
+++ b/templates/docs/patterns/labels.md
@@ -69,7 +69,11 @@ View example of the validated label pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_label';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-label;
 ```
 

--- a/templates/docs/patterns/links.md
+++ b/templates/docs/patterns/links.md
@@ -73,7 +73,11 @@ View example of the back to skip link pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_links';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-links;
 ```
 

--- a/templates/docs/patterns/list-tree.md
+++ b/templates/docs/patterns/list-tree.md
@@ -21,7 +21,11 @@ View example of the list tree pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_list-tree';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-list-tree;
 ```
 

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -149,25 +149,41 @@ View example of the divider list with an is-dark class
 To import list patterns into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_lists';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import '../vanilla';
+@include vf-base;
+
 @include vf-p-lists;
 ```
 
 To add dividers into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_divider';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import '../vanilla';
+@include vf-base;
+
 @include vf-p-divider;
 
 // grid column classes are used within divider component, so you need to include grid pattern as well
-@import 'patterns_grid';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import '../vanilla';
+@include vf-base;
+
 @include vf-p-grid;
 ```
 
 To include individual list patterns you need to include the `vf-p-list-placeholders` mixin first.
 
 ```scss
-@import 'patterns_lists';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-list-placeholders;
 
 // choose individual list patterns to include

--- a/templates/docs/patterns/logo-section.md
+++ b/templates/docs/patterns/logo-section.md
@@ -33,7 +33,11 @@ View example of the logo section pattern inside a six column parent container
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_logo-section';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-logo-section;
 ```
 

--- a/templates/docs/patterns/matrix.md
+++ b/templates/docs/patterns/matrix.md
@@ -27,7 +27,11 @@ View example of the matrix pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_matrix';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-matrix;
 ```
 

--- a/templates/docs/patterns/media-object.md
+++ b/templates/docs/patterns/media-object.md
@@ -36,7 +36,11 @@ View example of the pattern media object large
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_media-object';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-media-object;
 ```
 

--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -29,7 +29,11 @@ View example of the modal with a footer
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_modal';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-modal;
 ```
 

--- a/templates/docs/patterns/muted-heading.md
+++ b/templates/docs/patterns/muted-heading.md
@@ -20,7 +20,11 @@ View example of the pattern muted heading
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_muted-heading';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-muted-heading;
 ```
 

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -186,25 +186,29 @@ For more details about themes in Vanilla refer to the [Color theming](/docs/sett
 To import just navigation or sub-navigation component into your project, copy snippets below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_navigation';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-navigation;
 
 // sub-navigation is optional you can include it alongside navigation component
-@import 'patterns_subnav';
 @include vf-p-subnav;
 ```
 
 To import side navigation, copy snippet below:
 
 ```scss
-@import 'patterns_side-navigation';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-side-navigation;
 
 // optionally add icons and/or labels if you use them in side navigation__nav
-@import 'patterns_label';
 @include vf-p-label;
-
-@import 'patterns_icons';
 @include vf-p-icons;
 ```
 

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -128,7 +128,11 @@ variants. The following class substitutions can be used to support existing func
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_notifications';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-notification;
 ```
 

--- a/templates/docs/patterns/pagination.md
+++ b/templates/docs/patterns/pagination.md
@@ -53,11 +53,14 @@ View example of the article pagination pattern
 To import the pagination component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_pagination';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-pagination;
 
 // pagination uses icons for previous and next page buttons
-@import 'patterns_icons';
 @include vf-p-icons-common;
 @include vf-p-icon-chevron;
 ```

--- a/templates/docs/patterns/pull-quote.md
+++ b/templates/docs/patterns/pull-quote.md
@@ -44,7 +44,11 @@ View example of the small pull quote pattern with an image
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_pull-quotes';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-pull-quotes;
 ```
 

--- a/templates/docs/patterns/search-and-filter.md
+++ b/templates/docs/patterns/search-and-filter.md
@@ -69,13 +69,11 @@ View example of the search and filter with search prompt pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import '../base';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
 @include vf-base;
 
-@import '../patterns_chip';
-@import '../patterns_search-box';
-@import '../patterns_search-and-filter';
-@import '../utilities_off-screen';
 @include vf-p-chip;
 @include vf-p-search-box;
 @include vf-p-search-and-filter;

--- a/templates/docs/patterns/search-box.md
+++ b/templates/docs/patterns/search-box.md
@@ -33,11 +33,14 @@ View examples of search box navigation patterns
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_search-box';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-search-box;
 
 // search box uses icons for its buttons, so you need to include them as well
-@import 'patterns_icons';
 @include vf-p-icons-common;
 @include vf-p-icon-close;
 @include vf-p-icon-search;

--- a/templates/docs/patterns/slider.md
+++ b/templates/docs/patterns/slider.md
@@ -23,7 +23,11 @@ all range inputs, so adding `p-slider` class just to style `<input type="range">
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_slider';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-slider;
 ```
 

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -101,7 +101,11 @@ View example of the topped Suru strip pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_strip';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-strip;
 ```
 

--- a/templates/docs/patterns/switch.md
+++ b/templates/docs/patterns/switch.md
@@ -19,7 +19,11 @@ View example of the switch pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_switch';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-switch;
 ```
 

--- a/templates/docs/patterns/table-of-contents.md
+++ b/templates/docs/patterns/table-of-contents.md
@@ -19,11 +19,14 @@ View example of the table of contents pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_table-of-contents';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-table-of-contents;
 
 // list component is used within table of contents, so you need to include it as well
-@import 'patterns_lists';
 @include vf-p-lists;
 ```
 

--- a/templates/docs/patterns/tabs.md
+++ b/templates/docs/patterns/tabs.md
@@ -39,7 +39,11 @@ View example of the tabs content pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_tabs';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-tabs;
 ```
 

--- a/templates/docs/patterns/tooltips.md
+++ b/templates/docs/patterns/tooltips.md
@@ -41,7 +41,11 @@ View example of the detached tooltips pattern
 To import just this component into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'patterns_tooltips';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-p-tooltips;
 ```
 

--- a/templates/docs/utilities/align.md
+++ b/templates/docs/utilities/align.md
@@ -29,7 +29,12 @@ View example of the text align utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_content-align';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-align;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/baseline-grid.md
+++ b/templates/docs/utilities/baseline-grid.md
@@ -19,7 +19,12 @@ View example of the baseline grid utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_baseline-grid';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-baseline-grid;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/clearfix.md
+++ b/templates/docs/utilities/clearfix.md
@@ -23,7 +23,12 @@ View example of the clearfix utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_clearfix';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-clearfix;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/embedded-media.md
+++ b/templates/docs/utilities/embedded-media.md
@@ -19,7 +19,12 @@ View example of the embedded media utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_embedded-media';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-embedded-media;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/equal-height.md
+++ b/templates/docs/utilities/equal-height.md
@@ -19,7 +19,12 @@ View example of the equal height utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_equal-height';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-equal-height;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/floats.md
+++ b/templates/docs/utilities/floats.md
@@ -48,7 +48,12 @@ View example of the small screen floats utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_floats';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-floats;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/font-metrics.md
+++ b/templates/docs/utilities/font-metrics.md
@@ -21,7 +21,11 @@ View an example of the font metrics utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_font-metrics';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
 @include vf-u-visualise-baseline($horisontal-bleed: 2rem);
 ```
 

--- a/templates/docs/utilities/hide.md
+++ b/templates/docs/utilities/hide.md
@@ -23,7 +23,12 @@ View example of the Hide utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_hide';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-hide;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/image-position.md
+++ b/templates/docs/utilities/image-position.md
@@ -71,7 +71,12 @@ View example of the utilities image position bottom left
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_image-position';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-image-position;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/margin-collapse.md
+++ b/templates/docs/utilities/margin-collapse.md
@@ -19,7 +19,12 @@ View example of the margin collapse utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_margin-collapse';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-margin-collapse;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/no-print.md
+++ b/templates/docs/utilities/no-print.md
@@ -22,7 +22,12 @@ View example of the no-print utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_no-print';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-no-print;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/off-screen.md
+++ b/templates/docs/utilities/off-screen.md
@@ -19,7 +19,12 @@ View example of the off-screen utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_off-screen';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-off-screen;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/padding-collapse.md
+++ b/templates/docs/utilities/padding-collapse.md
@@ -19,7 +19,12 @@ View example of the padding collapse utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_padding-collapse';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-padding-collapse;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/show.md
+++ b/templates/docs/utilities/show.md
@@ -19,7 +19,12 @@ View example of the Show utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_show';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-show;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/truncate.md
+++ b/templates/docs/utilities/truncate.md
@@ -24,7 +24,12 @@ Note: `u-truncate` will affect any tooltips placed inside.
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_truncate';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-truncate;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/vertically-center.md
+++ b/templates/docs/utilities/vertically-center.md
@@ -21,7 +21,12 @@ View example of the vertically center utility
 To import just this utility into your project, copy the snippet below and include it in your main Sass file.
 
 ```scss
-@import 'utilities_vertically-center';
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework/scss/vanilla';
+@include vf-base;
+
+@include vf-u-vertically-center;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
## Done

We recently gave [a talk on best practices](https://drive.google.com/file/d/1PZ9hAwt189aRFUUfpwYKjdsXgHofBXiS/view) when using Vanilla in your project, but our documentation gives contradicting advice in that it suggests importing individual files from Vanilla, when it is far simpler to import just _vanilla.scss once, and then include the mixins you need. This PR updates the documentation to reflect that.

Fixes #3860

## QA

- Get comfortable
- Check nothing is broken on Percy
- Review docs changes for all patterns and utilities in https://vanilla-framework-3889.demos.haus/docs

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
