### PR TITLE
Truncates modal to fit content and centers

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.36.0",
+  "version": "2.36.1",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -25,7 +25,6 @@
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
 
-    bottom: $spv-inner--large;
     left: $sph-inner--large;
     margin-bottom: 0;
     max-height: calc(100% - #{2 * $spv-inner--large});
@@ -33,7 +32,6 @@
     overflow: auto;
     position: absolute;
     right: $sph-inner--large;
-    top: $spv-inner--large;
     width: auto;
 
     @media (min-width: $breakpoint-medium) {


### PR DESCRIPTION
## Done

- Truncates modal to fit where the content ends and centers the modal when viewing on mobile.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3906

## QA

- Open [demo](https://vanilla-framework-3982.demos.haus/docs/examples/patterns/modal/default)
- Check the modal works as expected and that it limits the size to fit that of the content.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Screenshot from 2021-09-14 12-18-11](https://user-images.githubusercontent.com/58276363/133240321-e9db4278-e483-470f-8e29-45f157fed184.png)

