### PR TITLE
Fix max-width of notifications text

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.34.0",
+  "version": "2.34.1",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -74,6 +74,7 @@ $notification-text-margin-bottom: $spv-outer--medium - $spv-nudge;
       @extend %common-default-text-properties;
 
       margin-bottom: $notification-text-margin-bottom;
+      max-width: unset;
       padding-right: 2 * $sph-inner;
     }
 
@@ -87,6 +88,7 @@ $notification-text-margin-bottom: $spv-outer--medium - $spv-nudge;
 
     .p-notification__message {
       margin: 0;
+      max-width: unset;
       padding: 0;
     }
 

--- a/templates/docs/examples/patterns/notifications/variants.html
+++ b/templates/docs/examples/patterns/notifications/variants.html
@@ -46,6 +46,16 @@
   </div>
 </div>
 
+<h5>Multiline</h5>
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Title:</h5>
+    <p class="p-notification__message">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum consequat pretium facilisis. Phasellus cursus neque vel elementum pharetra. Cras maximus neque non mi fermentum, vel ultrices sem rutrum. Aliquam ornare nulla et justo fermentum tincidunt. Duis in enim nec velit consequat sollicitudin ac eget arcu. Proin id leo nunc. Donec varius sem et mattis cursus.
+    </p>
+  </div>
+</div>
+
 <h5>Inline multiline</h5>
 <div class="p-notification--caution is-inline">
   <div class="p-notification__content">

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -99,3 +99,5 @@ The notification child classes have been replaced to support new variants. The f
 | `.p-notification__response` | `.p-notification__content` |
 | `.p-notification__status`   | `.p-notification__title`   |
 | `.p-icon--close`            | `.p-notification__close`   |
+
+The text content of the notifications should also be wrapped in element with `.p-notification__message` class name. This element didn't exist in previous version of notification pattern and should be added for best compatibility.


### PR DESCRIPTION
## Done

Fix max width of notifications text when `<p>` is used.

Fixes #3936 

## QA

- Open [demo](https://vanilla-framework-3938.demos.haus/docs/examples/patterns/notifications/variants)
- Make sure both multiline notifications render correctly (text uses whole width of notification):
  - https://vanilla-framework-3938.demos.haus/docs/examples/patterns/notifications/variants
- Make sure that changing deprecated `p-notification__response` to `p-notification__content` in this example works correctly:
  - https://vanilla-framework-3938.demos.haus/docs/examples/templates/maas-docs-grid

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1455" alt="Screenshot 2021-08-19 at 12 43 08" src="https://user-images.githubusercontent.com/83575/130055621-ba426c82-e7ab-468b-a7c7-53ff3d60ae91.png">

