### PR TITLE
Remove deprecated icon styles

### DIFF
--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -22,12 +22,6 @@
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 1a3 3 0 013 3v8a3 3 0 01-3 3H4a3 3 0 01-3-3V4a3 3 0 013-3h8zm0 1.5H4a1.5 1.5 0 00-1.493 1.356L2.5 4v8a1.5 1.5 0 001.356 1.493L4 13.5h8a1.5 1.5 0 001.493-1.356L13.5 12V4a1.5 1.5 0 00-1.356-1.493L12 2.5zM8.027 5.282l3.76 3.76-1.06 1.061-2.701-2.7-2.699 2.7-1.06-1.06 3.76-3.76z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
 
-@mixin vf-icon-contextual-menu($color) {
-  @include deprecate('3.0.0', 'Use the `vf-icon-chevron` mixin instead') {
-    @include vf-icon-chevron($color);
-  }
-}
-
 @mixin vf-icon-close($color) {
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero' d='M13.041 1.898l1.06 1.06L9.062 8l5.04 5.042-1.06 1.06L8 9.062 2.96 14.1l-1.06-1.06L6.938 8 1.9 2.96l1.06-1.06 5.04 5.04z'/%3E%3C/svg%3E");
 }
@@ -88,12 +82,6 @@
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 1a4 4 0 014 4v.5a3.987 3.987 0 01-1.139 2.795 6 6 0 014.135 5.48L15 14H1a6.003 6.003 0 014.14-5.706A3.98 3.98 0 014 5.5V5a4 4 0 014-4zm1 8.5H7a4.502 4.502 0 00-4.203 2.888l-.04.112h10.486l-.03-.084a4.504 4.504 0 00-4-2.911L9 9.5zm-1-7a2.5 2.5 0 00-2.495 2.336L5.5 5v.5a2.5 2.5 0 004.995.164L10.5 5.5V5A2.5 2.5 0 008 2.5z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
 
-@mixin vf-icon-question($color) {
-  @include deprecate('3.0.0', 'Use the `vf-icon-help` mixin instead') {
-    @include vf-icon-help($color);
-  }
-}
-
 @mixin vf-icon-spinner($color) {
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 13.5a5.488 5.488 0 004.183-1.929l1.317.76A6.988 6.988 0 018 15a6.988 6.988 0 01-5.5-2.669l1.316-.76A5.488 5.488 0 008 13.5zM6.999 1.071v1.52A5.502 5.502 0 002.815 9.84L1.5 10.6A7.002 7.002 0 016.764 1.11l.235-.038zM15 8c0 .918-.177 1.795-.498 2.6l-1.317-.761A5.502 5.502 0 009 2.59V1.07c3.392.485 6 3.403 6 6.929z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
@@ -120,18 +108,6 @@
 
 @mixin vf-icon-youtube {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='40' height='40'%3E%3Cdefs%3E%3Cpath id='a' d='M.014.009H40v28.173H.014z'/%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd' transform='translate(0 6)'%3E%3Cmask id='b' fill='%23fff'%3E%3Cuse xlink:href='%23a'/%3E%3C/mask%3E%3Cpath fill='%23DA322A' d='M39.164 4.4A5.026 5.026 0 0035.628.842C32.508 0 20 0 20 0S7.492 0 4.372.841a5.026 5.026 0 00-3.536 3.56C0 7.54 0 14.09 0 14.09s0 6.55.836 9.69a5.026 5.026 0 003.536 3.56c3.12.84 15.628.84 15.628.84s12.508 0 15.628-.84a5.026 5.026 0 003.536-3.56c.836-3.14.836-9.69.836-9.69s0-6.55-.836-9.69' mask='url(%23b)'/%3E%3Cpath fill='%23FFFFFE' d='M15.909 20.038V8.143l10.455 5.948-10.455 5.947'/%3E%3C/g%3E%3C/svg%3E");
-}
-
-@mixin vf-icon-canonical {
-  @include deprecate('3.0.0', 'Removing icon from framework please use an alternative icon from our social set') {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cpath fill='%23772953' d='M20 32.735c-7.033 0-12.735-5.7-12.735-12.735 0-7.034 5.702-12.735 12.735-12.735 7.034 0 12.736 5.701 12.736 12.735 0 7.035-5.701 12.735-12.735 12.735zM40 20c0 11.046-8.954 20-20 20S0 31.045 0 20C0 8.954 8.954 0 20 0s20 8.954 20 20zM20 4.865C11.64 4.865 4.865 11.641 4.865 20c0 8.36 6.776 15.135 15.135 15.135 8.36 0 15.135-6.775 15.135-15.135 0-8.358-6.775-15.135-15.135-15.135z'/%3E%3C/svg%3E");
-  }
-}
-
-@mixin vf-icon-ubuntu {
-  @include deprecate('3.0.0', 'Removing icon from framework please use an alternative icon from our social set') {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cg fill='none'%3E%3Cpath fill='%23E95420' d='M40 20.04c0 11.012-8.95 19.95-20 19.95S0 31.052 0 20.04C0 9.017 8.95.09 20 .09s20 8.927 20 19.95z'/%3E%3Cpath fill='%23FFF' d='M6.4 17.377a2.666 2.666 0 00-2.67 2.663c0 1.466 1.2 2.663 2.67 2.663s2.67-1.197 2.67-2.663c0-1.476-1.2-2.663-2.67-2.663zm19.07 12.1a2.667 2.667 0 102.67 4.618 2.667 2.667 0 00.98-3.641c-.75-1.267-2.38-1.706-3.65-.978zM12.2 20.04a7.749 7.749 0 013.32-6.364l-1.95-3.262a11.622 11.622 0 00-4.8 6.723 3.751 3.751 0 011.38 2.903c0 1.167-.54 2.214-1.38 2.903a11.578 11.578 0 004.8 6.723l1.95-3.262a7.749 7.749 0 01-3.32-6.364zm7.8-7.78c4.08 0 7.42 3.112 7.77 7.092l3.81-.06a11.503 11.503 0 00-3.45-7.501c-1.02.379-2.19.319-3.2-.26a3.737 3.737 0 01-1.83-2.643 11.8 11.8 0 00-3.1-.42c-1.85 0-3.59.43-5.14 1.198l1.86 3.312a7.81 7.81 0 013.28-.719zm0 15.56a7.89 7.89 0 01-3.29-.718l-1.86 3.312c1.55.768 3.3 1.197 5.14 1.197 1.07 0 2.11-.15 3.1-.419a3.728 3.728 0 011.83-2.643 3.742 3.742 0 013.2-.26 11.551 11.551 0 003.45-7.501l-3.81-.06c-.34 3.97-3.68 7.092-7.76 7.092zm5.46-17.226c1.28.738 2.91.299 3.65-.978.74-1.277.3-2.903-.98-3.64a2.673 2.673 0 00-3.65.977 2.676 2.676 0 00.98 3.64z'/%3E%3C/g%3E%3C/svg%3E");
-  }
 }
 
 @mixin vf-icon-rss {

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -8,7 +8,6 @@
   @include vf-p-icon-expand;
   @include vf-p-icon-collapse;
   @include vf-p-icon-chevron;
-  @include vf-p-icon-contextual-menu;
   @include vf-p-icon-close;
   @include vf-p-icon-help;
   @include vf-p-icon-info;
@@ -24,7 +23,6 @@
   @include vf-p-icon-success;
   @include vf-p-icon-share;
   @include vf-p-icon-user;
-  @include vf-p-icon-question;
   @include vf-p-icon-spinner;
   @include vf-p-icon-facebook;
   @include vf-p-icon-github;
@@ -32,12 +30,9 @@
   @include vf-p-icon-instagram;
   @include vf-p-icon-linkedin;
   @include vf-p-icon-youtube;
-  @include vf-p-icon-canonical;
-  @include vf-p-icon-ubuntu;
   @include vf-p-icon-rss;
   @include vf-p-icon-email;
   @include vf-p-icon-sizes;
-  @include vf-p-icon-in-button;
   @include vf-p-icon-show;
   @include vf-p-icon-hide;
 }
@@ -158,20 +153,6 @@
     [class*='--dark'] &,
     &.is-light {
       @include vf-icon-chevron($color-mid-x-light);
-    }
-  }
-}
-
-@mixin vf-p-icon-contextual-menu {
-  @include deprecate('3.0.0', 'Use the `p-icon--chevron` class instead') {
-    .p-icon--contextual-menu {
-      @extend %icon;
-      @include vf-icon-contextual-menu($color-mid-dark);
-
-      [class*='--dark'] &,
-      &.is-light {
-        @include vf-icon-contextual-menu($color-mid-x-light);
-      }
     }
   }
 }
@@ -342,12 +323,6 @@
   }
 }
 
-@mixin vf-p-icon-question {
-  @include deprecate('3.0.0', 'Use the `p-icon--help` class instead') {
-    // moved to vf-p-icon-help
-  }
-}
-
 @mixin vf-p-icon-spinner {
   .p-icon--spinner {
     @extend %icon;
@@ -402,24 +377,6 @@
   }
 }
 
-@mixin vf-p-icon-canonical {
-  @include deprecate('3.0.0', 'Removing icon from framework please use an alternative icon from our social set') {
-    .p-icon--canonical {
-      @extend %social-icon;
-      @include vf-icon-canonical;
-    }
-  }
-}
-
-@mixin vf-p-icon-ubuntu {
-  @include deprecate('3.0.0', 'Removing icon from framework please use an alternative icon from our social set') {
-    .p-icon--ubuntu {
-      @extend %social-icon;
-      @include vf-icon-ubuntu;
-    }
-  }
-}
-
 @mixin vf-p-icon-rss {
   .p-icon--rss {
     @extend %social-icon;
@@ -449,17 +406,6 @@
 
   .p-icon--xx-large {
     @include vf-icon-size($sp-xxx-large);
-  }
-}
-
-@mixin vf-p-icon-in-button {
-  @include deprecate('3.0.0', 'No longer necessary') {
-    // Style overides for icons within a button
-    [class*='p-button-'] {
-      [class*='p-icon-'] {
-        top: 0;
-      }
-    }
   }
 }
 

--- a/scss/standalone/patterns_notifications.scss
+++ b/scss/standalone/patterns_notifications.scss
@@ -5,7 +5,3 @@
 
 // needed in borderless demo
 @include vf-u-margin-collapse;
-
-// needed for deprecated notification pattern
-// can be removed in 3.0
-@include vf-p-icon-close;

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -108,11 +108,13 @@ Our icons have two predefined color styles: light and dark. The light variant is
       <div class="p-card col-3 u-vertically-center">
         <p><i class="p-icon--anchor" style="margin-right: 1rem;"></i>p-icon--anchor</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--show" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--show
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--show" style="margin-right: 1rem;"></i>p-icon--show</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--hide" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--hide
+    </div>
+    <div class="row u-equal-height">
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--hide" style="margin-right: 1rem;"></i>p-icon--hide</p>
       </div>
     </div>
   </div>
@@ -167,281 +169,281 @@ Outside of the standard set, additional icons are available for use, and need to
 <section>
   <div class="p-strip is-shallow u-no-padding--top">
     <div class="row">
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--applications" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--applications
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--applications" style="margin-right: 1rem;"></i>p-icon--applications</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--controllers" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--controllers
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--controllers" style="margin-right: 1rem;"></i>p-icon--controllers</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--fullscreen" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--fullscreen
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--fullscreen" style="margin-right: 1rem;"></i>p-icon--fullscreen</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--models" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--models
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--models" style="margin-right: 1rem;"></i>p-icon--models</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--machines" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--machines
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--machines" style="margin-right: 1rem;"></i>p-icon--machines</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--pin" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--pin
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--pin" style="margin-right: 1rem;"></i>p-icon--pin</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
-        <i class="p-icon--units" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--units
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--units" style="margin-right: 1rem;"></i>p-icon--units</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--priority-critical" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--priority-critical
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--priority-critical" style="margin-right: 1rem;"></i>p-icon--priority-critical</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--priority-high" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--priority-high
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--priority-high" style="margin-right: 1rem;"></i>p-icon--priority-high</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--priority-low" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--priority-low
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--priority-low" style="margin-right: 1rem;"></i>p-icon--priority-low</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--priority-medium" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--priority-medium
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--priority-medium" style="margin-right: 1rem;"></i>p-icon--priority-medium</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--priority-negligible" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--priority-negligible
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--priority-negligible" style="margin-right: 1rem;"></i>p-icon--priority-negligible</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--priority-unknown" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--priority-unknown
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--priority-unknown" style="margin-right: 1rem;"></i>p-icon--priority-unknown</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--add-canvas" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--add-canvas
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--add-canvas" style="margin-right: 1rem;"></i>p-icon--add-canvas</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--add-logical-volume" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--add-logical-volume
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--add-logical-volume" style="margin-right: 1rem;"></i>p-icon--add-logical-volume</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--add-partition" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--add-partition
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--add-partition" style="margin-right: 1rem;"></i>p-icon--add-partition</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--back-to-top" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--back-to-top
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--back-to-top" style="margin-right: 1rem;"></i>p-icon--back-to-top</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--begin-downloading" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--begin-downloading
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--begin-downloading" style="margin-right: 1rem;"></i>p-icon--begin-downloading</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--bundle" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--bundle
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--bundle" style="margin-right: 1rem;"></i>p-icon--bundle</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--canvas" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--canvas
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--canvas" style="margin-right: 1rem;"></i>p-icon--canvas</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--change-version" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--change-version
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--change-version" style="margin-right: 1rem;"></i>p-icon--change-version</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--comments" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--comments
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--comments" style="margin-right: 1rem;"></i>p-icon--comments</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--conflict-grey" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--conflict-grey
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--conflict-grey" style="margin-right: 1rem;"></i>p-icon--conflict-grey</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--conflict" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--conflict
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--conflict" style="margin-right: 1rem;"></i>p-icon--conflict</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--conflict-resolution-grey" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--conflict-resolution-grey
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--conflict-resolution-grey" style="margin-right: 1rem;"></i>p-icon--conflict-resolution-grey</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--conflict-resolution" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--conflict-resolution
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--conflict-resolution" style="margin-right: 1rem;"></i>p-icon--conflict-resolution</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--connected" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--connected
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--connected" style="margin-right: 1rem;"></i>p-icon--connected</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--containers" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--containers
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--containers" style="margin-right: 1rem;"></i>p-icon--containers</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--copy-to-clipboard" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--copy-to-clipboard
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--copy-to-clipboard" style="margin-right: 1rem;"></i>p-icon--copy-to-clipboard</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--disconnect" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--disconnect
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--disconnect" style="margin-right: 1rem;"></i>p-icon--disconnect</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--edit" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--edit
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--edit" style="margin-right: 1rem;"></i>p-icon--edit</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--export" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--export
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--export" style="margin-right: 1rem;"></i>p-icon--export</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--exposed" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--exposed
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--exposed" style="margin-right: 1rem;"></i>p-icon--exposed</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--filter" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--filter
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--filter" style="margin-right: 1rem;"></i>p-icon--filter</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--fork" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--fork
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--fork" style="margin-right: 1rem;"></i>p-icon--fork</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--get-link" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--get-link
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--get-link" style="margin-right: 1rem;"></i>p-icon--get-link</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--halfscreen-bar" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--halfscreen-bar
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--halfscreen-bar" style="margin-right: 1rem;"></i>p-icon--halfscreen-bar</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--highlight-off" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--highlight-off
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--highlight-off" style="margin-right: 1rem;"></i>p-icon--highlight-off</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--highlight-on" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--highlight-on
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--highlight-on" style="margin-right: 1rem;"></i>p-icon--highlight-on</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--home" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--home
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--home" style="margin-right: 1rem;"></i>p-icon--home</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--import" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--import
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--import" style="margin-right: 1rem;"></i>p-icon--import</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--in-progress" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--in-progress
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--in-progress" style="margin-right: 1rem;"></i>p-icon--in-progress</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--inspector-debug" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--inspector-debug
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--inspector-debug" style="margin-right: 1rem;"></i>p-icon--inspector-debug</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--loading-steps" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--loading-steps
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--loading-steps" style="margin-right: 1rem;"></i>p-icon--loading-steps</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--lock-locked-active" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--lock-locked-active
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--lock-locked-active" style="margin-right: 1rem;"></i>p-icon--lock-locked-active</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--lock-locked" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--lock-locked
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--lock-locked" style="margin-right: 1rem;"></i>p-icon--lock-locked</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--lock-unlock" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--lock-unlock
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--lock-unlock" style="margin-right: 1rem;"></i>p-icon--lock-unlock</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--maximise-bar" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--maximise-bar
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--maximise-bar" style="margin-right: 1rem;"></i>p-icon--maximise-bar</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--minimise-bar" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--minimise-bar
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--minimise-bar" style="margin-right: 1rem;"></i>p-icon--minimise-bar</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--mount-2" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--mount-2
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--mount-2" style="margin-right: 1rem;"></i>p-icon--mount-2</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--mount" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--mount
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--mount" style="margin-right: 1rem;"></i>p-icon--mount</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--unmount" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--unmount
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--unmount" style="margin-right: 1rem;"></i>p-icon--unmount</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--open-terminal" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--open-terminal
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--open-terminal" style="margin-right: 1rem;"></i>p-icon--open-terminal</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--plans" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--plans
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--plans" style="margin-right: 1rem;"></i>p-icon--plans</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--pods" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--pods
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--pods" style="margin-right: 1rem;"></i>p-icon--pods</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--power-error" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--power-error
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--power-error" style="margin-right: 1rem;"></i>p-icon--power-error</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--power-off" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--power-off
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--power-off" style="margin-right: 1rem;"></i>p-icon--power-off</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--power-on" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--power-on
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--power-on" style="margin-right: 1rem;"></i>p-icon--power-on</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--profile" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--profile
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--profile" style="margin-right: 1rem;"></i>p-icon--profile</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--restart" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--restart
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--restart" style="margin-right: 1rem;"></i>p-icon--restart</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--revisions" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--revisions
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--revisions" style="margin-right: 1rem;"></i>p-icon--revisions</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--security" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--security
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--security" style="margin-right: 1rem;"></i>p-icon--security</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--settings" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--settings
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--settings" style="margin-right: 1rem;"></i>p-icon--settings</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--sort-both" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--sort-both
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--sort-both" style="margin-right: 1rem;"></i>p-icon--sort-both</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--sort-down" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--sort-down
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--sort-down" style="margin-right: 1rem;"></i>p-icon--sort-down</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--sort-up" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--sort-up
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--sort-up" style="margin-right: 1rem;"></i>p-icon--sort-up</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--starred" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--starred
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--starred" style="margin-right: 1rem;"></i>p-icon--starred</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status-failed-small" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status-failed-small
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status-failed-small" style="margin-right: 1rem;"></i>p-icon--status-failed-small</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status-in-progress-small" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status-in-progress-small
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status-in-progress-small" style="margin-right: 1rem;"></i>p-icon--status-in-progress-small</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status-queued-small" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status-queued-small
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status-queued-small" style="margin-right: 1rem;"></i>p-icon--status-queued-small</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status-succeeded-small" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status-succeeded-small
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status-succeeded-small" style="margin-right: 1rem;"></i>p-icon--status-succeeded-small</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status-waiting-small" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status-waiting-small
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status-waiting-small" style="margin-right: 1rem;"></i>p-icon--status-waiting-small</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status-in-progress" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status-in-progress
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status-in-progress" style="margin-right: 1rem;"></i>p-icon--status-in-progress</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status-queued" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status-queued
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status-queued" style="margin-right: 1rem;"></i>p-icon--status-queued</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status-waiting" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status-waiting
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status-waiting" style="margin-right: 1rem;"></i>p-icon--status-waiting</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--status" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--status
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--status" style="margin-right: 1rem;"></i>p-icon--status</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--submit-bug" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--submit-bug
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--submit-bug" style="margin-right: 1rem;"></i>p-icon--submit-bug</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--success-grey" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--success-grey
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--success-grey" style="margin-right: 1rem;"></i>p-icon--success-grey</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--switcher-dashboard" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--switcher-dashboard
+      <div class="p-card col-3 u-vertically-center">
+        <i class="p-icon--switcher-dashboard" style="margin-right: 1rem;"></i>p-icon--switcher-dashboard
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--switcher-environments" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--switcher-environments
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--switcher-environments" style="margin-right: 1rem;"></i>p-icon--switcher-environments</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--switcher" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--switcher
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--switcher" style="margin-right: 1rem;"></i>p-icon--switcher</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--tag" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--tag
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--tag" style="margin-right: 1rem;"></i>p-icon--tag</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--task-outstanding" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--task-outstanding
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--task-outstanding" style="margin-right: 1rem;"></i>p-icon--task-outstanding</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--timed-out-grey" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--timed-out-grey
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--timed-out-grey" style="margin-right: 1rem;"></i>p-icon--timed-out-grey</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--timed-out" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--timed-out
+      <div class="p-card col-3 u-vertically-center">
+        <i class="p-icon--timed-out" style="margin-right: 1rem;"></i>p-icon--timed-out
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--topic" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--topic
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--topic" style="margin-right: 1rem;"></i>p-icon--topic</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--unit-pending" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--unit-pending
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--unit-pending" style="margin-right: 1rem;"></i>p-icon--unit-pending</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--unit-running" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--unit-running
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--unit-running" style="margin-right: 1rem;"></i>p-icon--unit-running</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--unstarred" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--unstarred
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--unstarred" style="margin-right: 1rem;"></i>p-icon--unstarred</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--user-group" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--user-group
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--user-group" style="margin-right: 1rem;"></i>p-icon--user-group</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--video-play" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--video-play
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--video-play" style="margin-right: 1rem;"></i>p-icon--video-play</p>
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-item: center;display: flex;">
-        <i class="p-icon--warning-grey" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--warning-grey
+      <div class="p-card col-3 u-vertically-center">
+        <p><i class="p-icon--warning-grey" style="margin-right: 1rem;"></i>p-icon--warning-grey</p>
       </div>
     </div>
   </div>
@@ -454,32 +456,32 @@ Our social icons are used to drive users to social content.
 <section>
   <div class="p-strip is-shallow u-no-padding--top">
     <div class="row">
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
+      <div class="p-card col-3" style="align-items:center; display:flex;">
         <i class="p-icon--facebook" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--facebook
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
+      <div class="p-card col-3" style="align-items:center; display:flex;">
         <i class="p-icon--instagram" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--instagram
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
+      <div class="p-card col-3" style="align-items:center; display:flex;">
         <i class="p-icon--twitter" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--twitter
       </div>
     </div>
     <div class="row">
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
+      <div class="p-card col-3" style="align-items:center; display:flex;">
         <i class="p-icon--linkedin" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--linkedin
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
+      <div class="p-card col-3" style="align-items:center; display:flex;">
         <i class="p-icon--youtube" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--youtube
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
+      <div class="p-card col-3" style="align-items:center; display:flex;">
         <i class="p-icon--github" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--github
       </div>
     </div>
     <div class="row">
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
+      <div class="p-card col-3" style="align-items:center; display:flex;">
         <i class="p-icon--rss" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--rss
       </div>
-      <div class="p-card col-3 u-vertically-center" style=" align-items:center;display:flex;">
+      <div class="p-card col-3" style="align-items:center; display:flex;">
         <i class="p-icon--email" style=" flex-shrink: 0;margin-right: 1rem;"></i>p-icon--email
       </div>
     </div>

--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -118,8 +118,6 @@ Our icons have two predefined color styles: light and dark. The light variant is
   </div>
 </section>
 
-<span class="p-label--deprecated">Deprecated</span> The `.p-icon--question` class has been deprecated and will be removed in version 3.0. Use class `.p-icon--help` instead. We will also be removing <code>p-icon--contextual-menu</code>, please use <code>p-icon--chevron-down</code> instead.
-
 ## Dark theme
 
 Our dark-themed icons are available when placed within a container that has the suffix `--dark` ex) `help-container--dark`. Icon colors will then be inverted to ensure legibility as shown in our example.
@@ -488,8 +486,6 @@ Our social icons are used to drive users to social content.
   </div>
 </section>
 
-<span class="p-label--deprecated">Deprecated</span> We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from our social icon set, they will no longer be available from our future release v3.0.
-
 ## Share
 
 If you wish to add share icons for Twitter, Facebook or LinkedIn, we recommend using the networks' official buttons:
@@ -563,19 +559,15 @@ If you use a limited set of icons you may want to include them individually to r
 @include vf-p-icon-success;
 @include vf-p-icon-share;
 @include vf-p-icon-user;
-@include vf-p-icon-question;
 @include vf-p-icon-spinner;
 @include vf-p-icon-facebook;
 @include vf-p-icon-twitter;
 @include vf-p-icon-instagram;
 @include vf-p-icon-linkedin;
 @include vf-p-icon-youtube;
-@include vf-p-icon-canonical;
-@include vf-p-icon-ubuntu;
 @include vf-p-icon-rss;
 @include vf-p-icon-email;
 @include vf-p-icon-sizes;
-@include vf-p-icon-in-button;
 @include vf-p-icon-hide;
 @include vf-p-icon-show;
 


### PR DESCRIPTION
## Done

Remove last batch of deprecated styling (icons).

Fixes #3744 

## QA

- Open [demo](https://vanilla-framework-3960.demos.haus/docs/patterns/icons)
- Make sure all deprecated icons are removed from the docs page and the code
- Drive-by: make sure all icons are correctly displayed in cards in the docs (next to their label)

