### PR TITLE
Add right padding to deprecated notification response element

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -200,6 +200,7 @@ $notification-text-margin-bottom: $spv-outer--medium - $spv-nudge;
 
       .p-notification__response {
         margin-bottom: $notification-text-margin-bottom;
+        padding-right: calc(#{$spv-inner--small} - 1px);
         padding-top: map-get($nudges, nudge--p) + map-get($browser-rounding-compensations, p);
       }
 

--- a/scss/standalone/patterns_notifications.scss
+++ b/scss/standalone/patterns_notifications.scss
@@ -5,3 +5,7 @@
 
 // needed in borderless demo
 @include vf-u-margin-collapse;
+
+// needed for deprecated notification pattern
+// can be removed in 3.0
+@include vf-p-icon-close;


### PR DESCRIPTION
## Done

- Added missing right padding to deprecated notification pattern

Fixes #3928 

## QA

- Open [demo](https://vanilla-framework-3930.demos.haus/docs/patterns/tooltips)
- Check that the text doesn't touch the border
  - Compare to [live version](https://vanillaframework.io/docs/patterns/tooltips)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.