### PR TITLE
Make header fixed in modal

### DIFF
--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -31,11 +31,11 @@
     max-height: calc(100% - #{2 * $spv-inner--large});
     max-width: $grid-max-width;
     overflow: auto;
+    padding-top: 0;
     position: absolute;
     right: $sph-inner--large;
     top: $spv-inner--large;
     width: auto;
-    padding-top: 0;
 
     @media (min-width: $breakpoint-medium) {
       bottom: initial;
@@ -49,16 +49,16 @@
   .p-modal__header {
     @extend %vf-pseudo-border--bottom;
 
+    background: $color-x-light;
     display: flex;
     justify-content: space-between;
     margin-bottom: $spv-inner--small;
+    // add padding to accommodate the width of p-modal__close
+    padding-right: $icon-size + $sph-inner--small * 2;
     padding-top: $spv-inner--large;
     position: sticky;
     top: 0;
     z-index: 10;
-    background: $color-x-light;
-    // add padding to accommodate the width of p-modal__close
-    padding-right: $icon-size + $sph-inner--small * 2;
   }
 
   .p-modal__title {
@@ -79,8 +79,8 @@
     box-sizing: content-box;
     height: $icon-size;
     margin: 0;
-    padding: $sp-unit;
     margin-top: $spv-inner--large;
+    padding: $sp-unit;
     position: absolute;
     right: 0;
     text-indent: -999em;

--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -35,6 +35,7 @@
     right: $sph-inner--large;
     top: $spv-inner--large;
     width: auto;
+    padding-top: 0;
 
     @media (min-width: $breakpoint-medium) {
       bottom: initial;
@@ -51,6 +52,11 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: $spv-inner--small;
+    padding-top: $spv-inner--large;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: $color-x-light;
     // add padding to accommodate the width of p-modal__close
     padding-right: $icon-size + $sph-inner--small * 2;
   }
@@ -74,6 +80,7 @@
     height: $icon-size;
     margin: 0;
     padding: $sp-unit;
+    margin-top: $spv-inner--large;
     position: absolute;
     right: 0;
     text-indent: -999em;


### PR DESCRIPTION
## Done

- Makes header fixed to the top of a modal when scrolling

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3926

## QA

- Open [demo](https://vanilla-framework-3983.demos.haus/docs/examples/patterns/modal/modal-scroll)
- Check header is fixed when scrolling in a modal
- Check it works on different screen sizes

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
