### PR TITLE
increase z-index of hr without margin bottom

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -201,7 +201,7 @@
     margin-bottom: -1px !important;
     // then lift it up on the z axis, so the negative margin doesn't cause it to be
     // obscured by neighbouring elements with color backgrounds
-    z-index: 1;
+    z-index: 2;
   }
 
   %icon {


### PR DESCRIPTION
## Done

Increase z-index of hr with no bottom margin so that it isn't obscured by focussed tabs (which have a `z-index` of `1` when focussed)

Fixes #3878 

## QA

- Open [demo](http://0.0.0.0:8101/docs/examples/templates/z-index)
- Open dev tools and trigger the focus state on any of the `a` elements within the tab patterns
- See that the `hr` above the tabs is still fully visible

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.

![Peek 2021-08-04 16-55](https://user-images.githubusercontent.com/2376968/128213754-53fbfa77-c715-4591-928b-bac927764036.gif)
