### PR TITLE
Add aria-describedby to fields with help or validation messages

### DIFF
--- a/templates/docs/examples/patterns/forms/_form-stacked.html
+++ b/templates/docs/examples/patterns/forms/_form-stacked.html
@@ -7,7 +7,7 @@
 
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="full-name-stacked" name="fullName" autocomplete="name" required>
+        <input type="text" id="full-name-stacked" name="fullName" autocomplete="name">
       </div>
     </div>
   </div>
@@ -19,8 +19,8 @@
 
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="username-stacked" name="username-stacked" autocomplete="username">
-        <p class="p-form-help-text">
+        <input type="text" id="username-stacked" name="username-stacked" autocomplete="username" aria-describedby="exampleHelpTextMessage">
+        <p class="p-form-help-text" id="exampleHelpTextMessage">
           30 characters or fewer.
         </p>
       </div>
@@ -29,14 +29,13 @@
   <div class="p-form__group row p-form-validation is-error">
 
     <div class="col-4">
-      <label for="username-stacked-error" class="p-form__label">Email address</label>
+      <label for="username-stacked-error" class="p-form__label is-required">Email address</label>
     </div>
 
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="username-stacked-error" class="p-form-validation__input" aria-invalid="true" name="username-stackederror" autocomplete="username"
-        aria-describedby="username-error-message-stacked">
-        <p class="p-form-validation__message" id="username-error-message-stacked" role="alert">This field is required.</p>
+        <input type="text" id="username-stacked-error" class="p-form-validation__input" aria-invalid="true" name="username-stackederror" autocomplete="username" aria-describedby="username-error-message-stacked" required>
+        <p class="p-form-validation__message" id="username-error-message-stacked">This field is required.</p>
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/forms/form-help-text.html
+++ b/templates/docs/examples/patterns/forms/form-help-text.html
@@ -6,15 +6,15 @@
 {% block content %}
 <form>
   <label for="exampleTextInputHelp">Email address</label>
-  <input class="p-form-validation__input" type="email" id="exampleTextInputHelp" placeholder="example@canonical.com" name="exampleTextInputHelp" autocomplete="email"/>
-  <p class="p-form-help-text">
+  <input class="p-form-validation__input" type="email" id="exampleTextInputHelp" placeholder="example@canonical.com" name="exampleTextInputHelp" autocomplete="email" aria-describedby="exampleInputHelpMessage"/>
+  <p class="p-form-help-text" id="exampleInputHelpMessage">
     A notification email will be sent to entered email address.
   </p>
 
   <label class="p-checkbox">
-    <input type="checkbox" aria-labelledby="checkboxLabel4" class="p-checkbox__input">
+    <input type="checkbox" aria-labelledby="checkboxLabel4" class="p-checkbox__input" aria-describedby="exampleTickHelpMessage">
     <span class="p-checkbox__label" id="checkboxLabel4">I agree to the Terms and Conditions</span>
   </label>
-  <p class="p-form-help-text is-tick-element">By checking this you confirm that you have read and agree to the Terms and Conditions.</p>
+  <p class="p-form-help-text is-tick-element" id="exampleTickHelpMessage">By checking this you confirm that you have read and agree to the Terms and Conditions.</p>
 </form>
 {% endblock %}

--- a/templates/docs/examples/patterns/forms/form-inline.html
+++ b/templates/docs/examples/patterns/forms/form-inline.html
@@ -8,8 +8,8 @@
   <div class="p-form__group">
     <label for="username-inline" class="p-form__label">Username</label>
     <div class="p-form__control">
-      <input type="text" id="username-inline" class="p-form__control" name="username-inline" autocomplete="username" required>
-      <p class="p-form-help-text">
+      <input type="text" id="username-inline" class="p-form__control" name="username-inline" autocomplete="username" required aria-describedby="exampleHelpTextMessage">
+      <p class="p-form-help-text" id="exampleHelpTextMessage">
         30 characters or fewer.
       </p>
     </div>
@@ -17,8 +17,8 @@
   <div class="p-form__group p-form-validation is-error">
     <label for="address-inline2" class="p-form__label">Email address</label>
     <div class="p-form__control">
-      <input type="email" id="email" class="p-form-validation__input" required aria-invalid="true" aria-describedby="input-error-message-inline" name="address-inline2" autocomplete="email">
-      <p class="p-form-validation__message" id="input-error-message-inline" role="alert">Please enter a valid email address.</p>
+      <input type="email" id="address-inline2" class="p-form-validation__input" required aria-invalid="true" aria-describedby="exampleErrorMessage" name="email" autocomplete="email">
+      <p class="p-form-validation__message" id="exampleErrorMessage">Please enter a valid email address.</p>
     </div>
   </div>
   <button class="p-button--positive">Sign up</button>

--- a/templates/docs/examples/patterns/forms/form-validation.html
+++ b/templates/docs/examples/patterns/forms/form-validation.html
@@ -7,33 +7,33 @@
 <form>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError">Email address</label>
-    <input class="p-form-validation__input" type="email" id="exampleTextInputError" placeholder="example@canonical.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true" />
-    <p class="p-form-validation__message" role="alert">This field is required.</p>
+    <input class="p-form-validation__input" type="email" id="exampleTextInputError" placeholder="example@canonical.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true" aria-describedby="exampleInputErrorMessage" />
+    <p class="p-form-validation__message" id="exampleInputErrorMessage">This field is required.</p>
   </div>
 
   <div class="p-form-validation is-caution">
     <label for="exampleTextInputCaution">Mail configuration ID</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputCaution" placeholder="14" name="exampleTextInputCaution" autocomplete="on"/>
-    <p class="p-form-validation__message" role="alert">No validation is performed in preview mode.</p>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputCaution" placeholder="14" name="exampleTextInputCaution" autocomplete="on" aria-describedby="exampleInputCautionMessage"/>
+    <p class="p-form-validation__message" id="exampleInputCautionMessage">No validation is performed in preview mode.</p>
   </div>
 
   <div class="p-form-validation is-success">
     <label for="exampleTextInputSuccess">Card number</label>
-    <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="**** **** **** ****" name="exampleTextInputSuccess" autocomplete="off"/>
-    <p class="p-form-validation__message" role="alert">Verified.</p>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="**** **** **** ****" name="exampleTextInputSuccess" autocomplete="off" aria-describedby="exampleInputSuccessMessage"/>
+    <p class="p-form-validation__message" id="exampleInputSuccessMessage">Verified.</p>
   </div>
 
   <div class="p-form-validation is-error">
     <label for="exampleSelectInputError">Ubuntu releases</label>
     <div class="p-form-validation__select-wrapper">
-      <select class="p-form-validation__input" id="exampleSelectInputError" name="exampleSelectInputError" aria-invalid="true">
+      <select class="p-form-validation__input" id="exampleSelectInputError" name="exampleSelectInputError" aria-invalid="true" aria-describedby="exampleSelectErrorMessage">
         <option value="">--Select an option--</option>
         <option value="1">Cosmic Cuttlefish</option>
         <option value="2">Bionic Beaver</option>
         <option value="3">Xenial Xerus</option>
       </select>
     </div>
-    <p class="p-form-validation__message" role="alert">You need to select an OS to complete your install.</p>
+    <p class="p-form-validation__message" id="exampleSelectErrorMessage">You need to select an OS to complete your install.</p>
   </div>
 </form>
 {% endblock %}

--- a/templates/docs/examples/patterns/forms/forms-required.html
+++ b/templates/docs/examples/patterns/forms/forms-required.html
@@ -8,8 +8,8 @@
   <label class="is-required">Indicates a required field</label>
   <div class="p-form-validation is-error">
     <label for="exampleTextInputError" class="is-required">Email address</label>
-    <input class="p-form-validation__input" required type="email" id="exampleTextInputError" placeholder="e.g joe@bloggs.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true">
-    <p class="p-form-validation__message">This field is required.</p>
+    <input class="p-form-validation__input" required type="email" id="exampleTextInputError" placeholder="e.g joe@bloggs.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true" aria-describedby="exampleInputErrorMessage">
+    <p class="p-form-validation__message" id="exampleInputErrorMessage">This field is required.</p>
   </div>
 </form>
 {% endblock %}

--- a/templates/docs/examples/patterns/forms/password-toggle.html
+++ b/templates/docs/examples/patterns/forms/password-toggle.html
@@ -17,7 +17,7 @@
 
 <div class="p-form-validation is-error">
   <div class="p-form-password-toggle">
-    <label for="password-error">Password</label>
+    <label for="password-error" class="is-required">Password</label>
     <button class="p-button--base u-no-margin--bottom has-icon" aria-live="polite" aria-controls="password-error">
       <span class="p-form-password-toggle__label">
         Show
@@ -25,8 +25,8 @@
       <i class="p-icon--show"></i>
     </button>
   </div>
-  <input type="password" name="password-error" id="password-error" class="p-form-validation__input" value="letmein">
-  <p class="p-form-validation__message" role="alert">Password is required</p>
+  <input type="password" name="password-error" id="password-error" class="p-form-validation__input" value="letmein" required aria-describedby="passwordRequiredErrorMessage">
+  <p class="p-form-validation__message" id="passwordRequiredErrorMessage">Password is required</p>
 </div>
 
 <script>


### PR DESCRIPTION
## Done

Adds `aria-describedby` to inputs with help text or validation messages.

## QA

- Make sure all validation or help text messages are connected to the inputs via aria-describedby and read by screen reader
- Examples to verify:
  - https://vanilla-framework-4135.demos.haus/docs/examples/patterns/forms/form-validation
  - https://vanilla-framework-4135.demos.haus/docs/examples/patterns/forms/form-help-text