### PR TITLE
Fix misused `aria-label` on mobile card table

### DIFF
--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -56,8 +56,8 @@
             overflow: visible;
           }
 
-          &[aria-label]::before {
-            content: attr(aria-label);
+          &[data-heading]::before {
+            content: attr(data-heading);
             display: block;
             margin-bottom: map-get($sp-after, x-small) - map-get($nudges, x-small) - $sp-unit;
             overflow: hidden;

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -70,7 +70,7 @@ View example of the expanding table pattern
 ## Responsive
 
 Applying the class `.p-table--mobile-card` will give any table a new responsive card view when on smaller screens. Each cell will require
-an `[aria-label]` to describe the cell on a mobile screen. We use the content to create a pseudo element and keep it line with the content.
+a `[data-heading]` attribute to describe the cell on a mobile screen. We use the content to create a pseudo element and keep it line with the content.
 
 The `<thead>` element is completely hidden from view on a smaller screen and if the table holds a `.p-contextual-menu` pattern all the children elements will be visible and be interactive.
 

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -57,7 +57,7 @@
       <td class="u-align--right"  data-heading="Cores">6</td>
       <td class="u-align--right"  data-heading="RAM">4 GiB</td>
       <td class="u-align--right"  data-heading="Disks">1</td>
-      <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">500GB</td>
+      <td class="u-align--right"  data-heading="Storage">500GB</td>
       <td class="has-overflow" data-heading="Actions">
         <span class="p-contextual-menu--left">
           <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-2" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
@@ -85,7 +85,7 @@
       <td class="u-align--right"  data-heading="Cores">8</td>
       <td class="u-align--right"  data-heading="RAM">16 GiB</td>
       <td class="u-align--right"  data-heading="Disks">3</td>
-      <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">6TB</td>
+      <td class="u-align--right"  data-heading="Storage">6TB</td>
       <td class="has-overflow" data-heading="Actions">
         <span class="p-contextual-menu--left">
           <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
@@ -113,7 +113,7 @@
       <td class="u-align--right"  data-heading="Cores">2</td>
       <td class="u-align--right"  data-heading="RAM">1 GiB</td>
       <td class="u-align--right"  data-heading="Disks">1</td>
-      <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">240GB</td>
+      <td class="u-align--right"  data-heading="Storage">240GB</td>
       <td class="has-overflow" data-heading="Actions">
         <span class="p-contextual-menu--left">
           <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>

--- a/templates/docs/examples/patterns/tables/table-mobile-card.html
+++ b/templates/docs/examples/patterns/tables/table-mobile-card.html
@@ -21,16 +21,16 @@
   </thead>
   <tbody>
     <tr>
-      <td aria-label="FQDN">LongEnoughToCauseEllipsis</td>
-      <td aria-label="Power">On</td>
-      <td aria-label="Status">Failed testing</td>
-      <td aria-label="Owner">Caleb</td>
-      <td aria-label="Zone">london</td>
-      <td class="u-align--right"  aria-label="Cores">4</td>
-      <td class="u-align--right"  aria-label="RAM">2 GiB</td>
-      <td class="u-align--right"  aria-label="Disks">1</td>
-      <td class="u-align--right"  aria-label="Storagelongenoughtocauseellipsis">2TB</td>
-      <td class="has-overflow" aria-label="Actions">
+      <td data-heading="FQDN">LongEnoughToCauseEllipsis</td>
+      <td data-heading="Power">On</td>
+      <td data-heading="Status">Failed testing</td>
+      <td data-heading="Owner">Caleb</td>
+      <td data-heading="Zone">london</td>
+      <td class="u-align--right" data-heading="Cores">4</td>
+      <td class="u-align--right" data-heading="RAM">2 GiB</td>
+      <td class="u-align--right" data-heading="Disks">1</td>
+      <td class="u-align--right" data-heading="Storage long enough to cause ellipsis">2TB</td>
+      <td class="has-overflow" data-heading="Actions">
         <span class="p-contextual-menu--left">
           <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-1" aria-expanded="true" aria-haspopup="true">Actions&hellip;</button>
           <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="false">
@@ -49,16 +49,16 @@
       </td>
     </tr>
     <tr>
-      <td aria-label="FQDN">upward-muskox</td>
-      <td aria-label="Power">Off</td>
-      <td aria-label="Status">Allocated</td>
-      <td aria-label="Owner">sparkiegeek</td>
-      <td aria-label="Zone">london</td>
-      <td class="u-align--right"  aria-label="Cores">6</td>
-      <td class="u-align--right"  aria-label="RAM">4 GiB</td>
-      <td class="u-align--right"  aria-label="Disks">1</td>
-      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">500GB</td>
-      <td class="has-overflow" aria-label="Actions">
+      <td data-heading="FQDN">upward-muskox</td>
+      <td data-heading="Power">Off</td>
+      <td data-heading="Status">Allocated</td>
+      <td data-heading="Owner">sparkiegeek</td>
+      <td data-heading="Zone">london</td>
+      <td class="u-align--right"  data-heading="Cores">6</td>
+      <td class="u-align--right"  data-heading="RAM">4 GiB</td>
+      <td class="u-align--right"  data-heading="Disks">1</td>
+      <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">500GB</td>
+      <td class="has-overflow" data-heading="Actions">
         <span class="p-contextual-menu--left">
           <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-2" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
           <span class="p-contextual-menu__dropdown" id="menu-2" aria-hidden="true">
@@ -77,16 +77,16 @@
       </td>
     </tr>
     <tr>
-      <td aria-label="FQDN">first-cattle</td>
-      <td aria-label="Power">On</td>
-      <td aria-label="Status">Failed to enter rescue mode</td>
-      <td aria-label="Owner">admin</td>
-      <td aria-label="Zone">london</td>
-      <td class="u-align--right"  aria-label="Cores">8</td>
-      <td class="u-align--right"  aria-label="RAM">16 GiB</td>
-      <td class="u-align--right"  aria-label="Disks">3</td>
-      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">6TB</td>
-      <td class="has-overflow" aria-label="Actions">
+      <td data-heading="FQDN">first-cattle</td>
+      <td data-heading="Power">On</td>
+      <td data-heading="Status">Failed to enter rescue mode</td>
+      <td data-heading="Owner">admin</td>
+      <td data-heading="Zone">london</td>
+      <td class="u-align--right"  data-heading="Cores">8</td>
+      <td class="u-align--right"  data-heading="RAM">16 GiB</td>
+      <td class="u-align--right"  data-heading="Disks">3</td>
+      <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">6TB</td>
+      <td class="has-overflow" data-heading="Actions">
         <span class="p-contextual-menu--left">
           <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
           <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
@@ -105,16 +105,16 @@
       </td>
     </tr>
     <tr>
-      <td aria-label="FQDN">golden-rodent</td>
-      <td aria-label="Power">Off</td>
-      <td aria-label="Status">Broken</td>
-      <td aria-label="Owner">&mdash;</td>
-      <td aria-label="Zone">london</td>
-      <td class="u-align--right"  aria-label="Cores">2</td>
-      <td class="u-align--right"  aria-label="RAM">1 GiB</td>
-      <td class="u-align--right"  aria-label="Disks">1</td>
-      <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">240GB</td>
-      <td class="has-overflow" aria-label="Actions">
+      <td data-heading="FQDN">golden-rodent</td>
+      <td data-heading="Power">Off</td>
+      <td data-heading="Status">Broken</td>
+      <td data-heading="Owner">&mdash;</td>
+      <td data-heading="Zone">london</td>
+      <td class="u-align--right"  data-heading="Cores">2</td>
+      <td class="u-align--right"  data-heading="RAM">1 GiB</td>
+      <td class="u-align--right"  data-heading="Disks">1</td>
+      <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">240GB</td>
+      <td class="has-overflow" data-heading="Actions">
         <span class="p-contextual-menu--left">
           <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
           <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true">

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -141,64 +141,64 @@
         </thead>
         <tbody>
           <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
+            <th data-heading="FQDN | MAC">Machine 1</th>
+            <td data-heading="Power">Off</td>
+            <td data-heading="Status">Ready</td>
+            <td data-heading="Owner | Pool">Maria</td>
+            <td data-heading="Cores" class="u-align--right">8</td>
+            <td data-heading="RAM(GB)" class="u-align--right">16</td>
+            <td data-heading="Disks" class="u-align--right">2</td>
+            <td data-heading="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
+            <th data-heading="FQDN | MAC">Machine 1</th>
+            <td data-heading="Power">Off</td>
+            <td data-heading="Status">Ready</td>
+            <td data-heading="Owner | Pool">Maria</td>
+            <td data-heading="Cores" class="u-align--right">8</td>
+            <td data-heading="RAM(GB)" class="u-align--right">16</td>
+            <td data-heading="Disks" class="u-align--right">2</td>
+            <td data-heading="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
+            <th data-heading="FQDN | MAC">Machine 1</th>
+            <td data-heading="Power">Off</td>
+            <td data-heading="Status">Ready</td>
+            <td data-heading="Owner | Pool">Maria</td>
+            <td data-heading="Cores" class="u-align--right">8</td>
+            <td data-heading="RAM(GB)" class="u-align--right">16</td>
+            <td data-heading="Disks" class="u-align--right">2</td>
+            <td data-heading="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
+            <th data-heading="FQDN | MAC">Machine 1</th>
+            <td data-heading="Power">Off</td>
+            <td data-heading="Status">Ready</td>
+            <td data-heading="Owner | Pool">Maria</td>
+            <td data-heading="Cores" class="u-align--right">8</td>
+            <td data-heading="RAM(GB)" class="u-align--right">16</td>
+            <td data-heading="Disks" class="u-align--right">2</td>
+            <td data-heading="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
+            <th data-heading="FQDN | MAC">Machine 1</th>
+            <td data-heading="Power">Off</td>
+            <td data-heading="Status">Ready</td>
+            <td data-heading="Owner | Pool">Maria</td>
+            <td data-heading="Cores" class="u-align--right">8</td>
+            <td data-heading="RAM(GB)" class="u-align--right">16</td>
+            <td data-heading="Disks" class="u-align--right">2</td>
+            <td data-heading="Storage(GB)" class="u-align--right">2</td>
           </tr>
           <tr>
-            <th aria-label="FQDN | MAC">Machine 1</th>
-            <td aria-label="Power">Off</td>
-            <td aria-label="Status">Ready</td>
-            <td aria-label="Owner | Pool">Maria</td>
-            <td aria-label="Cores" class="u-align--right">8</td>
-            <td aria-label="RAM(GB)" class="u-align--right">16</td>
-            <td aria-label="Disks" class="u-align--right">2</td>
-            <td aria-label="Storage(GB)" class="u-align--right">2</td>
+            <th data-heading="FQDN | MAC">Machine 1</th>
+            <td data-heading="Power">Off</td>
+            <td data-heading="Status">Ready</td>
+            <td data-heading="Owner | Pool">Maria</td>
+            <td data-heading="Cores" class="u-align--right">8</td>
+            <td data-heading="RAM(GB)" class="u-align--right">16</td>
+            <td data-heading="Disks" class="u-align--right">2</td>
+            <td data-heading="Storage(GB)" class="u-align--right">2</td>
           </tr>
         </tbody>
       </table>

--- a/templates/docs/examples/templates/responsive.html
+++ b/templates/docs/examples/templates/responsive.html
@@ -243,16 +243,16 @@
       </thead>
       <tbody>
         <tr>
-          <td aria-label="FQDN">LongEnoughToCauseEllipsis</td>
-          <td aria-label="Power">On</td>
-          <td aria-label="Status">Failed testing</td>
-          <td aria-label="Owner">Caleb</td>
-          <td aria-label="Zone">london</td>
-          <td class="u-align--right"  aria-label="Cores">4</td>
-          <td class="u-align--right"  aria-label="RAM">2 GiB</td>
-          <td class="u-align--right"  aria-label="Disks">1</td>
-          <td class="u-align--right"  aria-label="Storagelongenoughtocauseellipsis">2TB</td>
-          <td class="has-overflow" aria-label="Actions">
+          <td data-heading="FQDN">LongEnoughToCauseEllipsis</td>
+          <td data-heading="Power">On</td>
+          <td data-heading="Status">Failed testing</td>
+          <td data-heading="Owner">Caleb</td>
+          <td data-heading="Zone">london</td>
+          <td class="u-align--right"  data-heading="Cores">4</td>
+          <td class="u-align--right"  data-heading="RAM">2 GiB</td>
+          <td class="u-align--right"  data-heading="Disks">1</td>
+          <td class="u-align--right"  data-heading="Storagelongenoughtocauseellipsis">2TB</td>
+          <td class="has-overflow" data-heading="Actions">
             <span class="p-contextual-menu--left">
               <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-1" aria-expanded="true" aria-haspopup="true">Actions&hellip;</button>
               <span class="p-contextual-menu__dropdown" id="menu-1" aria-hidden="false">
@@ -271,16 +271,16 @@
           </td>
         </tr>
         <tr>
-          <td aria-label="FQDN">upward-muskox</td>
-          <td aria-label="Power">Off</td>
-          <td aria-label="Status">Allocated</td>
-          <td aria-label="Owner">sparkiegeek</td>
-          <td aria-label="Zone">london</td>
-          <td class="u-align--right"  aria-label="Cores">6</td>
-          <td class="u-align--right"  aria-label="RAM">4 GiB</td>
-          <td class="u-align--right"  aria-label="Disks">1</td>
-          <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">500GB</td>
-          <td class="has-overflow" aria-label="Actions">
+          <td data-heading="FQDN">upward-muskox</td>
+          <td data-heading="Power">Off</td>
+          <td data-heading="Status">Allocated</td>
+          <td data-heading="Owner">sparkiegeek</td>
+          <td data-heading="Zone">london</td>
+          <td class="u-align--right"  data-heading="Cores">6</td>
+          <td class="u-align--right"  data-heading="RAM">4 GiB</td>
+          <td class="u-align--right"  data-heading="Disks">1</td>
+          <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">500GB</td>
+          <td class="has-overflow" data-heading="Actions">
             <span class="p-contextual-menu--left">
               <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-2" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
               <span class="p-contextual-menu__dropdown" id="menu-2" aria-hidden="true">
@@ -299,16 +299,16 @@
           </td>
         </tr>
         <tr>
-          <td aria-label="FQDN">first-cattle</td>
-          <td aria-label="Power">On</td>
-          <td aria-label="Status">Failed to enter rescue mode</td>
-          <td aria-label="Owner">admin</td>
-          <td aria-label="Zone">london</td>
-          <td class="u-align--right"  aria-label="Cores">8</td>
-          <td class="u-align--right"  aria-label="RAM">16 GiB</td>
-          <td class="u-align--right"  aria-label="Disks">3</td>
-          <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">6TB</td>
-          <td class="has-overflow" aria-label="Actions">
+          <td data-heading="FQDN">first-cattle</td>
+          <td data-heading="Power">On</td>
+          <td data-heading="Status">Failed to enter rescue mode</td>
+          <td data-heading="Owner">admin</td>
+          <td data-heading="Zone">london</td>
+          <td class="u-align--right"  data-heading="Cores">8</td>
+          <td class="u-align--right"  data-heading="RAM">16 GiB</td>
+          <td class="u-align--right"  data-heading="Disks">3</td>
+          <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">6TB</td>
+          <td class="has-overflow" data-heading="Actions">
             <span class="p-contextual-menu--left">
               <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
               <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
@@ -327,16 +327,16 @@
           </td>
         </tr>
         <tr>
-          <td aria-label="FQDN">golden-rodent</td>
-          <td aria-label="Power">Off</td>
-          <td aria-label="Status">Broken</td>
-          <td aria-label="Owner">&mdash;</td>
-          <td aria-label="Zone">london</td>
-          <td class="u-align--right"  aria-label="Cores">2</td>
-          <td class="u-align--right"  aria-label="RAM">1 GiB</td>
-          <td class="u-align--right"  aria-label="Disks">1</td>
-          <td class="u-align--right"  aria-label="Storage this is long enough to cause wrapping">240GB</td>
-          <td class="has-overflow" aria-label="Actions">
+          <td data-heading="FQDN">golden-rodent</td>
+          <td data-heading="Power">Off</td>
+          <td data-heading="Status">Broken</td>
+          <td data-heading="Owner">&mdash;</td>
+          <td data-heading="Zone">london</td>
+          <td class="u-align--right"  data-heading="Cores">2</td>
+          <td class="u-align--right"  data-heading="RAM">1 GiB</td>
+          <td class="u-align--right"  data-heading="Disks">1</td>
+          <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">240GB</td>
+          <td class="has-overflow" data-heading="Actions">
             <span class="p-contextual-menu--left">
               <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
               <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true">

--- a/templates/docs/examples/templates/responsive.html
+++ b/templates/docs/examples/templates/responsive.html
@@ -251,7 +251,7 @@
           <td class="u-align--right"  data-heading="Cores">4</td>
           <td class="u-align--right"  data-heading="RAM">2 GiB</td>
           <td class="u-align--right"  data-heading="Disks">1</td>
-          <td class="u-align--right"  data-heading="Storagelongenoughtocauseellipsis">2TB</td>
+          <td class="u-align--right"  data-heading="Storage long enough to cause ellipsis">2TB</td>
           <td class="has-overflow" data-heading="Actions">
             <span class="p-contextual-menu--left">
               <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-1" aria-expanded="true" aria-haspopup="true">Actions&hellip;</button>
@@ -279,7 +279,7 @@
           <td class="u-align--right"  data-heading="Cores">6</td>
           <td class="u-align--right"  data-heading="RAM">4 GiB</td>
           <td class="u-align--right"  data-heading="Disks">1</td>
-          <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">500GB</td>
+          <td class="u-align--right"  data-heading="Storage">500GB</td>
           <td class="has-overflow" data-heading="Actions">
             <span class="p-contextual-menu--left">
               <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-2" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
@@ -307,7 +307,7 @@
           <td class="u-align--right"  data-heading="Cores">8</td>
           <td class="u-align--right"  data-heading="RAM">16 GiB</td>
           <td class="u-align--right"  data-heading="Disks">3</td>
-          <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">6TB</td>
+          <td class="u-align--right"  data-heading="Storage">6TB</td>
           <td class="has-overflow" data-heading="Actions">
             <span class="p-contextual-menu--left">
               <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>
@@ -335,7 +335,7 @@
           <td class="u-align--right"  data-heading="Cores">2</td>
           <td class="u-align--right"  data-heading="RAM">1 GiB</td>
           <td class="u-align--right"  data-heading="Disks">1</td>
-          <td class="u-align--right"  data-heading="Storage this is long enough to cause wrapping">240GB</td>
+          <td class="u-align--right"  data-heading="Storage">240GB</td>
           <td class="has-overflow" data-heading="Actions">
             <span class="p-contextual-menu--left">
               <button class="p-contextual-menu__toggle u-no-margin--bottom" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">Actions&hellip;</button>

--- a/templates/docs/examples/templates/tick-elements.html
+++ b/templates/docs/examples/templates/tick-elements.html
@@ -121,7 +121,7 @@
       </thead>
       <tbody>
         <tr>
-          <th aria-label="FQDN | MAC">
+          <th data-heading="FQDN | MAC">
             <form>
               <label class="p-checkbox--inline">
                 <input type="checkbox" aria-labelledby="checkboxExample6" class="p-checkbox__input" checked>
@@ -129,16 +129,16 @@
               </label>
             </form>
           </th>
-          <td aria-label="Power">Off</td>
-          <td aria-label="Status">Ready</td>
-          <td aria-label="Owner | Pool">Maria</td>
-          <td aria-label="Cores" class="u-align--right">8</td>
-          <td aria-label="RAM(GB)" class="u-align--right">16</td>
-          <td aria-label="Disks" class="u-align--right">2</td>
-          <td aria-label="Storage(GB)" class="u-align--right">2</td>
+          <td data-heading="Power">Off</td>
+          <td data-heading="Status">Ready</td>
+          <td data-heading="Owner | Pool">Maria</td>
+          <td data-heading="Cores" class="u-align--right">8</td>
+          <td data-heading="RAM(GB)" class="u-align--right">16</td>
+          <td data-heading="Disks" class="u-align--right">2</td>
+          <td data-heading="Storage(GB)" class="u-align--right">2</td>
         </tr>
         <tr>
-          <th aria-label="FQDN | MAC">
+          <th data-heading="FQDN | MAC">
             <form>
               <label class="p-radio--inline">
                 <input type="radio" aria-labelledby="radioExample5" class="p-radio__input" checked>
@@ -146,13 +146,13 @@
               </label>
             </form>
           </th>
-          <td aria-label="Power">Off</td>
-          <td aria-label="Status">Ready</td>
-          <td aria-label="Owner | Pool">Maria</td>
-          <td aria-label="Cores" class="u-align--right">8</td>
-          <td aria-label="RAM(GB)" class="u-align--right">16</td>
-          <td aria-label="Disks" class="u-align--right">2</td>
-          <td aria-label="Storage(GB)" class="u-align--right">2</td>
+          <td data-heading="Power">Off</td>
+          <td data-heading="Status">Ready</td>
+          <td data-heading="Owner | Pool">Maria</td>
+          <td data-heading="Cores" class="u-align--right">8</td>
+          <td data-heading="RAM(GB)" class="u-align--right">16</td>
+          <td data-heading="Disks" class="u-align--right">2</td>
+          <td data-heading="Storage(GB)" class="u-align--right">2</td>
         </tr>
       </tbody>
     </table>

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -166,6 +166,10 @@ The label pattern has been removed, and we've added tinted chips. The tints are 
 
 The `vf-p-label` mixin has been removed so you'll have to remove this from your code, along with `vf-p-label-new`, `vf-p-label-updated`, `vf-p-label-deprecated`, `vf-p-label-in-progress` and `vf-p-label-validated`.
 
+## Responsive tables
+
+The `aria-label` attribute on table cells of the responsive table has been replaced by `data-heading`. This is to ensure information in the cells of the table isn't missed by screen readers. Please replace all `aria-label`'s on `<td>` elements in tables using the `p-table--mobile-card` class.
+
 ## Variables
 
 `$grid-margin-width` is has been removed, as the grid margins differ at different breakpont. Use the values in `$grid-margin-widths` instead.


### PR DESCRIPTION
## Done

- Updated `aria-label` to `data-heading`
- Updated docs to reflect change

Fixes
#4131 

## QA

- Open [demo](insert-demo-url)
- Turn voice over on while reviewing the table, ensure the content of the cells is read out not just the title. Currently the title is read out twice, not sure how to fix this, I tried to use `content: attr(data-heading) / ' ';` but this hides the title both times. 
- Review updated documentation:
  - /docs/base/tables#responsive

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

