### PR TITLE
Remove unnecessary margin reset

### DIFF
--- a/scss/_patterns_table-expanding.scss
+++ b/scss/_patterns_table-expanding.scss
@@ -20,10 +20,6 @@
         flow: row;
         wrap: wrap;
       }
-
-      + tr {
-        margin: 0;
-      }
     }
 
     th,


### PR DESCRIPTION
## Done

Removes unnecessary margin reset from expanding table (which was conflicting with margin in mobile table cards).

Fixes #4163


## QA

- Open [demo](https://vanilla-framework-4177.demos.haus)
- Check if expanding table works as expected:
  - https://vanilla-framework-4177.demos.haus/docs/examples/patterns/tables/table-expanding
- In mobile-card example, add `p-table--expanding` class to the table and check if it still looks correctly in mobile view
  - https://vanilla-framework-4177.demos.haus/docs/examples/patterns/tables/table-mobile-card

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

