### PR TITLE
update side nav labels for 2.34.0

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -48,7 +48,7 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
               {{ side_nav_item("/docs/base/code", "Code") }}
-              {{ side_nav_item("/docs/base/forms", "Forms") }}
+              {{ side_nav_item("/docs/base/forms", "Forms", 'updated') }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
               {{ side_nav_item("/docs/base/tables", "Tables") }}
@@ -69,7 +69,7 @@
               {{ side_nav_item("/docs/patterns/images", "Images") }}
               {{ side_nav_item("/docs/patterns/inline-images", "Inline images") }}
               {{ side_nav_item("/docs/patterns/labels", "Labels") }}
-              {{ side_nav_item("/docs/patterns/links", "Links", "new") }}
+              {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
               {{ side_nav_item("/docs/patterns/lists", "Lists", "updated") }}
               {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}
@@ -78,7 +78,7 @@
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}
               {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
               {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
-              {{ side_nav_item("/docs/patterns/notification", "Notifications", "new") }}
+              {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
               {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -208,6 +208,8 @@ View example of the dense form elements
 
 ### Password toggle
 
+<span class="p-label--new">New</span>
+
 When using a password field, use this pattern to allow the user to toggle the password visibility.
 
 <div class="p-notification--information is-inline">


### PR DESCRIPTION
## Done

Cleaned up doc side nav labels for 2.34.0

## QA

- Open [demo](https://vanilla-framework-3933.demos.haus/docs)
- Check that the side nav has status labels relevant to the features in the [upcoming release](https://github.com/canonical-web-and-design/vanilla-framework/releases), and no others

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
- [x] Documentation side navigation should be updated with the relevant labels.
