### PR TITLE
Use official image for CircleCi with Python and node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: canonicalwebteam/dev:1.6.8
+    - image: cimg/python:3.8-node
       environment:
         SECRET_KEY: local_development_fake_key
 
@@ -26,11 +26,9 @@ jobs:
           # https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
           name: Install puppeteer dependencies
           command: |
-            mv /etc/apt/sources.list.d/nodesource.list /etc/apt/sources.list.d/nodesource.list.disabled
-            apt-get update
-            apt-get -y upgrade
-            apt-get -yq install gconf-service libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxss1 libxtst6 libappindicator1 libnss3 libasound2 libatk1.0-0 libc6 ca-certificates fonts-liberation lsb-release xdg-utils wget
-            mv /etc/apt/sources.list.d/nodesource.list.disabled /etc/apt/sources.list.d/nodesource.list
+            sudo apt-get update
+            sudo apt-get -y upgrade
+            sudo apt-get -yq install gconf-service libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxss1 libxtst6 libappindicator1 libnss3 libasound2 libatk1.0-0 libc6 ca-certificates fonts-liberation lsb-release xdg-utils wget
       - run:
           name: Install dependencies
           command: yarn && pip3 install -r requirements.txt


### PR DESCRIPTION
## Done

Update CircleCI image from our old dev docker image to official image with Python and node.

## QA

- Make sure all CI passes (especially circleci/percy)


