### PR TITLE
Change component status to what's new

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ If this PR contains Vanilla SCSS code changes, it should contain the following c
   - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
   - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
   - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
-- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [component status page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/component-status.md).
+- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
 - [ ] Documentation side navigation should be updated with the relevant labels.
 
 

--- a/guides/pull-requests.md
+++ b/guides/pull-requests.md
@@ -21,7 +21,7 @@ If your work includes any of the following:
 - deprecated patterns
 - breaking changes
 
-your changes should be listed in [Component Status](/templates/docs/component-status). Within that document is a list of all prior changes, each associated with a particual version release.
+your changes should be listed in [What's new](/templates/docs/whats-new) page. Within that document is a list of all prior changes, each associated with a particual version release.
 
 When updating the document, first note the [most recently released version of Vanilla](https://github.com/canonical-web-and-design/vanilla-framework/tags). If the changes listed in the "What's new in Vanilla" table match that version, those changes should be moved to the "Previously in Vanilla" table below.
 

--- a/guides/pull-requests.md
+++ b/guides/pull-requests.md
@@ -21,7 +21,7 @@ If your work includes any of the following:
 - deprecated patterns
 - breaking changes
 
-your changes should be listed in [What's new](/templates/docs/whats-new) page. Within that document is a list of all prior changes, each associated with a particual version release.
+your changes should be listed in [What's new](/templates/docs/whats-new) page. Within that document is a list of all prior changes, each associated with a particular version release.
 
 When updating the document, first note the [most recently released version of Vanilla](https://github.com/canonical-web-and-design/vanilla-framework/tags). If the changes listed in the "What's new in Vanilla" table match that version, those changes should be moved to the "Previously in Vanilla" table below.
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -6,3 +6,4 @@
 /css/(?P<path>.*): /static/css/{path}
 /js/(?P<path>.*): /static/js/{path}
 /docs/patterns/article-pagination: /docs/patterns/pagination
+/docs/component-status: /docs/whats-new

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -42,7 +42,7 @@
               {{ side_nav_item("/docs", "Get started") }}
               {{ side_nav_item("/docs/building-vanilla", "Building with Vanilla") }}
               {{ side_nav_item("/docs/customising-vanilla", "Customising Vanilla") }}
-              {{ side_nav_item("https://github.com/canonical-web-and-design/vanilla-framework/releases/latest", "What’s new in " ~ version) }}
+              {{ side_nav_item("/docs/whats-new", "What’s new in " ~ version) }}
             </ul>
 
             <ul class="p-side-navigation__list">
@@ -137,7 +137,7 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Resources</span></li>
               {{ side_nav_item("/docs/examples", "Component examples") }}
-              {{ side_nav_item("/docs/component-status", "Component status") }}
+              {{ side_nav_item("https://github.com/canonical-web-and-design/vanilla-framework/releases/latest", "Release notes for " ~ version) }}
               {{ side_nav_item("https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch", "Download Sketch UI Kit") }}
             </ul>
 

--- a/templates/docs/patterns/labels.md
+++ b/templates/docs/patterns/labels.md
@@ -12,7 +12,7 @@ Labels are static elements which you can apply to signify status, tags or any ot
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-    <span class="p-notification__status">Note:</span>These labels are used to inform <a href="/docs/component-status" class="p-notification__action">status</a> of components in Vanilla.
+    <span class="p-notification__status">Note:</span>These labels are used to inform <a href="/docs/whats-new" class="p-notification__action">status</a> of components in Vanilla.
   </p>
 </div>
 

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -4,13 +4,11 @@ context:
   title: What's new in Vanilla
 ---
 
-## What's new in Vanilla
+# What's new in Vanilla {{versionMinor}}
 
 <hr>
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
-
-### What's new in Vanilla {{versionMinor}}
 
 <table aria-label="What's new in Vanilla {{versionMinor}}">
   <thead>
@@ -50,7 +48,7 @@ When we add, make significant updates, or deprecate a component we update their 
   </tbody>
 </table>
 
-#### Previously in Vanilla
+## Previously in Vanilla
 
 <table>
   <thead>
@@ -608,13 +606,13 @@ When we add, make significant updates, or deprecate a component we update their 
   </tbody>
 </table>
 
-### Upgrade guide
+## Upgrade guide
 
 During the development of Vanilla v2 several CSS class names or SCSS mixins and placeholders have been deprecated and will be removed in the upcoming release v3.0.
 
 See [the upgrade guide](/docs/upgrade-guide-v3) to learn about all the breaking changes that will happen when these deprecated features are removed and how to update the code for a future version of Vanilla.
 
-### Status key
+## Status key
 
 <div class="row">
   <div class="col-3 u-equal-height">

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -1,10 +1,10 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Component status
+  title: What's new in Vanilla
 ---
 
-## Component status
+## What's new in Vanilla
 
 <hr>
 


### PR DESCRIPTION
## Done

Change "Component status" to "What's new in ..." and promote it to top of side navigation to make it more visible and accessible.


## QA

- Open [demo](https://vanilla-framework-3937.demos.haus/docs/whats-new)
- Make sure page under new URL works: https://vanilla-framework-3937.demos.haus/docs/whats-new
- Make sure old URL redirects to new page: https://vanilla-framework-3937.demos.haus/docs/component-status
- Make sure any other references to "Component status" are updated

### Check if PR is ready for release

This is just docs update, nothing to release in Vanilla package.

