### PR TITLE
Add theming for chips

### DIFF
--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -147,6 +147,36 @@
   }
 }
 
+@mixin vf-chip-default {
+  .p-chip {
+    @extend %vf-chip;
+  }
+}
+
+@mixin vf-chip-positive {
+  .p-chip--positive {
+    @extend %vf-chip;
+  }
+}
+
+@mixin vf-chip-caution {
+  .p-chip--caution {
+    @extend %vf-chip;
+  }
+}
+
+@mixin vf-chip-negative {
+  .p-chip--negative {
+    @extend %vf-chip;
+  }
+}
+
+@mixin vf-chip-information {
+  .p-chip--information {
+    @extend %vf-chip;
+  }
+}
+
 @mixin vf-chip-theme($chip-type, $colors-chip-tinted-backgrounds, $colors-chip-tinted-borders, $color-chip-value, $color-chip-lead) {
   $color-background: null;
   $color-border: null;
@@ -191,34 +221,4 @@
     $color-chip-value: $colors--dark-theme--text-default,
     $color-chip-lead: $colors--dark-theme--text-muted
   );
-}
-
-@mixin vf-chip-default {
-  .p-chip {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-positive {
-  .p-chip--positive {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-caution {
-  .p-chip--caution {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-negative {
-  .p-chip--negative {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-information {
-  .p-chip--information {
-    @extend %vf-chip;
-  }
 }

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -28,14 +28,12 @@
     }
 
     .p-chip__lead {
-      @extend %muted-text;
       @extend %x-small-text;
 
       text-transform: uppercase;
     }
 
     .p-chip__lead + .p-chip__value::before {
-      @extend %muted-text;
       @extend %x-small-text;
 
       content: ': ';
@@ -82,55 +80,133 @@
   @include vf-chip-caution;
   @include vf-chip-negative;
   @include vf-chip-information;
+
+  // Theming
+  @if ($theme-default-p-chip == 'dark') {
+    .p-chip {
+      @include vf-chip-dark-theme;
+    }
+    .p-chip.is-light {
+      @include vf-chip-light-theme;
+    }
+    .p-chip--positive {
+      @include vf-chip-dark-theme(positive);
+    }
+    .p-chip--positive.is-light {
+      @include vf-chip-light-theme(positive);
+    }
+    .p-chip--caution {
+      @include vf-chip-dark-theme(caution);
+    }
+    .p-chip--caution.is-light {
+      @include vf-chip-light-theme(caution);
+    }
+    .p-chip--negative {
+      @include vf-chip-dark-theme(negative);
+    }
+    .p-chip--negative.is-light {
+      @include vf-chip-light-theme(negative);
+    }
+    .p-chip--information {
+      @include vf-chip-dark-theme(information);
+    }
+    .p-chip--information.is-light {
+      @include vf-chip-light-theme(information);
+    }
+  } @else {
+    .p-chip {
+      @include vf-chip-light-theme;
+    }
+    .p-chip.is-dark {
+      @include vf-chip-dark-theme;
+    }
+    .p-chip--positive {
+      @include vf-chip-light-theme(positive);
+    }
+    .p-chip--positive.is-dark {
+      @include vf-chip-dark-theme(positive);
+    }
+    .p-chip--caution {
+      @include vf-chip-light-theme(caution);
+    }
+    .p-chip--caution.is-dark {
+      @include vf-chip-dark-theme(caution);
+    }
+    .p-chip--negative {
+      @include vf-chip-light-theme(negative);
+    }
+    .p-chip--negative.is-dark {
+      @include vf-chip-dark-theme(negative);
+    }
+    .p-chip--information {
+      @include vf-chip-light-theme(information);
+    }
+    .p-chip--information.is-dark {
+      @include vf-chip-dark-theme(information);
+    }
+  }
+}
+
+@mixin vf-chip-theme($type, $background, $border, $value-color, $lead-color) {
+  $color-background: null;
+  $color-border: null;
+
+  @if (map-has-key($background, $type)) {
+    $color-background: map-get($background, $type);
+    $color-border: map-get($border, $type);
+  } @else {
+    $color-background: map-get($background, neutral);
+    $color-border: map-get($background, neutral);
+  }
+
+  background-color: $color-background;
+  border: 1px solid $color-border;
+
+  .p-chip__value {
+    color: $value-color;
+  }
+  .p-chip__lead {
+    color: $lead-color;
+  }
+  .p-chip__lead + .p-chip__value::before {
+    color: $lead-color;
+  }
+}
+
+@mixin vf-chip-light-theme($type: neutral) {
+  @include vf-chip-theme($type, $colors-light-theme--tinted-backgrounds, $colors-light-theme--tinted-borders, $colors--light-theme--text-default, $colors--light-theme--text-muted);
+}
+
+@mixin vf-chip-dark-theme($type: neutral) {
+  @include vf-chip-theme($type, $colors-dark-theme--tinted-backgrounds, $colors-dark-theme--tinted-borders, $colors--dark-theme--text-default, $colors--dark-theme--text-muted);
 }
 
 @mixin vf-chip-default {
   .p-chip {
     @extend %vf-chip;
-    @include vf-chip-type(default);
   }
 }
 
 @mixin vf-chip-positive {
   .p-chip--positive {
     @extend %vf-chip;
-    @include vf-chip-type(positive);
   }
 }
 
 @mixin vf-chip-caution {
   .p-chip--caution {
     @extend %vf-chip;
-    @include vf-chip-type(caution);
   }
 }
 
 @mixin vf-chip-negative {
   .p-chip--negative {
     @extend %vf-chip;
-    @include vf-chip-type(negative);
   }
 }
 
 @mixin vf-chip-information {
   .p-chip--information {
     @extend %vf-chip;
-    @include vf-chip-type(information);
   }
-}
-
-@mixin vf-chip-type($type: neutral) {
-  $color-background: null;
-  $color-border: null;
-
-  @if (map-has-key($colors-light-theme--tinted-backgrounds, $type)) {
-    $color-background: map-get($colors-light-theme--tinted-backgrounds, $type);
-    $color-border: map-get($colors-light-theme--tinted-borders, $type);
-  } @else {
-    $color-background: map-get($colors-light-theme--tinted-backgrounds, neutral);
-    $color-border: map-get($colors-light-theme--tinted-borders, neutral);
-  }
-
-  background-color: $color-background;
-  border: 1px solid $color-border;
 }

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -147,38 +147,50 @@
   }
 }
 
-@mixin vf-chip-theme($type, $background, $border, $value-color, $lead-color) {
+@mixin vf-chip-theme($chip-type, $colors-chip-tinted-backgrounds, $colors-chip-tinted-borders, $color-chip-value, $color-chip-lead) {
   $color-background: null;
   $color-border: null;
 
-  @if (map-has-key($background, $type)) {
-    $color-background: map-get($background, $type);
-    $color-border: map-get($border, $type);
+  @if (map-has-key($colors-chip-tinted-backgrounds, $chip-type)) {
+    $color-background: map-get($colors-chip-tinted-backgrounds, $chip-type);
+    $color-border: map-get($colors-chip-tinted-borders, $chip-type);
   } @else {
-    $color-background: map-get($background, neutral);
-    $color-border: map-get($background, neutral);
+    $color-background: map-get($colors-chip-tinted-backgrounds, neutral);
+    $color-border: map-get($colors-chip-tinted-borders, neutral);
   }
 
   background-color: $color-background;
   border: 1px solid $color-border;
 
   .p-chip__value {
-    color: $value-color;
+    color: $color-chip-value;
   }
   .p-chip__lead {
-    color: $lead-color;
+    color: $color-chip-lead;
   }
   .p-chip__lead + .p-chip__value::before {
-    color: $lead-color;
+    color: $color-chip-lead;
   }
 }
 
-@mixin vf-chip-light-theme($type: neutral) {
-  @include vf-chip-theme($type, $colors-light-theme--tinted-backgrounds, $colors-light-theme--tinted-borders, $colors--light-theme--text-default, $colors--light-theme--text-muted);
+@mixin vf-chip-light-theme($chip-type: neutral) {
+  @include vf-chip-theme(
+    $chip-type: $chip-type,
+    $colors-chip-tinted-backgrounds: $colors-light-theme--tinted-backgrounds,
+    $colors-chip-tinted-borders: $colors-light-theme--tinted-borders,
+    $color-chip-value: $colors--light-theme--text-default,
+    $color-chip-lead: $colors--light-theme--text-muted
+  );
 }
 
-@mixin vf-chip-dark-theme($type: neutral) {
-  @include vf-chip-theme($type, $colors-dark-theme--tinted-backgrounds, $colors-dark-theme--tinted-borders, $colors--dark-theme--text-default, $colors--dark-theme--text-muted);
+@mixin vf-chip-dark-theme($chip-type: neutral) {
+  @include vf-chip-theme(
+    $chip-type: $chip-type,
+    $colors-chip-tinted-backgrounds: $colors-dark-theme--tinted-backgrounds,
+    $colors-chip-tinted-borders: $colors-dark-theme--tinted-borders,
+    $color-chip-value: $colors--dark-theme--text-default,
+    $color-chip-lead: $colors--dark-theme--text-muted
+  );
 }
 
 @mixin vf-chip-default {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -103,6 +103,14 @@ $colors-light-theme--tinted-backgrounds: (
 );
 
 $colors-light-theme--tinted-borders: (
+  neutral: $colors--light-theme--border-high-contrast,
+  positive: $color-positive,
+  caution: #ec6c04,
+  negative: $color-negative,
+  information: $color-information,
+);
+
+$colors-dark-theme--tinted-borders: (
   neutral: #bababa,
   positive: #33cc4a,
   caution: $color-caution,

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -103,11 +103,11 @@ $colors-light-theme--tinted-backgrounds: (
 );
 
 $colors-light-theme--tinted-borders: (
-  neutral: $colors--light-theme--border-high-contrast,
-  positive: $color-positive,
-  caution: #ec6c04,
-  negative: $color-negative,
-  information: $color-information,
+  neutral: #bababa,
+  positive: #33cc4a,
+  caution: $color-caution,
+  negative: #f87e8d,
+  information: #79b0e7,
 );
 
 // Dark theme

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -110,12 +110,20 @@ $colors-light-theme--tinted-borders: (
   information: $color-information,
 );
 
+$colors-dark-theme--tinted-backgrounds: (
+  neutral: rgba(255, 255, 255, 0.15),
+  positive: rgba(14, 134, 32, 0.5),
+  caution: rgba(199, 89, 0, 0.5),
+  negative: rgba(199, 22, 43, 0.5),
+  information: rgba(9, 89, 170, 0.5),
+);
+
 $colors-dark-theme--tinted-borders: (
-  neutral: #bababa,
+  neutral: #999,
   positive: #33cc4a,
-  caution: $color-caution,
+  caution: #f9a11f,
   negative: #f87e8d,
-  information: #79b0e7,
+  information: #3896f5,
 );
 
 // Dark theme

--- a/scss/_settings_themes.scss
+++ b/scss/_settings_themes.scss
@@ -7,3 +7,4 @@ $theme-default-p-divider: 'light' !default;
 $theme-default-p-contextual-menu: 'light' !default;
 $theme-default-p-inline-list--middot: 'light' !default;
 $theme-default-p-button: 'light' !default;
+$theme-default-p-chip: 'light' !default;

--- a/templates/docs/examples/patterns/chip/dark.html
+++ b/templates/docs/examples/patterns/chip/dark.html
@@ -24,6 +24,9 @@
   <div class="p-chip--information is-dark">
     <span class="p-chip__lead">Type</span>
     <span class="p-chip__value">Information</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
   </div>
 </section>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/dark.html
+++ b/templates/docs/examples/patterns/chip/dark.html
@@ -1,0 +1,29 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Chip / Dark{% endblock %}
+
+{% block standalone_css %}patterns_chip{% endblock %}
+
+{% block content %}
+<section class="p-strip" style="background: #111">
+  <div class="p-chip is-dark">
+    <span class="p-chip__lead">Type</span>
+    <span class="p-chip__value">Default</span>
+  </div>
+  <div class="p-chip--positive is-dark">
+    <span class="p-chip__lead">Type</span>
+    <span class="p-chip__value">Positive</span>
+  </div>
+  <div class="p-chip--caution is-dark">
+    <span class="p-chip__lead">Type</span>
+    <span class="p-chip__value">Caution</span>
+  </div>
+  <div class="p-chip--negative is-dark">
+    <span class="p-chip__lead">Type</span>
+    <span class="p-chip__value">Negative</span>
+  </div>
+  <div class="p-chip--information is-dark">
+    <span class="p-chip__lead">Type</span>
+    <span class="p-chip__value">Information</span>
+  </div>
+</section>
+{% endblock %}

--- a/templates/docs/examples/patterns/chip/variants.html
+++ b/templates/docs/examples/patterns/chip/variants.html
@@ -363,4 +363,366 @@
     </button>
   </span>
 </p>
+
+<div class="p-strip" style="background: #111">
+  <div class="p-chip is-dark">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip is-dark">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip--positive is-dark">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--positive is-dark">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--positive is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--positive is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip--caution is-dark">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--caution is-dark">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--caution is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--caution is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip--negative is-dark">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--negative is-dark">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--negative is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--negative is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip--information is-dark">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--information is-dark">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--information is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--information is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip--positive is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--positive is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--positive is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--positive is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip--caution is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--caution is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--caution is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--caution is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip--negative is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--negative is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--negative is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--negative is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip--information is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--information is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--information is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--information is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <div class="p-chip is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip is-dark">
+    <span class="p-chip__value">21.10</span>
+  </div>
+  
+  <div class="p-chip--positive is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--positive is-dark">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--caution is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--caution is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </div>
+  
+  <div class="p-chip--negative is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <div class="p-chip--negative is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </div>
+  
+  <br>
+  
+  <p style="color: #fff">Inline with some text
+  
+    <span class="p-chip is-dark is-inline"><span class="p-chip__value">21.10</span></span>
+  
+    <span class="p-chip--positive is-dark is-inline">
+      <span class="p-chip__value">21.10</span>
+      <button class="p-chip__dismiss">
+        <i class="p-icon--close is-light">Dismiss</i>
+      </button>
+    </span>
+  
+    <span class="p-chip--caution is-dark is-inline">
+      <span class="p-chip__lead">Owner</span>
+      <span class="p-chip__value">Bob</span>
+    </span>
+  
+    <span class="p-chip--negative is-dark is-inline">
+      <span class="p-chip__lead">Owner</span>
+      <span class="p-chip__value">Bob</span>
+      <button class="p-chip__dismiss">
+        <i class="p-icon--close is-light">Dismiss</i>
+      </button>
+    </span>
+  </p>
+  
+  <p style="color: #fff">Inline with some text
+  
+    <span class="p-chip is-dark is-dense is-inline"><span class="p-chip__value">21.10</span></span>
+  
+    <span class="p-chip--positive is-dark is-dense is-inline">
+      <span class="p-chip__value">21.10</span>
+      <button class="p-chip__dismiss">
+        <i class="p-icon--close is-light">Dismiss</i>
+      </button>
+    </span>
+  
+    <span class="p-chip--caution is-dark is-dense is-inline">
+      <span class="p-chip__lead">Owner</span>
+      <span class="p-chip__value">Bob</span>
+    </span>
+  
+    <span class="p-chip--negative is-dark is-dense is-inline">
+      <span class="p-chip__lead">Owner</span>
+      <span class="p-chip__value">Bob</span>
+      <button class="p-chip__dismiss">
+        <i class="p-icon--close is-light">Dismiss</i>
+      </button>
+    </span>
+  </p>
+</div>
 {% endblock %}

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -16,7 +16,7 @@ View example of the default chip pattern
 
 ### Chip with dismiss
 
-Chips have the option to be dismissed. Include the `p-chip__dismiss` class wrapping a close icon.
+Chips have the option to be dismissed. Include the `p-chip__dismiss` button wrapping a close icon.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/chip/with-dismiss" class="js-example">
 View example of the dismiss chip pattern

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -14,6 +14,14 @@ Use the chip component to display small actionable or informative pieces of info
 View example of the default chip pattern
 </a></div>
 
+### Chip with dismiss
+
+Chips have the option to be dismissed. Include the `p-chip__dismiss` class wrapping a close icon.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/chip/with-dismiss" class="js-example">
+View example of the dismiss chip pattern
+</a></div>
+
 ### Colour coding
 
 Chips come in 5 colours. The default is neutral (grey). Use any of the following flavours to style values that have semantic or otherwise colour-coded meaning:
@@ -42,10 +50,10 @@ View example of the inline chip pattern
 
 ### Dark chips
 
-To use chips on a dark background the `is-dark` class can be applied. To ensure the dark chips are accessible, the background colour used must be at the lightest `#2b2b2b`:
+To use chips on a dark background the `is-dark` class can be applied. If the chip includes the dismiss icon, you'll need to add the `is-light` class to the icon. To ensure the dark chips are accessible, the background colour used must be no lighter than `#2b2b2b`:
 
 <div class="embedded-example"><a href="/docs/examples/patterns/chip/dark" class="js-example">
-View example of the inline chip pattern
+View example of the dark chip pattern
 </a></div>
 
 ## Import

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -40,6 +40,14 @@ The default chip has margins and padding set so it aligns to paragraphs and with
 View example of the inline chip pattern
 </a></div>
 
+### Dark chips
+
+To use chips on a dark background the `is-dark` class can be applied. To ensure the dark chips are accessible, the background colour used must be at the lightest `#2b2b2b`:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/chip/dark" class="js-example">
+View example of the inline chip pattern
+</a></div>
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Added theming for chips with different shades of border/background/text for each chip type
- Added theme default setting for chips
- Added example in the docs
- Added an example for the dismiss chip as this was missing

Fixes #4158 

## QA

- Open [demo](insert-demo-url)
- Check the dark chip example
- Check adding `is-dark` or `is-light` class names work as expected
- Review updated documentation:
  - Chip documentation - new example for the dismiss chip and dark theme

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

