### PR TITLE
Add search box description to upgrade guide

### DIFF
--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -154,6 +154,10 @@ Refer to [navigation dropdowns documentation](/docs/patterns/navigation#dropdown
 
 The color variable `$color-navigation-background` has been removed, please use the default light and dark themed navigation patterns.
 
+### Expanding search box
+
+If a search box is being used in the top navigation, you now have the option to use the new [expanding search](/docs/examples/patterns/navigation/search-dark) component. We haven't removed the old search box, so this update is completely optional.
+
 ## Notifications
 
 The notification child classes have been replaced to support new variants. The following class substitutions can be used to support existing functionality:


### PR DESCRIPTION
## Done

- Add a new section to the navigation section in the upgrade guide, describing the use of the new expanding search box component. (Not sure if the link is correct?)
- NOTE: I will change the order of everything when tackling this [issue](https://github.com/canonical-web-and-design/vanilla-squad/issues/1172)

Fixes [#1175](https://github.com/canonical-web-and-design/vanilla-squad/issues/1175)

## QA

- Open [demo](https://vanilla-framework-4201.demos.haus)
- Review updated documentation:
  - new search box paragraph added to navigation section

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
