### PR TITLE
Fix labels in docs for 2.35

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -71,7 +71,7 @@
               {{ side_nav_item("/docs/patterns/labels", "Labels") }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists", "updated") }}
+              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
               {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
@@ -87,7 +87,7 @@
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}
               {{ side_nav_item("/docs/patterns/switch", "Switch") }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
-              {{ side_nav_item("/docs/patterns/tabs", "Tabs", 'updated') }}
+              {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}
               {{ side_nav_item("/docs/patterns/tooltips", "Tooltips") }}
             </ul>
 

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -23,7 +23,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <!-- 2.35 -->
     <tr>
       <th><a href="/docs/base/forms#validation">Forms / Validation</a></th>
-      <td><div class="p-label--deprecated">Updated</div></td>
+      <td><div class="p-label--updated">Updated</div></td>
       <td>2.35.0</td>
       <td>We've updated the styling of the form validation and required patterns</td>
     </tr>


### PR DESCRIPTION
## Done

Fixes labels in side navigation and what's new page for new 2.35 release.

## QA

- Open [demo](https://vanilla-framework-3964.demos.haus/docs/whats-new)
- Make sure the "Updated" label related to Form Validation change has correct color
- Make sure side navigation only has labels for relevant items (Forms in this case)
