### PR TITLE
Add interactive chips

### DIFF
--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -41,6 +41,7 @@
 
     .p-chip__value {
       @extend %small-text;
+      font-weight: $font-weight-bold;
     }
 
     .p-chip__dismiss {

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -44,24 +44,12 @@
     }
 
     .p-chip__dismiss {
-      @include vf-button-pattern(
-        $button-background-color: transparent,
-        $button-border-color: transparent,
-        $button-hover-background-color: transparent,
-        $button-hover-border-color: transparent
-      );
+      @extend %icon;
+      // also includes button and close icon styles in the theming section
 
       align-self: center;
-      border: none;
       flex: 0 0 auto;
-      height: $default-icon-size;
-      line-height: $default-icon-size;
-      margin-bottom: 0;
       margin-left: $sph--x-small;
-      margin-top: 0; // override top margin that button gets in some contexts (in paragraphs)
-      padding: 0;
-      position: relative;
-      width: $default-icon-size;
     }
 
     &.is-dense {
@@ -236,23 +224,15 @@
   }
 }
 
-@mixin vf-chip-theme($chip-type, $is-interactive, $colors-chip-tinted-backgrounds, $colors-chip-tinted-borders, $color-chip-value, $color-chip-lead) {
-  $color-background: null;
-  $color-background-hover: null;
-  $color-background-active: null;
-  $color-border: null;
-
-  @if (map-has-key($colors-chip-tinted-backgrounds, $chip-type)) {
-    $color-background: map-get($colors-chip-tinted-backgrounds, $chip-type, 'default');
-    $color-background-hover: map-get($colors-chip-tinted-backgrounds, $chip-type, 'hover');
-    $color-background-active: map-get($colors-chip-tinted-backgrounds, $chip-type, 'active');
-    $color-border: map-get($colors-chip-tinted-borders, $chip-type);
-  } @else {
-    $color-background: map-get($colors-chip-tinted-backgrounds, 'neutral', 'default');
-    $color-background-hover: map-get($colors-chip-tinted-backgrounds, 'neutral', 'hover');
-    $color-background-active: map-get($colors-chip-tinted-backgrounds, 'neutral', 'active');
-    $color-border: map-get($colors-chip-tinted-borders, neutral);
+@mixin vf-chip-theme($chip-type: neutral, $is-interactive: false, $colors-chip-tinted-backgrounds, $colors-chip-tinted-borders, $color-chip-value, $color-chip-lead) {
+  @if (not map-has-key($colors-chip-tinted-backgrounds, $chip-type)) {
+    $chip-type: neutral;
   }
+
+  $color-background: map-get($colors-chip-tinted-backgrounds, $chip-type, 'default');
+  $color-background-hover: map-get($colors-chip-tinted-backgrounds, $chip-type, 'hover');
+  $color-background-active: map-get($colors-chip-tinted-backgrounds, $chip-type, 'active');
+  $color-border: map-get($colors-chip-tinted-borders, $chip-type);
 
   background-color: $color-background;
   border: 1px solid $color-border;
@@ -276,6 +256,19 @@
       background-color: $color-background-active;
       border-color: $color-border;
     }
+  }
+
+  .p-chip__dismiss {
+    @include vf-icon-close($color-chip-lead);
+
+    @include vf-button-pattern(
+      $button-background-color: transparent,
+      $button-border-color: transparent,
+      $button-hover-background-color: $color-background-hover,
+      $button-hover-border-color: transparent,
+      $button-active-background-color: $color-background-active,
+      $button-active-border-color: transparent
+    );
   }
 }
 

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -266,6 +266,7 @@
       background-color: adjust-color($color-background, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount);
       border-color: $color-border;
     }
+    &[aria-pressed='true'],
     &.is-selected,
     &:active {
       background-color: adjust-color($color-background, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount);

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -238,13 +238,19 @@
 
 @mixin vf-chip-theme($chip-type, $is-interactive, $colors-chip-tinted-backgrounds, $colors-chip-tinted-borders, $color-chip-value, $color-chip-lead) {
   $color-background: null;
+  $color-background-hover: null;
+  $color-background-active: null;
   $color-border: null;
 
   @if (map-has-key($colors-chip-tinted-backgrounds, $chip-type)) {
-    $color-background: map-get($colors-chip-tinted-backgrounds, $chip-type);
+    $color-background: map-get($colors-chip-tinted-backgrounds, $chip-type, 'default');
+    $color-background-hover: map-get($colors-chip-tinted-backgrounds, $chip-type, 'hover');
+    $color-background-active: map-get($colors-chip-tinted-backgrounds, $chip-type, 'active');
     $color-border: map-get($colors-chip-tinted-borders, $chip-type);
   } @else {
-    $color-background: map-get($colors-chip-tinted-backgrounds, neutral);
+    $color-background: map-get($colors-chip-tinted-backgrounds, 'neutral', 'default');
+    $color-background-hover: map-get($colors-chip-tinted-backgrounds, 'neutral', 'hover');
+    $color-background-active: map-get($colors-chip-tinted-backgrounds, 'neutral', 'active');
     $color-border: map-get($colors-chip-tinted-borders, neutral);
   }
 
@@ -254,22 +260,20 @@
   .p-chip__value {
     color: $color-chip-value;
   }
-  .p-chip__lead {
-    color: $color-chip-lead;
-  }
+  .p-chip__lead,
   .p-chip__lead + .p-chip__value::before {
     color: $color-chip-lead;
   }
 
   @if ($is-interactive) {
     &:hover {
-      background-color: adjust-color($color-background, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount);
+      background-color: $color-background-hover;
       border-color: $color-border;
     }
     &[aria-pressed='true'],
     &.is-selected,
     &:active {
-      background-color: adjust-color($color-background, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount);
+      background-color: $color-background-active;
       border-color: $color-border;
     }
   }

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -256,19 +256,19 @@
       background-color: $color-background-active;
       border-color: $color-border;
     }
-  }
+  } @else {
+    .p-chip__dismiss {
+      @include vf-icon-close($color-chip-lead);
 
-  .p-chip__dismiss {
-    @include vf-icon-close($color-chip-lead);
-
-    @include vf-button-pattern(
-      $button-background-color: transparent,
-      $button-border-color: transparent,
-      $button-hover-background-color: $color-background-hover,
-      $button-hover-border-color: transparent,
-      $button-active-background-color: $color-background-active,
-      $button-active-border-color: transparent
-    );
+      @include vf-button-pattern(
+        $button-background-color: transparent,
+        $button-border-color: transparent,
+        $button-hover-background-color: $color-background-hover,
+        $button-hover-border-color: transparent,
+        $button-active-background-color: $color-background-active,
+        $button-active-border-color: transparent
+      );
+    }
   }
 }
 

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -74,11 +74,13 @@
     }
   }
 
-  @include vf-chip-default;
-  @include vf-chip-positive;
-  @include vf-chip-caution;
-  @include vf-chip-negative;
-  @include vf-chip-information;
+  .p-chip,
+  .p-chip--positive,
+  .p-chip--caution,
+  .p-chip--negative,
+  .p-chip--information {
+    @extend %vf-chip;
+  }
 
   // Theming
   @if ($theme-default-p-chip == 'dark') {
@@ -88,29 +90,73 @@
     .p-chip.is-light {
       @include vf-chip-light-theme;
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip {
+      @include vf-chip-dark-theme($is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip.is-light {
+      @include vf-chip-light-theme($is-interactive: true);
+    }
+
     .p-chip--positive {
       @include vf-chip-dark-theme(positive);
     }
     .p-chip--positive.is-light {
       @include vf-chip-light-theme(positive);
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--positive {
+      @include vf-chip-dark-theme($chip-type: positive, $is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--positive.is-light {
+      @include vf-chip-light-theme($chip-type: positive, $is-interactive: true);
+    }
+
     .p-chip--caution {
       @include vf-chip-dark-theme(caution);
     }
     .p-chip--caution.is-light {
       @include vf-chip-light-theme(caution);
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--caution {
+      @include vf-chip-dark-theme($chip-type: caution, $is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--caution.is-light {
+      @include vf-chip-light-theme($chip-type: caution, $is-interactive: true);
+    }
+
     .p-chip--negative {
       @include vf-chip-dark-theme(negative);
     }
     .p-chip--negative.is-light {
       @include vf-chip-light-theme(negative);
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--negative {
+      @include vf-chip-dark-theme($chip-type: negative, $is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--negative.is-light {
+      @include vf-chip-light-theme($chip-type: negative, $is-interactive: true);
+    }
+
     .p-chip--information {
       @include vf-chip-dark-theme(information);
     }
     .p-chip--information.is-light {
       @include vf-chip-light-theme(information);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--information {
+      @include vf-chip-dark-theme($chip-type: information, $is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--information.is-light {
+      @include vf-chip-light-theme($chip-type: information, $is-interactive: true);
     }
   } @else {
     .p-chip {
@@ -119,64 +165,78 @@
     .p-chip.is-dark {
       @include vf-chip-dark-theme;
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip {
+      @include vf-chip-light-theme($is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip.is-dark {
+      @include vf-chip-dark-theme($is-interactive: true);
+    }
+
     .p-chip--positive {
       @include vf-chip-light-theme(positive);
     }
     .p-chip--positive.is-dark {
       @include vf-chip-dark-theme(positive);
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--positive {
+      @include vf-chip-light-theme($chip-type: positive, $is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--positive.is-dark {
+      @include vf-chip-dark-theme($chip-type: positive, $is-interactive: true);
+    }
+
     .p-chip--caution {
       @include vf-chip-light-theme(caution);
     }
     .p-chip--caution.is-dark {
       @include vf-chip-dark-theme(caution);
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--caution {
+      @include vf-chip-light-theme($chip-type: caution, $is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--caution.is-dark {
+      @include vf-chip-dark-theme($chip-type: caution, $is-interactive: true);
+    }
+
     .p-chip--negative {
       @include vf-chip-light-theme(negative);
     }
     .p-chip--negative.is-dark {
       @include vf-chip-dark-theme(negative);
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--negative {
+      @include vf-chip-light-theme($chip-type: negative, $is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--negative.is-dark {
+      @include vf-chip-dark-theme($chip-type: negative, $is-interactive: true);
+    }
+
     .p-chip--information {
       @include vf-chip-light-theme(information);
     }
     .p-chip--information.is-dark {
       @include vf-chip-dark-theme(information);
     }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--information {
+      @include vf-chip-light-theme($chip-type: information, $is-interactive: true);
+    }
+    // stylelint-disable-next-line selector-max-type
+    button.p-chip--information.is-dark {
+      @include vf-chip-dark-theme($chip-type: information, $is-interactive: true);
+    }
   }
 }
 
-@mixin vf-chip-default {
-  .p-chip {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-positive {
-  .p-chip--positive {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-caution {
-  .p-chip--caution {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-negative {
-  .p-chip--negative {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-information {
-  .p-chip--information {
-    @extend %vf-chip;
-  }
-}
-
-@mixin vf-chip-theme($chip-type, $colors-chip-tinted-backgrounds, $colors-chip-tinted-borders, $color-chip-value, $color-chip-lead) {
+@mixin vf-chip-theme($chip-type, $is-interactive, $colors-chip-tinted-backgrounds, $colors-chip-tinted-borders, $color-chip-value, $color-chip-lead) {
   $color-background: null;
   $color-border: null;
 
@@ -200,11 +260,24 @@
   .p-chip__lead + .p-chip__value::before {
     color: $color-chip-lead;
   }
+
+  @if ($is-interactive) {
+    &:hover {
+      background-color: adjust-color($color-background, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount);
+      border-color: $color-border;
+    }
+    &.is-selected,
+    &:active {
+      background-color: adjust-color($color-background, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount);
+      border-color: $color-border;
+    }
+  }
 }
 
-@mixin vf-chip-light-theme($chip-type: neutral) {
+@mixin vf-chip-light-theme($chip-type: neutral, $is-interactive: false) {
   @include vf-chip-theme(
     $chip-type: $chip-type,
+    $is-interactive: $is-interactive,
     $colors-chip-tinted-backgrounds: $colors-light-theme--tinted-backgrounds,
     $colors-chip-tinted-borders: $colors-light-theme--tinted-borders,
     $color-chip-value: $colors--light-theme--text-default,
@@ -212,9 +285,10 @@
   );
 }
 
-@mixin vf-chip-dark-theme($chip-type: neutral) {
+@mixin vf-chip-dark-theme($chip-type: neutral, $is-interactive: false) {
   @include vf-chip-theme(
     $chip-type: $chip-type,
+    $is-interactive: $is-interactive,
     $colors-chip-tinted-backgrounds: $colors-dark-theme--tinted-backgrounds,
     $colors-chip-tinted-borders: $colors-dark-theme--tinted-borders,
     $color-chip-value: $colors--dark-theme--text-default,

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -279,7 +279,7 @@
     $colors-chip-tinted-backgrounds: $colors-light-theme--tinted-backgrounds,
     $colors-chip-tinted-borders: $colors-light-theme--tinted-borders,
     $color-chip-value: $colors--light-theme--text-default,
-    $color-chip-lead: $colors--light-theme--text-muted
+    $color-chip-lead: $colors--light-theme--text-default
   );
 }
 
@@ -290,6 +290,6 @@
     $colors-chip-tinted-backgrounds: $colors-dark-theme--tinted-backgrounds,
     $colors-chip-tinted-borders: $colors-dark-theme--tinted-borders,
     $color-chip-value: $colors--dark-theme--text-default,
-    $color-chip-lead: $colors--dark-theme--text-muted
+    $color-chip-lead: $colors--dark-theme--text-default
   );
 }

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -153,12 +153,14 @@
       border: 0;
     }
 
+    // hide chips lead when there are in panel
+    // FIXME: this should be handled in HTML/React, not CSS
     .p-chip {
-      @include vf-focus;
+      .p-chip__lead {
+        display: none;
+      }
 
-      cursor: pointer;
-
-      &__lead {
+      .p-chip__lead + .p-chip__value::before {
         display: none;
       }
     }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -105,9 +105,9 @@ $colors-light-theme--tinted-backgrounds: (
     active: hsl(129deg 100% 39% / #{10% + $active-background-opacity-amount * 100%}),
   ),
   caution: (
-    default: hsl(37deg 100% 39% / 10%),
-    hover: hsl(37deg 100% 39% / #{10% + $hover-background-opacity-amount * 100%}),
-    active: hsl(37deg 100% 39% / #{10% + $active-background-opacity-amount * 100%}),
+    default: hsl(27deg 100% 39% / 10%),
+    hover: hsl(27deg 100% 39% / #{10% + $hover-background-opacity-amount * 100%}),
+    active: hsl(27deg 100% 39% / #{10% + $active-background-opacity-amount * 100%}),
   ),
   negative: (
     default: hsl(354deg 100% 39% / 10%),
@@ -124,7 +124,7 @@ $colors-light-theme--tinted-backgrounds: (
 $colors-light-theme--tinted-borders: (
   neutral: $colors--light-theme--border-high-contrast,
   positive: $color-positive,
-  caution: #ec6c04,
+  caution: hsl(27deg 100% 39%),
   negative: $color-negative,
   information: $color-information,
 );
@@ -142,7 +142,7 @@ $colors--dark-theme--background-hover: rgba($colors--dark-theme--text-default, $
 $colors--dark-theme--background-overlay: transparentize($color-dark, 0.15) !default;
 
 $colors--dark-theme--border-default: rgba($colors--dark-theme--text-default, 0.2) !default;
-$colors--dark-theme--border-high-contrast: rgba($colors--dark-theme--text-default, 0.4) !default;
+$colors--dark-theme--border-high-contrast: hsl(0deg 0% 60%) !default;
 $colors--dark-theme--border-low-contrast: rgba($colors--dark-theme--text-default, 0.1) !default;
 
 $colors-dark-theme--tinted-backgrounds: (
@@ -152,33 +152,33 @@ $colors-dark-theme--tinted-backgrounds: (
     active: rgba(255, 255, 255, 0.25),
   ),
   positive: (
-    default: rgba(14, 134, 32, 0.5),
-    hover: adjust-color(rgba(14, 134, 32, 0.5), $lightness: 100% * $hover-background-opacity-amount, $saturation: 100% * 2 * $hover-background-opacity-amount),
-    active: adjust-color(rgba(14, 134, 32, 0.5), $lightness: 100% * $active-background-opacity-amount, $saturation: 100% * 2 * $active-background-opacity-amount),
+    default: hsl(129deg 90% 39% / 20%),
+    hover: hsl(129deg 100% 39% / #{20% + 2 * $hover-background-opacity-amount * 100%}),
+    active: hsl(129deg 100% 39% / #{20% + 2 * $active-background-opacity-amount * 100%}),
   ),
   caution: (
-    default: rgba(199, 89, 0, 0.5),
-    hover: adjust-color(rgba(199, 89, 0, 0.5), $lightness: 100% * $hover-background-opacity-amount, $saturation: 100% * 2 * $hover-background-opacity-amount),
-    active: adjust-color(rgba(199, 89, 0, 0.5), $lightness: 100% * $active-background-opacity-amount, $saturation: 100% * 2 * $active-background-opacity-amount),
+    default: hsl(27deg 100% 50% / 20%),
+    hover: hsl(27deg 100% 60% / #{20% + 2 * $hover-background-opacity-amount * 100%}),
+    active: hsl(27deg 100% 50% / #{20% + 2 * $active-background-opacity-amount * 100%}),
   ),
   negative: (
-    default: rgba(199, 22, 43, 0.5),
-    hover: adjust-color(rgba(199, 22, 43, 0.5), $lightness: 100% * $hover-background-opacity-amount, $saturation: 100% * 2 * $hover-background-opacity-amount),
-    active: adjust-color(rgba(199, 22, 43, 0.5), $lightness: 100% * $active-background-opacity-amount, $saturation: 100% * 2 * $active-background-opacity-amount),
+    default: hsl(353deg 100% 70% / 20%),
+    hover: hsl(353deg 100% 70% / #{20% + 2 * $hover-background-opacity-amount * 100%}),
+    active: hsl(353deg 100% 70% / #{20% + 2 * $active-background-opacity-amount * 100%}),
   ),
   information: (
-    default: rgba(9, 89, 170, 0.5),
-    hover: adjust-color(rgba(9, 89, 170, 0.5), $lightness: 100% * $hover-background-opacity-amount, $saturation: 100% * 2 * $hover-background-opacity-amount),
-    active: adjust-color(rgba(9, 89, 170, 0.5), $lightness: 100% * $active-background-opacity-amount, $saturation: 100% * 2 * $active-background-opacity-amount),
+    default: hsl(210deg 100% 50% / 20%),
+    hover: hsl(210deg 100% 50% / #{20% + 2 * $hover-background-opacity-amount * 100%}),
+    active: hsl(210deg 100% 50% / #{20% + 2 * $active-background-opacity-amount * 100%}),
   ),
 );
 
 $colors-dark-theme--tinted-borders: (
-  neutral: #999,
-  positive: #33cc4a,
-  caution: #f9a11f,
-  negative: #f87e8d,
-  information: #3896f5,
+  neutral: hsl(0deg 0% 65%),
+  positive: hsl(129deg 60% 65%),
+  caution: hsl(27deg 80% 65%),
+  negative: hsl(353deg 80% 70%),
+  information: hsl(210deg 80% 65%),
 );
 
 // Branding colors

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -39,7 +39,7 @@ $color-focus-negative: #3b0006 !default;
 
 // Button background color changes
 $hover-background-opacity-amount: 0.05;
-$active-background-opacity-amount: 0.08;
+$active-background-opacity-amount: 0.1;
 
 $muted-text-opacity-amount: 0.6;
 $inactive-text-opacity-amount: 0.75;
@@ -100,24 +100,24 @@ $colors-light-theme--tinted-backgrounds: (
     active: adjust-color(#f2f2f2, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
   ),
   positive: (
-    default: #e8fdec,
-    hover: adjust-color(#e8fdec, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
-    active: adjust-color(#e8fdec, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+    default: hsl(129deg 90% 39% / 10%),
+    hover: hsl(129deg 100% 39% / #{10% + $hover-background-opacity-amount * 100%}),
+    active: hsl(129deg 100% 39% / #{10% + $active-background-opacity-amount * 100%}),
   ),
   caution: (
-    default: #fef1dc,
-    hover: adjust-color(#fef1dc, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
-    active: adjust-color(#fef1dc, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+    default: hsl(37deg 100% 39% / 10%),
+    hover: hsl(37deg 100% 39% / #{10% + $hover-background-opacity-amount * 100%}),
+    active: hsl(37deg 100% 39% / #{10% + $active-background-opacity-amount * 100%}),
   ),
   negative: (
-    default: #fce8ea,
-    hover: adjust-color(#fce8ea, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
-    active: adjust-color(#fce8ea, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+    default: hsl(354deg 100% 39% / 10%),
+    hover: hsl(354deg 100% 39% / #{10% + $hover-background-opacity-amount * 100%}),
+    active: hsl(354deg 100% 39% / #{10% + $active-background-opacity-amount * 100%}),
   ),
   information: (
-    default: #e5f2ff,
-    hover: adjust-color(#e5f2ff, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
-    active: adjust-color(#e5f2ff, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+    default: hsl(210deg 100% 39% / 10%),
+    hover: hsl(210deg 100% 39% / #{10% + $hover-background-opacity-amount * 100%}),
+    active: hsl(210deg 100% 39% / #{10% + $active-background-opacity-amount * 100%}),
   ),
 );
 

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -93,13 +93,32 @@ $colors--light-theme--border-default: rgba($color-x-dark, 0.15) !default;
 $colors--light-theme--border-high-contrast: rgba($color-x-dark, 0.56) !default;
 $colors--light-theme--border-low-contrast: rgba($color-x-dark, 0.1) !default;
 
-//XXX: add dark theme versions of tinted background and border colours for use with dark theme chips, notificaitons, etc.
 $colors-light-theme--tinted-backgrounds: (
-  neutral: #f2f2f2,
-  positive: #e8fdec,
-  caution: #fef1dc,
-  negative: #fce8ea,
-  information: #e5f2ff,
+  neutral: (
+    default: #f2f2f2,
+    hover: adjust-color(#f2f2f2, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(#f2f2f2, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+  ),
+  positive: (
+    default: #e8fdec,
+    hover: adjust-color(#e8fdec, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(#e8fdec, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+  ),
+  caution: (
+    default: #fef1dc,
+    hover: adjust-color(#fef1dc, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(#fef1dc, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+  ),
+  negative: (
+    default: #fce8ea,
+    hover: adjust-color(#fce8ea, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(#fce8ea, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+  ),
+  information: (
+    default: #e5f2ff,
+    hover: adjust-color(#e5f2ff, $lightness: -100% * $hover-background-opacity-amount, $saturation: -100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(#e5f2ff, $lightness: -100% * $active-background-opacity-amount, $saturation: -100% * 2 * $active-background-opacity-amount),
+  ),
 );
 
 $colors-light-theme--tinted-borders: (
@@ -108,22 +127,6 @@ $colors-light-theme--tinted-borders: (
   caution: #ec6c04,
   negative: $color-negative,
   information: $color-information,
-);
-
-$colors-dark-theme--tinted-backgrounds: (
-  neutral: rgba(255, 255, 255, 0.15),
-  positive: rgba(14, 134, 32, 0.5),
-  caution: rgba(199, 89, 0, 0.5),
-  negative: rgba(199, 22, 43, 0.5),
-  information: rgba(9, 89, 170, 0.5),
-);
-
-$colors-dark-theme--tinted-borders: (
-  neutral: #999,
-  positive: #33cc4a,
-  caution: #f9a11f,
-  negative: #f87e8d,
-  information: #3896f5,
 );
 
 // Dark theme
@@ -141,6 +144,42 @@ $colors--dark-theme--background-overlay: transparentize($color-dark, 0.15) !defa
 $colors--dark-theme--border-default: rgba($colors--dark-theme--text-default, 0.2) !default;
 $colors--dark-theme--border-high-contrast: rgba($colors--dark-theme--text-default, 0.4) !default;
 $colors--dark-theme--border-low-contrast: rgba($colors--dark-theme--text-default, 0.1) !default;
+
+$colors-dark-theme--tinted-backgrounds: (
+  neutral: (
+    default: rgba(255, 255, 255, 0.15),
+    hover: rgba(255, 255, 255, 0.2),
+    active: rgba(255, 255, 255, 0.25),
+  ),
+  positive: (
+    default: rgba(14, 134, 32, 0.5),
+    hover: adjust-color(rgba(14, 134, 32, 0.5), $lightness: 100% * $hover-background-opacity-amount, $saturation: 100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(rgba(14, 134, 32, 0.5), $lightness: 100% * $active-background-opacity-amount, $saturation: 100% * 2 * $active-background-opacity-amount),
+  ),
+  caution: (
+    default: rgba(199, 89, 0, 0.5),
+    hover: adjust-color(rgba(199, 89, 0, 0.5), $lightness: 100% * $hover-background-opacity-amount, $saturation: 100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(rgba(199, 89, 0, 0.5), $lightness: 100% * $active-background-opacity-amount, $saturation: 100% * 2 * $active-background-opacity-amount),
+  ),
+  negative: (
+    default: rgba(199, 22, 43, 0.5),
+    hover: adjust-color(rgba(199, 22, 43, 0.5), $lightness: 100% * $hover-background-opacity-amount, $saturation: 100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(rgba(199, 22, 43, 0.5), $lightness: 100% * $active-background-opacity-amount, $saturation: 100% * 2 * $active-background-opacity-amount),
+  ),
+  information: (
+    default: rgba(9, 89, 170, 0.5),
+    hover: adjust-color(rgba(9, 89, 170, 0.5), $lightness: 100% * $hover-background-opacity-amount, $saturation: 100% * 2 * $hover-background-opacity-amount),
+    active: adjust-color(rgba(9, 89, 170, 0.5), $lightness: 100% * $active-background-opacity-amount, $saturation: 100% * 2 * $active-background-opacity-amount),
+  ),
+);
+
+$colors-dark-theme--tinted-borders: (
+  neutral: #999,
+  positive: #33cc4a,
+  caution: #f9a11f,
+  negative: #f87e8d,
+  information: #3896f5,
+);
 
 // Branding colors
 $color-brand: #333 !default;

--- a/templates/docs/examples/patterns/chip/colors.html
+++ b/templates/docs/examples/patterns/chip/colors.html
@@ -4,24 +4,24 @@
 {% block standalone_css %}patterns_chip{% endblock %}
 
 {% block content %}
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__lead">Type</span>
   <span class="p-chip__value">Default</span>
-</div>
-<div class="p-chip--positive">
+</span>
+<span class="p-chip--positive">
   <span class="p-chip__lead">Type</span>
   <span class="p-chip__value">Positive</span>
-</div>
-<div class="p-chip--caution">
+</span>
+<span class="p-chip--caution">
   <span class="p-chip__lead">Type</span>
   <span class="p-chip__value">Caution</span>
-</div>
-<div class="p-chip--negative">
+</span>
+<span class="p-chip--negative">
   <span class="p-chip__lead">Type</span>
   <span class="p-chip__value">Negative</span>
-</div>
-<div class="p-chip--information">
+</span>
+<span class="p-chip--information">
   <span class="p-chip__lead">Type</span>
   <span class="p-chip__value">Information</span>
-</div>
+</span>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/dark.html
+++ b/templates/docs/examples/patterns/chip/dark.html
@@ -24,9 +24,7 @@
   <span class="p-chip--information is-dark">
     <span class="p-chip__lead">Type</span>
     <span class="p-chip__value">Information</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
+    <button class="p-chip__dismiss">Dismiss</button>
   </span>
 </section>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/dark.html
+++ b/templates/docs/examples/patterns/chip/dark.html
@@ -5,28 +5,28 @@
 
 {% block content %}
 <section class="p-strip" style="background: #111">
-  <div class="p-chip is-dark">
+  <span class="p-chip is-dark">
     <span class="p-chip__lead">Type</span>
     <span class="p-chip__value">Default</span>
-  </div>
-  <div class="p-chip--positive is-dark">
+  </span>
+  <span class="p-chip--positive is-dark">
     <span class="p-chip__lead">Type</span>
     <span class="p-chip__value">Positive</span>
-  </div>
-  <div class="p-chip--caution is-dark">
+  </span>
+  <span class="p-chip--caution is-dark">
     <span class="p-chip__lead">Type</span>
     <span class="p-chip__value">Caution</span>
-  </div>
-  <div class="p-chip--negative is-dark">
+  </span>
+  <span class="p-chip--negative is-dark">
     <span class="p-chip__lead">Type</span>
     <span class="p-chip__value">Negative</span>
-  </div>
-  <div class="p-chip--information is-dark">
+  </span>
+  <span class="p-chip--information is-dark">
     <span class="p-chip__lead">Type</span>
     <span class="p-chip__value">Information</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 </section>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/default.html
+++ b/templates/docs/examples/patterns/chip/default.html
@@ -4,16 +4,16 @@
 {% block standalone_css %}patterns_chip{% endblock %}
 
 {% block content %}
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">
     Bob
   </span>
-</div>
+</span>
 
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__value">
     21.10
   </span>
-</div>
+</span>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/default.html
+++ b/templates/docs/examples/patterns/chip/default.html
@@ -6,14 +6,10 @@
 {% block content %}
 <span class="p-chip">
   <span class="p-chip__lead">Owner</span>
-  <span class="p-chip__value">
-    Bob
-  </span>
+  <span class="p-chip__value">Bob</span>
 </span>
 
 <span class="p-chip">
-  <span class="p-chip__value">
-    21.10
-  </span>
+  <span class="p-chip__value">21.10</span>
 </span>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/dense.html
+++ b/templates/docs/examples/patterns/chip/dense.html
@@ -4,10 +4,10 @@
 {% block standalone_css %}patterns_chip{% endblock %}
 
 {% block content %}
-<div class="p-chip is-dense">
+<span class="p-chip is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">
     Bob
   </span>
-</div>
+</span>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/dense.html
+++ b/templates/docs/examples/patterns/chip/dense.html
@@ -6,8 +6,6 @@
 {% block content %}
 <span class="p-chip is-dense">
   <span class="p-chip__lead">Owner</span>
-  <span class="p-chip__value">
-    Bob
-  </span>
+  <span class="p-chip__value">Bob</span>
 </span>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/inline.html
+++ b/templates/docs/examples/patterns/chip/inline.html
@@ -6,8 +6,6 @@
 {% block content %}
 <span class="p-chip is-inline">
   <span class="p-chip__lead">Owner</span>
-  <span class="p-chip__value">
-    Bob
-  </span>
+  <span class="p-chip__value">Bob</span>
 </span>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/inline.html
+++ b/templates/docs/examples/patterns/chip/inline.html
@@ -4,10 +4,10 @@
 {% block standalone_css %}patterns_chip{% endblock %}
 
 {% block content %}
-<div class="p-chip is-inline">
+<span class="p-chip is-inline">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">
     Bob
   </span>
-</div>
+</span>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/interactive.html
+++ b/templates/docs/examples/patterns/chip/interactive.html
@@ -6,21 +6,15 @@
 {% block content %}
 <button class="p-chip">
   <span class="p-chip__lead">Owner</span>
-  <span class="p-chip__value">
-    Bob
-  </span>
+  <span class="p-chip__value">Bob</span>
 </button>
 
 <button class="p-chip">
-  <span class="p-chip__value">
-    21.10
-  </span>
+  <span class="p-chip__value">21.10</span>
 </button>
 
 <button class="p-chip" aria-pressed="true">
-  <span class="p-chip__value">
-    Selected
-  </span>
+  <span class="p-chip__value">Selected</span>
 </button>
 
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/interactive.html
+++ b/templates/docs/examples/patterns/chip/interactive.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Chip / Interactive{% endblock %}
+
+{% block standalone_css %}patterns_chip{% endblock %}
+
+{% block content %}
+<button class="p-chip">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">
+    Bob
+  </span>
+</button>
+
+<button class="p-chip">
+  <span class="p-chip__value">
+    21.10
+  </span>
+</button>
+
+<button class="p-chip" aria-pressed="true">
+  <span class="p-chip__value">
+    Selected
+  </span>
+</button>
+
+{% endblock %}

--- a/templates/docs/examples/patterns/chip/long-values.html
+++ b/templates/docs/examples/patterns/chip/long-values.html
@@ -8,7 +8,7 @@
   <span class="p-chip__lead">Short lead</span>
   <span class="p-chip__value">Short value</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 <span class="p-chip">
@@ -21,7 +21,7 @@
     Short value + dismiss button
   </span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 <span class="p-chip">
@@ -37,7 +37,7 @@
     Short value
   </span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 <span class="p-chip">
@@ -48,7 +48,7 @@
     An even longer value An even longer value An even longer value An even longer value An even longer value An even longer value An even longer value An even longer value
   </span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 

--- a/templates/docs/examples/patterns/chip/long-values.html
+++ b/templates/docs/examples/patterns/chip/long-values.html
@@ -4,32 +4,32 @@
 {% block standalone_css %}patterns_chip{% endblock %}
 
 {% block content %}
-<div class="p-chip is-selected">
+<span class="p-chip is-selected">
   <span class="p-chip__lead">Short lead</span>
   <span class="p-chip__value">Short value</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
-<div class="p-chip">
+</span>
+<span class="p-chip">
   <span class="p-chip__value">
     Short value only
   </span>
-</div>
-<div class="p-chip">
+</span>
+<span class="p-chip">
   <span class="p-chip__value">
     Short value + dismiss button
   </span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
-<div class="p-chip">
+</span>
+<span class="p-chip">
   <span class="p-chip__value">
     A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead A very long value, no lead
   </span>
-</div>
-<div class="p-chip">
+</span>
+<span class="p-chip">
   <span class="p-chip__lead">
     Very long lead, short value Very long lead, short value Very long lead, short value Very long lead, short value Very long lead, short value Very long lead, short valueVery long lead, short value Very long lead, short value Very long lead, short value Very long lead, short value Very long lead, short value Very long lead, short value
   </span>
@@ -39,8 +39,8 @@
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
-<div class="p-chip">
+</span>
+<span class="p-chip">
   <span class="p-chip__lead">
     A very long lead A very long lead A very long lead A very long lead A very long lead
   </span>
@@ -50,6 +50,6 @@
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/variants.html
+++ b/templates/docs/examples/patterns/chip/variants.html
@@ -479,7 +479,7 @@
 
 </p>
 
-<div class="p-strip--dark" style="background: #111">
+<div class="p-strip--dark" style="background: #2B2B2B">
 
   <span class="p-chip is-dark">
     <span class="p-chip__value">21.10</span>

--- a/templates/docs/examples/patterns/chip/variants.html
+++ b/templates/docs/examples/patterns/chip/variants.html
@@ -28,6 +28,15 @@
   </button>
 </div>
 
+<button class="p-chip">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
+
 <br>
 
 <div class="p-chip--positive">
@@ -53,6 +62,15 @@
     <i class="p-icon--close">Dismiss</i>
   </button>
 </div>
+
+<button class="p-chip--positive">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--positive">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
 
 <br>
 
@@ -80,6 +98,15 @@
   </button>
 </div>
 
+<button class="p-chip--caution">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--caution">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
+
 <br>
 
 <div class="p-chip--negative">
@@ -105,6 +132,15 @@
     <i class="p-icon--close">Dismiss</i>
   </button>
 </div>
+
+<button class="p-chip--negative">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--negative">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
 
 <br>
 
@@ -132,6 +168,15 @@
   </button>
 </div>
 
+<button class="p-chip--information">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--information">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
+
 <br>
 
 <div class="p-chip is-dense">
@@ -157,6 +202,15 @@
     <i class="p-icon--close">Dismiss</i>
   </button>
 </div>
+
+<button class="p-chip is-dense">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip is-dense">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
 
 <br>
 
@@ -184,6 +238,15 @@
   </button>
 </div>
 
+<button class="p-chip--positive is-dense">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--positive is-dense">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
+
 <br>
 
 <div class="p-chip--caution is-dense">
@@ -210,6 +273,15 @@
   </button>
 </div>
 
+<button class="p-chip--caution is-dense">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--caution is-dense">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
+
 <br>
 
 <div class="p-chip--negative is-dense">
@@ -236,6 +308,15 @@
   </button>
 </div>
 
+<button class="p-chip--negative is-dense">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--negative is-dense">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
+
 <br>
 
 <div class="p-chip--information is-dense">
@@ -261,6 +342,15 @@
     <i class="p-icon--close">Dismiss</i>
   </button>
 </div>
+
+<button class="p-chip--information is-dense">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--information is-dense">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
 
 <br>
 
@@ -312,9 +402,18 @@
   </button>
 </div>
 
+<button class="p-chip--information is-dense">
+  <span class="p-chip__value">21.10</span>
+</button>
+
+<button class="p-chip--information">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</button>
+
 <br>
 
-<p>Inline with some text
+<p>Inline
 
   <span class="p-chip is-inline"><span class="p-chip__value">21.10</span></span>
 
@@ -337,9 +436,17 @@
       <i class="p-icon--close">Dismiss</i>
     </button>
   </span>
+
+  <button class="p-chip--information is-inline"><span class="p-chip__value">21.10</span></button>
+
+  <button class="p-chip is-inline">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
 </p>
 
-<p>Inline with some text
+<p>Inline
 
   <span class="p-chip is-dense is-inline"><span class="p-chip__value">21.10</span></span>
 
@@ -362,25 +469,34 @@
       <i class="p-icon--close">Dismiss</i>
     </button>
   </span>
+
+  <button class="p-chip--information is-dense is-inline"><span class="p-chip__value">21.10</span></button>
+
+  <button class="p-chip is-dense is-inline">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
 </p>
 
-<div class="p-strip" style="background: #111">
+<div class="p-strip--dark" style="background: #111">
+
   <div class="p-chip is-dark">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -388,25 +504,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip is-dark">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip--positive is-dark">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--positive is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--positive is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--positive is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -414,25 +539,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--positive is-dark">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--positive is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip--caution is-dark">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--caution is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--caution is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--caution is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -440,25 +574,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--caution is-dark">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--caution is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip--negative is-dark">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--negative is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--negative is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--negative is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -466,25 +609,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--negative is-dark">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--negative is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip--information is-dark">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--information is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--information is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--information is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -492,25 +644,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--information is-dark">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--information is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip is-dark is-dense">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -518,25 +679,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip--positive is-dark is-dense">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--positive is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--positive is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--positive is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -544,25 +714,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--positive is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--positive is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip--caution is-dark is-dense">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--caution is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--caution is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--caution is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -570,25 +749,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--caution is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--caution is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip--negative is-dark is-dense">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--negative is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--negative is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--negative is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -596,25 +784,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--negative is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--negative is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip--information is-dark is-dense">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--information is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--information is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--information is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -622,41 +819,50 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--information is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--information is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
+
   <div class="p-chip is-dark is-dense">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip is-dark">
     <span class="p-chip__value">21.10</span>
   </div>
-  
+
   <div class="p-chip--positive is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--positive is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--caution is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--caution is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </div>
-  
+
   <div class="p-chip--negative is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -664,7 +870,7 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
   <div class="p-chip--negative is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
@@ -672,25 +878,34 @@
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
   </div>
-  
+
+  <button class="p-chip--information is-dark is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip--information is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
   <br>
-  
-  <p style="color: #fff">Inline with some text
-  
+
+  <p style="color: #fff">Inline
+
     <span class="p-chip is-dark is-inline"><span class="p-chip__value">21.10</span></span>
-  
+
     <span class="p-chip--positive is-dark is-inline">
       <span class="p-chip__value">21.10</span>
       <button class="p-chip__dismiss">
         <i class="p-icon--close is-light">Dismiss</i>
       </button>
     </span>
-  
+
     <span class="p-chip--caution is-dark is-inline">
       <span class="p-chip__lead">Owner</span>
       <span class="p-chip__value">Bob</span>
     </span>
-  
+
     <span class="p-chip--negative is-dark is-inline">
       <span class="p-chip__lead">Owner</span>
       <span class="p-chip__value">Bob</span>
@@ -698,24 +913,33 @@
         <i class="p-icon--close is-light">Dismiss</i>
       </button>
     </span>
+
+    <button class="p-chip--information is-dark is-inline">
+      <span class="p-chip__value">21.10</span>
+    </button>
+
+    <button class="p-chip is-dark is-inline">
+      <span class="p-chip__lead">Owner</span>
+      <span class="p-chip__value">Bob</span>
+    </button>
   </p>
-  
-  <p style="color: #fff">Inline with some text
-  
+
+  <p style="color: #fff">Inline
+
     <span class="p-chip is-dark is-dense is-inline"><span class="p-chip__value">21.10</span></span>
-  
+
     <span class="p-chip--positive is-dark is-dense is-inline">
       <span class="p-chip__value">21.10</span>
       <button class="p-chip__dismiss">
         <i class="p-icon--close is-light">Dismiss</i>
       </button>
     </span>
-  
+
     <span class="p-chip--caution is-dark is-dense is-inline">
       <span class="p-chip__lead">Owner</span>
       <span class="p-chip__value">Bob</span>
     </span>
-  
+
     <span class="p-chip--negative is-dark is-dense is-inline">
       <span class="p-chip__lead">Owner</span>
       <span class="p-chip__value">Bob</span>
@@ -723,6 +947,15 @@
         <i class="p-icon--close is-light">Dismiss</i>
       </button>
     </span>
+
+    <button class="p-chip--information is-dark is-dense is-inline">
+      <span class="p-chip__value">21.10</span>
+    </button>
+
+    <button class="p-chip is-dark is-dense is-inline">
+      <span class="p-chip__lead">Owner</span>
+      <span class="p-chip__value">Bob</span>
+    </button>
   </p>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/variants.html
+++ b/templates/docs/examples/patterns/chip/variants.html
@@ -4,29 +4,29 @@
 {% block standalone_css %}patterns_chip{% endblock %}
 
 {% block content %}
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip">
   <span class="p-chip__value">21.10</span>
@@ -39,29 +39,29 @@
 
 <br>
 
-<div class="p-chip--positive">
+<span class="p-chip--positive">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--positive">
+<span class="p-chip--positive">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--positive">
+<span class="p-chip--positive">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip--positive">
+<span class="p-chip--positive">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip--positive">
   <span class="p-chip__value">21.10</span>
@@ -74,29 +74,29 @@
 
 <br>
 
-<div class="p-chip--caution">
+<span class="p-chip--caution">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--caution">
+<span class="p-chip--caution">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--caution">
+<span class="p-chip--caution">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip--caution">
+<span class="p-chip--caution">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip--caution">
   <span class="p-chip__value">21.10</span>
@@ -109,29 +109,29 @@
 
 <br>
 
-<div class="p-chip--negative">
+<span class="p-chip--negative">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--negative">
+<span class="p-chip--negative">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--negative">
+<span class="p-chip--negative">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip--negative">
+<span class="p-chip--negative">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip--negative">
   <span class="p-chip__value">21.10</span>
@@ -144,29 +144,29 @@
 
 <br>
 
-<div class="p-chip--information">
+<span class="p-chip--information">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--information">
+<span class="p-chip--information">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--information">
+<span class="p-chip--information">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip--information">
+<span class="p-chip--information">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip--information">
   <span class="p-chip__value">21.10</span>
@@ -179,29 +179,29 @@
 
 <br>
 
-<div class="p-chip is-dense">
+<span class="p-chip is-dense">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip is-dense">
+<span class="p-chip is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip is-dense">
+<span class="p-chip is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip is-dense">
+<span class="p-chip is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip is-dense">
   <span class="p-chip__value">21.10</span>
@@ -214,29 +214,29 @@
 
 <br>
 
-<div class="p-chip--positive is-dense">
+<span class="p-chip--positive is-dense">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--positive is-dense">
+<span class="p-chip--positive is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--positive is-dense">
+<span class="p-chip--positive is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip--positive is-dense">
+<span class="p-chip--positive is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip--positive is-dense">
   <span class="p-chip__value">21.10</span>
@@ -249,29 +249,29 @@
 
 <br>
 
-<div class="p-chip--caution is-dense">
+<span class="p-chip--caution is-dense">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--caution is-dense">
+<span class="p-chip--caution is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--caution is-dense">
+<span class="p-chip--caution is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip--caution is-dense">
+<span class="p-chip--caution is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip--caution is-dense">
   <span class="p-chip__value">21.10</span>
@@ -284,29 +284,29 @@
 
 <br>
 
-<div class="p-chip--negative is-dense">
+<span class="p-chip--negative is-dense">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--negative is-dense">
+<span class="p-chip--negative is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--negative is-dense">
+<span class="p-chip--negative is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip--negative is-dense">
+<span class="p-chip--negative is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip--negative is-dense">
   <span class="p-chip__value">21.10</span>
@@ -319,29 +319,29 @@
 
 <br>
 
-<div class="p-chip--information is-dense">
+<span class="p-chip--information is-dense">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--information is-dense">
+<span class="p-chip--information is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--information is-dense">
+<span class="p-chip--information is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-</div>
+</span>
 
-<div class="p-chip--information is-dense">
+<span class="p-chip--information is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
 <button class="p-chip--information is-dense">
   <span class="p-chip__value">21.10</span>
@@ -354,53 +354,53 @@
 
 <br>
 
-<div class="p-chip is-dense">
+<span class="p-chip is-dense">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__value">21.10</span>
-</div>
+</span>
 
-<div class="p-chip--positive is-dense">
-  <span class="p-chip__value">21.10</span>
-  <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
-  </button>
-</div>
-
-<div class="p-chip--positive">
+<span class="p-chip--positive is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--caution is-dense">
-  <span class="p-chip__lead">Owner</span>
-  <span class="p-chip__value">Bob</span>
-</div>
-
-<div class="p-chip--caution">
-  <span class="p-chip__lead">Owner</span>
-  <span class="p-chip__value">Bob</span>
-</div>
-
-<div class="p-chip--negative is-dense">
-  <span class="p-chip__lead">Owner</span>
-  <span class="p-chip__value">Bob</span>
+<span class="p-chip--positive">
+  <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 
-<div class="p-chip--negative">
+<span class="p-chip--caution is-dense">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</span>
+
+<span class="p-chip--caution">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+</span>
+
+<span class="p-chip--negative is-dense">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
+
+<span class="p-chip--negative">
+  <span class="p-chip__lead">Owner</span>
+  <span class="p-chip__value">Bob</span>
+  <button class="p-chip__dismiss">
+    <i class="p-icon--close">Dismiss</i>
+  </button>
+</span>
 
 <button class="p-chip--information is-dense">
   <span class="p-chip__value">21.10</span>
@@ -481,29 +481,29 @@
 
 <div class="p-strip--dark" style="background: #111">
 
-  <div class="p-chip is-dark">
+  <span class="p-chip is-dark">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip is-dark">
+  <span class="p-chip is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip is-dark">
+  <span class="p-chip is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip is-dark">
+  <span class="p-chip is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip is-dark">
     <span class="p-chip__value">21.10</span>
@@ -516,29 +516,29 @@
 
   <br>
 
-  <div class="p-chip--positive is-dark">
+  <span class="p-chip--positive is-dark">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--positive is-dark">
+  <span class="p-chip--positive is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--positive is-dark">
+  <span class="p-chip--positive is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip--positive is-dark">
+  <span class="p-chip--positive is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip--positive is-dark">
     <span class="p-chip__value">21.10</span>
@@ -551,29 +551,29 @@
 
   <br>
 
-  <div class="p-chip--caution is-dark">
+  <span class="p-chip--caution is-dark">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--caution is-dark">
+  <span class="p-chip--caution is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--caution is-dark">
+  <span class="p-chip--caution is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip--caution is-dark">
+  <span class="p-chip--caution is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip--caution is-dark">
     <span class="p-chip__value">21.10</span>
@@ -586,29 +586,29 @@
 
   <br>
 
-  <div class="p-chip--negative is-dark">
+  <span class="p-chip--negative is-dark">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--negative is-dark">
+  <span class="p-chip--negative is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--negative is-dark">
+  <span class="p-chip--negative is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip--negative is-dark">
+  <span class="p-chip--negative is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip--negative is-dark">
     <span class="p-chip__value">21.10</span>
@@ -621,29 +621,29 @@
 
   <br>
 
-  <div class="p-chip--information is-dark">
+  <span class="p-chip--information is-dark">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--information is-dark">
+  <span class="p-chip--information is-dark">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--information is-dark">
+  <span class="p-chip--information is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip--information is-dark">
+  <span class="p-chip--information is-dark">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip--information is-dark">
     <span class="p-chip__value">21.10</span>
@@ -656,29 +656,29 @@
 
   <br>
 
-  <div class="p-chip is-dark is-dense">
+  <span class="p-chip is-dark is-dense">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip is-dark is-dense">
+  <span class="p-chip is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip is-dark is-dense">
+  <span class="p-chip is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip is-dark is-dense">
+  <span class="p-chip is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip is-dark is-dense">
     <span class="p-chip__value">21.10</span>
@@ -691,29 +691,29 @@
 
   <br>
 
-  <div class="p-chip--positive is-dark is-dense">
+  <span class="p-chip--positive is-dark is-dense">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--positive is-dark is-dense">
+  <span class="p-chip--positive is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--positive is-dark is-dense">
+  <span class="p-chip--positive is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip--positive is-dark is-dense">
+  <span class="p-chip--positive is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip--positive is-dark is-dense">
     <span class="p-chip__value">21.10</span>
@@ -726,29 +726,29 @@
 
   <br>
 
-  <div class="p-chip--caution is-dark is-dense">
+  <span class="p-chip--caution is-dark is-dense">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--caution is-dark is-dense">
+  <span class="p-chip--caution is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--caution is-dark is-dense">
+  <span class="p-chip--caution is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip--caution is-dark is-dense">
+  <span class="p-chip--caution is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip--caution is-dark is-dense">
     <span class="p-chip__value">21.10</span>
@@ -761,29 +761,29 @@
 
   <br>
 
-  <div class="p-chip--negative is-dark is-dense">
+  <span class="p-chip--negative is-dark is-dense">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--negative is-dark is-dense">
+  <span class="p-chip--negative is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--negative is-dark is-dense">
+  <span class="p-chip--negative is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip--negative is-dark is-dense">
+  <span class="p-chip--negative is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip--negative is-dark is-dense">
     <span class="p-chip__value">21.10</span>
@@ -796,29 +796,29 @@
 
   <br>
 
-  <div class="p-chip--information is-dark is-dense">
+  <span class="p-chip--information is-dark is-dense">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--information is-dark is-dense">
+  <span class="p-chip--information is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--information is-dark is-dense">
+  <span class="p-chip--information is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
-  </div>
+  </span>
 
-  <div class="p-chip--information is-dark is-dense">
+  <span class="p-chip--information is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
   <button class="p-chip--information is-dark is-dense">
     <span class="p-chip__value">21.10</span>
@@ -831,53 +831,53 @@
 
   <br>
 
-  <div class="p-chip is-dark is-dense">
+  <span class="p-chip is-dark is-dense">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip is-dark">
+  <span class="p-chip is-dark">
     <span class="p-chip__value">21.10</span>
-  </div>
+  </span>
 
-  <div class="p-chip--positive is-dark is-dense">
-    <span class="p-chip__value">21.10</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </div>
-
-  <div class="p-chip--positive is-dark">
+  <span class="p-chip--positive is-dark is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--caution is-dark is-dense">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-  </div>
-
-  <div class="p-chip--caution is-dark">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-  </div>
-
-  <div class="p-chip--negative is-dark is-dense">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
+  <span class="p-chip--positive is-dark">
+    <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
 
-  <div class="p-chip--negative is-dark">
+  <span class="p-chip--caution is-dark is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </span>
+
+  <span class="p-chip--caution is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </span>
+
+  <span class="p-chip--negative is-dark is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
       <i class="p-icon--close is-light">Dismiss</i>
     </button>
-  </div>
+  </span>
+
+  <span class="p-chip--negative is-dark">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      <i class="p-icon--close is-light">Dismiss</i>
+    </button>
+  </span>
 
   <button class="p-chip--information is-dark is-dense">
     <span class="p-chip__value">21.10</span>

--- a/templates/docs/examples/patterns/chip/variants.html
+++ b/templates/docs/examples/patterns/chip/variants.html
@@ -11,7 +11,7 @@
 <span class="p-chip">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -24,7 +24,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -46,7 +46,7 @@
 <span class="p-chip--positive">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -59,7 +59,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -81,7 +81,7 @@
 <span class="p-chip--caution">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -94,7 +94,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -116,7 +116,7 @@
 <span class="p-chip--negative">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -129,7 +129,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -151,7 +151,7 @@
 <span class="p-chip--information">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -164,7 +164,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -186,7 +186,7 @@
 <span class="p-chip is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -199,7 +199,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -221,7 +221,7 @@
 <span class="p-chip--positive is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -234,7 +234,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -256,7 +256,7 @@
 <span class="p-chip--caution is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -269,7 +269,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -291,7 +291,7 @@
 <span class="p-chip--negative is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -304,7 +304,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -326,7 +326,7 @@
 <span class="p-chip--information is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -339,7 +339,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -365,14 +365,14 @@
 <span class="p-chip--positive is-dense">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
 <span class="p-chip--positive">
   <span class="p-chip__value">21.10</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -390,7 +390,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -398,7 +398,7 @@
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
+    Dismiss
   </button>
 </span>
 
@@ -420,7 +420,7 @@
   <span class="p-chip--positive is-inline">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
@@ -433,7 +433,7 @@
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
@@ -453,7 +453,7 @@
   <span class="p-chip--positive is-dense is-inline">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
@@ -466,7 +466,7 @@
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close">Dismiss</i>
+      Dismiss
     </button>
   </span>
 

--- a/templates/docs/examples/patterns/chip/with-dismiss.html
+++ b/templates/docs/examples/patterns/chip/with-dismiss.html
@@ -4,11 +4,11 @@
 {% block standalone_css %}patterns_chip{% endblock %}
 
 {% block content %}
-<div class="p-chip">
+<span class="p-chip">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
   <button class="p-chip__dismiss">
     <i class="p-icon--close">Dismiss</i>
   </button>
-</div>
+</span>
 {% endblock %}

--- a/templates/docs/examples/patterns/chip/with-dismiss.html
+++ b/templates/docs/examples/patterns/chip/with-dismiss.html
@@ -7,8 +7,6 @@
 <span class="p-chip">
   <span class="p-chip__lead">Owner</span>
   <span class="p-chip__value">Bob</span>
-  <button class="p-chip__dismiss">
-    <i class="p-icon--close">Dismiss</i>
-  </button>
+  <button class="p-chip__dismiss">Dismiss</button>
 </span>
 {% endblock %}

--- a/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
+++ b/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
@@ -7,9 +7,9 @@
 <ul class="p-inline-list--stretch">
   <li class="p-inline-list__item"><h3>Documentation</h3></li>
   <li class="p-inline-list__item u-vertically-center u-align--right">
-    <div class="p-chip--positive is-inline">
+    <span class="p-chip--positive is-inline">
       <span class="p-chip__value">New</span>
-    </div>
+    </span>
   </li>
 </ul>
 {% endblock %}

--- a/templates/docs/examples/patterns/search-and-filter/_default-script.js
+++ b/templates/docs/examples/patterns/search-and-filter/_default-script.js
@@ -2,9 +2,12 @@
   Toggles visibility of filter panel.
   @param {HTMLElement} panel Filter panel to show or hide.
 */
-function togglePanel(container, panel) {
+function togglePanel(container, panel, collapse) {
+  if (typeof collapse === 'undefined') {
+    collapse = panel.getAttribute('aria-hidden') !== 'false';
+  }
   if (panel && container) {
-    if (panel.getAttribute('aria-hidden') === 'false') {
+    if (collapse) {
       panel.setAttribute('aria-hidden', 'true');
       container.setAttribute('aria-expanded', 'false');
     } else {
@@ -20,10 +23,10 @@ function togglePanel(container, panel) {
   var container = pattern.querySelector('.p-search-and-filter__search-container');
   input.addEventListener('blur', function (event) {
     var targetPanel = pattern.querySelector('.p-search-and-filter__panel');
-    togglePanel(container, targetPanel);
+    togglePanel(container, targetPanel, true);
   });
   input.addEventListener('focus', function (event) {
     var targetPanel = pattern.querySelector('.p-search-and-filter__panel');
-    togglePanel(container, targetPanel);
+    togglePanel(container, targetPanel, false);
   });
 });

--- a/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
+++ b/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
@@ -6,43 +6,43 @@
 {% block content %}
 <div class="p-search-and-filter">
   <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
-    <span class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
     </span>
@@ -57,66 +57,66 @@
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Cloud</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <button class="p-chip">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </span>
+        </button>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Region</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </span>
+        </button>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Owner</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <button class="p-chip">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </span>
+        </button>
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
+++ b/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
@@ -8,43 +8,43 @@
   <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-search-and-filter__selected-count" role="button" tabindex="0">+2</span>
     <form class="p-search-and-filter__box" data-overflowing="false">

--- a/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
+++ b/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
@@ -6,46 +6,46 @@
 {% block content %}
 <div class="p-search-and-filter">
   <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
-    <div class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
+    </span>
     <span class="p-search-and-filter__selected-count" role="button" tabindex="0">+2</span>
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
@@ -57,66 +57,66 @@
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Cloud</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </div>
+        </span>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Region</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </div>
+        </span>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Owner</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </div>
+        </span>
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/search-and-filter/default.html
+++ b/templates/docs/examples/patterns/search-and-filter/default.html
@@ -16,66 +16,66 @@
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Cloud</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <button class="p-chip">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </span>
+        </button>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Region</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </span>
+        </button>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Owner</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <button class="p-chip">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </span>
-        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </button>
+        <button class="p-chip">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </span>
+        </button>
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/search-and-filter/default.html
+++ b/templates/docs/examples/patterns/search-and-filter/default.html
@@ -16,66 +16,66 @@
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Cloud</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </div>
+        </span>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Region</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </div>
+        </span>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Owner</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </div>
+        </span>
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/search-and-filter/expanded.html
+++ b/templates/docs/examples/patterns/search-and-filter/expanded.html
@@ -1,26 +1,18 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Search and filter / With chips{% endblock %}
+{% block title %}Search and filter / Expanded{% endblock %}
 
 {% block standalone_css %}patterns_search-and-filter{% endblock %}
 
 {% block content %}
 <div class="p-search-and-filter">
-  <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
-    <span class="p-chip">
-      <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </span>
-    <span class="p-chip">
-      <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </span>
+  <div class="p-search-and-filter__search-container" aria-expanded="true" data-active="true" data-empty="true">
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="">
       <button alt="search" class="u-off-screen" type="submit">Search</button>
     </form>
   </div>
-  <div class="p-search-and-filter__panel" aria-hidden="true">
+  <div class="p-search-and-filter__panel" aria-hidden="false">
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Cloud</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">

--- a/templates/docs/examples/patterns/search-and-filter/with-chips.html
+++ b/templates/docs/examples/patterns/search-and-filter/with-chips.html
@@ -8,11 +8,11 @@
   <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-      <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
+      <button class="p-chip__dismiss">Dismiss</button>
     </span>
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>

--- a/templates/docs/examples/patterns/search-and-filter/with-chips.html
+++ b/templates/docs/examples/patterns/search-and-filter/with-chips.html
@@ -6,14 +6,14 @@
 {% block content %}
 <div class="p-search-and-filter">
   <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
-    <div class="p-chip" aria-pressed="true" role="button">
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
-    <div class="p-chip" aria-pressed="true" role="button">
+    </span>
+    <span class="p-chip" aria-pressed="true" role="button">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
       <button class="p-chip__dismiss"><i class="p-icon--close">Dismiss</i></button>
-    </div>
+    </span>
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="">
@@ -24,66 +24,66 @@
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Cloud</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </div>
+        </span>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Region</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </div>
+        </span>
       </div>
     </div>
 
     <div class="p-filter-panel-section">
       <h3 class="p-filter-panel-section__heading">Owner</h3>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </div>
-        <div class="p-chip" aria-pressed="false" role="button" tabindex="0">
+        </span>
+        <span class="p-chip" aria-pressed="false" role="button" tabindex="0">
           <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </div>
+        </span>
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -40,7 +40,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-chip--caution is-inline">
+                  <span class="p-chip--caution {% if is_dark %}is-dark{% endif %} is-inline">
                     <span class="p-chip__value">In progress</span>
                   </span>
                 </div></a>
@@ -60,21 +60,21 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <span class="p-chip--positive is-inline">
+          <span class="p-chip--positive {% if is_dark %}is-dark{% endif %} is-inline">
             <span class="p-chip__value">New</span>
           </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <span class="p-chip--information is-inline">
+          <span class="p-chip--information {% if is_dark %}is-dark{% endif %} is-inline">
             <span class="p-chip__value">Updated</span>
           </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-chip--information is-inline">
+          <span class="p-chip--information {% if is_dark %}is-dark{% endif %} is-inline">
             <span class="p-chip__value">Validated</span>
           </span>
         </div></a>

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -40,9 +40,9 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <div class="p-chip--caution is-inline">
+                  <span class="p-chip--caution is-inline">
                     <span class="p-chip__value">In progress</span>
-                  </div>
+                  </span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -60,23 +60,23 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <div class="p-chip--positive is-inline">
+          <span class="p-chip--positive is-inline">
             <span class="p-chip__value">New</span>
-          </div>
+          </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <div class="p-chip--information is-inline">
+          <span class="p-chip--information is-inline">
             <span class="p-chip__value">Updated</span>
-          </div>
+          </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <div class="p-chip--information is-inline">
+          <span class="p-chip--information is-inline">
             <span class="p-chip__value">Validated</span>
-          </div>
+          </span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_docs.html
+++ b/templates/docs/examples/patterns/side-navigation/_docs.html
@@ -24,9 +24,9 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Quick start<span class="p-side-navigation__status">
-          <div class="p-chip--positive is-inline">
+          <span class="p-chip--positive is-inline">
             <span class="p-chip__value">New</span>
-          </div>
+          </span>
         </span></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -43,7 +43,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-chip--caution is-inline">
+                  <span class="p-chip--caution {% if is_dark %}is-dark{% endif %} is-inline">
                     <span class="p-chip__value">In progress</span>
                   </span>
                 </div></a>
@@ -63,21 +63,21 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <span class="p-chip--positive is-inline">
+          <span class="p-chip--positive {% if is_dark %}is-dark{% endif %} is-inline">
             <span class="p-chip__value">New</span>
           </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <span class="p-chip--information is-inline">
+          <span class="p-chip--information {% if is_dark %}is-dark{% endif %} is-inline">
             <span class="p-chip__value">Updated</span>
           </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-chip--information is-inline">
+          <span class="p-chip--information {% if is_dark %}is-dark{% endif %} is-inline">
             <span class="p-chip__value">Validated</span>
           </span>
         </div></a>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -43,9 +43,9 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <div class="p-chip--caution is-inline">
+                  <span class="p-chip--caution is-inline">
                     <span class="p-chip__value">In progress</span>
-                  </div>
+                  </span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -63,23 +63,23 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <div class="p-chip--positive is-inline">
+          <span class="p-chip--positive is-inline">
             <span class="p-chip__value">New</span>
-          </div>
+          </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <div class="p-chip--information is-inline">
+          <span class="p-chip--information is-inline">
             <span class="p-chip__value">Updated</span>
-          </div>
+          </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <div class="p-chip--information is-inline">
+          <span class="p-chip--information is-inline">
             <span class="p-chip__value">Validated</span>
-          </div>
+          </span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
@@ -33,9 +33,9 @@
       <span class="p-side-navigation__text">
         Version 0.4.0
         <div class="p-side-navigation__status">
-          <div class="p-chip--caution is-dense is-dark is-inline">
+          <span class="p-chip--caution is-dense is-dark is-inline">
             <span class="p-chip__value">Beta</span>
-          </div>
+          </span>
         </div>
       </span>
     </li>

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -29,9 +29,9 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <div class="p-chip--caution is-dark is-dense is-inline">
+                  <span class="p-chip--caution is-dark is-dense is-inline">
                     <span class="p-chip__value">In progress</span>
-                  </div>
+                  </span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -49,23 +49,23 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">First level link with a label</span><div class="p-side-navigation__status">
-          <div class="p-chip--positive is-dark is-dense is-inline">
+          <span class="p-chip--positive is-dark is-dense is-inline">
             <span class="p-chip__value">New</span>
-          </div>
+          </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label">First level link with a label is long and wraps wraps wraps wraps wraps wraps</span><div class="p-side-navigation__status">
-          <div class="p-chip--information is-dark is-dense is-inline">
+          <span class="p-chip--information is-dark is-dense is-inline">
             <span class="p-chip__value">Updated</span>
-          </div>
+          </span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <div class="p-chip--information is-dark is-dense is-inline">
+          <span class="p-chip--information is-dark is-dense is-inline">
             <span class="p-chip__value">Validated</span>
-          </div>
+          </span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/icons.html
+++ b/templates/docs/examples/patterns/side-navigation/icons.html
@@ -38,9 +38,9 @@
           <i class="p-icon--help p-side-navigation__icon"></i>
           Get help
           <span class="p-side-navigation__status">
-            <div class="p-chip--information is-dense is-inline">
+            <span class="p-chip--information is-dense is-inline">
               <span class="p-chip__value">Updated</span>
-            </div>
+            </span>
           </span>
         </a>
       </li>

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -26,7 +26,7 @@ The Vanilla docs use colour coded chips to highlight recent changes in component
 
 ## Chip with dismiss
 
-Chips have the option to be dismissed. Include the `p-chip__dismiss` button wrapping a close icon.
+Chips have the option to be dismissed by including a button with a `p-chip__dismiss` class.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/chip/with-dismiss" class="js-example">
 View example of the dismiss chip pattern

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -14,14 +14,6 @@ Use the chip component to display small actionable or informative pieces of info
 View example of the default chip pattern
 </a></div>
 
-### Chip with dismiss
-
-Chips have the option to be dismissed. Include the `p-chip__dismiss` button wrapping a close icon.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/chip/with-dismiss" class="js-example">
-View example of the dismiss chip pattern
-</a></div>
-
 ### Colour coding
 
 Chips come in 5 colours. The default is neutral (grey). Use any of the following flavours to style values that have semantic or otherwise colour-coded meaning:
@@ -31,6 +23,22 @@ View example of the coloured chip pattern
 </a></div>
 
 The Vanilla docs use colour coded chips to highlight recent changes in component status. You can see them in the side navigation.
+
+### Chip with dismiss
+
+Chips have the option to be dismissed. Include the `p-chip__dismiss` button wrapping a close icon.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/chip/with-dismiss" class="js-example">
+View example of the dismiss chip pattern
+</a></div>
+
+### Interactive
+
+Chips can be implemented as `button` elements to make them clickable and selectable. You can mark chip as selected by adding `aria-pressed="true"` attribute to the chip element.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/chip/interactive" class="js-example">
+View example of the interactive chip pattern
+</a></div>
 
 ### Dense chips
 

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -58,7 +58,7 @@ View example of the inline chip pattern
 
 ## Dark chips
 
-To use chips on a dark background the `is-dark` class can be applied. If the chip includes the dismiss icon, you'll need to add the `is-light` class to the icon. To ensure the dark chips are accessible, the background colour used must be no lighter than `#2b2b2b`:
+To use chips on a dark background the `is-dark` class can be applied. If the chip includes the dismiss icon, you'll need to add the `is-light` class to the icon. To ensure the dark chips are accessible, the background colour used must `#2b2b2b` or darker:
 
 <div class="embedded-example"><a href="/docs/examples/patterns/chip/dark" class="js-example">
 View example of the dark chip pattern

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -14,7 +14,7 @@ Use the chip component to display small actionable or informative pieces of info
 View example of the default chip pattern
 </a></div>
 
-### Colour coding
+## Colour coding
 
 Chips come in 5 colours. The default is neutral (grey). Use any of the following flavours to style values that have semantic or otherwise colour-coded meaning:
 
@@ -24,7 +24,7 @@ View example of the coloured chip pattern
 
 The Vanilla docs use colour coded chips to highlight recent changes in component status. You can see them in the side navigation.
 
-### Chip with dismiss
+## Chip with dismiss
 
 Chips have the option to be dismissed. Include the `p-chip__dismiss` button wrapping a close icon.
 
@@ -32,7 +32,7 @@ Chips have the option to be dismissed. Include the `p-chip__dismiss` button wrap
 View example of the dismiss chip pattern
 </a></div>
 
-### Interactive
+## Interactive
 
 Chips can be implemented as `button` elements to make them clickable and selectable. You can mark chip as selected by adding `aria-pressed="true"` attribute to the chip element.
 
@@ -40,7 +40,7 @@ Chips can be implemented as `button` elements to make them clickable and selecta
 View example of the interactive chip pattern
 </a></div>
 
-### Dense chips
+## Dense chips
 
 If you need to place a chip in a dense context, use the class `is-dense` to reduce the padding and overall height of the chip:
 
@@ -48,7 +48,7 @@ If you need to place a chip in a dense context, use the class `is-dense` to redu
 View example of the dense chip pattern
 </a></div>
 
-### Inline chips
+## Inline chips
 
 The default chip has margins and padding set so it aligns to paragraphs and within search fields. If you need to use as an inline element nested inside another element, use the class `is-inline`:
 
@@ -56,7 +56,7 @@ The default chip has margins and padding set so it aligns to paragraphs and with
 View example of the inline chip pattern
 </a></div>
 
-### Dark chips
+## Dark chips
 
 To use chips on a dark background the `is-dark` class can be applied. If the chip includes the dismiss icon, you'll need to add the `is-light` class to the icon. To ensure the dark chips are accessible, the background colour used must be no lighter than `#2b2b2b`:
 

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -48,10 +48,6 @@ View example of the positive notification pattern
 
 ### Borderless
 
-<div class="p-chip--positive">
-  <span class="p-chip__value">New</span>
-</div>
-
 In cases where a notification sits inside another component, such as a table cell or a card, it may be useful to remove the outer border and highlight bar.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/notifications/borderless/" class="js-example">
@@ -59,10 +55,6 @@ View example of the borderless notification pattern
 </a></div>
 
 ### Inline
-
-<div class="p-chip--positive">
-  <span class="p-chip__value">New</span>
-</div>
 
 When vertical space is limited, you can use the inline variant.
 
@@ -74,10 +66,6 @@ View example of the inline notification pattern
 
 ### Buttons
 
-<div class="p-chip--positive">
-  <span class="p-chip__value">New</span>
-</div>
-
 Notifications can have actions in either button or link form. These will appear below the notification message.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/notifications/action/" class="js-example">
@@ -86,10 +74,6 @@ View example of the notification actions.
 
 ### Dismissible
 
-<div class="p-chip--information is-inline">
-  <span class="p-chip__value">Updated</span>
-</div>
-
 Notifications that can be dismissed can include a close button.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/notifications/dismissible/" class="js-example">
@@ -97,10 +81,6 @@ View example of the dismissible notification pattern
 </a></div>
 
 ## Timestamp
-
-<div class="p-chip--positive">
-  <span class="p-chip__value">New</span>
-</div>
 
 For notifications in which recency is important, you can include a section for time.
 

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -174,6 +174,8 @@ The `aria-label` attribute on table cells of the responsive table has been repla
 
 By default chips are not interactive anymore (they don't have hover, focus or active state). To make chip interactive you should use `<button class="p-chip">` instead of `<span class="p-chip">`.
 
+The dismiss button in the chip now provides its own icon, so it should not include separate icon element. Please remove any icons from the chips, and only keep the `Dismiss` text in the button.
+
 ## Variables
 
 `$grid-margin-width` is has been removed, as the grid margins differ at different breakpont. Use the values in `$grid-margin-widths` instead.

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -172,7 +172,7 @@ The `aria-label` attribute on table cells of the responsive table has been repla
 
 ## Chips
 
-By default chips are not interactive anymore (they don't have hover, focus or active state). To make chip interactive you should use `<button class="p-chip">` instead of `<span class="p-chip">`.
+By default, chips are not interactive anymore (they don't have hover, focus or active state). Apply the class to a button element to get interactive behaviour, e.g.: `<button class="p-chip">` instead of `<span class="p-chip">`.
 
 The dismiss button in the chip now provides its own icon, so it should not include separate icon element. Please remove any icons from the chips, and only keep the `Dismiss` text in the button.
 

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -170,6 +170,10 @@ The `vf-p-label` mixin has been removed so you'll have to remove this from your 
 
 The `aria-label` attribute on table cells of the responsive table has been replaced by `data-heading`. This is to ensure information in the cells of the table isn't missed by screen readers. Please replace all `aria-label`'s on `<td>` elements in tables using the `p-table--mobile-card` class.
 
+## Chips
+
+By default chips are not interactive anymore (they don't have hover, focus or active state). To make chip interactive you should use `<button class="p-chip">` instead of `<span class="p-chip">`.
+
 ## Variables
 
 `$grid-margin-width` is has been removed, as the grid margins differ at different breakpont. Use the values in `$grid-margin-widths` instead.

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -22,7 +22,17 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 3.00 -->
     <tr>
-      <th><a href="/docs/base/forms#datalist">Chips</a></th>
+      <th><a href="/docs/patterns/chip#interactive">Chips / Interactive</a></th>
+      <td>
+        <div class="p-chip--information is-dense is-inline">
+          <span class="p-chip__value">Updated</span>
+        </div>
+      </td>
+      <td>3.0.0</td>
+      <td>We've reimplemented interactive chips using <code>button</code> elements.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/chip">Chips / Tinted</a></th>
       <td>
         <div class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
@@ -32,14 +42,14 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>We've added tinted chips. The tints are based on the semantic colours (positive, caution, negative) plus a dark blue one that matches the blue used in the information flavour of the notification component. The default chip colour (grey) is now referred to as "neutral".</td>
     </tr>
     <tr>
-      <th><a href="/docs/base/forms#datalist">Labels</a></th>
+      <th><a href="/docs/patterns/chip">Labels</a></th>
       <td>
         <div class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
+          <span class="p-chip__value">Removed</span>
         </div>
       </td>
       <td>3.0.0</td>
-      <td>We've deprecated the labels pattern as the new tinted chips can be used instead.</td>
+      <td>We've removed the labels pattern as the new tinted chips can be used instead.</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -24,9 +24,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip#interactive">Chips / Interactive</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>3.0.0</td>
       <td>We've reimplemented interactive chips using <code>button</code> elements.</td>
@@ -34,9 +34,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Chips / Tinted</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>3.0.0</td>
       <td>We've added tinted chips. The tints are based on the semantic colours (positive, caution, negative) plus a dark blue one that matches the blue used in the information flavour of the notification component. The default chip colour (grey) is now referred to as "neutral".</td>
@@ -44,9 +44,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Labels</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Removed</span>
-        </div>
+        </span>
       </td>
       <td>3.0.0</td>
       <td>We've removed the labels pattern as the new tinted chips can be used instead.</td>
@@ -70,9 +70,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#datalist">Forms / Datalist</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.37.0</td>
       <td>We've added documentation for datalist</td>
@@ -81,9 +81,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion#with-tick-elements">Accordion / Tick elements</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.36.0</td>
       <td>We've added a variation of the accordion using tick elements</td>
@@ -91,9 +91,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/card#content-bleed">Card / Content Bleed</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.36.0</td>
       <td>We added a <code>.p-card__inner</code> element so that it's possible to have a mix of padded and not padded content within a card.</td>
@@ -101,9 +101,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#help-text">Form / Help text</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.36.0</td>
       <td>We added a class name to aligned help text with checkboxes or radio buttons</td>
@@ -112,9 +112,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#validation">Forms / Validation</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.35.0</td>
       <td>We've updated the styling of the form validation and required patterns</td>
@@ -123,9 +123,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#password-showhide">Forms / Password toggle</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.34.0</td>
       <td>Password fields now have a show/hide toggle.</td>
@@ -133,9 +133,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#status">Lists / Crossed</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.34.0</td>
       <td>We added a <code>is-crossed</code> modifier class for lists, to complement the existing <code>is-ticked</code> modifier.</td>
@@ -143,9 +143,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#status">Lists / Ticked</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.34.0</td>
       <td>We updated the color of the <code>is-ticked</code> icon on lists to <code>$color-positive</code>, where previously it was <code>$color-accent</code>.</td>
@@ -153,9 +153,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/tabs#tab-buttons">Tabs / Tab Buttons</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.34.0</td>
       <td>We added a new type of tab pattern, `p-tab-buttons`, which can display tabs like a group of buttons.</td>
@@ -164,9 +164,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/links#skip-link">Links / Skip Link</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.33.0</td>
       <td>We added a new link variant, <code>.p-link--skip</code>, that places a link offscreen and is revealed on focus.</td>
@@ -174,9 +174,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/notification">Notifications</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.33.0</td>
       <td>Notifications have been updated with a new appearance, requiring a new HTML structure.</td>
@@ -184,9 +184,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/notification#deprecated">Notifications structure</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.33.0</td>
       <td>The following notification classes have been deprecated: <code>.p-notification__response</code>, <code>.p-notification__status</code></td>
@@ -195,9 +195,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Labels / Default</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.32.0</td>
       <td>We've added a default label <code>p-label</code></td>
@@ -205,9 +205,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#theming">Button / Dark</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.32.0</td>
       <td>We added the dark theme to the buttons.</td>
@@ -215,9 +215,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#neutral">Button / Neutral</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.32.0</td>
       <td>The neutral button variant <code>p-button--neutral</code> is deprecated, please use default <code>p-button</code> instead.</td>
@@ -225,9 +225,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#overflow">Tables / Overflow</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.32.0</td>
       <td>We introduced the <code>.has-overflow</code> utility for table cells, to aid with the display of components that need to overflow the cell, such as tooltips and contextual menus.</td>
@@ -235,9 +235,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#responsive">Tables / Responsive</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.32.0</td>
       <td>The <code>.p-table--mobile-card</code> previously contained style overrides for the <a href="https://vanillaframework.io/docs/examples/patterns/contextual-menu/default">contextual menu pattern</a>, these have been removed so that contextual menus within responsive tables look and behave the same as they do elsewhere.</td>
@@ -246,9 +246,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Dropdown</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.31.0</td>
       <td>We introduced the <code>.p-navigation__item--dropdown-toggle</code> class, as a replacement for the now deprecated <code>.p-subnav</code> class.</td>
@@ -256,9 +256,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Sub-navigation</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.31.0</td>
       <td>The <code>.p-subnav</code> class previously could theoretically be used outside of the main <code>.p-navigation</code> component, which was not intended. It has been deprecated, and succeeded by the <code>.p-navigation__item--dropdown-toggle</code> class.</td>
@@ -267,29 +267,29 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#link">Button / Link</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.30.0</td>
       <td>Buttons can now assume the appearance of a standard link.</td>
     </tr>
     <tr>
-      <th><a href="/docs/patterns/lists#theming">Lists / Divider</a></th>
+      <th><a href="/docs/patterns/lists#theming">Lists / spanider</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.30.0</td>
-      <td>We added a dark theme to responsive divider lists.</td>
+      <td>We added a dark theme to responsive spanider lists.</td>
     </tr>
     <tr>
       <th><a href="/docs/patterns/tabs#content">Tabs / Content</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.30.0</td>
       <td>The tab pattern can now be used either as a navigation list, or as controls for panes of content.</td>
@@ -298,9 +298,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/fluid-breakout#toolbar">Fluid breakout - toolbar</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.29.0</td>
       <td>We added support for a toolbar within the fluid-breakout layout.</td>
@@ -309,9 +309,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/modal">Modal footer</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.28.0</td>
       <td>We added the optional footer to the modal pattern.</td>
@@ -319,9 +319,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/logo-section">Logo section</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.28.0</td>
       <td>A new logo section</td>
@@ -329,9 +329,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/logo-section">Inline images</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.28.0</td>
       <td>The inline images component has now been deprecated. Please use the logo section component instead.</td>
@@ -339,9 +339,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#empty">Table - empty</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.28.0</td>
       <td>We added a basic styling for the table <code>&lt;caption&gt;</code> in empty tables</td>
@@ -349,9 +349,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/tooltips#detached">Tooltips - detached</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.28.0</td>
       <td>We added the <code>.is-detached</code> utility, providing a way for tooltips to exist separately from their associated element.</td>
@@ -360,9 +360,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#social">GitHub icon</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.27.0</td>
       <td>We added the GitHub icon <code>.p-icon--github</code> to our social icons set.</td>
@@ -370,9 +370,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#bordered">Code snippet - bordered</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.27.0</td>
       <td>We added the utility class <code>.is-bordered</code> to the code snippet.</td>
@@ -381,9 +381,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/search-and-filter">Search and filter</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.26.0</td>
       <td>We added the new Search and filter component.</td>
@@ -391,9 +391,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application#aside-area">Application layout - animations</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.26.0</td>
       <td>We added <code>is-collapsed</code> class that allows animating the application layout aside panel.</td>
@@ -401,9 +401,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#expanding">Tables expanding</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.26.0</td>
       <td>We renamed and deprecated <code>p-table-expanding</code> and <code>p-table-expanding__panel</code>. Use <code>p-table--expanding</code> and <code>p-table__expanding-panel</code> instead.</td>
@@ -411,9 +411,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#sortable">Tables sorting</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.26.0</td>
       <td>We removed <code>p-table--sortable</code> class name. Sorting can be enabled on any table by adding <code>aria-sort</code> attributes.</td>
@@ -421,9 +421,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#indeterminate-state-checkbox">Forms / Checkbox indeterminate</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.26.0</td>
       <td>We added indeterminate state checkboxes. If a checkbox has <code>checkbox.indeterminate = true;</code> set via JavaScript, the checkbox will show a state between checked and unchecked.</td>
@@ -431,9 +431,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/sticky-footer">Sticky footer</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.26.0</td>
       <td>We added a new <code>.l-site</code> layout, which can accommodate a sticky footer.</td>
@@ -441,9 +441,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion">Accordions</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.26.0</td>
       <td>We deprecated the previous accordion tab patterns, <code>.p-accordion__tab</code> and <code>.p-accordion__tab--with-title .p-accordion__title</code>, in favour of a more accessible pattern. Please use <code>.p-accordion__heading .p-accordion__tab</code>.</td>
@@ -452,9 +452,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#extra-small-capitalised-text">Typography / Extra small caps</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.25.0</td>
       <td>We added new extra small capitalised text <code>p-text--x-small-capitalised</code>.</td>
@@ -462,9 +462,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#baseline-alignment-small-extra-small-and-paragraph-text">Typography / Baseline alignment</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.25.0</td>
       <td>We added a couple of util classes to help aligning small text on the baseline along default text size.</td>
@@ -472,9 +472,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators#muted-horizontal-rule">Separators / Muted</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.25.0</td>
       <td>We added new muted variant of horizontal rule.</td>
@@ -482,9 +482,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators#fixed-width-horizontal-rule">Separators / Fixed width</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.25.0</td>
       <td>We added new fixed width variant of horizontal rule to allow aligning it with full 12-column grid layouts.</td>
@@ -492,9 +492,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#middot">Lists / Middot</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.25.0</td>
       <td>We added a dark theme to middot lists.</td>
@@ -503,9 +503,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#dropdowns">Code snippet - Dropdowns</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.24.0</td>
       <td>We added the ability to accommodate multiple selects within a <code>.p-code-snippet__header</code>, either inline, using the <code>.is-stacked</code> utility to class to have the dropdowns below the title.</td>
@@ -513,9 +513,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#inline">Code inline - dark</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.24.0</td>
       <td>We've updated inline <code>code</code> elements to support being nested within a <code>.p-strip--dark</code> element, and to support an <code>.is-dark</code> utility class.</td>
@@ -523,9 +523,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/fluid-breakout">Fluid breakout</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.24.0</td>
       <td>We added a new <code>l-fluid-breakout</code> layout that can be used to break out of the constraints of a 12-column grid and allow content to bleed into the page margins on larger screens.</td>
@@ -533,9 +533,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/grid">Grid - "orphan" columns</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.24.0</td>
       <td>We deprecated the use of `.col` classes without a direct parent with a class `.row`.</td>
@@ -544,9 +544,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#active">Active button</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.23.0</td>
       <td>The <code>is-active</code> class was deprecated and given a more appropriate name: <code>is-processing</code>.</td>
@@ -554,9 +554,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#processing">Processing button</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.23.0</td>
       <td>We renamed <code>is-active</code> button state class to <code>is-processing</code>, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
@@ -564,9 +564,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet - Dropdowns</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.23.0</td>
       <td>We add the ability to include a select within in a code snippet, allowing users to switch between related code examples.</td>
@@ -574,9 +574,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.23.0</td>
       <td>We added a utility class for <code>.p-code-snippet__block</code> that allows content to wrap, rather than horizontally scroll: <code>.is-wrapped</code>.</td>
@@ -585,9 +585,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators">Separator</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.22.0</td>
       <td>The new <code>p-separator</code> component has been added to be used as a separator between content blocks.</td>
@@ -595,9 +595,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.22.0</td>
       <td>The new <code>.p-code-snippet</code> component has been added, to be used to display code examples in a number of different formats.</td>
@@ -605,9 +605,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#copyable">Code copyable</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.22.0</td>
       <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>
@@ -615,9 +615,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#numbered">Code numbered</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.22.0</td>
       <td><code>.p-code-numbered</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--numbered</code> instead.</td>
@@ -626,9 +626,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Contextual Menu</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.21.0</td>
       <td>The <code>p-icon--contextual-menu</code> has been deprecated and will be removed in future release v3.0. Please use existing <code>.p-icon--chevron-down</code> and <code>.p-icon--chevron-up</code> icons instead.</td>
@@ -636,19 +636,19 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#additional">Icons - Additional</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.21.0</td>
-      <td>We added many more icons, outside of the base icon set. These icons are not included in Vanilla by default, but can be individually included as needed.</td>
+      <td>We added many more icons, outside of the base icon set. These icons are not included in Vanilla by default, but can be inspanidually included as needed.</td>
     </tr>
     <tr>
       <th><a href="/docs/layouts/application#panels">Application layout - panels</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">In progress</span>
-        </div>
+        </span>
       </td>
       <td>2.21.0</td>
       <td>We continue working on application layout panels styling. We improved the positioning of the logo, title and controls in panel headers.</td>
@@ -656,9 +656,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#application-layout">Application layout - side navigation</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.21.0</td>
       <td>We implemented and documented improvements for <a href="/docs/patterns/navigation#application-layout">side navigation component</a> for the <a href="/docs/layouts/application#side-navigation">application layout</a>.</td>
@@ -666,9 +666,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#sticky">Side navigation - Sticky</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.21.0</td>
       <td>Side navigation component used to be sticky by default. We now introduced new <code>is-sticky</code> variant that should be used to optionally make side navigation sticky.</td>
@@ -677,9 +677,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application#responsive-application-layout">Application layout panels</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.20.0</td>
       <td>We updated the responsive styles of application layout panels and introduced some class names and variables for more flexible customization options.</td>
@@ -687,9 +687,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#small">Small buttons</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.20.0</td>
       <td>We added an <code>is-small</code> modifier class for buttons, which can be combined with <code>is-dense</code>.</td>
@@ -697,9 +697,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#small">Active buttons</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.20.0</td>
       <td>We added an <code>is-active</code> state class for buttons, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
@@ -708,9 +708,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#expanding">Expanding table column placeholder</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.19.2</td>
       <td>We started using <code>aria-hidden="true"</code> attribute to hide the placeholder table header in place of previously used <code>u-hide</code> utility.</td>
@@ -718,9 +718,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#icons">Table icons</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.19.0</td>
       <td>We added a <code>p-table__cell--icon-placeholder</code> class to properly align icons in table cells.</td>
@@ -729,9 +729,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/breadcrumbs">Breadcrumbs</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.18.0</td>
       <td>We updated the markup of the breadcrumbs component to comply with accessibility requirements. The class <code>.p-breadcrumbs</code> is now moved onto a <code>&lt;nav&gt;</code> element, the unordered list has been changed to an ordered one that has a class <code>.p-breadcrumbs__items</code>. </td>
@@ -739,9 +739,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/breadcrumbs#deprecated-markup">Breadcrumbs</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.18.0</td>
       <td>Top level <code>&lt;ul&gt;</code> with a class <code>.p-breadcrumbs</code> is now deprecated for the Breadcrumbs pattern.</td>
@@ -750,9 +750,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#checkbox">Checkbox and radio buttons components</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.17.0</td>
       <td>We introduced new <code>.p-checkbox</code> and <code>.p-radio</code> components. They replace the existing styling of base form inputs.</td>
@@ -760,9 +760,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#deprecated-base-checkboxes">Checkbox and radio buttons elements</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.17.0</td>
       <td>Base styled checkboxes and radio buttons (on <code>&lt;input type="checkbox"&gt;</code> or <code>&lt;input type="radio"&gt;</code> elements) are deprecated and they will be reverted to native browser inputs in future version of Vanilla. Please use on bWe added new layout styles for building responsive full-screen applications.</td>
@@ -771,9 +771,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application">Application layout</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.16.0</td>
       <td>We added new layout styles for building responsive full-screen applications.</td>
@@ -781,9 +781,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/strip#suru-strip">Suru strip</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.16.0</td>
       <td>We added new strip variants <code>.p-strip--suru</code> and <code>.p-strip--suru-topped</code>.</td>
@@ -792,9 +792,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Chip</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.15.0</td>
       <td>We added the new <code>.p-chip</code> component to be used to display small actionable pieces of information.</td>
@@ -803,9 +803,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#inline-stretched">List inline stretched</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.14.0</td>
       <td>We added the new <code>.p-inline-list--stretch</code> list variant that arranges items so they span the full width of the parent container.</td>
@@ -814,9 +814,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion#headings">Accordion</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.13.0</td>
       <td>We updated the accordion component with a new <code>.p-accordion__tab--with-title</code> variant that allows using headings in accordion buttons.</td>
@@ -825,9 +825,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#muted-text">Muted text</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.12.0</td>
       <td>New <code>u-text--muted</code> utility class has been added.</td>
@@ -835,9 +835,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons">Icons</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.12.0</td>
       <td>The icons have been updated to new style.</td>
@@ -845,9 +845,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Question</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.12.0</td>
       <td>The <code>p-icon--question</code> has been deprecated will be removed in future release v3.0. Please use existing `.p-icon--help` icon instead.</td>
@@ -856,9 +856,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.11.0</td>
       <td>A no-JS fallback was added for the side navigation toggle functionality on small screens.</td>
@@ -866,9 +866,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#raw-html">Side navigation</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.11.0</td>
       <td>A new raw HTML variant of the side navigation component.</td>
@@ -877,9 +877,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.10.0</td>
       <td>Update to the responsive styling of the side navigation.</td>
@@ -888,9 +888,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.9.0</td>
       <td>New side navigation component was added.</td>
@@ -899,9 +899,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.8.0</td>
       <td>New navigation classes (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) were added to replace existing (<code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code>).</td>
@@ -909,9 +909,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.8.0</td>
       <td>Navigation classes <code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code> are deprecated and will be removed in future release v3.0. Please use new class names (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) instead.</td>
@@ -920,9 +920,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/contextual-menu#theming">Contextual menu</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.7.0</td>
       <td>Added dark theme to contextual menu.</td>
@@ -930,9 +930,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#heading-classes">Heading classes</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.7.0</td>
       <td>New heading classes with numbers (<code>p-heading--1</code>, ...) were added for consistency with other class names we use.</td>
@@ -940,9 +940,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#heading-classes">Heading classes</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.7.0</td>
       <td>Heading classes with numbers as words (<code>p-heading--one</code>, <code>--two</code>, ...) are deprecated and will be removed in future release v3.0. Please use class names with numbers (<code>p-heading--1</code>, <code>--2</code>, ...) instead.</td>
@@ -950,9 +950,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms/#range">Range input</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.6.0</td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
@@ -960,9 +960,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms/#checkbox">Checkbox, radio button</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.6.0</td>
       <td>New `is-table-header` added to properly align checkboxes and radio buttons used in table headers.</td>
@@ -970,9 +970,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/slider">Slider</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.6.0</td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
@@ -980,9 +980,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/contextual-menu/#indicator">Contextual menu</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.5.0</td>
       <td>Optional state indicator was added to contextual menu</td>
@@ -990,9 +990,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/font-metrics/">Font metrics</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-visualise-font-metrics</code> utility to visualise font metrics</td>
@@ -1000,9 +1000,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography/#line-length">Line length</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>$max-width--default</code> variable and <code>u-no-max-width</code> utility to control line length</td>
@@ -1010,9 +1010,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/table-cell-padding-overlap/">Table cell padding overlap</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-table-cell-padding-overlap</code> utility to overlap table cell padding</td>
@@ -1020,9 +1020,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/truncate/">Truncation</a></th>
       <td>
-        <div class="p-chip--positive is-dense is-inline">
+        <span class="p-chip--positive is-dense is-inline">
           <span class="p-chip__value">New</span>
-        </div>
+        </span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-truncate</code> utility to truncate text with ellipsis</td>
@@ -1030,9 +1030,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons/#social">Social icons</a></th>
       <td>
-        <div class="p-chip--information is-dense is-inline">
+        <span class="p-chip--information is-dense is-inline">
           <span class="p-chip__value">Updated</span>
-        </div>
+        </span>
       </td>
       <td>2.5.0</td>
       <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>
@@ -1040,9 +1040,9 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons/#social">Social icons</a></th>
       <td>
-        <div class="p-chip--negative is-dense is-inline">
+        <span class="p-chip--negative is-dense is-inline">
           <span class="p-chip__value">Deprecated</span>
-        </div>
+        </span>
       </td>
       <td>2.5.0</td>
       <td>We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from social icon set in future release v3.0</td>
@@ -1061,41 +1061,41 @@ See [the upgrade guide](/docs/upgrade-guide-v3) to learn about all the breaking 
 <div class="row">
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <div class="p-chip--positive is-dense is-inline">
+      <span class="p-chip--positive is-dense is-inline">
         <span class="p-chip__value">New</span>
-      </div>
+      </span>
       <p class="p-card__content">Newly released components, utilities or settings that are safe to use in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <div class="p-chip--negative is-desne is-inline">
+      <span class="p-chip--negative is-desne is-inline">
         <span class="p-chip__value">Deprecated</span>
-      </div>
+      </span>
       <p class="p-card__content">These components, utilities or settings are in the process of being removed and should no longer be used in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <div class="p-chip--information is-dense is-inline">
+      <span class="p-chip--information is-dense is-inline">
         <span class="p-chip__value">In progress</span>
-      </div>
+      </span>
       <p class="p-card__content">Design spec and code implementation are not yet finished.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <div class="p-chip--information is-dense is-inline">
+      <span class="p-chip--information is-dense is-inline">
         <span class="p-chip__value">Updated</span>
-      </div>
+      </span>
       <p class="p-card__content">These are existing components, utilities or settings that have been updated either through design or code.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
   <div class="p-card--highlighted">
-      <div class="p-chip--positive is-dense is-inline">
+      <span class="p-chip--positive is-dense is-inline">
         <span class="p-chip__value">Validated</span>
-      </div>
+      </span>
       <p class="p-card__content">Proposal approved in our bi-weekly meeting . A design spec is created and development starts ready for code review.</p>
     </div>
   </div>

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -43,7 +43,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Specificity per selector',
       benchmark: 15,
-      threshold: 21,
+      threshold: 22,
       result: results['specificity-per-selector'],
     },
     {


### PR DESCRIPTION
## Done

Adds interactive chips (using `button` elements). Also makes sure chips respect aria-pressed (#3416)
Drive-by: fix chips overrides in search&filter component.

Fixes #4167
Fixes #3416 
Fixes #4166

## QA

- Open [demo](https://vanilla-framework-4169.demos.haus/docs/examples/patterns/chip/interactive)
- Check if new examples with interactive chips work:
  - https://vanilla-framework-4169.demos.haus/docs/examples/patterns/chip/interactive
  - All variants (interactive are at the end of each row): https://vanilla-framework-4169.demos.haus/docs/examples/patterns/chip/variants
- Make sure search&filter looks as expected (note that Vanilla examples are not fully interactive, just expand/collapse):
  - https://vanilla-framework-4169.demos.haus/docs/examples/patterns/search-and-filter/with-chips
- Review updated documentation:
  - https://vanilla-framework-4169.demos.haus/docs/patterns/chip


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.



