### PR TITLE
Inline labels

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -82,7 +82,7 @@
   // stylelint-disable selector-max-type -- base styles can use type selectors
   label {
     cursor: pointer;
-    display: block;
+    display: inline-block;
     margin-bottom: $spv--large - $spv-nudge;
     margin-top: 0;
     max-width: $max-width--default;

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -149,6 +149,7 @@
   // Fix label alignment when text drops to new line
   .p-checkbox,
   .p-radio {
+    display: block;
     padding-left: $sph--large + $form-tick-box-size;
     text-indent: -1 * ($sph--large + $form-tick-box-size);
 

--- a/templates/docs/examples/base/forms/tick-elements.html
+++ b/templates/docs/examples/base/forms/tick-elements.html
@@ -4,6 +4,7 @@
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
+<p>This is not the recommended way to implement checkboxes and radio inputs in Vanilla. Please use the <a href="/docs/examples/patterns/forms/tick-variants">tick element patterns</a> instead.</p>
 <form>
   <div>
     <input type="checkbox" id="checkbox1" name="checkbox1" />

--- a/templates/docs/examples/base/forms/tick-elements.html
+++ b/templates/docs/examples/base/forms/tick-elements.html
@@ -1,0 +1,38 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Tick Elements{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block content %}
+<form>
+  <div>
+    <input type="checkbox" id="checkbox1" name="checkbox1" />
+    <label for="checkbox1">Checkbox 1</label>
+  </div>
+
+  <div>
+    <input type="checkbox" id="checkbox2" name="checkbox2" />
+    <label for="checkbox2">Checkbox 2</label>
+  </div>
+
+  <div>
+    <input type="checkbox" id="checkbox3" name="checkbox3" />
+    <label for="checkbox3">Checkbox 3</label>
+  </div>
+
+  <div>
+    <input type="radio" id="radio1" name="radio" />
+    <label for="radio1">Radio 1</label>
+  </div>
+
+  <div>
+    <input type="radio" id="radio2" name="radio" />
+    <label for="radio2">Radio 2</label>
+  </div>
+
+  <div>
+    <input type="radio" id="radio3" name="radio" />
+    <label for="radio3">Radio 3</label>
+  </div>
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/switch.html
+++ b/templates/docs/examples/patterns/switch.html
@@ -9,16 +9,19 @@
     <input type="checkbox" class="p-switch" id="checkbox1" checked/>
     <span class="p-switch__slider"></span>
 </label>
+<br />
 <label for="checkbox2">
     Off
     <input type="checkbox" class="p-switch"  id="checkbox2"/>
     <span class="p-switch__slider"></span>
 </label>
+<br />
 <label for="checkbox3">
     On disabled
     <input type="checkbox" class="p-switch"  id="checkbox3" checked disabled/>
     <span class="p-switch__slider"></span>
 </label>
+<br />
 <label for="checkbox4">
     Off disabled
     <input type="checkbox" class="p-switch"  id="checkbox4" disabled/>


### PR DESCRIPTION
## Done

- Set display of labels to `inline-block`, rather than `block`.
- Added an example with base tick elements

Fixes #4104 

## QA

- Visit https://vanilla-framework-4110.demos.haus/docs/examples/base/forms/tick-elements
- See that the elements look good
- Check Percy, see that other examples are not affected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.