### PR TITLE
Update modal accessibility docs

### DIFF
--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -12,6 +12,12 @@ The modal component can be used to overlay an area of the screen which can conta
 
 On `p-modal` set display to `display:flex` or `display:none` to toggle the visibility of the modal.
 
+<div class="p-notification--information">
+  <div class="p-notification__content">
+    <p class="p-notification__message">The element that launches a given modal should include a trailing ellipsis, e.g. "Launch modal&hellip;". This is a convention used to indicate that the element launches a dialog.</p>
+  </div>
+</div>
+
 <div class="embedded-example"><a href="/docs/examples/patterns/modal/default/" class="js-example" data-height="400">
 View example of the modal pattern
 </a></div>
@@ -23,6 +29,12 @@ Optional footer element with a `p-modal__footer` class name can be added to the 
 <div class="embedded-example"><a href="/docs/examples/patterns/modal/footer/" class="js-example" data-height="400">
 View example of the modal with a footer
 </a></div>
+
+## Accessibility
+
+JavaScript should be used with the modal pattern to trap focus within an open modal, preventing elements behind the modal from unintentionally receiving focus via keyboard input. The examples on this page include JavaScript that can help to achieve this.
+
+See [WCAG Success Criterion 2.1.2](https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-trapping.html) for further information.
 
 ## Import
 
@@ -38,12 +50,6 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Accessibility
-
-For any elements that launch a modal, please ensure that the label contains a trailing ellipsis `…`, e.g. "Launch modal&hellip;". This is a convention used to indicate that the element launches a dialog.
-
-When a modal is launched, focus should be set and contained within the modal dialog, using JavaScript. When the modal is closed, focus should be set back to the element that opened it.
 
 ## React
 


### PR DESCRIPTION
## Done

Updated accessibility note on modal docs to try to make them less vague.

Fixes #3974 

## QA

- Open [demo](https://vanilla-framework-3998.demos.haus/docs/patterns/modal)
- Read the docs, see that they are clear enough

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
