### PR TITLE
Reword text-max-width section of upgrade guide

### DIFF
--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -191,13 +191,15 @@ We removed the `p-table--sortable` that was previously required to enable sortin
 ## Text element max-width
 
 Max-widths should not be based on font-size. Legacy classes, placeholders, and mixins that used a font-size based max-width setting have been removed.
-The sole remaining variable to control max-widths was also renamed from `$max-width--default` to `$text-max-width`. All other heading max-width variables have been replaced by `$text-max-width`.
+All heading related max-width variables have been replaced by one single variable - `$text-max-width`, which is an updated version of the `$max-width--default` variable.
 
 List of removed max width features includes:
 
 - `max-width--p` and `%measure--p` placeholders
 - `.measure--p` class name
 - `vf-b-typography-max-widths`, `p-max-width`, `heading-max-width--short`, `heading-max-width--long`, `p-max-width--long` mixins.
+
+You can add `max-width: $text-max-width` to replace them.
 
 ## Labels
 


### PR DESCRIPTION
## Done

- Reword the text-max-width section to give more clarity what to do with the removed variables. 

Fixes [#1181](https://github.com/canonical-web-and-design/vanilla-squad/issues/1181)

## QA

- Open [demo](insert-demo-url)
- Review updated documentation:
  - upgrade guide

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
