### PR TITLE
Add `p-notification__action` class info to upgrade guide

### DIFF
--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -166,6 +166,8 @@ The notification child classes have been replaced to support new variants. The f
 
 The text content of the notifications should also be wrapped in element with `.p-notification__message` class name. This element didn't exist in previous version of notification pattern and should be added for best compatibility.
 
+Additionally the `p-notification__action` class should no longer be used for links in notification text. Instead, it should be used for notification action buttons. Please see the notifications [docs](/docs/patterns/notification#actions) for examples.
+
 ## Pagination links
 
 The `.p-article-pagination__link` was removed, as only its variants (`.p-article-pagination__link--next` and `.p-article-pagination__link--previous`) were meant to be used.


### PR DESCRIPTION
## Done

- Add a paragraph about the `p-notification__action` class to the Notifications section of the upgrade guide

Fixes [#1177](https://github.com/canonical-web-and-design/vanilla-squad/issues/1177)

## QA

- Open [demo](insert-demo-url)
- Review updated documentation:
  - Notifications section of upgrade guide

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
