### PR TITLE
WIP: Allow card content to bleed into margins for backgrounds

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -41,6 +41,11 @@
     padding: $spv-inner--large;
   }
 
+  %vf-card-content {
+    margin: -#{$spv-inner--large};
+    padding: $spv-inner--large;
+  }
+
   //accordion, table
   %single-border-text-vpadding--scaling {
     padding-bottom: $table-cell-vertical-padding;

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -73,7 +73,7 @@
   }
 
   .p-card__content {
-    @extend %u-no-margin--bottom--default-text;
+    @extend %vf-card-content;
   }
 
   .p-card__thumbnail {


### PR DESCRIPTION
## Done
Added negative margins to card content so that it can have a background that fills the whole card

## QA
- Check the card examples:
  - https://vanilla-framework-3910.demos.haus/docs/examples/patterns/card/default
  - https://vanilla-framework-3910.demos.haus/docs/examples/patterns/card/header
  - https://vanilla-framework-3910.demos.haus/docs/examples/patterns/card/highlighted
  - https://vanilla-framework-3910.demos.haus/docs/examples/patterns/card/overlay

## Issue
Fixes https://github.com/canonical-web-and-design/vanilla-squad/issues/971
