### PR TITLE
Cross list

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -1,5 +1,7 @@
 @import 'settings';
-$tick-height: 0.875rem; // 14px value from svg as rem so it can be used in calculations
+$list-status-icon-height: 0.875rem; // 14px value from svg as rem so it can be used in calculations
+$list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that positions the icon correctly
+
 $spv-list-item--inner: null;
 @if ($pad-lists) {
   $spv-list-item--inner: $spv-inner--x-small; // padding top and bottom for lists containing loose text.
@@ -50,6 +52,15 @@ $spv-list-item--inner: null;
       }
     }
     // stylelint-enable selector-max-type
+  }
+
+  %vf-list-item-state-base {
+    @extend %vf-list;
+
+    background-position-y: $spv-list-item--inner + $list-status-icon-nudge;
+    background-repeat: no-repeat;
+    background-size: $list-status-icon-height;
+    padding-left: 2rem;
   }
 }
 
@@ -122,16 +133,16 @@ $spv-list-item--inner: null;
   }
 }
 
-// Displays item with a tick bullet
+// Displays item with a state icon
 @mixin vf-p-list-item-state {
   .is-ticked {
-    @extend %vf-list;
-    @include vf-icon-success($color-accent);
+    @extend %vf-list-item-state-base;
+    @include vf-icon-success;
+  }
 
-    background-position-y: $spv-list-item--inner + 0.3rem; // 0.3rem seems to be a magic number that positions the icon correctly
-    background-repeat: no-repeat;
-    background-size: $tick-height;
-    padding-left: 2rem;
+  .is-crossed {
+    @extend %vf-list-item-state-base;
+    @include vf-icon-error;
   }
 }
 

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -71,7 +71,7 @@
               {{ side_nav_item("/docs/patterns/labels", "Labels") }}
               {{ side_nav_item("/docs/patterns/links", "Links", "new") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
+              {{ side_nav_item("/docs/patterns/lists", "Lists", "updated") }}
               {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}

--- a/templates/docs/component-status.md
+++ b/templates/docs/component-status.md
@@ -23,12 +23,24 @@ When we add, make significant updates, or deprecate a component we update their 
   </thead>
   <tbody>
     <!-- 2.34 -->
-      <tr>
-        <th><a href="/docs/base/forms#password-showhide">Forms / Password toggle</a></th>
-        <td><div class="p-label--new">New</div></td>
-        <td>2.34.0</td>
-        <td>Password fields now have a show/hide toggle.</td>
-      </tr>
+    <tr>
+      <th><a href="/docs/base/forms#password-showhide">Forms / Password toggle</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.34.0</td>
+      <td>Password fields now have a show/hide toggle.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/lists#status">Lists / Crossed</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.34.0</td>
+      <td>We added a <code>is-crossed</code> modifier class for lists, to complement the existing <code>is-ticked</code> modifier.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/lists#status">Lists / Ticked</a></th>
+      <td><div class="p-label--updated">Updated</div></td>
+      <td>2.34.0</td>
+      <td>We updated the color of the <code>is-ticked</code> icon on lists to <code>$color-positive</code>, where previously it was <code>$color-accent</code>.</td>
+    </tr>
   </tbody>
 </table>
 
@@ -44,7 +56,7 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-  <!-- 2.33 -->
+    <!-- 2.33 -->
     <tr>
       <th><a href="/docs/patterns/links#skip-link">Links / Skip Link</a></th>
       <td><div class="p-label--new">New</div></td>

--- a/templates/docs/examples/patterns/lists/lists-status.html
+++ b/templates/docs/examples/patterns/lists/lists-status.html
@@ -1,12 +1,11 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Lists / Ticked{% endblock %}
+{% block title %}Lists / Status{% endblock %}
 
 {% block standalone_css %}patterns_lists{% endblock %}
 
 {% block content %}
 <ul class="p-list">
   <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
-  <li class="p-list__item is-ticked">Fixed-price deployment</li>
-  <li class="p-list__item is-ticked">Reference architecture</li>
+  <li class="p-list__item is-crossed">24 x 7 support</li>
 </ul>
 {% endblock %}

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -20,18 +20,18 @@ items than the basic lists.
 View example of the list pattern
 </a></div>
 
-### Ticked
+### Status
 
-Add the class `.is-ticked` to each list item to display tick icons.
+Add the `.is-ticked` or `.is-crossed` classes to each list item to display tick/cross icons.
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-    <span class="p-notification__status">Note:</span>The color of the tick icon is set by the <code>$color-accent</code> variable in <code>settings.scss</code>.
+    <span class="p-notification__status">Note:</span>The color of the tick icon is set by the <code>$color-accent</code> variable in <code>settings.scss</code>, and the color of the cross icon is set by the <code>$color-accent-background</code> variable.
   </p>
 </div>
 
-<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-ticked/" class="js-example">
-View example of the ticked list pattern
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-status/" class="js-example">
+View example of the list status pattern
 </a></div>
 
 ### Horizontal divider

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -24,12 +24,6 @@ View example of the list pattern
 
 Add the `.is-ticked` or `.is-crossed` classes to each list item to display tick/cross icons.
 
-<div class="p-notification--information">
-  <p class="p-notification__response">
-    <span class="p-notification__status">Note:</span>The color of the tick icon is set by the <code>$color-accent</code> variable in <code>settings.scss</code>, and the color of the cross icon is set by the <code>$color-accent-background</code> variable.
-  </p>
-</div>
-
 <div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-status/" class="js-example">
 View example of the list status pattern
 </a></div>


### PR DESCRIPTION
## Done

Added `is-crossed` modifier pattern to list items
- Also changed the colour of the `is-ticked` icon to `$color-positive`

Fixes #3836 

## QA

- Open [demo](https://vanilla-framework-3912.demos.haus/docs/examples/patterns/lists/lists-status)
- See that there is a ticked and crossed list item
- Review updated documentation:
  - [Docs](https://vanilla-framework-3912.demos.haus/docs/patterns/lists#status)
  - [Component status](https://vanilla-framework-3912.demos.haus/docs/component-status)


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Screenshot from 2021-08-05 15-29-16](https://user-images.githubusercontent.com/2376968/128367482-16cb38ec-be50-4fec-a06b-4e97f58f5ab9.png)

