### PR TITLE
No indentation accordion variation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.35.0",
+  "version": "2.36.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -156,5 +156,9 @@
     &[aria-hidden='true'] {
       display: none;
     }
+
+    &.has-tick-elements {
+      padding-left: 1em;
+    }
   }
 }

--- a/scss/standalone/patterns_accordion.scss
+++ b/scss/standalone/patterns_accordion.scss
@@ -1,4 +1,6 @@
 @import '../vanilla';
 @include vf-base;
 
+// needed for the example with checkboxes
+@include vf-p-form-tick-elements;
 @include vf-p-accordion;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -48,7 +48,7 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
               {{ side_nav_item("/docs/base/code", "Code") }}
-              {{ side_nav_item("/docs/base/forms", "Forms", 'updated') }}
+              {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
               {{ side_nav_item("/docs/base/tables", "Tables") }}
@@ -57,7 +57,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
-              {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
+              {{ side_nav_item("/docs/patterns/accordion", "Accordion", 'updated') }}
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
               {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
               {{ side_nav_item("/docs/patterns/card", "Cards") }}

--- a/templates/docs/examples/patterns/accordion/tick-elements.html
+++ b/templates/docs/examples/patterns/accordion/tick-elements.html
@@ -1,0 +1,53 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Accordion / Tick elements{% endblock %}
+
+{% block standalone_css %}patterns_accordion{% endblock %}
+
+{% block content %}
+<aside class="p-accordion">
+  <ul class="p-accordion__list">
+    <li class="p-accordion__group">
+      <div role="heading" aria-level="3" class="p-accordion__heading">
+        <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">Networking</button>
+      </div>
+      <section class="p-accordion__panel has-tick-elements" id="tab1-section" aria-controls="tab1-section" aria-expanded="true">
+        <label class="p-checkbox">
+          <input type="checkbox" class="p-checkbox__input" name="vendor" value="working-offline">
+          <span class="p-checkbox__label">Working offline</span>
+        </label>
+        <label class="p-checkbox">
+          <input type="checkbox" class="p-checkbox__input" name="vendor" value="fan-container-networking">
+          <span class="p-checkbox__label">Fan container networking</span>
+        </label>
+        <label class="p-checkbox">
+          <input type="checkbox" class="p-checkbox__input" name="vendor" value="network-spaces">
+          <span class="p-checkbox__label">Network spaces</span>
+        </label>
+      </section>
+    </li>
+    <li class="p-accordion__group">
+      <div role="heading" aria-level="3" class="p-accordion__heading">
+        <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Miscellaneous</button>
+      </div>
+      <section class="p-accordion__panel has-tick-elements" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
+        <label class="p-radio">
+          <input type="radio" class="p-radio__input" name="vendor" value="juju-gui">
+          <span class="p-radio__label">Juju GUI</span>
+        </label>
+        <label class="p-radio">
+          <input type="radio" class="p-radio__input" name="vendor" value="centos-support">
+          <span class="p-radio__label">CentOS support</span>
+        </label>
+        <label class="p-radio">
+          <input type="radio" class="p-radio__input" name="vendor" value="juju-metrics">
+          <span class="p-radio__label">Collecting Juju metrics</span>
+        </label>
+      </section>
+    </li>
+  </ul>
+</aside>
+
+<script>
+  {% include 'docs/examples/patterns/accordion/_script.js' %}
+</script>
+{% endblock %}

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -36,6 +36,14 @@ View example of the accordion pattern
 View example of the accordion pattern
 </a></div>
 
+## With tick elements
+
+When checkboxes or radio buttons are used inside accordion panels add `has-tick-elements` class name to the panel `p-accordion__panel` element, to properly align tick elements with accordion controls.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/accordion/tick-elements/" class="js-example">
+View example of the accordion pattern
+</a></div>
+
 ## Headings
 
 <span class="p-label--deprecated">Deprecated</span>

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -20,12 +20,12 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-    <!-- 2.35 -->
+    <!-- 2.36 -->
     <tr>
-      <th><a href="/docs/base/forms#validation">Forms / Validation</a></th>
-      <td><div class="p-label--updated">Updated</div></td>
-      <td>2.35.0</td>
-      <td>We've updated the styling of the form validation and required patterns</td>
+      <th><a href="/docs/patterns/accordion#with-tick-elements">Accordion / Tick elements</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.36.0</td>
+      <td>We've added a variation of the accordion using tick elements</td>
     </tr>
   </tbody>
 </table>
@@ -42,6 +42,13 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 2.35 -->
+    <tr>
+      <th><a href="/docs/base/forms#validation">Forms / Validation</a></th>
+      <td><div class="p-label--deprecated">Updated</div></td>
+      <td>2.35.0</td>
+      <td>We've updated the styling of the form validation and required patterns</td>
+    </tr>
     <!-- 2.34 -->
     <tr>
       <th><a href="/docs/base/forms#password-showhide">Forms / Password toggle</a></th>


### PR DESCRIPTION
## Done

Variation to remove indendation for checkboxes.

Removing 2 rems will adjust the indentation/padding for the default accordion, but if we add checkboxes, it will push the content further, therefore, I removed 1 rem to specifically accomodate for checkboxes.

Therefore, something we need to decides is whether we want to accomodate the indentation for checkboxes or general accordions without checkboxes.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3913
Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3885

## QA

- Open https://vanilla-framework-3963.demos.haus/docs/examples/patterns/accordion/tick-elements
- Check that paddings have been removed, compare with /docs/examples/patterns/accordion/default
- Review updated documentation:
  - Added example in documentation https://vanilla-framework-3963.demos.haus/docs/examples/patterns/accordion/tick-elements
  - Standalone should also work now: https://vanilla-framework-3963.demos.haus/docs/examples/standalone/patterns/accordion/tick-elements
  - What's new page updated https://vanilla-framework-3963.demos.haus/docs/whats-new
### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![checkbox-accordion](https://user-images.githubusercontent.com/14939793/131717224-88ad6610-a83f-4890-b2e9-114e257fddc0.png)
