### PR TITLE
Update default value of navigation breakpoint

### DIFF
--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -2,6 +2,6 @@
 $breakpoint-x-small: 460px !default;
 $breakpoint-small: 620px !default;
 $breakpoint-large: 1036px !default;
-$breakpoint-navigation-threshold: $breakpoint-large !default;
+$breakpoint-navigation-threshold: $breakpoint-small !default;
 $breakpoint-heading-threshold: $breakpoint-large !default;
 $breakpoint-x-large: 1681px !default; // exclude most laptops

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -28,7 +28,7 @@ The navigation pattern is one of the first patterns to implement the new theming
 - Add a state class to the `p-navigation` class: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark
 
 You can change the breakpoint at which the menu changes to a small screen menu
-by adjusting the `$breakpoint-navigation-threshold` in `_settings_breakpoints.scss`.
+by adjusting the `$breakpoint-navigation-threshold` variable from `_settings_breakpoints.scss`.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/navigation/default/" class="js-example">
 View example of the navigation pattern

--- a/templates/docs/settings/breakpoint-settings.md
+++ b/templates/docs/settings/breakpoint-settings.md
@@ -16,7 +16,7 @@ Vanilla uses three main breakpoints for screen sizes, below you can see the sett
 | `$breakpoint-small`                | `620px`             | Mobile or tablet  |
 | `$breakpoint-large`                | `1036px`            | Desktop           |
 | `$breakpoint-x-large`              | `1681px`            | Large desktop     |
-| `$breakpoint-navigation-threshold` | `$breakpoint-large` | Desktop           |
+| `$breakpoint-navigation-threshold` | `$breakpoint-small` | Mobile or tablet  |
 | `$breakpoint-heading-threshold`    | `$breakpoint-large` | Desktop           |
 
 <br>
@@ -59,7 +59,7 @@ The `$breakpoint-navigation-threshold` is the breakpoint in which the navigation
 
 <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/68db306c-global-layout-breakpoint-navigation.png" alt="navigation-breakpoint">
 
-If you have a large number of menu items, you may consider overriding this value to a large breakpoint so the navigation snaps to a burger menu at a larger breakpoint.
+If you have a large number of menu items, you may consider overriding this value to a larger value so the navigation snaps to a burger menu at a larger breakpoint.
 
 ## Modifying the heading breakpoint threshold
 

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -128,7 +128,7 @@ The `.p-article-pagination__link` was removed, as only its variants (`.p-article
 
 The `$breakpoint-medium` variable has been removed from Vanilla. All media queries in components and utilities that used this value have been updated to either `$breakpoint-large` or `$breakpoint-small` (whichever was more relevant). If you use `$breakpoint-medium` in your project it should be replaced with `$breakpoint-large` or `$breakpoint-small`.
 
-The default value of `$breakpoint-navigation-threshold` was previously set to `$breakpoint-medium` and is now `$breakpoint-large`. This value should be overridden in project code to adjust the threshold when navigation switches to dropdown based on the number of navigation items.
+The default value of `$breakpoint-navigation-threshold` was previously set to `$breakpoint-medium` and is now `$breakpoint-small`. This value should be overridden in project code to adjust the threshold when navigation switches to dropdown based on the number of navigation items.
 
 ## Variable refactor
 


### PR DESCRIPTION
## Done

Move default value of navigation threshold breakpoint to small screens, update all related docs.

## QA

- Open [demo](https://vanilla-framework-4111.demos.haus/docs/examples/patterns/navigation/dropdown)
- check if navigation goes to mobile view on small screen (< 620px)
  - https://vanilla-framework-4111.demos.haus/docs/examples/patterns/navigation/dropdown
- Review updated docs:
  - https://vanilla-framework-4111.demos.haus/docs/settings/breakpoint-settings
