### PR TITLE
Make dismiss in chips round

### DIFF
--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -49,6 +49,7 @@
       // also includes button and close icon styles in the theming section
 
       align-self: center;
+      border-radius: 50%;
       flex: 0 0 auto;
       margin-left: $sph--x-small;
     }

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -49,7 +49,7 @@
       // also includes button and close icon styles in the theming section
 
       align-self: center;
-      background-size: calc(map-get($icon-sizes, accordion));
+      background-size: map-get($icon-sizes, accordion);
       border-radius: 50%;
       flex: 0 0 auto;
       margin-left: $sph--x-small;

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -49,6 +49,7 @@
       // also includes button and close icon styles in the theming section
 
       align-self: center;
+      background-size: calc(map-get($icon-sizes, accordion));
       border-radius: 50%;
       flex: 0 0 auto;
       margin-left: $sph--x-small;

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -49,10 +49,13 @@
       // also includes button and close icon styles in the theming section
 
       align-self: center;
-      background-size: map-get($icon-sizes, accordion);
+      background-size: map-get($icon-sizes, small);
       border-radius: 50%;
       flex: 0 0 auto;
       margin-left: $sph--x-small;
+      @media (min-width: $breakpoint-x-large) {
+        background-size: map-get($icon-sizes, small) / $font-size-ratio--largescreen; //ensure no rounding happens as it positions the icon off center
+      }
     }
 
     &.is-dense {

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -118,7 +118,7 @@ $form-radio-circle-offset: 0.5 * ($form-tick-box-size - $form-radio-inner-circle
 $text-max-width: 40em !default;
 
 $icon-sizes: (
-  accordion: $sp-unit * 1.5,
+  small: $sp-unit * 1.5,
   default: $sp-unit * 2,
   heading-icon--x-small: $sp-unit * 3,
   heading-icon--small: $sp-unit * 4,

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -177,6 +177,12 @@ Also, the dismiss button in chips has been updated. It now provides its own icon
 
 ## Variables
 
+The `accordion` key in map `$icon-sizes` has been renamed to `small`. It is currently used in chips, and is suitable to other situations where the icons sits next to small text.
+
+| Old map call                      | New map call                  |
+| --------------------------------- | ----------------------------- |
+| `map-get($icon-sizes, accordion)` | `map-get($icon-sizes, small)` |
+
 `$grid-margin-width` is has been removed, as the grid margins differ at different breakpont. Use the values in `$grid-margin-widths` instead.
 
 ### Variable refactor
@@ -219,21 +225,21 @@ So any calls that previously included `nudge--` as in `map-get($nudges, nudge--p
 
 Full list of changed keys:
 
-| Old key             | New key      |
-| ------------------- | ------------ |
-| nudge--h1-large     | h1-large     |
-| nudge--h4-large     | h4-large     |
-| nudge--h1           | h1           |
-| nudge--h1-mobile    | h1-mobile    |
-| nudge--h2           | h2           |
-| nudge--h2-mobile    | h2-mobile    |
-| nudge--h3           | h3           |
-| nudge--h3-mobile    | h3-mobile    |
-| nudge--h4           | h4           |
-| nudge--h4-mobile    | h4-mobile    |
-| nudge--h6           | h6           |
-| nudge--h6-large     | h6-mobile    |
-| nudge--p            | p            |
-| nudge--p-ubuntumono | p-ubuntumono |
-| nudge--small        | small        |
-| nudge--x-small      | x-small      |
+| Old key               | New key        |
+| --------------------- | -------------- |
+| `nudge--h1-large`     | `h1-large`     |
+| `nudge--h4-large`     | `h4-large`     |
+| `nudge--h1`           | `h1`           |
+| `nudge--h1-mobile`    | `h1-mobile`    |
+| `nudge--h2`           | `h2`           |
+| `nudge--h2-mobile`    | `h2-mobile`    |
+| `nudge--h3`           | `h3`           |
+| `nudge--h3-mobile`    | `h3-mobile`    |
+| `nudge--h4`           | `h4`           |
+| `nudge--h4-mobile`    | `h4-mobile`    |
+| `nudge--h6`           | `h6`           |
+| `nudge--h6-large`     | `h6-mobile`    |
+| `nudge--p`            | `p`            |
+| `nudge--p-ubuntumono` | `p-ubuntumono` |
+| `nudge--small`        | `small`        |
+| `nudge--x-small`      | `x-small`      |


### PR DESCRIPTION
## Done

Make dismiss button in chips round.

Fixes #4189 

## QA

- Open [demo](https://vanilla-framework-4191.demos.haus/docs/examples/patterns/chip/variants)
- Verify that rounded dismiss button in chips looks as expected


## Screenshots

<img width="153" alt="Screenshot 2021-12-09 at 14 15 52" src="https://user-images.githubusercontent.com/83575/145403301-5fc8ce87-0edc-4232-ae37-bc72f14b629c.png">

