### PR TITLE
Make notificaiton margin-bottom not depend on scaling factor

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -15,7 +15,7 @@ $notification-icon-vert-offset: $spv-inner--small + $borderless-notification-ico
 // We still need a little space so things like the border on the __meta do not crash into the preceding text element, so we use a reduced amount of margin
 // being text, it still needs to align to the baseline grid. So we need to subtract $spv-nudge (the amount applied to this text as padding-top) from the total amount of margin-bottom.
 // As a result, padding-top + margin-bottom == an exact multiple of the base spacing unit, $sp-unit (which is .5rem)
-$notification-text-margin-bottom: map-get($sp-after, p-dense) - $spv-nudge;
+$notification-text-margin-bottom: $spv-outer--medium - $spv-nudge;
 
 // Notification style patterns
 @mixin vf-p-notification {


### PR DESCRIPTION
## Done

Replace the variable used to define margin-bottom on notificaiton content with one that doesn't depend on  the scaling factor `$multi`.

Fixes #3898

## QA

- Open docs/examples/patterns/notifications/variants
- Verify notification looks as in the screenshot below regardless of the value of the scaling factor $multi

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![image](https://user-images.githubusercontent.com/2741678/128055384-aec694f7-c753-4226-a02e-0a29bc71225f.png)
