### PR TITLE
Hide Chrome's search clear icon on search and filter pattern

### DIFF
--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -131,6 +131,10 @@
       margin-right: -$search-filter-actions-width; // compensate for the space reserved for counter
       min-width: 6rem;
       position: relative;
+
+      &::-webkit-search-cancel-button {
+        -webkit-appearance: none; // stylelint-disable-line property-no-vendor-prefix
+      }
     }
 
     .p-chip + .p-search-and-filter__box {


### PR DESCRIPTION
## Done

Search and filter pattern: removed the icon/button that Chrome automatically adds to search inputs (we already have [an example where we roll our own](https://vanillaframework.io/docs/examples/patterns/search-and-filter/with-search-prompt))

Fixes #3891 

## QA

- In Chrome, open [demo](https://vanilla-framework-3917.demos.haus/docs/examples/patterns/search-and-filter/default)
- Type anything into the search box, no cross icon should appear

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
