### PR TITLE
Add datalist to examples

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -84,3 +84,4 @@ playbook
 timestamp
 div
 u-no-padding--top
+datalist

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.36.1",
+  "version": "2.37.1",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.37.1",
+  "version": "2.37.0",
   "files": [
     "/scss",
     "!/scss/docs"

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -162,7 +162,7 @@
     }
   }
 
-  [type='text'] {
+  input[list] {
     &::-webkit-calendar-picker-indicator {
       opacity: 0;
     }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -162,6 +162,12 @@
     }
   }
 
+  [type='text'] {
+    &::-webkit-calendar-picker-indicator {
+      opacity: 0;
+    }
+  }
+
   // Select styles
   select {
     @include vf-icon-chevron;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -57,10 +57,10 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
-              {{ side_nav_item("/docs/patterns/accordion", "Accordion", 'updated') }}
+              {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
               {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
-              {{ side_nav_item("/docs/patterns/card", "Cards", 'updated') }}
+              {{ side_nav_item("/docs/patterns/card", "Cards") }}
               {{ side_nav_item("/docs/patterns/chip", "Chips") }}
               {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}
               {{ side_nav_item("/docs/patterns/grid", "Grid") }}

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -48,7 +48,7 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
               {{ side_nav_item("/docs/base/code", "Code") }}
-              {{ side_nav_item("/docs/base/forms", "Forms", 'updated') }}
+              {{ side_nav_item("/docs/base/forms", "Forms", 'new') }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
               {{ side_nav_item("/docs/base/tables", "Tables") }}

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -132,6 +132,14 @@ Use the `multiple` attribute to create a multiple select control.
 View example of the base multiple selects
 </a></div>
 
+## Datalist
+
+Use the `<datalist>` element to create drop-down list with text input.
+
+<div class="embedded-example"><a href="/docs/examples/base/forms/datalist/" class="js-example">
+View example of the base datalist
+</a></div>
+
 ## Range
 
 The `<input type="range">` allows a user to select from a specified range of values, where the precise value is not considered important.

--- a/templates/docs/examples/base/forms/datalist.html
+++ b/templates/docs/examples/base/forms/datalist.html
@@ -1,0 +1,20 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Datalist{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block content %}
+
+<form>
+  <label for="ice-cream-choice">Choose a flavor:</label>
+  <input type="text" list="ice-cream-flavors" id="ice-cream-choice" name="ice-cream-choice" />
+
+  <datalist id="ice-cream-flavors">
+      <option value="Chocolate">
+      <option value="Coconut">
+      <option value="Mint">
+      <option value="Strawberry">
+      <option value="Vanilla">
+  </datalist>
+</form>
+{% endblock %}

--- a/templates/docs/examples/base/forms/datalist.html
+++ b/templates/docs/examples/base/forms/datalist.html
@@ -10,11 +10,11 @@
   <input type="text" list="ice-cream-flavors" id="ice-cream-choice" name="ice-cream-choice" />
 
   <datalist id="ice-cream-flavors">
-      <option value="Chocolate">
-      <option value="Coconut">
-      <option value="Mint">
-      <option value="Strawberry">
-      <option value="Vanilla">
+      <option value="Vanilla">Vanilla</option>
+      <option value="Chocolate">Chocolate</option>
+      <option value="Coconut">Coconut</option>
+      <option value="Mint">Mint</option>
+      <option value="Strawberry">Strawberry</option>
   </datalist>
 </form>
 {% endblock %}

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -32,7 +32,6 @@ When we add, make significant updates, or deprecate a component we update their 
 
 ## Previously in Vanilla
 
-
 <table>
   <thead>
     <tr>

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -20,6 +20,29 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+  <!-- 2.37 -->
+    <tr>
+      <th><a href="/docs/base/forms#datalist">Forms / Datalist</a></th>
+      <td><div class="p-label--new">New</div></td>
+      <td>2.37.0</td>
+      <td>We've added documentation for datalist</td>
+    </tr>
+  </tbody>
+</table>
+
+## Previously in Vanilla
+
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 2.36 -->
     <tr>
       <th><a href="/docs/patterns/accordion#with-tick-elements">Accordion / Tick elements</a></th>
@@ -39,21 +62,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>2.36.0</td>
       <td>We added a class name to aligned help text with checkboxes or radio buttons</td>
     </tr>
-  </tbody>
-</table>
-
-## Previously in Vanilla
-
-<table>
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 2.35 -->
     <tr>
       <th><a href="/docs/base/forms#validation">Forms / Validation</a></th>


### PR DESCRIPTION
## Done

- Adds datalist to examples without any styling.

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/2673

## QA

- Open [demo](https://vanilla-framework-3984.demos.haus/docs/examples/base/forms/datalist)
- Choose your favorite ice cream 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Screenshot from 2021-09-15 13-35-09](https://user-images.githubusercontent.com/58276363/133426449-18c57932-a197-4254-958e-a9e7ccbadf2c.png)
