### PR TITLE
Remove specific node versions from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,5 @@
     "stylelint-order": "5.0.0",
     "stylelint-prettier": "2.0.0",
     "svgo": "2.8.0"
-  },
-  "engines": {
-    "node": "^14 || ^16 || ^18"
   }
 }


### PR DESCRIPTION
## Done

For the sake of renovate we specify the expected node versions in renovate.json, so specifying them in package.json is redundant and unnecessary.

https://github.com/canonical-web-and-design/vanilla-framework/blob/f28cda8560d24f67b14b0ccc93ae3303788a0736/renovate.json#L18-L20


Fixes canonical-web-and-design/vanilla-squad#1187