### PR TITLE
Add dart-sass build info

### DIFF
--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -27,7 +27,7 @@ In the script that builds the CSS in your `package.json`, you should include the
 Make a folder `src/`, create a file inside called `style.scss` and import Vanilla:
 
 ```
-@import vanilla-framework/scss/vanilla;
+@import "vanilla-framework/scss/vanilla";
 @include vanilla;
 ```
 
@@ -86,7 +86,7 @@ In the script that builds the CSS in your `package.json`, you should include the
 Make a folder `src/`, create a file inside called `style.scss` and import Vanilla:
 
 ```
-@import vanilla-framework/scss/vanilla;
+@import "vanilla-framework/scss/vanilla";
 @include vanilla;
 ```
 

--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -10,7 +10,66 @@ context:
 
 Here you will find information on how you can use different tools to build Vanilla into production CSS.
 
+### dart-sass
+
+To get set up with [`dart-sass`](https://github.com/sass/dart-sass), add the `sass` and `vanilla-framework` packages to your project dependencies:
+
+```
+yarn add sass vanilla-framework
+```
+
+In the script that builds the CSS in your `package.json`, you should include the path to `node_modules` when looking for `@import`s. In this example, we have called the build script `"build-css"`:
+
+```
+"build-css": "sass -w --load-path=node_modules src:dist --style=compressed"
+```
+
+Make a folder `src/`, create a file inside called `style.scss` and import Vanilla:
+
+```
+@import vanilla-framework/scss/vanilla;
+@include vanilla;
+```
+
+Now run `yarn build-css`, which will convert any Sass files in the `src/` folder to CSS in the `dist/` folder. In this case, `src/style.scss` will compile to `dist/style.css`, which can then be safely included in an HTML file. Your project's folder structure should now look something like this:
+
+<ul class="p-list-tree" aria-multiselectable="true" role="tablist">
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-1-btn" role="tab" aria-controls="sub-1" aria-expanded="false">dist</button>
+    <ul class="p-list-tree" id="sub-1" role="tabpanel" aria-hidden="true" aria-labelledby="sub-1-btn">
+      <li class="p-list-tree__item">style.css</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-2-btn" role="tab" aria-controls="sub-2" aria-expanded="false">node_modules</button>
+    <ul class="p-list-tree" id="sub-2" role="tabpanel" aria-hidden="true" aria-labelledby="sub-2-btn">
+      <li class="p-list-tree__item">modules</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item p-list-tree__item--group">
+    <button class="p-list-tree__toggle" id="sub-3-btn" role="tab" aria-controls="sub-3" aria-expanded="false">src</button>
+    <ul class="p-list-tree" id="sub-3" role="tabpanel" aria-hidden="true" aria-labelledby="sub-3-btn">
+      <li class="p-list-tree__item">style.scss</li>
+    </ul>
+  </li>
+  <li class="p-list-tree__item">index.html</li>
+  <li class="p-list-tree__item">package.json</li>
+  <li class="p-list-tree__item">yarn.lock</li>
+</ul>
+
+To watch for changes in your Sass files, add the following script to your `package.json`:
+
+```
+"watch-css":  "yarn build-css && sass --load-path=node_modules -w src:dist --style=compressed"
+```
+
+Now if you open an extra terminal and run `yarn watch-css`, the CSS will be rebuilt every time your Sass files are edited and saved.
+
 ### node-sass
+
+<span class="p-label--deprecated">Deprecated</span>
+
+`node-sass` is now deprecated in favour of `dart-sass`, described above. Vanilla will switch to using `dart-sass` by default with the release of version 3.0.
 
 To quickly get set up with [`node-sass`](https://github.com/sass/node-sass), add the `node-sass` and `vanilla-framework` packages to your project dependencies:
 


### PR DESCRIPTION
## Done

- Added information on building Vanilla css with `dart-sass` package
- Added a note to `node-sass` instructions that it is deprecated, and will be replaced in the Vanilla project by `dart-sass` in 3.0

Fixes #3849 

## QA

- Most thorough way to QA is to:
  - clone this [Vanilla masterclass repo](https://github.com/sowasred2012/vanilla-playground)
  - in the repo's [package.json](https://github.com/sowasred2012/vanilla-playground/blob/master/package.json), remove the dependencies and scripts, then follow the `dart-sass` [build docs in the demo](https://vanilla-framework-3893.demos.haus/docs/building-vanilla#dart-sass).
  - When `dart-sass` is successfully set up, opening `index.html` in the masterclass repo should show a very Vanilla looking page

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
