### PR TITLE
Remove deprecated styles for headings, buttons and grid

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -93,35 +93,29 @@
   //@section Adjusted spacing for headings (or a p) following a paragraph
   p:not([class*='p-heading--']):not([class*='p-muted-heading']) {
     & + h1,
-    & + .p-heading--1,
-    & + .p-heading--one {
+    & + .p-heading--1 {
       @extend %sp--ph1;
     }
 
     & + h2,
-    & + .p-heading--2,
-    & + .p-heading--two {
+    & + .p-heading--2 {
       @extend %sp--ph2;
     }
 
     & + h3,
-    & + .p-heading--3,
-    & + .p-heading--three {
+    & + .p-heading--3 {
       @extend %sp--ph3;
     }
 
     & + h4,
-    & + .p-heading--4,
-    & + .p-heading--four {
+    & + .p-heading--4 {
       @extend %sp--ph4;
     }
 
     & + h5,
     & + .p-heading--5,
-    & + .p-heading--five,
     & + h6,
-    & + .p-heading--6,
-    & + .p-heading--six {
+    & + .p-heading--6 {
       @extend %sp--ph5;
     }
 

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -5,7 +5,6 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 // Default button styling
 @mixin vf-p-buttons {
   @include vf-button-plain;
-  @include vf-button-neutral;
   @include vf-button-brand;
   @include vf-button-positive;
   @include vf-button-negative;
@@ -13,14 +12,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   @include vf-button-link;
   @include vf-button-inline;
   @include vf-button-processing;
-  @include vf-button-active;
   @include vf-button-icon;
-}
-
-@mixin vf-button-white-success-icon {
-  @include deprecate('3.0.0', 'vf-button-white-success-icon mixin will be removed as it is not needed, %vf-button-white-success-icon is part of base styles') {
-    //
-  }
 }
 
 @mixin vf-button-plain {
@@ -58,21 +50,6 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
       &.is-dark {
         @extend %p-button-dark;
       }
-    }
-  }
-}
-
-// p-button--neutral is is exactly the same as p-button, so we are deprecating it
-@mixin vf-button-neutral {
-  @include deprecate('3.0.0', 'Use the `p-button` instead') {
-    %p-button--neutral {
-      @extend %vf-button-base;
-
-      @include vf-button-pattern;
-    }
-
-    .p-button--neutral {
-      @extend %p-button--neutral;
     }
   }
 }
@@ -323,14 +300,6 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 @mixin vf-button-processing {
   [class*='p-button'].is-processing {
     opacity: 1 !important;
-  }
-}
-
-@mixin vf-button-active {
-  @include deprecate('3.0.0', 'Use the `vf-button-processing instead') {
-    [class*='p-button'].is-active {
-      opacity: 1 !important;
-    }
   }
 }
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -1,13 +1,5 @@
 @import 'settings';
 
-@mixin vf-p-grid-modifications {
-  @include deprecate('3.0.0', 'vf-p-grid-modifications mixin will be removed') {
-    .row {
-      width: 100%;
-    }
-  }
-}
-
 // CSS grid implementation of columns for all screens sizes
 @mixin vf-grid-column($col) {
   @supports (display: grid) {

--- a/scss/_patterns_headings.scss
+++ b/scss/_patterns_headings.scss
@@ -25,30 +25,4 @@
   .p-heading--6 {
     @extend %vf-heading-6;
   }
-
-  @include deprecate('3.0.0', 'Use the `p-heading--1`, `p-heading--2`, ... instead') {
-    .p-heading--one {
-      @extend %vf-heading-1;
-    }
-
-    .p-heading--two {
-      @extend %vf-heading-2;
-    }
-
-    .p-heading--three {
-      @extend %vf-heading-3;
-    }
-
-    .p-heading--four {
-      @extend %vf-heading-4;
-    }
-
-    .p-heading--five {
-      @extend %vf-heading-5;
-    }
-
-    .p-heading--six {
-      @extend %vf-heading-6;
-    }
-  }
 }

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -46,7 +46,6 @@
   // stylelint-disable selector-max-type
   h1,
   .p-heading--1,
-  .p-heading--one,
   .u-match-h1 {
     [class*='p-icon'] {
       @include vf-icon-size($x-height);
@@ -57,7 +56,6 @@
 
   h2,
   .p-heading--2,
-  .p-heading--two,
   .u-match-h2 {
     [class*='p-icon'] {
       @include vf-icon-size($x-height);
@@ -68,7 +66,6 @@
 
   h3,
   .p-heading--3,
-  .p-heading--three,
   .u-match-h3 {
     [class*='p-icon'] {
       @include vf-icon-size($default-icon-size);
@@ -79,7 +76,6 @@
 
   h4,
   .p-heading--4,
-  .p-heading--four,
   .u-match-h4 {
     [class*='p-icon'] {
       vertical-align: 0;

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -26,9 +26,6 @@ $grid-margin-widths: (
   large: $sp-unit * 3,
 ) !default;
 
-@include deprecate('3.0.0', 'Use the `$grid-margin-widths` map instead') {
-  $grid-margin-width: $sph-outer--large !default;
-}
 // Grid breakout template
 $l-fluid-breakout-max-width: $grid-max-width !default;
 $l-fluid-breakout-aside-width: 14rem !default;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -99,9 +99,6 @@
   @include vf-p-form-validation;
   @include vf-p-form-tick-elements;
   @include vf-p-forms;
-  @include deprecate('3.0.0', 'vf-p-grid-modifications mixin will be removed') {
-    @include vf-p-grid-modifications;
-  }
   @include vf-p-grid;
   @include vf-p-heading-icon;
   @include vf-p-headings;

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -77,8 +77,6 @@ modified to look like a particular heading size.
 View example of the heading pattern
 </a></div>
 
-<span class="p-label--deprecated">Deprecated</span> Heading classes with numbers as words (`p-heading--one`, `--two`, ...) are deprecated and will be removed in future release v3.0. Please use class names with numbers (`p-heading--1`, `--2`, ...) instead.
-
 ## Sub-headings
 
 Sub-headings visually convey importance beneath a heading, or a line of text that expands on the meaning of the heading immediately before it.

--- a/templates/docs/examples/patterns/buttons/neutral.html
+++ b/templates/docs/examples/patterns/buttons/neutral.html
@@ -1,9 +1,0 @@
-{% extends "_layouts/examples.html" %}
-{% block title %}Buttons / Neutral - Deprecated{% endblock %}
-
-{% block standalone_css %}patterns_buttons{% endblock %}
-
-{% block content %}
-<button class="p-button--neutral">Neutral button</button>
-<button class="p-button--neutral" disabled>Neutral button disabled</button>
-{% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/dropdown.html
+++ b/templates/docs/examples/patterns/code-snippet/dropdown.html
@@ -17,9 +17,9 @@
     </div>
   </div>
 
-  <pre id="html-panel" class="p-code-snippet__block--numbered is-wrapped"><code>&#60;h1 class="p-heading--two"&#62;How to use code snippets&#60;/h1&#62;</code></pre>
+  <pre id="html-panel" class="p-code-snippet__block--numbered is-wrapped"><code>&#60;h1 class="p-heading--2"&#62;How to use code snippets&#60;/h1&#62;</code></pre>
 
-  <pre id="css-panel" class="p-code-snippet__block u-hide" aria-hidden="true"><code>.p-heading--two {
+  <pre id="css-panel" class="p-code-snippet__block u-hide" aria-hidden="true"><code>.p-heading--2 {
 color: red;
 }</code></pre>
 

--- a/templates/docs/examples/patterns/separator.html
+++ b/templates/docs/examples/patterns/separator.html
@@ -6,7 +6,7 @@
 {% block content %}
 
 <h2>Modern enterprise open&nbsp;source</h2>
-<p class="p-heading--four">Publisher of Ubuntu.<br> Security. Support. Managed Services.</p>
+<p class="p-heading--4">Publisher of Ubuntu.<br> Security. Support. Managed Services.</p>
 <p><button>Contact Canonical</button></p>
 
 <hr class="p-separator">

--- a/templates/docs/examples/templates/external-links.html
+++ b/templates/docs/examples/templates/external-links.html
@@ -37,7 +37,6 @@
       <a class="p-button is-dark"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive is-dark"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative is-dark"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral is-dark"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base is-dark"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -50,7 +49,6 @@
       <a class="p-button"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -63,7 +61,6 @@
       <a class="p-button is-dark"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive is-dark"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative is-dark"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral is-dark"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base is-dark"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -76,7 +73,6 @@
       <a class="p-button"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base"><span class="p-link--external">External base button</span></a>
     </div>
   </div>
@@ -89,7 +85,6 @@
       <a class="p-button is-dark"><span class="p-link--external">External button</span></a>
       <a class="p-button--positive is-dark"><span class="p-link--external">External positive button</span></a>
       <a class="p-button--negative is-dark"><span class="p-link--external">External negative button</span></a>
-      <a class="p-button--neutral is-dark"><span class="p-link--external">External neutral button</span></a><!-- deprecated, but we keep it here for reference until 3.0 -->
       <a class="p-button--base is-dark"><span class="p-link--external">External base button</span></a>
     </div>
   </div>

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -103,7 +103,7 @@
   <section class="p-strip is-shallow u-no-padding--bottom">
     <div class="u-fixed-width">
       <a href="#snaps">‹ My snaps</a>
-      <h1 class="p-heading--three">
+      <h1 class="p-heading--3">
         my-awesome-snap
       </h1>
 

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -24,12 +24,6 @@ A default button can be used to indicate a positive action that isn't necessaril
 View example of the default button pattern
 </a></div>
 
-## Neutral
-
-<span class="p-label--deprecated">Deprecated</span>
-
-The neutral button style provided by `p-button--neutral` is exactly the same as default `p-button` styling, so neutral variant is deprecated and will be removed in future version 3.0 of Vanilla. Please use `p-button` instead.
-
 ## Base
 
 A base button can be used to discretely indicate a secondary action. It is often used alongside a default button.
@@ -111,12 +105,6 @@ In cases where a button needs to indicate that an action is occurring (e.g. savi
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/processing/" class="js-example">
 View example of the processing button pattern
 </a></div>
-
-## Active
-
-<span class="p-label--deprecated">Deprecated</span>
-
-The `is-active` utility class was renamed to the more appropriate `is-processing`, as mentioned above.
 
 ## Theming
 

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -4,9 +4,9 @@
 
 {% block content %}
   {% if results and results.entries %}
-    <h1 class="p-heading--two">We've found these results for your search <strong>"{{ query }}"</strong></h1>
+    <h1 class="p-heading--2">We've found these results for your search <strong>"{{ query }}"</strong></h1>
   {% else %}
-    <h1 class="p-heading--two">We haven't found any results for your search <strong>"{{ query }}"</strong>.</h1>
+    <h1 class="p-heading--2">We haven't found any results for your search <strong>"{{ query }}"</strong>.</h1>
   {% endif %}
 
   {% if  results and results.entries %}


### PR DESCRIPTION
## Done

Remove deprecated styles related to:

- headings (`--one`, `--two`, etc class names), updated examples that still used those
- neutral button was removed, updated any examples that still used them
- removed is-active button
- removed unnecessary button icon mixin
- removed deprecated grid settings

Part of #3744 

## QA

- Open [demo](insert-demo-url)
- Check the code to see which examples were affected
- Make sure affected examples render as expected
- Make sure relevant doc pages don't include deprecated docs anymore

