### PR TITLE
Bring back labels component

### DIFF
--- a/guides/pull-requests.md
+++ b/guides/pull-requests.md
@@ -52,13 +52,7 @@ Any affected examples in your PR should have an appropriate label, either `new`,
 An example's documentation should then also include a status label within the body of the page, using the appropriate label:
 
 ```
-<span class="p-chip--positive is-dense">
-  <span class="p-chip__value">New</span>
-</span>
-<span class="p-chip--information is-dense">
-  <span class="p-chip__value">Updated</span>
-</span>
-<span class="p-chip--negative is-dense">
-  <span class="p-chip__value">Deprecated</span>
-</span>
+<span class="p-label--new">New</span>
+<span class="p-label--updated">Updated</span>
+<span class="p-label--deprecated">Deprecated</span>
 ```

--- a/guides/pull-requests.md
+++ b/guides/pull-requests.md
@@ -52,7 +52,7 @@ Any affected examples in your PR should have an appropriate label, either `new`,
 An example's documentation should then also include a status label within the body of the page, using the appropriate label:
 
 ```
-<span class="p-label--new">New</span>
-<span class="p-label--updated">Updated</span>
-<span class="p-label--deprecated">Deprecated</span>
+<span class="p-label--positive">New</span>
+<span class="p-label--information">Updated</span>
+<span class="p-label--negative">Deprecated</span>
 ```

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -41,7 +41,6 @@
 /docs/patterns/link: /docs/patterns/links
 /docs/patterns/top: /docs/patterns/links#back-to-top
 /docs/patterns/list: /docs/patterns/lists
-/docs/patterns/labels: /docs/patterns/chips
 /docs/patterns/sub-nav: /docs/patterns/navigation#sub-navigation
 /docs/patterns/side-navigation: /docs/patterns/navigation#side-navigation
 /docs/patterns/article-pagination: /docs/patterns/pagination#article-pagination

--- a/scss/_patterns_label.scss
+++ b/scss/_patterns_label.scss
@@ -1,0 +1,76 @@
+@import 'settings';
+
+// Default label styling
+@mixin vf-p-label {
+  %vf-label {
+    @extend %x-small-text;
+    @extend %u-no-margin--bottom--small;
+
+    border-radius: $border-radius;
+    display: inline-block;
+    font-weight: $font-weight-bold;
+    padding: map-get($nudges, x-small) $sph--small;
+    text-align: center;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .p-label {
+    @extend %vf-label;
+
+    background-color: $color-mid-dark;
+    color: $color-x-light;
+  }
+
+  @include vf-p-label-validated;
+  @include vf-p-label-in-progress;
+  @include vf-p-label-new;
+  @include vf-p-label-updated;
+  @include vf-p-label-deprecated;
+}
+
+// Override local variables
+@mixin vf-p-label-validated {
+  .p-label--validated {
+    @extend %vf-label;
+
+    background-color: $color-label-validated;
+    color: $color-x-light;
+  }
+}
+
+@mixin vf-p-label-in-progress {
+  .p-label--in-progress {
+    @extend %vf-label;
+
+    background-color: $color-caution;
+    color: $color-dark;
+  }
+}
+
+@mixin vf-p-label-new {
+  .p-label--new {
+    @extend %vf-label;
+
+    background-color: $color-positive;
+    color: $color-x-light;
+  }
+}
+
+@mixin vf-p-label-updated {
+  .p-label--updated {
+    @extend %vf-label;
+
+    background-color: $color-information;
+    color: $color-x-light;
+  }
+}
+
+@mixin vf-p-label-deprecated {
+  .p-label--deprecated {
+    @extend %vf-label;
+
+    background-color: $color-negative;
+    color: $color-x-light;
+  }
+}

--- a/scss/_patterns_label.scss
+++ b/scss/_patterns_label.scss
@@ -22,52 +22,28 @@
     color: $color-x-light;
   }
 
-  @include vf-p-label-validated;
-  @include vf-p-label-in-progress;
-  @include vf-p-label-new;
-  @include vf-p-label-updated;
-  @include vf-p-label-deprecated;
-}
-
-// Override local variables
-@mixin vf-p-label-validated {
-  .p-label--validated {
-    @extend %vf-label;
-
-    background-color: $color-label-validated;
-    color: $color-x-light;
-  }
-}
-
-@mixin vf-p-label-in-progress {
-  .p-label--in-progress {
-    @extend %vf-label;
-
-    background-color: $color-caution;
-    color: $color-dark;
-  }
-}
-
-@mixin vf-p-label-new {
-  .p-label--new {
+  .p-label--positive {
     @extend %vf-label;
 
     background-color: $color-positive;
     color: $color-x-light;
   }
-}
 
-@mixin vf-p-label-updated {
-  .p-label--updated {
+  .p-label--caution {
+    @extend %vf-label;
+
+    background-color: $color-caution;
+    color: $color-dark;
+  }
+
+  .p-label--information {
     @extend %vf-label;
 
     background-color: $color-information;
     color: $color-x-light;
   }
-}
 
-@mixin vf-p-label-deprecated {
-  .p-label--deprecated {
+  .p-label--negative {
     @extend %vf-label;
 
     background-color: $color-negative;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -21,6 +21,7 @@
 @import 'patterns_headings';
 @import 'patterns_icons';
 @import 'patterns_image';
+@import 'patterns_label';
 @import 'patterns_links';
 @import 'patterns_list-tree';
 @import 'patterns_lists';
@@ -101,6 +102,7 @@
   @include vf-p-form-password-toggle;
   @include vf-p-icons;
   @include vf-p-image;
+  @include vf-p-label;
   @include vf-p-links;
   @include vf-p-list-tree;
   @include vf-p-lists;

--- a/scss/standalone/patterns_label.scss
+++ b/scss/standalone/patterns_label.scss
@@ -1,0 +1,4 @@
+@import '../vanilla';
+@include vf-base;
+
+@include vf-p-label;

--- a/scss/standalone/patterns_side-navigation.scss
+++ b/scss/standalone/patterns_side-navigation.scss
@@ -4,7 +4,7 @@
 @include vf-p-side-navigation;
 
 // labels and icons for navigation statuses
-@include vf-p-chip;
+@include vf-p-label;
 @include vf-p-icons;
 
 // grid is used in group example with differents side nav variants

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -32,7 +32,7 @@
                     {{ title }}
                     {% if label %}
                       <span class="p-side-navigation__status">
-                        <span class="p-label--{{ label|lower }}">
+                        <span class="p-label--{{ type|lower }}">
                           {{ label|capitalize }}
                         </span>
                       </span>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -32,8 +32,8 @@
                     {{ title }}
                     {% if label %}
                       <span class="p-side-navigation__status">
-                        <span class="p-chip--{{ type|lower }} is-inline is-dense">
-                          <span class="p-chip__value">{{ label|capitalize }}</span>
+                        <span class="p-label--{{ label|lower }}">
+                          {{ label|capitalize }}
                         </span>
                       </span>
                     {% endif %}
@@ -72,6 +72,7 @@
               {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}
               {{ side_nav_item("/docs/patterns/icons", "Icons") }}
               {{ side_nav_item("/docs/patterns/images", "Images") }}
+              {{ side_nav_item("/docs/patterns/labels", "Labels") }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
               {{ side_nav_item("/docs/patterns/lists", "Lists") }}

--- a/templates/docs/examples/patterns/labels.html
+++ b/templates/docs/examples/patterns/labels.html
@@ -1,0 +1,13 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Labels / Default{% endblock %}
+
+{% block standalone_css %}patterns_label{% endblock %}
+
+{% block content %}
+<div class="p-label">Default</div>
+<div class="p-label--deprecated">Deprecated</div>
+<div class="p-label--in-progress">In progress</div>
+<div class="p-label--new">New</div>
+<div class="p-label--updated">Updated</div>
+<div class="p-label--validated">Validated</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/labels.html
+++ b/templates/docs/examples/patterns/labels.html
@@ -5,9 +5,8 @@
 
 {% block content %}
 <div class="p-label">Default</div>
-<div class="p-label--deprecated">Deprecated</div>
-<div class="p-label--in-progress">In progress</div>
-<div class="p-label--new">New</div>
-<div class="p-label--updated">Updated</div>
-<div class="p-label--validated">Validated</div>
+<div class="p-label--positive">Positive</div>
+<div class="p-label--caution">Caution</div>
+<div class="p-label--negative">Negative</div>
+<div class="p-label--information">Information</div>
 {% endblock %}

--- a/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
+++ b/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
@@ -7,7 +7,7 @@
 <ul class="p-inline-list--stretch">
   <li class="p-inline-list__item"><h3>Documentation</h3></li>
   <li class="p-inline-list__item u-vertically-center u-align--right">
-    <span class="p-label--new">New</span>
+    <span class="p-label--positive">New</span>
   </li>
 </ul>
 {% endblock %}

--- a/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
+++ b/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
@@ -7,9 +7,7 @@
 <ul class="p-inline-list--stretch">
   <li class="p-inline-list__item"><h3>Documentation</h3></li>
   <li class="p-inline-list__item u-vertically-center u-align--right">
-    <span class="p-chip--positive is-inline">
-      <span class="p-chip__value">New</span>
-    </span>
+    <span class="p-label--new">New</span>
   </li>
 </ul>
 {% endblock %}

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -40,9 +40,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-chip--caution {% if is_dark %}is-dark{% endif %} is-inline">
-                    <span class="p-chip__value">In progress</span>
-                  </span>
+                  <span class="p-label--in-progress">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -60,23 +58,17 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <span class="p-chip--positive {% if is_dark %}is-dark{% endif %} is-inline">
-            <span class="p-chip__value">New</span>
-          </span>
+          <span class="p-label--new">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <span class="p-chip--information {% if is_dark %}is-dark{% endif %} is-inline">
-            <span class="p-chip__value">Updated</span>
-          </span>
+          <span class="p-label--information">Updated</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-chip--information {% if is_dark %}is-dark{% endif %} is-inline">
-            <span class="p-chip__value">Validated</span>
-          </span>
+          <span class="p-label--validated">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -40,7 +40,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-label--in-progress">In progress</span>
+                  <span class="p-label--caution">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -58,7 +58,7 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <span class="p-label--new">New</span>
+          <span class="p-label--positive">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
@@ -68,7 +68,7 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-label--validated">Validated</span>
+          <span class="p-label--positive">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_docs.html
+++ b/templates/docs/examples/patterns/side-navigation/_docs.html
@@ -24,9 +24,7 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Quick start<span class="p-side-navigation__status">
-          <span class="p-chip--positive is-inline">
-            <span class="p-chip__value">New</span>
-          </span>
+          <span class="p-label--new">New</span>
         </span></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_docs.html
+++ b/templates/docs/examples/patterns/side-navigation/_docs.html
@@ -24,7 +24,7 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Quick start<span class="p-side-navigation__status">
-          <span class="p-label--new">New</span>
+          <span class="p-label--positive">New</span>
         </span></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -43,7 +43,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-label--in-progress">In progress</span>
+                  <span class="p-label--caution">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -61,17 +61,17 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <span class="p-label--new">New</span>
+          <span class="p-label--positive">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <span class="p-label--updated">Updated</span>
+          <span class="p-label--information">Updated</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-label--validated">Validated</span>
+          <span class="p-label--positive">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -43,9 +43,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-chip--caution {% if is_dark %}is-dark{% endif %} is-inline">
-                    <span class="p-chip__value">In progress</span>
-                  </span>
+                  <span class="p-label--in-progress">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -63,23 +61,17 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <span class="p-chip--positive {% if is_dark %}is-dark{% endif %} is-inline">
-            <span class="p-chip__value">New</span>
-          </span>
+          <span class="p-label--new">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <span class="p-chip--information {% if is_dark %}is-dark{% endif %} is-inline">
-            <span class="p-chip__value">Updated</span>
-          </span>
+          <span class="p-label--updated">Updated</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-chip--information {% if is_dark %}is-dark{% endif %} is-inline">
-            <span class="p-chip__value">Validated</span>
-          </span>
+          <span class="p-label--validated">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
@@ -33,7 +33,7 @@
       <span class="p-side-navigation__text">
         Version 0.4.0
         <div class="p-side-navigation__status">
-          <span class="p-label--in-progress">Beta</span>
+          <span class="p-label--caution">Beta</span>
         </div>
       </span>
     </li>

--- a/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
@@ -33,9 +33,7 @@
       <span class="p-side-navigation__text">
         Version 0.4.0
         <div class="p-side-navigation__status">
-          <span class="p-chip--caution is-dense is-dark is-inline">
-            <span class="p-chip__value">Beta</span>
-          </span>
+          <span class="p-label--in-progress">Beta</span>
         </div>
       </span>
     </li>

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -29,7 +29,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-label--in-progress">In progress</span>
+                  <span class="p-label--caution">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -47,17 +47,17 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">First level link with a label</span><div class="p-side-navigation__status">
-          <span class="p-label--new">New</span>
+          <span class="p-label--positive">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label">First level link with a label is long and wraps wraps wraps wraps wraps wraps</span><div class="p-side-navigation__status">
-          <span class="p-updated">Updated</span>
+          <span class="p-label--information">Updated</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-validated">Validated</span>
+          <span class="p-label--information">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -29,9 +29,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-chip--caution is-dark is-dense is-inline">
-                    <span class="p-chip__value">In progress</span>
-                  </span>
+                  <span class="p-label--in-progress">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -49,23 +47,17 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">First level link with a label</span><div class="p-side-navigation__status">
-          <span class="p-chip--positive is-dark is-dense is-inline">
-            <span class="p-chip__value">New</span>
-          </span>
+          <span class="p-label--new">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label">First level link with a label is long and wraps wraps wraps wraps wraps wraps</span><div class="p-side-navigation__status">
-          <span class="p-chip--information is-dark is-dense is-inline">
-            <span class="p-chip__value">Updated</span>
-          </span>
+          <span class="p-updated">Updated</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-chip--information is-dark is-dense is-inline">
-            <span class="p-chip__value">Validated</span>
-          </span>
+          <span class="p-validated">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/icons.html
+++ b/templates/docs/examples/patterns/side-navigation/icons.html
@@ -38,9 +38,7 @@
           <i class="p-icon--help p-side-navigation__icon"></i>
           Get help
           <span class="p-side-navigation__status">
-            <span class="p-chip--information is-dense is-inline">
-              <span class="p-chip__value">Updated</span>
-            </span>
+            <span class="p-label--updated">Updated</span>
           </span>
         </a>
       </li>

--- a/templates/docs/examples/patterns/side-navigation/icons.html
+++ b/templates/docs/examples/patterns/side-navigation/icons.html
@@ -38,7 +38,7 @@
           <i class="p-icon--help p-side-navigation__icon"></i>
           Get help
           <span class="p-side-navigation__status">
-            <span class="p-label--updated">Updated</span>
+            <span class="p-label--information">Updated</span>
           </span>
         </a>
       </li>

--- a/templates/docs/patterns/labels.md
+++ b/templates/docs/patterns/labels.md
@@ -1,0 +1,35 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Labels | Components
+---
+
+# Labels
+
+<hr>
+
+Labels are static elements which you can apply to signify status, tags or any other information you find useful.
+
+<div class="p-notification--information">
+  <p class="p-notification__content">
+    <span class="p-notification__title">Note:</span>These labels are used to inform <a href="/docs/whats-new">status</a> of components in Vanilla.
+  </p>
+</div>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/labels/" class="js-example">
+View example of the labels pattern
+</a></div>
+
+## Import
+
+To import just this component into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework';
+@include vf-base;
+@include vf-p-label;
+```
+
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/patterns/slider.md
+++ b/templates/docs/patterns/slider.md
@@ -15,11 +15,6 @@ when you want to provide a numeric representation of the slider value, as well a
 View example of the slider pattern
 </a></div>
 
-<span class="p-chip--information is-inline is-dense">
-  <span class="p-chip__value">Updated</span>
-</span>In version 2.6.0 Vanilla framework added slider styling as default for
-all range inputs, so adding `p-slider` class just to style `<input type="range">` is not necessary any more.
-
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -153,7 +153,7 @@ List of removed max width features includes:
 
 ## Labels
 
-The color variants of the label pattern have been renamed to use consistent semantic naming with coloured chips. Old class names based on Vanilla component status names have been removed. Previous `p-label--validated` variant doesn't have direct equivalent, please use `p-label--positive` or `p-label--information` depending on your use case.
+The colour variants of the label pattern have been renamed to use consistent semantic naming with coloured chips. Old class names based on Vanilla component status names have been removed. Previous `p-label--validated` variant doesn't have direct equivalent, please use `p-label--positive` or `p-label--information` depending on your use case.
 
 | Removed classes         | Replaced by                                    |
 | ----------------------- | ---------------------------------------------- |

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -153,18 +153,17 @@ List of removed max width features includes:
 
 ## Labels
 
-The label pattern has been removed, and we've added tinted chips. The tints are based on the semantic colours (positive, caution, negative) plus a dark blue one that matches the blue used in the information flavour of the notification component. The default chip colour (grey) is now referred to as "neutral". Please read the [chip documentation](/docs/patterns/chip) to see how the markup and class names have changed, including the addition of `p-chip__lead` and `p-chip__value` classes. In places where you're replacing the `p-label` you'll probably need to add the `is-dense` modifier.
+The color variants of the label pattern have been renamed to use consistent semantic naming with coloured chips. Old class names based on Vanilla component status names have been removed. Previous `p-label--validated` variant doesn't have direct equivalent, please use `p-label--positive` or `p-label--information` depending on your use case.
 
-| Deprecated classes      | Replaced by            |
-| ----------------------- | ---------------------- |
-| `.p-label`              | `.p-chip`              |
-| `.p-label--deprecated`  | `.p-chip--negative`    |
-| `.p-label--in-progress` | `.p-chip--caution`     |
-| `.p-label--new`         | `.p-chip--positive`    |
-| `.p-label--updated`     | `.p-chip--information` |
-| `.p-label--validated`   | `.p-chip--information` |
+| Removed classes         | Replaced by                                    |
+| ----------------------- | ---------------------------------------------- |
+| `.p-label--deprecated`  | `.p-label--negative`                           |
+| `.p-label--in-progress` | `.p-label--caution`                            |
+| `.p-label--new`         | `.p-label--positive`                           |
+| `.p-label--updated`     | `.p-label--information`                        |
+| `.p-label--validated`   | `.p-label--information` or `p-label--positive` |
 
-The `vf-p-label` mixin has been removed so you'll have to remove this from your code, along with `vf-p-label-new`, `vf-p-label-updated`, `vf-p-label-deprecated`, `vf-p-label-in-progress` and `vf-p-label-validated`.
+The individual mixins for label variants have been removed. All necessary styles are included in main `vf-p-label` mixin, If you use any of the following individual mixins you can remove them from your code: `vf-p-label-new`, `vf-p-label-updated`, `vf-p-label-deprecated`, `vf-p-label-in-progress` and `vf-p-label-validated`.
 
 ## Responsive tables
 

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -24,19 +24,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip#interactive">Chips / Interactive</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
-      </td>
-      <td>3.0.0</td>
-      <td>We've reimplemented interactive chips using <code>button</code> elements.</td>
-    </tr>
-    <tr>
-      <th><a href="/docs/patterns/chip">Chips / Tinted</a></th>
-      <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>3.0.0</td>
       <td>We've added tinted chips. The tints are based on the semantic colours (positive, caution, negative) plus a dark blue one that matches the blue used in the information flavour of the notification component. The default chip colour (grey) is now referred to as "neutral".</td>
@@ -44,9 +32,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Labels</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Removed</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>3.0.0</td>
       <td>We've removed the labels pattern as the new tinted chips can be used instead.</td>
@@ -70,9 +56,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#datalist">Forms / Datalist</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.37.0</td>
       <td>We've added documentation for datalist</td>
@@ -81,9 +65,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion#with-tick-elements">Accordion / Tick elements</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.36.0</td>
       <td>We've added a variation of the accordion using tick elements</td>
@@ -91,9 +73,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/card#content-bleed">Card / Content Bleed</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.36.0</td>
       <td>We added a <code>.p-card__inner</code> element so that it's possible to have a mix of padded and not padded content within a card.</td>
@@ -101,9 +81,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#help-text">Form / Help text</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.36.0</td>
       <td>We added a class name to aligned help text with checkboxes or radio buttons</td>
@@ -112,9 +90,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#validation">Forms / Validation</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.35.0</td>
       <td>We've updated the styling of the form validation and required patterns</td>
@@ -123,9 +99,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#password-showhide">Forms / Password toggle</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.34.0</td>
       <td>Password fields now have a show/hide toggle.</td>
@@ -133,9 +107,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#status">Lists / Crossed</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.34.0</td>
       <td>We added a <code>is-crossed</code> modifier class for lists, to complement the existing <code>is-ticked</code> modifier.</td>
@@ -143,9 +115,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#status">Lists / Ticked</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.34.0</td>
       <td>We updated the color of the <code>is-ticked</code> icon on lists to <code>$color-positive</code>, where previously it was <code>$color-accent</code>.</td>
@@ -153,9 +123,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/tabs#tab-buttons">Tabs / Tab Buttons</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.34.0</td>
       <td>We added a new type of tab pattern, `p-tab-buttons`, which can display tabs like a group of buttons.</td>
@@ -164,9 +132,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/links#skip-link">Links / Skip Link</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.33.0</td>
       <td>We added a new link variant, <code>.p-link--skip</code>, that places a link offscreen and is revealed on focus.</td>
@@ -174,9 +140,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/notification">Notifications</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.33.0</td>
       <td>Notifications have been updated with a new appearance, requiring a new HTML structure.</td>
@@ -184,9 +148,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/notification#deprecated">Notifications structure</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.33.0</td>
       <td>The following notification classes have been deprecated: <code>.p-notification__response</code>, <code>.p-notification__status</code></td>
@@ -195,9 +157,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Labels / Default</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.32.0</td>
       <td>We've added a default label <code>p-label</code></td>
@@ -205,9 +165,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#theming">Button / Dark</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.32.0</td>
       <td>We added the dark theme to the buttons.</td>
@@ -215,9 +173,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#neutral">Button / Neutral</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.32.0</td>
       <td>The neutral button variant <code>p-button--neutral</code> is deprecated, please use default <code>p-button</code> instead.</td>
@@ -225,9 +181,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#overflow">Tables / Overflow</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.32.0</td>
       <td>We introduced the <code>.has-overflow</code> utility for table cells, to aid with the display of components that need to overflow the cell, such as tooltips and contextual menus.</td>
@@ -235,9 +189,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#responsive">Tables / Responsive</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.32.0</td>
       <td>The <code>.p-table--mobile-card</code> previously contained style overrides for the <a href="https://vanillaframework.io/docs/examples/patterns/contextual-menu/default">contextual menu pattern</a>, these have been removed so that contextual menus within responsive tables look and behave the same as they do elsewhere.</td>
@@ -246,9 +198,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Dropdown</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.31.0</td>
       <td>We introduced the <code>.p-navigation__item--dropdown-toggle</code> class, as a replacement for the now deprecated <code>.p-subnav</code> class.</td>
@@ -256,9 +206,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Sub-navigation</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.31.0</td>
       <td>The <code>.p-subnav</code> class previously could theoretically be used outside of the main <code>.p-navigation</code> component, which was not intended. It has been deprecated, and succeeded by the <code>.p-navigation__item--dropdown-toggle</code> class.</td>
@@ -267,9 +215,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#link">Button / Link</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.30.0</td>
       <td>Buttons can now assume the appearance of a standard link.</td>
@@ -277,9 +223,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#theming">Lists / spanider</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.30.0</td>
       <td>We added a dark theme to responsive spanider lists.</td>
@@ -287,9 +231,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/tabs#content">Tabs / Content</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.30.0</td>
       <td>The tab pattern can now be used either as a navigation list, or as controls for panes of content.</td>
@@ -298,9 +240,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/fluid-breakout#toolbar">Fluid breakout - toolbar</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.29.0</td>
       <td>We added support for a toolbar within the fluid-breakout layout.</td>
@@ -309,9 +249,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/modal">Modal footer</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added the optional footer to the modal pattern.</td>
@@ -319,9 +257,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/logo-section">Logo section</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.28.0</td>
       <td>A new logo section</td>
@@ -329,9 +265,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/logo-section">Inline images</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.28.0</td>
       <td>The inline images component has now been deprecated. Please use the logo section component instead.</td>
@@ -339,9 +273,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#empty">Table - empty</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added a basic styling for the table <code>&lt;caption&gt;</code> in empty tables</td>
@@ -349,9 +281,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/tooltips#detached">Tooltips - detached</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added the <code>.is-detached</code> utility, providing a way for tooltips to exist separately from their associated element.</td>
@@ -360,9 +290,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#social">GitHub icon</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.27.0</td>
       <td>We added the GitHub icon <code>.p-icon--github</code> to our social icons set.</td>
@@ -370,9 +298,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#bordered">Code snippet - bordered</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.27.0</td>
       <td>We added the utility class <code>.is-bordered</code> to the code snippet.</td>
@@ -381,9 +307,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/search-and-filter">Search and filter</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added the new Search and filter component.</td>
@@ -391,9 +315,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application#aside-area">Application layout - animations</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.26.0</td>
       <td>We added <code>is-collapsed</code> class that allows animating the application layout aside panel.</td>
@@ -401,9 +323,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#expanding">Tables expanding</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We renamed and deprecated <code>p-table-expanding</code> and <code>p-table-expanding__panel</code>. Use <code>p-table--expanding</code> and <code>p-table__expanding-panel</code> instead.</td>
@@ -411,9 +331,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#sortable">Tables sorting</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We removed <code>p-table--sortable</code> class name. Sorting can be enabled on any table by adding <code>aria-sort</code> attributes.</td>
@@ -421,9 +339,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#indeterminate-state-checkbox">Forms / Checkbox indeterminate</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added indeterminate state checkboxes. If a checkbox has <code>checkbox.indeterminate = true;</code> set via JavaScript, the checkbox will show a state between checked and unchecked.</td>
@@ -431,9 +347,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/sticky-footer">Sticky footer</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added a new <code>.l-site</code> layout, which can accommodate a sticky footer.</td>
@@ -441,9 +355,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion">Accordions</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We deprecated the previous accordion tab patterns, <code>.p-accordion__tab</code> and <code>.p-accordion__tab--with-title .p-accordion__title</code>, in favour of a more accessible pattern. Please use <code>.p-accordion__heading .p-accordion__tab</code>.</td>
@@ -452,9 +364,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#extra-small-capitalised-text">Typography / Extra small caps</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new extra small capitalised text <code>p-text--x-small-capitalised</code>.</td>
@@ -462,9 +372,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#baseline-alignment-small-extra-small-and-paragraph-text">Typography / Baseline alignment</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added a couple of util classes to help aligning small text on the baseline along default text size.</td>
@@ -472,9 +380,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators#muted-horizontal-rule">Separators / Muted</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new muted variant of horizontal rule.</td>
@@ -482,9 +388,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators#fixed-width-horizontal-rule">Separators / Fixed width</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new fixed width variant of horizontal rule to allow aligning it with full 12-column grid layouts.</td>
@@ -492,9 +396,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#middot">Lists / Middot</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.25.0</td>
       <td>We added a dark theme to middot lists.</td>
@@ -503,9 +405,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#dropdowns">Code snippet - Dropdowns</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.24.0</td>
       <td>We added the ability to accommodate multiple selects within a <code>.p-code-snippet__header</code>, either inline, using the <code>.is-stacked</code> utility to class to have the dropdowns below the title.</td>
@@ -513,9 +413,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#inline">Code inline - dark</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.24.0</td>
       <td>We've updated inline <code>code</code> elements to support being nested within a <code>.p-strip--dark</code> element, and to support an <code>.is-dark</code> utility class.</td>
@@ -523,9 +421,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/fluid-breakout">Fluid breakout</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.24.0</td>
       <td>We added a new <code>l-fluid-breakout</code> layout that can be used to break out of the constraints of a 12-column grid and allow content to bleed into the page margins on larger screens.</td>
@@ -533,9 +429,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/grid">Grid - "orphan" columns</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.24.0</td>
       <td>We deprecated the use of `.col` classes without a direct parent with a class `.row`.</td>
@@ -544,9 +438,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#active">Active button</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.23.0</td>
       <td>The <code>is-active</code> class was deprecated and given a more appropriate name: <code>is-processing</code>.</td>
@@ -554,9 +446,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#processing">Processing button</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.23.0</td>
       <td>We renamed <code>is-active</code> button state class to <code>is-processing</code>, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
@@ -564,9 +454,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet - Dropdowns</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.23.0</td>
       <td>We add the ability to include a select within in a code snippet, allowing users to switch between related code examples.</td>
@@ -574,9 +462,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.23.0</td>
       <td>We added a utility class for <code>.p-code-snippet__block</code> that allows content to wrap, rather than horizontally scroll: <code>.is-wrapped</code>.</td>
@@ -585,9 +471,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators">Separator</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.22.0</td>
       <td>The new <code>p-separator</code> component has been added to be used as a separator between content blocks.</td>
@@ -595,9 +479,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.22.0</td>
       <td>The new <code>.p-code-snippet</code> component has been added, to be used to display code examples in a number of different formats.</td>
@@ -605,9 +487,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#copyable">Code copyable</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.22.0</td>
       <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>
@@ -615,9 +495,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#numbered">Code numbered</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.22.0</td>
       <td><code>.p-code-numbered</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--numbered</code> instead.</td>
@@ -626,9 +504,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Contextual Menu</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.21.0</td>
       <td>The <code>p-icon--contextual-menu</code> has been deprecated and will be removed in future release v3.0. Please use existing <code>.p-icon--chevron-down</code> and <code>.p-icon--chevron-up</code> icons instead.</td>
@@ -636,9 +512,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#additional">Icons - Additional</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.21.0</td>
       <td>We added many more icons, outside of the base icon set. These icons are not included in Vanilla by default, but can be inspanidually included as needed.</td>
@@ -646,9 +520,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application#panels">Application layout - panels</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">In progress</span>
-        </span>
+        <span class="p-label--in-progress">In progress</span>
       </td>
       <td>2.21.0</td>
       <td>We continue working on application layout panels styling. We improved the positioning of the logo, title and controls in panel headers.</td>
@@ -656,9 +528,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#application-layout">Application layout - side navigation</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.21.0</td>
       <td>We implemented and documented improvements for <a href="/docs/patterns/navigation#application-layout">side navigation component</a> for the <a href="/docs/layouts/application#side-navigation">application layout</a>.</td>
@@ -666,9 +536,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#sticky">Side navigation - Sticky</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.21.0</td>
       <td>Side navigation component used to be sticky by default. We now introduced new <code>is-sticky</code> variant that should be used to optionally make side navigation sticky.</td>
@@ -677,9 +545,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application#responsive-application-layout">Application layout panels</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.20.0</td>
       <td>We updated the responsive styles of application layout panels and introduced some class names and variables for more flexible customization options.</td>
@@ -687,9 +553,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#small">Small buttons</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.20.0</td>
       <td>We added an <code>is-small</code> modifier class for buttons, which can be combined with <code>is-dense</code>.</td>
@@ -697,9 +561,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#small">Active buttons</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.20.0</td>
       <td>We added an <code>is-active</code> state class for buttons, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
@@ -708,9 +570,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#expanding">Expanding table column placeholder</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.19.2</td>
       <td>We started using <code>aria-hidden="true"</code> attribute to hide the placeholder table header in place of previously used <code>u-hide</code> utility.</td>
@@ -718,9 +578,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#icons">Table icons</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.19.0</td>
       <td>We added a <code>p-table__cell--icon-placeholder</code> class to properly align icons in table cells.</td>
@@ -729,9 +587,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/breadcrumbs">Breadcrumbs</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.18.0</td>
       <td>We updated the markup of the breadcrumbs component to comply with accessibility requirements. The class <code>.p-breadcrumbs</code> is now moved onto a <code>&lt;nav&gt;</code> element, the unordered list has been changed to an ordered one that has a class <code>.p-breadcrumbs__items</code>. </td>
@@ -739,9 +595,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/breadcrumbs#deprecated-markup">Breadcrumbs</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.18.0</td>
       <td>Top level <code>&lt;ul&gt;</code> with a class <code>.p-breadcrumbs</code> is now deprecated for the Breadcrumbs pattern.</td>
@@ -750,9 +604,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#checkbox">Checkbox and radio buttons components</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.17.0</td>
       <td>We introduced new <code>.p-checkbox</code> and <code>.p-radio</code> components. They replace the existing styling of base form inputs.</td>
@@ -760,9 +612,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#deprecated-base-checkboxes">Checkbox and radio buttons elements</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.17.0</td>
       <td>Base styled checkboxes and radio buttons (on <code>&lt;input type="checkbox"&gt;</code> or <code>&lt;input type="radio"&gt;</code> elements) are deprecated and they will be reverted to native browser inputs in future version of Vanilla. Please use on bWe added new layout styles for building responsive full-screen applications.</td>
@@ -771,9 +621,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application">Application layout</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.16.0</td>
       <td>We added new layout styles for building responsive full-screen applications.</td>
@@ -781,9 +629,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/strip#suru-strip">Suru strip</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.16.0</td>
       <td>We added new strip variants <code>.p-strip--suru</code> and <code>.p-strip--suru-topped</code>.</td>
@@ -792,9 +638,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Chip</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.15.0</td>
       <td>We added the new <code>.p-chip</code> component to be used to display small actionable pieces of information.</td>
@@ -803,9 +647,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#inline-stretched">List inline stretched</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.14.0</td>
       <td>We added the new <code>.p-inline-list--stretch</code> list variant that arranges items so they span the full width of the parent container.</td>
@@ -814,9 +656,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion#headings">Accordion</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.13.0</td>
       <td>We updated the accordion component with a new <code>.p-accordion__tab--with-title</code> variant that allows using headings in accordion buttons.</td>
@@ -825,9 +665,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#muted-text">Muted text</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.12.0</td>
       <td>New <code>u-text--muted</code> utility class has been added.</td>
@@ -835,9 +673,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons">Icons</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.12.0</td>
       <td>The icons have been updated to new style.</td>
@@ -845,9 +681,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Question</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.12.0</td>
       <td>The <code>p-icon--question</code> has been deprecated will be removed in future release v3.0. Please use existing `.p-icon--help` icon instead.</td>
@@ -856,9 +690,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.11.0</td>
       <td>A no-JS fallback was added for the side navigation toggle functionality on small screens.</td>
@@ -866,9 +698,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#raw-html">Side navigation</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.11.0</td>
       <td>A new raw HTML variant of the side navigation component.</td>
@@ -877,9 +707,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.10.0</td>
       <td>Update to the responsive styling of the side navigation.</td>
@@ -888,9 +716,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.9.0</td>
       <td>New side navigation component was added.</td>
@@ -899,9 +725,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.8.0</td>
       <td>New navigation classes (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) were added to replace existing (<code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code>).</td>
@@ -909,9 +733,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.8.0</td>
       <td>Navigation classes <code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code> are deprecated and will be removed in future release v3.0. Please use new class names (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) instead.</td>
@@ -920,9 +742,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/contextual-menu#theming">Contextual menu</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.7.0</td>
       <td>Added dark theme to contextual menu.</td>
@@ -930,9 +750,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#heading-classes">Heading classes</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.7.0</td>
       <td>New heading classes with numbers (<code>p-heading--1</code>, ...) were added for consistency with other class names we use.</td>
@@ -940,9 +758,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#heading-classes">Heading classes</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.7.0</td>
       <td>Heading classes with numbers as words (<code>p-heading--one</code>, <code>--two</code>, ...) are deprecated and will be removed in future release v3.0. Please use class names with numbers (<code>p-heading--1</code>, <code>--2</code>, ...) instead.</td>
@@ -950,9 +766,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms/#range">Range input</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.6.0</td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
@@ -960,9 +774,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms/#checkbox">Checkbox, radio button</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.6.0</td>
       <td>New `is-table-header` added to properly align checkboxes and radio buttons used in table headers.</td>
@@ -970,9 +782,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/slider">Slider</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.6.0</td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
@@ -980,9 +790,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/contextual-menu/#indicator">Contextual menu</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.5.0</td>
       <td>Optional state indicator was added to contextual menu</td>
@@ -990,9 +798,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/font-metrics/">Font metrics</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-visualise-font-metrics</code> utility to visualise font metrics</td>
@@ -1000,9 +806,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography/#line-length">Line length</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>$max-width--default</code> variable and <code>u-no-max-width</code> utility to control line length</td>
@@ -1010,9 +814,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/table-cell-padding-overlap/">Table cell padding overlap</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-table-cell-padding-overlap</code> utility to overlap table cell padding</td>
@@ -1020,9 +822,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/truncate/">Truncation</a></th>
       <td>
-        <span class="p-chip--positive is-dense is-inline">
-          <span class="p-chip__value">New</span>
-        </span>
+        <span class="p-label--new">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-truncate</code> utility to truncate text with ellipsis</td>
@@ -1030,9 +830,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons/#social">Social icons</a></th>
       <td>
-        <span class="p-chip--information is-dense is-inline">
-          <span class="p-chip__value">Updated</span>
-        </span>
+        <span class="p-label--updated">Updated</span>
       </td>
       <td>2.5.0</td>
       <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>
@@ -1040,9 +838,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons/#social">Social icons</a></th>
       <td>
-        <span class="p-chip--negative is-dense is-inline">
-          <span class="p-chip__value">Deprecated</span>
-        </span>
+        <span class="p-label--deprecated">Deprecated</span>
       </td>
       <td>2.5.0</td>
       <td>We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from social icon set in future release v3.0</td>
@@ -1061,41 +857,31 @@ See [the upgrade guide](/docs/upgrade-guide-v3) to learn about all the breaking 
 <div class="row">
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-chip--positive is-dense is-inline">
-        <span class="p-chip__value">New</span>
-      </span>
+      <span class="p-label--new">New</span>
       <p class="p-card__content">Newly released components, utilities or settings that are safe to use in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-chip--negative is-desne is-inline">
-        <span class="p-chip__value">Deprecated</span>
-      </span>
+      <span class="p-label--deprecated">Deprecated</span>
       <p class="p-card__content">These components, utilities or settings are in the process of being removed and should no longer be used in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-chip--information is-dense is-inline">
-        <span class="p-chip__value">In progress</span>
-      </span>
+      <span class="p-label--in-progress">In progress</span>
       <p class="p-card__content">Design spec and code implementation are not yet finished.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-chip--information is-dense is-inline">
-        <span class="p-chip__value">Updated</span>
-      </span>
+      <span class="p-label--updated">Updated</span>
       <p class="p-card__content">These are existing components, utilities or settings that have been updated either through design or code.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
   <div class="p-card--highlighted">
-      <span class="p-chip--positive is-dense is-inline">
-        <span class="p-chip__value">Validated</span>
-      </span>
+      <span class="p-label--validated">Validated</span>
       <p class="p-card__content">Proposal approved in our bi-weekly meeting . A design spec is created and development starts ready for code review.</p>
     </div>
   </div>

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -24,7 +24,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip#interactive">Chips / Interactive</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>3.0.0</td>
       <td>We've added tinted chips. The tints are based on the semantic colours (positive, caution, negative) plus a dark blue one that matches the blue used in the information flavour of the notification component. The default chip colour (grey) is now referred to as "neutral".</td>
@@ -32,7 +32,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Labels</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>3.0.0</td>
       <td>We've removed the labels pattern as the new tinted chips can be used instead.</td>
@@ -56,7 +56,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#datalist">Forms / Datalist</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.37.0</td>
       <td>We've added documentation for datalist</td>
@@ -65,7 +65,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion#with-tick-elements">Accordion / Tick elements</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.36.0</td>
       <td>We've added a variation of the accordion using tick elements</td>
@@ -73,7 +73,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/card#content-bleed">Card / Content Bleed</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.36.0</td>
       <td>We added a <code>.p-card__inner</code> element so that it's possible to have a mix of padded and not padded content within a card.</td>
@@ -81,7 +81,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#help-text">Form / Help text</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.36.0</td>
       <td>We added a class name to aligned help text with checkboxes or radio buttons</td>
@@ -90,7 +90,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#validation">Forms / Validation</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.35.0</td>
       <td>We've updated the styling of the form validation and required patterns</td>
@@ -99,7 +99,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#password-showhide">Forms / Password toggle</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.34.0</td>
       <td>Password fields now have a show/hide toggle.</td>
@@ -107,7 +107,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#status">Lists / Crossed</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.34.0</td>
       <td>We added a <code>is-crossed</code> modifier class for lists, to complement the existing <code>is-ticked</code> modifier.</td>
@@ -115,7 +115,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#status">Lists / Ticked</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.34.0</td>
       <td>We updated the color of the <code>is-ticked</code> icon on lists to <code>$color-positive</code>, where previously it was <code>$color-accent</code>.</td>
@@ -123,7 +123,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/tabs#tab-buttons">Tabs / Tab Buttons</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.34.0</td>
       <td>We added a new type of tab pattern, `p-tab-buttons`, which can display tabs like a group of buttons.</td>
@@ -132,7 +132,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/links#skip-link">Links / Skip Link</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.33.0</td>
       <td>We added a new link variant, <code>.p-link--skip</code>, that places a link offscreen and is revealed on focus.</td>
@@ -140,7 +140,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/notification">Notifications</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.33.0</td>
       <td>Notifications have been updated with a new appearance, requiring a new HTML structure.</td>
@@ -148,7 +148,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/notification#deprecated">Notifications structure</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.33.0</td>
       <td>The following notification classes have been deprecated: <code>.p-notification__response</code>, <code>.p-notification__status</code></td>
@@ -157,7 +157,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Labels / Default</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.32.0</td>
       <td>We've added a default label <code>p-label</code></td>
@@ -165,7 +165,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#theming">Button / Dark</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.32.0</td>
       <td>We added the dark theme to the buttons.</td>
@@ -173,7 +173,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#neutral">Button / Neutral</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.32.0</td>
       <td>The neutral button variant <code>p-button--neutral</code> is deprecated, please use default <code>p-button</code> instead.</td>
@@ -181,7 +181,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#overflow">Tables / Overflow</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.32.0</td>
       <td>We introduced the <code>.has-overflow</code> utility for table cells, to aid with the display of components that need to overflow the cell, such as tooltips and contextual menus.</td>
@@ -189,7 +189,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#responsive">Tables / Responsive</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.32.0</td>
       <td>The <code>.p-table--mobile-card</code> previously contained style overrides for the <a href="https://vanillaframework.io/docs/examples/patterns/contextual-menu/default">contextual menu pattern</a>, these have been removed so that contextual menus within responsive tables look and behave the same as they do elsewhere.</td>
@@ -198,7 +198,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Dropdown</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.31.0</td>
       <td>We introduced the <code>.p-navigation__item--dropdown-toggle</code> class, as a replacement for the now deprecated <code>.p-subnav</code> class.</td>
@@ -206,7 +206,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Sub-navigation</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.31.0</td>
       <td>The <code>.p-subnav</code> class previously could theoretically be used outside of the main <code>.p-navigation</code> component, which was not intended. It has been deprecated, and succeeded by the <code>.p-navigation__item--dropdown-toggle</code> class.</td>
@@ -215,7 +215,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#link">Button / Link</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.30.0</td>
       <td>Buttons can now assume the appearance of a standard link.</td>
@@ -223,7 +223,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#theming">Lists / spanider</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.30.0</td>
       <td>We added a dark theme to responsive spanider lists.</td>
@@ -231,7 +231,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/tabs#content">Tabs / Content</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.30.0</td>
       <td>The tab pattern can now be used either as a navigation list, or as controls for panes of content.</td>
@@ -240,7 +240,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/fluid-breakout#toolbar">Fluid breakout - toolbar</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.29.0</td>
       <td>We added support for a toolbar within the fluid-breakout layout.</td>
@@ -249,7 +249,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/modal">Modal footer</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added the optional footer to the modal pattern.</td>
@@ -257,7 +257,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/logo-section">Logo section</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.28.0</td>
       <td>A new logo section</td>
@@ -265,7 +265,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/logo-section">Inline images</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.28.0</td>
       <td>The inline images component has now been deprecated. Please use the logo section component instead.</td>
@@ -273,7 +273,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#empty">Table - empty</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added a basic styling for the table <code>&lt;caption&gt;</code> in empty tables</td>
@@ -281,7 +281,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/tooltips#detached">Tooltips - detached</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added the <code>.is-detached</code> utility, providing a way for tooltips to exist separately from their associated element.</td>
@@ -290,7 +290,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#social">GitHub icon</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.27.0</td>
       <td>We added the GitHub icon <code>.p-icon--github</code> to our social icons set.</td>
@@ -298,7 +298,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#bordered">Code snippet - bordered</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.27.0</td>
       <td>We added the utility class <code>.is-bordered</code> to the code snippet.</td>
@@ -307,7 +307,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/search-and-filter">Search and filter</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added the new Search and filter component.</td>
@@ -315,7 +315,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application#aside-area">Application layout - animations</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.26.0</td>
       <td>We added <code>is-collapsed</code> class that allows animating the application layout aside panel.</td>
@@ -323,7 +323,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#expanding">Tables expanding</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We renamed and deprecated <code>p-table-expanding</code> and <code>p-table-expanding__panel</code>. Use <code>p-table--expanding</code> and <code>p-table__expanding-panel</code> instead.</td>
@@ -331,7 +331,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#sortable">Tables sorting</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We removed <code>p-table--sortable</code> class name. Sorting can be enabled on any table by adding <code>aria-sort</code> attributes.</td>
@@ -339,7 +339,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#indeterminate-state-checkbox">Forms / Checkbox indeterminate</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added indeterminate state checkboxes. If a checkbox has <code>checkbox.indeterminate = true;</code> set via JavaScript, the checkbox will show a state between checked and unchecked.</td>
@@ -347,7 +347,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/sticky-footer">Sticky footer</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added a new <code>.l-site</code> layout, which can accommodate a sticky footer.</td>
@@ -355,7 +355,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion">Accordions</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We deprecated the previous accordion tab patterns, <code>.p-accordion__tab</code> and <code>.p-accordion__tab--with-title .p-accordion__title</code>, in favour of a more accessible pattern. Please use <code>.p-accordion__heading .p-accordion__tab</code>.</td>
@@ -364,7 +364,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#extra-small-capitalised-text">Typography / Extra small caps</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new extra small capitalised text <code>p-text--x-small-capitalised</code>.</td>
@@ -372,7 +372,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#baseline-alignment-small-extra-small-and-paragraph-text">Typography / Baseline alignment</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added a couple of util classes to help aligning small text on the baseline along default text size.</td>
@@ -380,7 +380,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators#muted-horizontal-rule">Separators / Muted</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new muted variant of horizontal rule.</td>
@@ -388,7 +388,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators#fixed-width-horizontal-rule">Separators / Fixed width</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new fixed width variant of horizontal rule to allow aligning it with full 12-column grid layouts.</td>
@@ -396,7 +396,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#middot">Lists / Middot</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.25.0</td>
       <td>We added a dark theme to middot lists.</td>
@@ -405,7 +405,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#dropdowns">Code snippet - Dropdowns</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.24.0</td>
       <td>We added the ability to accommodate multiple selects within a <code>.p-code-snippet__header</code>, either inline, using the <code>.is-stacked</code> utility to class to have the dropdowns below the title.</td>
@@ -413,7 +413,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#inline">Code inline - dark</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.24.0</td>
       <td>We've updated inline <code>code</code> elements to support being nested within a <code>.p-strip--dark</code> element, and to support an <code>.is-dark</code> utility class.</td>
@@ -421,7 +421,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/fluid-breakout">Fluid breakout</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.24.0</td>
       <td>We added a new <code>l-fluid-breakout</code> layout that can be used to break out of the constraints of a 12-column grid and allow content to bleed into the page margins on larger screens.</td>
@@ -429,7 +429,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/grid">Grid - "orphan" columns</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.24.0</td>
       <td>We deprecated the use of `.col` classes without a direct parent with a class `.row`.</td>
@@ -438,7 +438,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#active">Active button</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.23.0</td>
       <td>The <code>is-active</code> class was deprecated and given a more appropriate name: <code>is-processing</code>.</td>
@@ -446,7 +446,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#processing">Processing button</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.23.0</td>
       <td>We renamed <code>is-active</code> button state class to <code>is-processing</code>, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
@@ -454,7 +454,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet - Dropdowns</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.23.0</td>
       <td>We add the ability to include a select within in a code snippet, allowing users to switch between related code examples.</td>
@@ -462,7 +462,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.23.0</td>
       <td>We added a utility class for <code>.p-code-snippet__block</code> that allows content to wrap, rather than horizontally scroll: <code>.is-wrapped</code>.</td>
@@ -471,7 +471,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/separators">Separator</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.22.0</td>
       <td>The new <code>p-separator</code> component has been added to be used as a separator between content blocks.</td>
@@ -479,7 +479,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.22.0</td>
       <td>The new <code>.p-code-snippet</code> component has been added, to be used to display code examples in a number of different formats.</td>
@@ -487,7 +487,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#copyable">Code copyable</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.22.0</td>
       <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>
@@ -495,7 +495,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/code#numbered">Code numbered</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.22.0</td>
       <td><code>.p-code-numbered</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--numbered</code> instead.</td>
@@ -504,7 +504,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Contextual Menu</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.21.0</td>
       <td>The <code>p-icon--contextual-menu</code> has been deprecated and will be removed in future release v3.0. Please use existing <code>.p-icon--chevron-down</code> and <code>.p-icon--chevron-up</code> icons instead.</td>
@@ -512,7 +512,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#additional">Icons - Additional</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.21.0</td>
       <td>We added many more icons, outside of the base icon set. These icons are not included in Vanilla by default, but can be inspanidually included as needed.</td>
@@ -520,7 +520,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application#panels">Application layout - panels</a></th>
       <td>
-        <span class="p-label--in-progress">In progress</span>
+        <span class="p-label--caution">In progress</span>
       </td>
       <td>2.21.0</td>
       <td>We continue working on application layout panels styling. We improved the positioning of the logo, title and controls in panel headers.</td>
@@ -528,7 +528,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#application-layout">Application layout - side navigation</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.21.0</td>
       <td>We implemented and documented improvements for <a href="/docs/patterns/navigation#application-layout">side navigation component</a> for the <a href="/docs/layouts/application#side-navigation">application layout</a>.</td>
@@ -536,7 +536,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#sticky">Side navigation - Sticky</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.21.0</td>
       <td>Side navigation component used to be sticky by default. We now introduced new <code>is-sticky</code> variant that should be used to optionally make side navigation sticky.</td>
@@ -545,7 +545,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application#responsive-application-layout">Application layout panels</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.20.0</td>
       <td>We updated the responsive styles of application layout panels and introduced some class names and variables for more flexible customization options.</td>
@@ -553,7 +553,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#small">Small buttons</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.20.0</td>
       <td>We added an <code>is-small</code> modifier class for buttons, which can be combined with <code>is-dense</code>.</td>
@@ -561,7 +561,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/buttons#small">Active buttons</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.20.0</td>
       <td>We added an <code>is-active</code> state class for buttons, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
@@ -570,7 +570,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#expanding">Expanding table column placeholder</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.19.2</td>
       <td>We started using <code>aria-hidden="true"</code> attribute to hide the placeholder table header in place of previously used <code>u-hide</code> utility.</td>
@@ -578,7 +578,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/tables#icons">Table icons</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.19.0</td>
       <td>We added a <code>p-table__cell--icon-placeholder</code> class to properly align icons in table cells.</td>
@@ -587,7 +587,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/breadcrumbs">Breadcrumbs</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.18.0</td>
       <td>We updated the markup of the breadcrumbs component to comply with accessibility requirements. The class <code>.p-breadcrumbs</code> is now moved onto a <code>&lt;nav&gt;</code> element, the unordered list has been changed to an ordered one that has a class <code>.p-breadcrumbs__items</code>. </td>
@@ -595,7 +595,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/breadcrumbs#deprecated-markup">Breadcrumbs</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.18.0</td>
       <td>Top level <code>&lt;ul&gt;</code> with a class <code>.p-breadcrumbs</code> is now deprecated for the Breadcrumbs pattern.</td>
@@ -604,7 +604,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#checkbox">Checkbox and radio buttons components</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.17.0</td>
       <td>We introduced new <code>.p-checkbox</code> and <code>.p-radio</code> components. They replace the existing styling of base form inputs.</td>
@@ -612,7 +612,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms#deprecated-base-checkboxes">Checkbox and radio buttons elements</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.17.0</td>
       <td>Base styled checkboxes and radio buttons (on <code>&lt;input type="checkbox"&gt;</code> or <code>&lt;input type="radio"&gt;</code> elements) are deprecated and they will be reverted to native browser inputs in future version of Vanilla. Please use on bWe added new layout styles for building responsive full-screen applications.</td>
@@ -621,7 +621,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/layouts/application">Application layout</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.16.0</td>
       <td>We added new layout styles for building responsive full-screen applications.</td>
@@ -629,7 +629,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/strip#suru-strip">Suru strip</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.16.0</td>
       <td>We added new strip variants <code>.p-strip--suru</code> and <code>.p-strip--suru-topped</code>.</td>
@@ -638,7 +638,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Chip</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.15.0</td>
       <td>We added the new <code>.p-chip</code> component to be used to display small actionable pieces of information.</td>
@@ -647,7 +647,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#inline-stretched">List inline stretched</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.14.0</td>
       <td>We added the new <code>.p-inline-list--stretch</code> list variant that arranges items so they span the full width of the parent container.</td>
@@ -656,7 +656,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/accordion#headings">Accordion</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.13.0</td>
       <td>We updated the accordion component with a new <code>.p-accordion__tab--with-title</code> variant that allows using headings in accordion buttons.</td>
@@ -665,7 +665,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#muted-text">Muted text</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.12.0</td>
       <td>New <code>u-text--muted</code> utility class has been added.</td>
@@ -673,7 +673,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons">Icons</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.12.0</td>
       <td>The icons have been updated to new style.</td>
@@ -681,7 +681,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Question</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.12.0</td>
       <td>The <code>p-icon--question</code> has been deprecated will be removed in future release v3.0. Please use existing `.p-icon--help` icon instead.</td>
@@ -690,7 +690,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.11.0</td>
       <td>A no-JS fallback was added for the side navigation toggle functionality on small screens.</td>
@@ -698,7 +698,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#raw-html">Side navigation</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.11.0</td>
       <td>A new raw HTML variant of the side navigation component.</td>
@@ -707,7 +707,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.10.0</td>
       <td>Update to the responsive styling of the side navigation.</td>
@@ -716,7 +716,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.9.0</td>
       <td>New side navigation component was added.</td>
@@ -725,7 +725,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.8.0</td>
       <td>New navigation classes (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) were added to replace existing (<code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code>).</td>
@@ -733,7 +733,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.8.0</td>
       <td>Navigation classes <code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code> are deprecated and will be removed in future release v3.0. Please use new class names (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) instead.</td>
@@ -742,7 +742,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/contextual-menu#theming">Contextual menu</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.7.0</td>
       <td>Added dark theme to contextual menu.</td>
@@ -750,7 +750,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#heading-classes">Heading classes</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.7.0</td>
       <td>New heading classes with numbers (<code>p-heading--1</code>, ...) were added for consistency with other class names we use.</td>
@@ -758,7 +758,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography#heading-classes">Heading classes</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.7.0</td>
       <td>Heading classes with numbers as words (<code>p-heading--one</code>, <code>--two</code>, ...) are deprecated and will be removed in future release v3.0. Please use class names with numbers (<code>p-heading--1</code>, <code>--2</code>, ...) instead.</td>
@@ -766,7 +766,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms/#range">Range input</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.6.0</td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
@@ -774,7 +774,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/forms/#checkbox">Checkbox, radio button</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.6.0</td>
       <td>New `is-table-header` added to properly align checkboxes and radio buttons used in table headers.</td>
@@ -782,7 +782,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/slider">Slider</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.6.0</td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
@@ -790,7 +790,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/contextual-menu/#indicator">Contextual menu</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Optional state indicator was added to contextual menu</td>
@@ -798,7 +798,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/font-metrics/">Font metrics</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-visualise-font-metrics</code> utility to visualise font metrics</td>
@@ -806,7 +806,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/base/typography/#line-length">Line length</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>$max-width--default</code> variable and <code>u-no-max-width</code> utility to control line length</td>
@@ -814,7 +814,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/table-cell-padding-overlap/">Table cell padding overlap</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-table-cell-padding-overlap</code> utility to overlap table cell padding</td>
@@ -822,7 +822,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/utilities/truncate/">Truncation</a></th>
       <td>
-        <span class="p-label--new">New</span>
+        <span class="p-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-truncate</code> utility to truncate text with ellipsis</td>
@@ -830,7 +830,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons/#social">Social icons</a></th>
       <td>
-        <span class="p-label--updated">Updated</span>
+        <span class="p-label--information">Updated</span>
       </td>
       <td>2.5.0</td>
       <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>
@@ -838,7 +838,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/icons/#social">Social icons</a></th>
       <td>
-        <span class="p-label--deprecated">Deprecated</span>
+        <span class="p-label--negative">Deprecated</span>
       </td>
       <td>2.5.0</td>
       <td>We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from social icon set in future release v3.0</td>
@@ -857,32 +857,26 @@ See [the upgrade guide](/docs/upgrade-guide-v3) to learn about all the breaking 
 <div class="row">
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--new">New</span>
+      <span class="p-label--positive">New</span>
       <p class="p-card__content">Newly released components, utilities or settings that are safe to use in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--deprecated">Deprecated</span>
+      <span class="p-label--negative">Deprecated</span>
       <p class="p-card__content">These components, utilities or settings are in the process of being removed and should no longer be used in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--in-progress">In progress</span>
+      <span class="p-label--caution">In progress</span>
       <p class="p-card__content">Design spec and code implementation are not yet finished.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--updated">Updated</span>
+      <span class="p-label--information">Updated</span>
       <p class="p-card__content">These are existing components, utilities or settings that have been updated either through design or code.</p>
-    </div>
-  </div>
-  <div class="col-3 u-equal-height">
-  <div class="p-card--highlighted">
-      <span class="p-label--validated">Validated</span>
-      <p class="p-card__content">Proposal approved in our bi-weekly meeting . A design spec is created and development starts ready for code review.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Labels are back to replace non-interactive chips

Fixes #4183

## QA

- Open [demo](https://vanilla-framework-4184.demos.haus/docs/patterns/labels)
- Check labels examples and docs
  - https://vanilla-framework-4184.demos.haus/docs/patterns/labels
- Make sure we use labels in all places where they have been before:
  - check side navigation in vanilla docs
  - check what's new page
  - check side navigation and application layout examples

