### PR TITLE
Add missing import sections

### DIFF
--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -196,9 +196,6 @@ To import just this layout into your project, copy the snippet below and include
 @include vf-base;
 
 @include vf-l-application;
-@include vf-l-application-panels;
-@include vf-application-layout--when-collapsed;
-@include vf-application-layout--when-expanded;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -184,3 +184,21 @@ $main-panel-visible-width: 20rem;
 ```
 
 [View the full screen example of the application layout with custom JAAS panels](/docs/examples/layouts/application/JAAS/).
+
+## Import
+
+To import just this layout into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework';
+@include vf-base;
+
+@include vf-l-application;
+@include vf-l-application-panels;
+@include vf-application-layout--when-collapsed;
+@include vf-application-layout--when-expanded;
+```
+
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/layouts/sticky-footer.md
+++ b/templates/docs/layouts/sticky-footer.md
@@ -15,3 +15,18 @@ View an example of the website layout with sticky footer
 </a></div>
 
 [View full screen example of the website layout with sticky footer](/docs/examples/layouts/sticky-footer/).
+
+## Import
+
+To import just this sticky footer into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework';
+@include vf-base;
+
+@include vf-l-site;
+```
+
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
## Done

- Added import section to `/docs/layouts/application`
- Drive by: added import section to `/docs/layouts/sticky-footer` as this was also missing

Fixes #4136 

## QA

- Open [demo](insert-demo-url)
- Check the import section lists all relevant includes on both sticky footer and application layout

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

