### PR TITLE
Enable labels to truncate with ellipses

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -106,6 +106,10 @@
       position: relative;
     }
 
+    &.u-truncate {
+      width: auto;
+    }
+
     @each $state, $color in $states {
       &.has-#{$state} {
         color: $color;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -107,6 +107,7 @@
     }
 
     &.u-truncate {
+      // width: fit-content prevents ellipses when u-truncate is applied
       width: auto;
     }
 

--- a/templates/docs/examples/utilities/truncate.html
+++ b/templates/docs/examples/utilities/truncate.html
@@ -36,13 +36,9 @@
   </table>
   <p class="u-truncate">This sentence will truncate and reveal an ellipsis once it exceeds the paragraph's max-width.</p>
 
-  <div class="row">
-    <div class="col-3">
-      <label class="p-checkbox u-truncate">
-        <input type="checkbox" class="p-checkbox__input">
-        <span class="p-checkbox__label">This label will truncate at the end of the col</span>
-      </label>
-    </div>
-  </div>
+  <label class="p-checkbox u-truncate" style="width: 20rem;">
+    <input type="checkbox" class="p-checkbox__input">
+    <span class="p-checkbox__label">This label will truncate at the end of the col</span>
+  </label>
 
 {% endblock %}

--- a/templates/docs/examples/utilities/truncate.html
+++ b/templates/docs/examples/utilities/truncate.html
@@ -2,7 +2,7 @@
 {% block title %}Truncate text{% endblock %}
 
 {% block content %}
-<table aria-label="Table example demonstrating how to use Vanilla's truncation utility">
+  <table aria-label="Table example demonstrating how to use Vanilla's truncation utility">
     <thead>
       <tr>
         <th>FQDN</th>
@@ -35,4 +35,14 @@
     </tbody>
   </table>
   <p class="u-truncate">This sentence will truncate and reveal an ellipsis once it exceeds the paragraph's max-width.</p>
+
+  <div class="row">
+    <div class="col-3">
+      <label class="p-checkbox u-truncate">
+        <input type="checkbox" class="p-checkbox__input">
+        <span class="p-checkbox__label">This label will truncate at the end of the col</span>
+      </label>
+    </div>
+  </div>
+
 {% endblock %}


### PR DESCRIPTION
## Done

- Added `width: auto` to the `_base_form` label to enable ellipses when the `.u-truncate` class is added. 

Fixes [list issues/bugs if needed]

- [#3914](https://github.com/canonical-web-and-design/vanilla-framework/issues/3914)

## QA

- Open [demo](https://vanilla-framework-3931.demos.haus/docs/examples/utilities/truncate)
- Check the label truncates and reveals an ellipses
- Compare against [live](https://ubuntu.com/certified/servers) 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.

