### PR TITLE
Add contextual menu icon update to upgrade guide

### DIFF
--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -97,7 +97,7 @@ Using `.u-hide` utility inside expanding table to hide table heading placeholder
 ## Icons
 
 The `.p-icon--question` icon has been removed. Please use the existing `.p-icon--help` icon instead.
-Corresponding mixins `vf-p-icon-question` and `vf-icon-question` have also been removed. Please use `vf-p-icon-help` and `vf-icon-help`, respectively, instead. The `p-icon--contextual-menu` icon has been removed and replaced by the chevron `p-icon--chevron-down` or `p-icon--chevron-down` icons. The mixin `vf-icon-contextual-menu` has also been removed.
+Corresponding mixins `vf-p-icon-question` and `vf-icon-question` have also been removed. Please use `vf-p-icon-help` and `vf-icon-help`, respectively, instead. The `p-icon--contextual-menu` icon has been removed and replaced by the chevron `p-icon--chevron-down` or `p-icon--chevron-up` icons. The mixin `vf-icon-contextual-menu` has also been removed.
 
 The `vf-p-icon-in-button` mixin is no longer necessary and has been removed. Any code that includes this mixin can be removed.
 

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -97,7 +97,7 @@ Using `.u-hide` utility inside expanding table to hide table heading placeholder
 ## Icons
 
 The `.p-icon--question` icon has been removed. Please use the existing `.p-icon--help` icon instead.
-Corresponding mixins `vf-p-icon-question` and `vf-icon-question` have also been removed. Please use `vf-p-icon-help` and `vf-icon-help`, respectively, instead. The `p-icon--contextual-menu` icon has been removed and replaced by the chevron `p-icon--chevron-down` or `p-icon--chevron-down` icons.
+Corresponding mixins `vf-p-icon-question` and `vf-icon-question` have also been removed. Please use `vf-p-icon-help` and `vf-icon-help`, respectively, instead. The `p-icon--contextual-menu` icon has been removed and replaced by the chevron `p-icon--chevron-down` or `p-icon--chevron-down` icons. The mixin `vf-icon-contextual-menu` has also been removed.
 
 The `vf-p-icon-in-button` mixin is no longer necessary and has been removed. Any code that includes this mixin can be removed.
 

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -97,7 +97,7 @@ Using `.u-hide` utility inside expanding table to hide table heading placeholder
 ## Icons
 
 The `.p-icon--question` icon has been removed. Please use the existing `.p-icon--help` icon instead.
-Corresponding mixins `vf-p-icon-question` and `vf-icon-question` have also been removed. Please use `vf-p-icon-help` and `vf-icon-help`, respectively, instead.
+Corresponding mixins `vf-p-icon-question` and `vf-icon-question` have also been removed. Please use `vf-p-icon-help` and `vf-icon-help`, respectively, instead. The `p-icon--contextual-menu` icon has been removed and replaced by the chevron `p-icon--chevron-down` or `p-icon--chevron-down` icons.
 
 The `vf-p-icon-in-button` mixin is no longer necessary and has been removed. Any code that includes this mixin can be removed.
 


### PR DESCRIPTION
## Done

- Added description of the `p-icon--contextual-menu` update to chevron icons to the upgrade guide.

Fixes [#1174](https://github.com/canonical-web-and-design/vanilla-squad/issues/1174)

## QA

- Open [demo](https://vanilla-framework-4196.demos.haus/docs/upgrade-guide-v3)
- Review updated documentation:
  - New sentence mentioning update in upgrade guide

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

