### PR TITLE
Refactor margin/gutter scss maps

### DIFF
--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -69,7 +69,7 @@
 
       // set static gutter width per breakpoint
       @media (min-width: $threshold-4-6-col) {
-        grid-gap: 0 map-get($grid-gutter-widths, large);
+        grid-gap: 0 map-get($grid-gutter-widths, default);
         grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
 
         & > * {
@@ -78,7 +78,7 @@
       }
 
       @media (min-width: $threshold-6-12-col) {
-        grid-gap: 0 map-get($grid-gutter-widths, large);
+        grid-gap: 0 map-get($grid-gutter-widths, default);
         grid-template-columns: repeat($grid-columns, minmax(0, 1fr));
 
         & > * {
@@ -94,13 +94,13 @@
     padding-right: map-get($grid-margin-widths, small);
 
     @media (min-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, large);
-      padding-right: map-get($grid-margin-widths, large);
+      padding-left: map-get($grid-margin-widths, default);
+      padding-right: map-get($grid-margin-widths, default);
     }
 
     @media (min-width: $threshold-6-12-col) {
-      padding-left: map-get($grid-margin-widths, large);
-      padding-right: map-get($grid-margin-widths, large);
+      padding-left: map-get($grid-margin-widths, default);
+      padding-right: map-get($grid-margin-widths, default);
     }
   }
 }

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -69,7 +69,7 @@
 
       // set static gutter width per breakpoint
       @media (min-width: $threshold-4-6-col) {
-        grid-gap: 0 map-get($grid-gutter-widths, medium);
+        grid-gap: 0 map-get($grid-gutter-widths, large);
         grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
 
         & > * {
@@ -94,8 +94,8 @@
     padding-right: map-get($grid-margin-widths, small);
 
     @media (min-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, medium);
-      padding-right: map-get($grid-margin-widths, medium);
+      padding-left: map-get($grid-margin-widths, large);
+      padding-right: map-get($grid-margin-widths, large);
     }
 
     @media (min-width: $threshold-6-12-col) {

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -24,13 +24,13 @@
       width: calc(100% - #{2 * map-get($grid-margin-widths, small)});
 
       @media (min-width: $threshold-4-6-col) {
-        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, large)});
-        width: calc(100% - #{2 * map-get($grid-margin-widths, large)});
+        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, default)});
+        width: calc(100% - #{2 * map-get($grid-margin-widths, default)});
       }
 
       @media (min-width: $threshold-6-12-col) {
-        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, large)});
-        width: calc(100% - #{2 * map-get($grid-margin-widths, large)});
+        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, default)});
+        width: calc(100% - #{2 * map-get($grid-margin-widths, default)});
       }
 
       .row &,

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -24,8 +24,8 @@
       width: calc(100% - #{2 * map-get($grid-margin-widths, small)});
 
       @media (min-width: $threshold-4-6-col) {
-        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, medium)});
-        width: calc(100% - #{2 * map-get($grid-margin-widths, medium)});
+        max-width: calc(#{$grid-max-width} - #{2 * map-get($grid-margin-widths, large)});
+        width: calc(100% - #{2 * map-get($grid-margin-widths, large)});
       }
 
       @media (min-width: $threshold-6-12-col) {

--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -25,8 +25,8 @@
     }
 
     @media (min-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, medium);
-      padding-right: map-get($grid-margin-widths, medium);
+      padding-left: map-get($grid-margin-widths, large);
+      padding-right: map-get($grid-margin-widths, large);
     }
 
     @media (min-width: $threshold-6-12-col) {

--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -25,13 +25,13 @@
     }
 
     @media (min-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, large);
-      padding-right: map-get($grid-margin-widths, large);
+      padding-left: map-get($grid-margin-widths, default);
+      padding-right: map-get($grid-margin-widths, default);
     }
 
     @media (min-width: $threshold-6-12-col) {
-      padding-left: map-get($grid-margin-widths, large);
-      padding-right: map-get($grid-margin-widths, large);
+      padding-left: map-get($grid-margin-widths, default);
+      padding-right: map-get($grid-margin-widths, default);
     }
 
     @media (min-width: $l-fluid-breakout-3-col-threshold) {
@@ -51,8 +51,8 @@
       width: 100%;
 
       @media (min-width: $l-fluid-breakout-3-col-threshold) {
-        padding-left: map-get($grid-margin-widths, large);
-        padding-right: map-get($grid-margin-widths, large);
+        padding-left: map-get($grid-margin-widths, default);
+        padding-right: map-get($grid-margin-widths, default);
       }
 
       @media (min-width: $breakpoint-large) {
@@ -97,11 +97,11 @@
       @extend %l-fluid-breakout__aside-common-properties#{$suffix};
 
       @media (min-width: $breakpoint-large) {
-        padding-right: map-get($grid-margin-widths, large);
+        padding-right: map-get($grid-margin-widths, default);
       }
 
       @media (min-width: $l-fluid-breakout-3-col-threshold) {
-        padding-left: map-get($grid-margin-widths, large);
+        padding-left: map-get($grid-margin-widths, default);
         padding-right: 0;
       }
     }
@@ -110,13 +110,13 @@
       @extend %l-fluid-breakout__aside-common-properties#{$suffix};
 
       @media (min-width: $breakpoint-large) {
-        padding-left: map-get($grid-margin-widths, large);
+        padding-left: map-get($grid-margin-widths, default);
         padding-right: 0;
       }
 
       @media (min-width: $l-fluid-breakout-3-col-threshold) {
         padding-left: 0;
-        padding-right: map-get($grid-margin-widths, large);
+        padding-right: map-get($grid-margin-widths, default);
       }
 
       @extend %l-fluid-breakout__aside-common-properties#{$suffix};
@@ -139,8 +139,8 @@
       }
 
       @media (min-width: $l-fluid-breakout-3-col-threshold) {
-        margin-left: map-get($grid-margin-widths, large);
-        margin-right: map-get($grid-margin-widths, large);
+        margin-left: map-get($grid-margin-widths, default);
+        margin-right: map-get($grid-margin-widths, default);
       }
     }
 

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -28,7 +28,7 @@
       &:not(:first-child)::before {
         bottom: 0;
         content: '';
-        left: map-get($grid-gutter-widths, large) * -0.5; // "large" here is not a typo. The grid switches to 12 columns at breakpoint medium. Hence the use of large-screen gutter
+        left: map-get($grid-gutter-widths, default) * -0.5; // "large" here is not a typo. The grid switches to 12 columns at breakpoint medium. Hence the use of large-screen gutter
         position: absolute;
         top: 0;
         width: 1px;

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -128,13 +128,13 @@
       right: map-get($grid-margin-widths, small);
 
       @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col - 1) {
-        left: map-get($grid-margin-widths, large);
-        right: map-get($grid-margin-widths, large);
+        left: map-get($grid-margin-widths, default);
+        right: map-get($grid-margin-widths, default);
       }
 
       @media (min-width: $threshold-6-12-col) {
-        left: map-get($grid-margin-widths, large);
-        right: map-get($grid-margin-widths, large);
+        left: map-get($grid-margin-widths, default);
+        right: map-get($grid-margin-widths, default);
       }
     }
   }

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -128,8 +128,8 @@
       right: map-get($grid-margin-widths, small);
 
       @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col - 1) {
-        left: map-get($grid-margin-widths, medium);
-        right: map-get($grid-margin-widths, medium);
+        left: map-get($grid-margin-widths, large);
+        right: map-get($grid-margin-widths, large);
       }
 
       @media (min-width: $threshold-6-12-col) {

--- a/scss/_patterns_logo-section.scss
+++ b/scss/_patterns_logo-section.scss
@@ -16,7 +16,7 @@
   @if $breakpoint == medium {
     $grid-column-count: $grid-columns-medium;
     $grid-column-prefix: $grid-medium-col-prefix;
-    $gutter: map-get($grid-gutter-widths, medium);
+    $gutter: map-get($grid-gutter-widths, large);
     $media-query-keyword: min-width;
     $media-query-width: $threshold-4-6-col;
     $logo-column-span: 1;
@@ -103,7 +103,7 @@
   }
 
   $margin-small: map-get($grid-gutter-widths, small);
-  $margin-medium: map-get($grid-gutter-widths, medium);
+  $margin-medium: map-get($grid-gutter-widths, large);
   $margin-large: map-get($grid-gutter-widths, large);
 
   .p-logo-section__items {

--- a/scss/_patterns_logo-section.scss
+++ b/scss/_patterns_logo-section.scss
@@ -16,14 +16,14 @@
   @if $breakpoint == medium {
     $grid-column-count: $grid-columns-medium;
     $grid-column-prefix: $grid-medium-col-prefix;
-    $gutter: map-get($grid-gutter-widths, large);
+    $gutter: map-get($grid-gutter-widths, default);
     $media-query-keyword: min-width;
     $media-query-width: $threshold-4-6-col;
     $logo-column-span: 1;
   } @else if $breakpoint == large {
     $grid-column-count: $grid-columns;
     $grid-column-prefix: $grid-large-col-prefix;
-    $gutter: map-get($grid-gutter-widths, large);
+    $gutter: map-get($grid-gutter-widths, default);
     $media-query-keyword: min-width;
     $media-query-width: $threshold-6-12-col;
     $logo-column-span: 2;
@@ -103,8 +103,8 @@
   }
 
   $margin-small: map-get($grid-gutter-widths, small);
-  $margin-medium: map-get($grid-gutter-widths, large);
-  $margin-large: map-get($grid-gutter-widths, large);
+  $margin-medium: map-get($grid-gutter-widths, default);
+  $margin-large: map-get($grid-gutter-widths, default);
 
   .p-logo-section__items {
     display: flex;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -14,7 +14,7 @@ $lightness-threshold: 70;
     padding-left: map-get($grid-margin-widths, small);
 
     @media (min-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, medium);
+      padding-left: map-get($grid-margin-widths, large);
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
@@ -27,7 +27,7 @@ $lightness-threshold: 70;
     padding-right: map-get($grid-margin-widths, small);
 
     @media (min-width: $threshold-4-6-col) {
-      padding-right: map-get($grid-margin-widths, medium);
+      padding-right: map-get($grid-margin-widths, large);
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
@@ -102,8 +102,8 @@ $lightness-threshold: 70;
       order: -1;
 
       @media (min-width: $threshold-4-6-col) {
-        margin-left: map-get($grid-margin-widths, medium);
-        margin-right: map-get($grid-margin-widths, medium);
+        margin-left: map-get($grid-margin-widths, large);
+        margin-right: map-get($grid-margin-widths, large);
       }
 
       @media (min-width: $breakpoint-navigation-threshold) {
@@ -336,7 +336,7 @@ $lightness-threshold: 70;
         width: map-get($icon-sizes, default);
 
         @media (min-width: $threshold-4-6-col) {
-          right: map-get($grid-margin-widths, medium);
+          right: map-get($grid-margin-widths, large);
         }
 
         @media (min-width: $breakpoint-navigation-threshold) {
@@ -439,7 +439,7 @@ $lightness-threshold: 70;
       width: map-get($icon-sizes, default);
 
       @media (min-width: $threshold-4-6-col) {
-        right: map-get($grid-margin-widths, medium);
+        right: map-get($grid-margin-widths, large);
       }
 
       @media (min-width: $breakpoint-navigation-threshold) {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -14,7 +14,7 @@ $lightness-threshold: 70;
     padding-left: map-get($grid-margin-widths, small);
 
     @media (min-width: $threshold-4-6-col) {
-      padding-left: map-get($grid-margin-widths, large);
+      padding-left: map-get($grid-margin-widths, default);
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
@@ -27,7 +27,7 @@ $lightness-threshold: 70;
     padding-right: map-get($grid-margin-widths, small);
 
     @media (min-width: $threshold-4-6-col) {
-      padding-right: map-get($grid-margin-widths, large);
+      padding-right: map-get($grid-margin-widths, default);
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
@@ -102,8 +102,8 @@ $lightness-threshold: 70;
       order: -1;
 
       @media (min-width: $threshold-4-6-col) {
-        margin-left: map-get($grid-margin-widths, large);
-        margin-right: map-get($grid-margin-widths, large);
+        margin-left: map-get($grid-margin-widths, default);
+        margin-right: map-get($grid-margin-widths, default);
       }
 
       @media (min-width: $breakpoint-navigation-threshold) {
@@ -207,7 +207,7 @@ $lightness-threshold: 70;
       display: flex;
       flex-direction: row;
       justify-content: space-between;
-      margin-right: map-get($grid-margin-widths, large);
+      margin-right: map-get($grid-margin-widths, default);
       width: 100%;
     }
   }
@@ -336,7 +336,7 @@ $lightness-threshold: 70;
         width: map-get($icon-sizes, default);
 
         @media (min-width: $threshold-4-6-col) {
-          right: map-get($grid-margin-widths, large);
+          right: map-get($grid-margin-widths, default);
         }
 
         @media (min-width: $breakpoint-navigation-threshold) {
@@ -439,7 +439,7 @@ $lightness-threshold: 70;
       width: map-get($icon-sizes, default);
 
       @media (min-width: $threshold-4-6-col) {
-        right: map-get($grid-margin-widths, large);
+        right: map-get($grid-margin-widths, default);
       }
 
       @media (min-width: $breakpoint-navigation-threshold) {

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -357,7 +357,7 @@
   #{$prop}: $multiplier * map-get($grid-margin-widths, small) + $offset;
 
   @media (min-width: $threshold-4-6-col) {
-    #{$prop}: $multiplier * map-get($grid-margin-widths, medium) + $offset;
+    #{$prop}: $multiplier * map-get($grid-margin-widths, large) + $offset;
   }
 
   @media (min-width: $threshold-6-12-col) {

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -357,11 +357,11 @@
   #{$prop}: $multiplier * map-get($grid-margin-widths, small) + $offset;
 
   @media (min-width: $threshold-4-6-col) {
-    #{$prop}: $multiplier * map-get($grid-margin-widths, large) + $offset;
+    #{$prop}: $multiplier * map-get($grid-margin-widths, default) + $offset;
   }
 
   @media (min-width: $threshold-6-12-col) {
-    #{$prop}: $multiplier * map-get($grid-margin-widths, large) + $offset;
+    #{$prop}: $multiplier * map-get($grid-margin-widths, default) + $offset;
   }
 }
 

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -16,12 +16,12 @@ $grid-large-col-prefix: #{$grid-column-prefix} !default;
 
 $grid-gutter-widths: (
   small: $sp-unit * 3,
-  large: $sp-unit * 4,
+  default: $sp-unit * 4,
 ) !default;
 
 $grid-margin-widths: (
   small: $sp-unit * 2,
-  large: $sp-unit * 3,
+  default: $sp-unit * 3,
 ) !default;
 
 // Grid breakout template

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -16,13 +16,11 @@ $grid-large-col-prefix: #{$grid-column-prefix} !default;
 
 $grid-gutter-widths: (
   small: $sp-unit * 3,
-  medium: $sp-unit * 4,
   large: $sp-unit * 4,
 ) !default;
 
 $grid-margin-widths: (
   small: $sp-unit * 2,
-  medium: $sp-unit * 3,
   large: $sp-unit * 3,
 ) !default;
 

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -34,6 +34,15 @@ The `.p-link--external` class has been removed, so elements using that class wil
 
 ### Column classes
 
+The scss maps defining grid margins and gutters have been simplified. In both `$grid-gutter-widths` and `$grid-margin-widths`, the following keys havechanged:
+
+| Old key  | New key   |
+| -------- | --------- |
+| `medium` | `default` |
+| `large`  | `default` |
+
+### Column classes
+
 Use of `.col` classes outside of `.row` is no longer supported. If you use `.col-X` class names outside of `.row`, or your custom styling depends on specificity of a `.col-X` class name, you will need to review and update your styles accordingly.
 
 ### Column layout change


### PR DESCRIPTION
## Done

Replace medium with large, delete keys (they use same values so no need forseparate vars)
Fixes #3278

## QA

- Ensure no percy changes presnt
- Check code changes, verify no instances of `map-get($grid-gutter-widths, medium)` remain

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
