### PR TITLE
Document a card with an image

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -57,8 +57,8 @@
   // If possible, please consider adding a modifier to a base pattern, so it can be used elsewhere too.
 
   .p-card__image {
+    display: block;
     margin-bottom: $spv-inner--small;
-    vertical-align: top;
     width: 100%;
   }
 

--- a/templates/docs/examples/patterns/card/image.html
+++ b/templates/docs/examples/patterns/card/image.html
@@ -4,15 +4,20 @@
 {% block standalone_css %}patterns_card{% endblock %}
 
 {% block content %}
-<div class="p-card">
-    <div class="p-card__content">
-        <img class="p-card__image" alt="" height="185" width="330" src="https://assets.ubuntu.com/v1/36f1139e-Design-and-Web-Team-Blog.jpg">
-        <h4>
-            <a href="#">Open Source Robotics Challenges – Planning for Security</a>
-        </h4>
-        <p class="u-no-padding--bottom">Open Source Robotics Challenges is a series of blogs that will share guidelines and advice for open source companies to overcome market barriers.&nbsp; We will...</p>
+<div class="row">
+    <div class="col-4">
+        <div class="p-card">
+            <div class="p-card__content">
+                <img class="p-card__image" alt="" height="185" width="330" src="https://assets.ubuntu.com/v1/36f1139e-Design-and-Web-Team-Blog.jpg">
+                <h4>
+                    <a href="#">Open Source Robotics Challenges</a>
+                </h4>
+                <p class="u-no-padding--bottom">Open Source Robotics Challenges is a series of blogs...</p>
+            </div>
+        </div>
     </div>
- </div>
+</div>
+
 {% endblock %}
 
 

--- a/templates/docs/examples/patterns/card/image.html
+++ b/templates/docs/examples/patterns/card/image.html
@@ -1,0 +1,18 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Card / Image{% endblock %}
+
+{% block standalone_css %}patterns_card{% endblock %}
+
+{% block content %}
+<div class="p-card">
+    <div class="p-card__content">
+        <img class="p-card__image" alt="" height="185" width="330" src="https://assets.ubuntu.com/v1/36f1139e-Design-and-Web-Team-Blog.jpg">
+        <h4>
+            <a href="#">Open Source Robotics Challenges – Planning for Security</a>
+        </h4>
+        <p class="u-no-padding--bottom">Open Source Robotics Challenges is a series of blogs that will share guidelines and advice for open source companies to overcome market barriers.&nbsp; We will...</p>
+    </div>
+ </div>
+{% endblock %}
+
+

--- a/templates/docs/patterns/card.md
+++ b/templates/docs/patterns/card.md
@@ -26,6 +26,14 @@ The purpose of the header card is to display information, grouped under a headin
 View example of the header card pattern
 </a></div>
 
+## Image
+
+Any images used as part of the card content should have a `.p-card__image` class name.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/card/image/" class="js-example">
+View example of the card pattern with an image
+</a></div>
+
 ## Highlighted
 
 The purpose of the highlighted card should be used when you can interact with the content.


### PR DESCRIPTION
## Done

Updated the documentation to include undocumented `p-card__image` class name.

Fixes #3902 

## QA

- Open [demo](https://vanilla-framework-3932.demos.haus/docs/examples/patterns/card/image)
- Check if card demo with image works as expected: https://vanilla-framework-3932.demos.haus/docs/examples/patterns/card/image
- Review updated documentation:
  - https://vanilla-framework-3932.demos.haus/docs/patterns/card#image

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="890" alt="Screenshot 2021-08-23 at 13 41 56" src="https://user-images.githubusercontent.com/83575/130441456-89ad2ac7-9ff2-4dd5-affe-dd69e3a77409.png">

