### PR TITLE
Document font-weight variables

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -18,7 +18,7 @@ $code-inline-padding: 0.25rem;
 
     b,
     strong {
-      font-weight: bold;
+      font-weight: $font-weight-bold;
     }
   }
 

--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -14,7 +14,7 @@
         font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
-        font-weight: 400;
+        font-weight: $font-weight-bold;
         src: url('#{$assets-path}0c7b8dc0-Ubuntu-R-subset.woff2') format('woff2'), url('#{$assets-path}ef4d35ed-Ubuntu-R-subset.woff') format('woff');
         unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
       }
@@ -32,7 +32,7 @@
         font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: italic;
-        font-weight: 400;
+        font-weight: $font-weight-bold;
         src: url('#{$assets-path}fd4ec0c7-Ubuntu-RI-subset.woff2') format('woff2'), url('#{$assets-path}89be6515-Ubuntu-RI-subset.woff') format('woff');
         unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
       }
@@ -41,7 +41,7 @@
         font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
-        font-weight: 100;
+        font-weight: $font-weight-display-heading;
         src: url('#{$assets-path}3baab91b-Ubuntu-Th-subset.woff2') format('woff2'), url('#{$assets-path}cb89e3ac-Ubuntu-Th-subset.woff') format('woff');
         unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
       }
@@ -59,7 +59,7 @@
         font-display: $font-display-option;
         font-family: 'Ubuntu Mono';
         font-style: normal;
-        font-weight: 400;
+        font-weight: $font-weight-bold;
         src: url('#{$assets-path}a662364d-UbuntuMono-B-subset.woff2') format('woff2'), url('#{$assets-path}22f97dd9-UbuntuMono-B-subset.woff') format('woff');
         unicode-range: U+0-FF, U+131, U+152, U+153, U+2BB, U+2BC, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
       }
@@ -76,7 +76,7 @@
         font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
-        font-weight: 400;
+        font-weight: $font-weight-bold;
         src: url('#{$assets-path}fff37993-Ubuntu-R_W.woff2') format('woff2'), url('#{$assets-path}7af50859-Ubuntu-R_W.woff') format('woff');
       }
 
@@ -92,7 +92,7 @@
         font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: italic;
-        font-weight: 400;
+        font-weight: $font-weight-bold;
         src: url('#{$assets-path}fca66073-ubuntu-ri-webfont.woff2') format('woff2'), url('#{$assets-path}f0898c72-ubuntu-ri-webfont.woff') format('woff');
       }
 
@@ -100,7 +100,7 @@
         font-display: $font-display-option;
         font-family: 'Ubuntu';
         font-style: normal;
-        font-weight: 100;
+        font-weight: $font-weight-display-heading;
         src: url('#{$assets-path}7f100985-Ubuntu-Th_W.woff2') format('woff2'), url('#{$assets-path}502cc3a1-Ubuntu-Th_W.woff') format('woff');
       }
 
@@ -116,7 +116,7 @@
         font-display: $font-display-option;
         font-family: 'Ubuntu Mono';
         font-style: normal;
-        font-weight: 400;
+        font-weight: $font-weight-bold;
         src: url('#{$assets-path}dd4acb63-UbuntuMono-B.woff2') format('woff2'), url('#{$assets-path}e8e36b19-UbuntuMono-B.woff') format('woff');
       }
     }

--- a/scss/_base_syntax-highlighting.scss
+++ b/scss/_base_syntax-highlighting.scss
@@ -70,7 +70,7 @@
 
     &.important,
     &.bold {
-      font-weight: bold;
+      font-weight: $font-weight-bold;
     }
     &.italic {
       font-style: italic;

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -7,7 +7,7 @@
 
     font-size: #{map-get($font-sizes, h1-mobile)}rem;
     font-style: normal;
-    font-weight: 100;
+    font-weight: $font-weight-display-heading;
     line-height: map-get($line-heights, h1-mobile);
     margin-bottom: map-get($sp-after, h1-mobile) - map-get($nudges, nudge--h1-mobile);
     margin-top: 0;
@@ -37,7 +37,7 @@
 
     font-size: #{map-get($font-sizes, h2-mobile)}rem;
     font-style: normal;
-    font-weight: 100;
+    font-weight: $font-weight-display-heading;
     line-height: map-get($line-heights, h2-mobile);
     margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, nudge--h2-mobile);
     margin-top: 0;
@@ -60,7 +60,7 @@
 
     font-size: #{map-get($font-sizes, h3-mobile)}rem;
     font-style: normal;
-    font-weight: 100;
+    font-weight: $font-weight-display-heading;
     line-height: map-get($line-heights, h3-mobile);
     margin-bottom: map-get($sp-after, h3-mobile) - map-get($nudges, nudge--h3-mobile);
     margin-top: 0;

--- a/scss/_patterns_code-copyable.scss
+++ b/scss/_patterns_code-copyable.scss
@@ -22,7 +22,7 @@ $cc-button-size: 36px;
       background: transparent;
       border: 0;
       font-family: unquote($font-monospace);
-      font-weight: 300;
+      font-weight: $font-weight-regular-text;
       line-height: map-get($line-heights, default-text);
       margin-bottom: 0;
       margin-top: 0;

--- a/scss/_patterns_label.scss
+++ b/scss/_patterns_label.scss
@@ -8,7 +8,7 @@
 
     border-radius: $border-radius;
     display: inline-block;
-    font-weight: 400;
+    font-weight: $font-weight-bold;
     padding: map-get($nudges, nudge--x-small) $sph-inner--small;
     text-align: center;
     text-decoration: none;

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -12,6 +12,7 @@ $base-font-sizes: (
   base: 1rem,
   large: $font-size-largescreen,
 ) !default;
+$font-weight-display-heading: 100 !default;
 $font-weight-regular-text: 300 !default;
 $font-weight-bold: 400 !default;
 

--- a/templates/docs/settings/font-settings.md
+++ b/templates/docs/settings/font-settings.md
@@ -21,6 +21,16 @@ All Ubuntu sites and applications should use the Ubuntu font, as it has been spe
 | `$font-base-size`      | `1rem`                                                |
 | `$font-heading-family` | `$font-base-family`                                   |
 
+### Font weight
+
+Vanilla uses three font weight settings in tandem with the Ubuntu font, which can be overridden to suit your needs:
+
+| Setting                        | Default value | Notes                                                                   |
+| ------------------------------ | ------------- | ----------------------------------------------------------------------- |
+| `$font-weight-display-heading` | `100`         | This lighter font weight is used by `h1`, `h2` and `h3` elements which  |
+| `$font-weight-regular-text`    | `300`         | Vanilla's default font-weight                                           |
+| `$font-weight-bold`            | `400`         | Most often used on elements with very small text to make them stand out |
+
 <br>
 <hr>
 


### PR DESCRIPTION
## Done

- Documented font-weight variables
- Replaced inline font-weight definitions with variables
- Added `$font-weight-display-heading` variable

Fixes #3348 

## QA

- Open [demo](https://vanilla-framework-3894.demos.haus/docs/settings/font-settings#font-weight)
- Check that the documentation makes sense
- Check Percy, nothing should have changed

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
