### PR TITLE
Prevent renovate from upgrading python in CircleCi image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": ["config:base", "group:allNonMajor", "schedule:monthly"],
   "labels": ["Maintenance 🔨"],
-  "dependencyDashboard": false
+  "dependencyDashboard": false,
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["cimg/python"],
+      "allowedVersions": "<=3.8"
+    }
+  ]
 }


### PR DESCRIPTION
## Done

Prevent renovate from upgrading python in CircleCi image, which fails the build (as in #4165)

