### PR TITLE
Clean up media query breakpoints in components

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -75,12 +75,6 @@
     p + p > & {
       margin-top: $spv-nudge-compensation;
     }
-
-    @media (max-width: $breakpoint-x-small - 1) {
-      p & + & {
-        margin-top: $sp-unit + $spv-nudge-compensation;
-      }
-    }
     // stylelint-enable selector-max-type
   }
 

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -12,13 +12,13 @@
   }
 
   %span-full-grid-on-mobile {
-    @media (max-width: $threshold-4-6-col) {
+    @media (max-width: $threshold-4-6-col - 1) {
       grid-column: auto / span $grid-columns-small;
     }
   }
 
   %span-full-grid-on-tablet {
-    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col - 1) {
       grid-column: auto / span $grid-columns-medium;
     }
   }

--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -149,7 +149,7 @@
       grid-column: 2 / -1;
       grid-template-columns: repeat(2, minmax(0, 1fr));
 
-      @media (max-width: $threshold-4-6-col) {
+      @media (max-width: $threshold-4-6-col - 1) {
         grid-template-columns: repeat(1, minmax(0, 1fr));
         width: $l-fluid-breakout-main-child-width;
       }
@@ -163,7 +163,7 @@
       &:nth-child(2) {
         justify-content: flex-end;
 
-        @media (max-width: $threshold-4-6-col) {
+        @media (max-width: $threshold-4-6-col - 1) {
           justify-content: flex-start;
         }
       }

--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -55,7 +55,7 @@
     padding-left: $sp-xx-large;
     text-align: left;
 
-    @media (max-width: $breakpoint-x-small) {
+    @media (max-width: $breakpoint-x-small - 1) {
       margin-right: 0;
       width: auto;
 
@@ -84,7 +84,7 @@
     padding-right: $sp-xx-large;
     text-align: right;
 
-    @media (max-width: $breakpoint-x-small) {
+    @media (max-width: $breakpoint-x-small - 1) {
       width: 100%;
     }
 

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -82,10 +82,6 @@
       position: relative;
       top: 0.05rem;
 
-      @media (max-width: $breakpoint-x-small) {
-        width: auto;
-      }
-
       [class*='p-icon'] {
         vertical-align: calc(#{0.5 * $cap-height} - #{0.5 * $default-icon-size});
       }

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -10,7 +10,7 @@
   .p-divider__block {
     position: relative;
 
-    @media (max-width: $threshold-6-12-col) {
+    @media (max-width: $threshold-6-12-col - 1) {
       padding-bottom: $spv--large;
       padding-top: $spv--large;
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -27,7 +27,7 @@
   }
 
   // mobile grid
-  @media (max-width: $threshold-4-6-col) {
+  @media (max-width: $threshold-4-6-col - 1) {
     @for $i from $grid-columns-small through 1 {
       .#{$grid-small-col-prefix}#{$i} {
         @include vf-grid-column($i);
@@ -38,7 +38,7 @@
   }
 
   // tablet grid
-  @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+  @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col - 1) {
     @for $i from $grid-columns-medium through 1 {
       .#{$grid-medium-col-prefix}#{$i} {
         @include vf-grid-column($i);
@@ -94,11 +94,11 @@
   @each $label, $breakpoint-min, $breakpoint-max, $col-count in $offsets {
     $query: null;
     @if $breakpoint-min == 0 {
-      $query: '(max-width: #{$breakpoint-max})';
+      $query: '(max-width: #{$breakpoint-max - 1})';
     } @else if $breakpoint-max == -1 {
       $query: '(min-width: #{$breakpoint-min})';
     } @else {
-      $query: '(min-width: #{$breakpoint-min}) and (max-width: #{$breakpoint-max})';
+      $query: '(min-width: #{$breakpoint-min}) and (max-width: #{$breakpoint-max - 1})';
     }
 
     @media #{$query} {
@@ -127,7 +127,7 @@
       position: absolute;
       right: map-get($grid-margin-widths, small);
 
-      @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+      @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col - 1) {
         left: map-get($grid-margin-widths, medium);
         right: map-get($grid-margin-widths, medium);
       }

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -4,7 +4,7 @@
   .p-heading-icon {
     margin-bottom: $spv--x-large;
 
-    @media (min-width: $threshold-6-12-col) {
+    @media (min-width: $breakpoint-heading-threshold) {
       margin-bottom: 0;
     }
   }
@@ -25,7 +25,7 @@
     margin-top: map-get($nudges, nudge--h3-mobile);
     width: map-get($icon-sizes, heading-icon--small);
 
-    @media (min-width: $threshold-6-12-col) {
+    @media (min-width: $breakpoint-heading-threshold) {
       height: map-get($icon-sizes, heading-icon);
       margin-top: map-get($nudges, nudge--h3);
       width: map-get($icon-sizes, heading-icon);
@@ -38,7 +38,7 @@
       margin-top: $sp-x-small;
       width: map-get($icon-sizes, heading-icon--x-small);
 
-      @media (min-width: $threshold-6-12-col) {
+      @media (min-width: $breakpoint-heading-threshold) {
         height: map-get($icon-sizes, heading-icon--small);
         margin-top: 0;
         width: map-get($icon-sizes, heading-icon--small);

--- a/scss/_patterns_matrix.scss
+++ b/scss/_patterns_matrix.scss
@@ -139,7 +139,7 @@
   .p-matrix__desc {
     margin-bottom: $spv-nudge-compensation;
 
-    @media (max-width: $breakpoint-heading-threshold) {
+    @media (max-width: $breakpoint-heading-threshold - 1) {
       margin-top: -#{$sp-unit};
     }
 

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -108,7 +108,7 @@
   .p-pull-quote--large {
     .p-pull-quote__quote {
       &:first-of-type::before {
-        @media (max-width: $breakpoint-heading-threshold) {
+        @media (max-width: $breakpoint-heading-threshold - 1) {
           top: 0.75rem;
         }
       }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -113,7 +113,7 @@
     }
   }
 
-  @media (min-width: $breakpoint-large) {
+  @media (min-width: $threshold-6-12-col) {
     // make whole navigation sticky on large screens
     .p-side-navigation.is-sticky,
     [class*='p-side-navigation--'].is-sticky {

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -10,7 +10,7 @@
       text-align: left;
     }
 
-    @media (max-width: $threshold-6-12-col) {
+    @media (max-width: $threshold-6-12-col - 1) {
       @supports (display: grid) {
         thead {
           display: none;

--- a/templates/docs/examples/layouts/application/JAAS.html
+++ b/templates/docs/examples/layouts/application/JAAS.html
@@ -24,7 +24,7 @@
     use 13rem. This value should be adjusted on the application level based on
     the content that needs to stay visible on the screen.
   */
-  @media (min-width: 772px) {
+  @media (min-width: 620px) {
     .l-aside.is-jaas {
       max-width: calc(100vw - 3rem - 13rem);
     }

--- a/templates/docs/examples/layouts/application/split.html
+++ b/templates/docs/examples/layouts/application/split.html
@@ -5,7 +5,7 @@
 <style>
   {% include "docs/examples/layouts/application/_styles.css" %}
 
-  @media (min-width: 772px) {
+  @media (min-width: 620px) {
     .l-aside.is-split {
       max-width: calc((100vw - 3rem) / 2);
     }


### PR DESCRIPTION
## Done

- Remove or rename any remaining misaligned media query breakpoints in compoenents.
- make sure max-width media queries don't overlap min-width media queries by 1px


Fixes #4082

## QA

- Make sure there are no unexpected changes in Percy
- Make sure responsive components work as expected, especially around 1px of breakpoints (619px, 620px, 1035px, 1036px): https://vanilla-framework-4107.demos.haus/docs/examples/templates/responsive



