### PR TITLE
Add text max width util

### DIFF
--- a/scss/_utilities_text-max-width.scss
+++ b/scss/_utilities_text-max-width.scss
@@ -1,0 +1,5 @@
+@mixin vf-u-text-max-width {
+  .u-text-max-width {
+    max-width: $text-max-width;
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -73,6 +73,7 @@
 @import 'utilities_off-screen';
 @import 'utilities_padding-collapse';
 @import 'utilities_show';
+@import 'utilities_text-max-width';
 @import 'utilities_truncate';
 @import 'utilities_vertical-spacing';
 @import 'utilities_vertically-center';
@@ -152,6 +153,7 @@
   @include vf-u-padding-collapse;
   @include vf-u-truncate;
   @include vf-u-text-muted;
+  @include vf-u-text-max-width;
   @include vf-u-vertical-spacing;
   @include vf-u-vertically-center;
   @include vf-u-hide; // import after vf-u-vertically-center as both set the display property

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -111,6 +111,7 @@
               {{ side_nav_item("/docs/utilities/no-print", "No print") }}
               {{ side_nav_item("/docs/utilities/off-screen", "Off-screen") }}
               {{ side_nav_item("/docs/utilities/padding-collapse", "Padding collapse") }}
+              {{ side_nav_item("/docs/utilities/text-max-width", "Text max width") }}
               {{ side_nav_item("/docs/utilities/table-cell-padding-overlap", "Table cell padding overlap") }}
               {{ side_nav_item("/docs/utilities/truncate", "Truncation") }}
               {{ side_nav_item("/docs/utilities/show", "Show") }}

--- a/templates/docs/examples/utilities/text-max-width.html
+++ b/templates/docs/examples/utilities/text-max-width.html
@@ -3,10 +3,14 @@
 
 {% block content %}
 
+<p>This is an example paragraph to show where paragraphs wrap because of the max-width applied to them.</p>
+
+<ul class="p-list">
+  <li class="p-list__item">Here is an example of an li element without the .u-text-max-width class applied to the ul, where the text doesn't wrap.</li>
+</ul>
+
 <ul class="p-list u-text-max-width">
-  <li class="p-list__item">List item 1</li>
-  <li class="p-list__item">List item 2</li>
-  <li class="p-list__item">This is a sentence long enough to show the <code>u-text-max-width</code> class adding a max width to text within a list element</li>
+  <li class="p-list__item">Here is an example of an li element with the .u-text-max-width class applied to the ul, where the text wraps.</li>
 </ul>
 
 {% endblock content %}

--- a/templates/docs/examples/utilities/text-max-width.html
+++ b/templates/docs/examples/utilities/text-max-width.html
@@ -1,0 +1,12 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Text max width{% endblock %}
+
+{% block content %}
+
+<ul class="p-list u-text-max-width">
+  <li class="p-list__item">List item 1</li>
+  <li class="p-list__item">List item 2</li>
+  <li class="p-list__item">This is a sentence long enough to show the <code>u-text-max-width</code> class adding a max width to text within a list element</li>
+</ul>
+
+{% endblock content %}

--- a/templates/docs/utilities/text-max-width.md
+++ b/templates/docs/utilities/text-max-width.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Text max width | Utilities
+---
+
+# Text max width
+
+<hr>
+
+By default, unordered/ordered lists do not have a max-width, as they may be used for various purposes (e.g. navigation). When they contain text only, we recommend adding the `.u-text-max-width` utility to the `ul/ol` element to ensure the list's width matches that of a paragraph:
+
+<div class="embedded-example"><a href="/docs/examples/utilities/text-max-width/" class="js-example">
+View example of the off-screen utility
+</a></div>
+
+## Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework';
+@include vf-base;
+
+@include vf-u-text-max-width;
+```
+
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
## Done

- Added a new utility `u-text-max-width` which uses the '$text-max-width' value. This can be applied to list elements composed of text. 

Fixes [list issues/bugs if needed]

#4159 

## QA

- Inspect the list in the `Text element max-width` section [here](), Add the new `u-text-max-width` class to the `<ul>` element and check the text max with changes to match the rest of the text. 
- Review updated documentation:
  - Not sure if I need to add this to the docs? I can update the upgrade guide in the other [PR](https://github.com/canonical-web-and-design/vanilla-framework/pull/4119)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
