### PR TITLE
add forms input a11y docs

### DIFF
--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -219,6 +219,12 @@ When using a password field, use this pattern to allow the user to toggle the pa
 View example of the password toggle
 </a></div>
 
+## Accessibility
+
+Validated form input elements should indicate errors with `aria-invalid` attribute. JavaScript is required to achieve this.
+
+See [WCAG Success Criterion 3.3.1 - Using Aria-Invalid to Indicate An Error Field](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA21) for further information.
+
 ## Import
 
 To import just this base element into your project, copy the snippet below and include it in your main Sass file.

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -221,7 +221,7 @@ View example of the password toggle
 
 ## Accessibility
 
-Validated form input elements should indicate errors with `aria-invalid` attribute. JavaScript is required to achieve this.
+Validated form input elements should indicate errors with `aria-invalid` attribute.
 
 See [WCAG Success Criterion 3.3.1 - Using Aria-Invalid to Indicate An Error Field](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA21) for further information.
 

--- a/templates/docs/examples/patterns/forms/form-validation.html
+++ b/templates/docs/examples/patterns/forms/form-validation.html
@@ -7,7 +7,7 @@
 <form>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError">Email address</label>
-    <input class="p-form-validation__input" type="email" id="exampleTextInputError" placeholder="example@canonical.com" name="exampleTextInputError" autocomplete="email" />
+    <input class="p-form-validation__input" type="email" id="exampleTextInputError" placeholder="example@canonical.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true" />
     <p class="p-form-validation__message" role="alert">This field is required.</p>
   </div>
 
@@ -26,7 +26,7 @@
   <div class="p-form-validation is-error">
     <label for="exampleSelectInputError">Ubuntu releases</label>
     <div class="p-form-validation__select-wrapper">
-      <select class="p-form-validation__input" id="exampleSelectInputError" name="exampleSelectInputError">
+      <select class="p-form-validation__input" id="exampleSelectInputError" name="exampleSelectInputError" aria-invalid="true">
         <option value="">--Select an option--</option>
         <option value="1">Cosmic Cuttlefish</option>
         <option value="2">Bionic Beaver</option>

--- a/templates/docs/examples/patterns/forms/forms-required.html
+++ b/templates/docs/examples/patterns/forms/forms-required.html
@@ -8,7 +8,7 @@
   <label class="is-required">Indicates a required field</label>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError" class="is-required">Email address</label>
-    <input class="p-form-validation__input" required type="email" id="exampleTextInputError" placeholder="e.g joe@bloggs.com" name="exampleTextInputError" autocomplete="email">
+    <input class="p-form-validation__input" required type="email" id="exampleTextInputError" placeholder="e.g joe@bloggs.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true">
     <p class="p-form-validation__message">This field is required.</p>
   </div>
 </form>


### PR DESCRIPTION
## Done

add forms input a11y docs section

Fixes https://github.com/canonical-web-and-design/react-components/issues/639

## QA

- Review updated documentation:
  - https://vanilla-framework-4125.demos.haus/docs/base/forms#validation
  - https://vanilla-framework-4125.demos.haus/docs/base/forms#required
  - https://vanilla-framework-4125.demos.haus/docs/base/forms#accessibility
  - focusing on invalid fields (fields that have an error) in examples will make the screen reader announce that it's invalid (e.g. VoiceOver will announce "invalid data").

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
