### PR TITLE
Add hover state for uncollpased accordion button

### DIFF
--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -51,6 +51,10 @@
 
       // override base expanded button styles
       background-color: inherit;
+      &:hover {
+        background-color: $colors--light-theme--background-hover;
+      }
+
       background-size: $icon-size;
     }
 


### PR DESCRIPTION
## Done

Add hover state for uncollpased accordion button

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3950

## QA

- Open [demo](https://vanilla-framework-3973.demos.haus//docs/examples/patterns/accordion/default)  compare with [current](https://vanillaframework.io/docs/examples/patterns/accordion/default)

When accordion is opened, hover over the button to highlight the hover state. Now all buttons should have hover state


- Review updated documentation:
  - Updated existing accordion examples https://vanilla-framework-3973.demos.haus//docs/examples/patterns/accordion/default/docs/patterns/accordion#accordion
 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] **Done in master already** Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] **Done in master already** Documentation side navigation should be updated with the relevant labels.


## Screenshots

![hover-state](https://user-images.githubusercontent.com/14939793/132319646-287d4d24-87a4-445c-ac32-5f269cea3dba.png)

