### PR TITLE
Build mandatory field legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.34.1",
+  "version": "2.35.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_base_forms-tick-elements.scss
+++ b/scss/_base_forms-tick-elements.scss
@@ -141,7 +141,9 @@ $box-offsets-top: (
       @extend %vf-tick-in-label;
     }
 
-    & + label {
+    & + label,
+    //Ensuring the required labels don't break on base checkbox
+    & + label.is-required {
       @extend %vf-pseudo-tick-box;
 
       // Align with different text styles

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -100,9 +100,8 @@
     padding-top: map-get($nudges, nudge--p);
     width: fit-content;
 
-    &.is-required::after {
-      color: $color-negative;
-      content: ' *';
+    &.is-required::before {
+      content: '* ';
       position: relative;
     }
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -100,7 +100,7 @@
     padding-top: map-get($nudges, nudge--p);
     width: fit-content;
 
-    &.is-required::before {
+    &.is-required::after {
       content: '* ';
       position: relative;
     }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -100,7 +100,7 @@
     padding-top: map-get($nudges, nudge--p);
     width: fit-content;
 
-    &.is-required::after {
+    &.is-required::before {
       content: '* ';
       position: relative;
     }

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -8,7 +8,22 @@
   .p-radio,
   .p-radio--heading,
   .p-radio--inline {
+    $asterisk-width: 1ch;
+
     position: relative;
+    // repositioning asterisk in front of the label
+    &.is-required {
+      &::before {
+        display: block;
+        left: $sph-inner + $form-tick-box-size;
+        position: absolute;
+        width: $asterisk-width;
+      }
+      .p-radio__label,
+      .p-checkbox__label {
+        padding-left: calc(#{$sph-inner + $form-tick-box-size} + #{$asterisk-width});
+      }
+    }
   }
 
   // specify both [type] and class to fight specificity of base `label [type]` styles

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -192,7 +192,7 @@ View example of form validation patterns
 
 ## Required
 
-By applying the class `.is-required` the attribute specifies that an input field must be filled out before submitting the form.
+By applying the class `.is-required` the attribute specifies that an input field must be filled out before submitting the form. You can also add a legend to the form to be explicit about the meaning of the asterisk.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/forms/forms-required/" class="js-example">
 View example of an input required element

--- a/templates/docs/examples/patterns/forms/forms-required.html
+++ b/templates/docs/examples/patterns/forms/forms-required.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 <form>
+  <label class="is-required">Indicates a required field</label>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError" class="is-required">Email address</label>
     <input class="p-form-validation__input" required type="email" id="exampleTextInputError" placeholder="e.g joe@bloggs.com" name="exampleTextInputError" autocomplete="email">


### PR DESCRIPTION
## Done

- Add a legend label to the `/docs/examples/patterns/forms/forms-required.html` example.
- Update the docs to mention it
- NOTE: This PR is made branched from this [PR](https://github.com/canonical-web-and-design/vanilla-framework/pull/3948) so that one must be reviewed and merged before this one is reviewed.  

Fixes #3945 

## QA

- Open [demo](https://vanilla-framework-3951.demos.haus/docs/examples/patterns/forms/forms-required)
- Check the legend is visible. 
- Review updated documentation:
  - Check the updated text [here](https://vanilla-framework-3951.demos.haus/docs/base/forms#required)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md). (Will check whether I need to do this tomorrow - also will rebase once the others are merged to ensure there's no conflicts in the what's new page)
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Screenshot 2021-08-24 at 16 44 55](https://user-images.githubusercontent.com/58959073/130647941-04d5e08b-1f74-47d7-9507-66b2fca6ef35.png)

