### PR TITLE
Move unnecessary dependencies to devDependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             git config --global user.name "CircleCI"
             git checkout -b percy
       - build-tools/merge-with-parent:
-          parent: main
+          parent: vanilla-2.0
       - run:
           # https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
           name: Install puppeteer dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM node:16 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json package.json
 ADD yarn.lock yarn.lock
-RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install --production
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 
 
 # Build stage: Build vanilla-framework itself

--- a/package.json
+++ b/package.json
@@ -43,24 +43,22 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "2.37.0",
+  "version": "2.37.1",
   "files": [
     "/scss",
     "!/scss/docs"
   ],
-  "dependencies": {
+  "devDependencies": {
     "@canonical/cookie-policy": "3.3.0",
     "@canonical/latest-news": "1.2.0",
-    "autoprefixer": "10.4.0",
-    "node-sass": "6.0.1",
-    "postcss": "8.3.11",
-    "postcss-cli": "8.3.1"
-  },
-  "devDependencies": {
     "@percy/script": "1.1.0",
+    "autoprefixer": "10.4.0",
     "get-site-urls": "1.1.7",
     "markdown-spellcheck": "1.3.1",
+    "node-sass": "6.0.1",
     "parker": "0.0.10",
+    "postcss": "8.3.11",
+    "postcss-cli": "8.3.1",
     "prettier": "2.4.1",
     "stylelint": "13.13.1",
     "stylelint-config-prettier": "8.0.2",


### PR DESCRIPTION
## Done

Moved `node-sass` and other dependencies to `devDependencies` to avoid installing them in project using Vanilla.

Updated our Dockerfile accordingly.

### IMPORTANT:

This PR is agains `vanilla-2.0` branch, it's meant to be released as hotfix to Vanilla 2.0.

## QA

- Make sure CI passes