### PR TITLE
Change order of variable names

### DIFF
--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -260,15 +260,15 @@ We've simplified the spacing variables in Vanilla. Please use the mapping below 
 | Deprecated variable              | Replaced by                    | Default value |
 | -------------------------------- | ------------------------------ | ------------- |
 | `$multi`                         | Dropped. Delete any instances  | `–`           |
-| `$spv-inner--x-small`            | `$spv--x-small`                | `0.25rem`     |
-| `$spv-inner--x-small--scaleable` | `$spv--small`                  | `0.5rem`      |
 | `$spv-inner--small`              | `$spv--small`                  | `0.5rem`      |
+| `$spv-inner--x-small--scaleable` | `$spv--small`                  | `0.5rem`      |
+| `$spv-inner--x-small`            | `$spv--x-small`                | `0.25rem`     |
 | `$spv-inner--medium`             | `$spv--medium`                 | `0.75rem`     |
 | `$spv-inner--scaleable`          | `$spv--large`                  | `1rem`        |
 | `$spv-inner--large`              | `$spv--large`                  | `1rem`        |
 | `$spv-inner--x-large`            | Express as a sum of other vars | `2.75rem`     |
-| `$spv-outer--small`              | `$spv--small`                  | `0.5rem`      |
 | `$spv-outer--small-scaleable`    | `$spv--large`                  | `1rem`        |
+| `$spv-outer--small`              | `$spv--small`                  | `0.5rem`      |
 | `$spv-outer--medium`             | `$spv--large`                  | `1rem`        |
 | `$spv-outer--scaleable`          | `$spv--x-large`                | `1.5rem`      |
 | `$spv-outer--shallow-scaleable`  | `$spv--x-large`                | `1.5rem`      |
@@ -280,11 +280,11 @@ We've simplified the spacing variables in Vanilla. Please use the mapping below 
 | Spacing variable      | Formula                        | Default value |
 | --------------------- | ------------------------------ | ------------- |
 | `$sph-inner--small`   | `$sph--small`                  | `0.5rem`      |
-| `$sph-inner`          | `$sph--large`                  | `1rem`        |
 | `$sph-inner--large`   | Express as a sum of other vars | `1.5rem`      |
 | `$sph-inner--x-large` | Express as a sum of other vars | `2.5rem`      |
-| `$sph-outer`          | `$sph--small`                  | `0.5rem`      |
+| `$sph-inner`          | `$sph--large`                  | `1rem`        |
 | `$sph-outer--large`   | Express as sum of above vars   | `1.5rem`      |
+| `$sph-outer`          | `$sph--small`                  | `0.5rem`      |
 
 The keys in map `$nudges` no longer include the `nudge--` prefix. Please note these fail silently, so it is essential do a thorough search and replace them as part of the upgrade.
 So any calls that previously included `nudge--` as in `map-get($nudges, nudge--p)`, should now be renamed to `map-get($nudges, p)`.
@@ -295,17 +295,17 @@ Full list of changed keys:
 | --------------------- | -------------- |
 | `nudge--h1-large`     | `h1-large`     |
 | `nudge--h4-large`     | `h4-large`     |
-| `nudge--h1`           | `h1`           |
 | `nudge--h1-mobile`    | `h1-mobile`    |
-| `nudge--h2`           | `h2`           |
+| `nudge--h1`           | `h1`           |
 | `nudge--h2-mobile`    | `h2-mobile`    |
-| `nudge--h3`           | `h3`           |
+| `nudge--h2`           | `h2`           |
 | `nudge--h3-mobile`    | `h3-mobile`    |
-| `nudge--h4`           | `h4`           |
+| `nudge--h3`           | `h3`           |
 | `nudge--h4-mobile`    | `h4-mobile`    |
-| `nudge--h6`           | `h6`           |
+| `nudge--h4`           | `h4`           |
 | `nudge--h6-large`     | `h6-mobile`    |
-| `nudge--p`            | `p`            |
+| `nudge--h6`           | `h6`           |
 | `nudge--p-ubuntumono` | `p-ubuntumono` |
+| `nudge--p`            | `p`            |
 | `nudge--small`        | `small`        |
 | `nudge--x-small`      | `x-small`      |

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -135,14 +135,14 @@ Refer to [navigation documentation](/docs/patterns/navigation) for more details 
 
 ### Subnav component was replaced by navigation dropdowns
 
-Navigation dropdowns implemented as separate `.p-subnav` class has also been removed. This class name and its associated child elements should be updated simply by substituting the following class names:
+Navigation dropdowns implemented with separate `.p-subnav` classes have also been removed. This class name and its associated child elements should be updated simply by substituting the following class names:
 
 | Removed classes           | Replaced by                            |
 | ------------------------- | -------------------------------------- |
-| `.p-subnav`               | `.p-navigation__item--dropdown-toggle` |
-| `.p-subnav__items`        | `.p-navigation__dropdown`              |
 | `.p-subnav__items--right` | `.p-navigation__dropdown--right`       |
+| `.p-subnav__items`        | `.p-navigation__dropdown`              |
 | `.p-subnav__item`         | `.p-navigation__dropdown-item`         |
+| `.p-subnav`               | `.p-navigation__item--dropdown-toggle` |
 
 The `<a>` element that toggles the dropdown element should have the `.p-navigation__link` class, as well as an `aria-controls` attribute that references the `id` attribute of the dropdown element.
 


### PR DESCRIPTION
## Done

- Changed the order of variable names to make sure find and replace doesn't break 

Fixes [#1183](https://app.zenhub.com/workspaces/-design-system-tribe-59438c953747487777fbe484/issues/canonical-web-and-design/vanilla-squad/1183)

## QA

- Open [demo](insert-demo-url)
- Review updated documentation:
  - check order of variable names

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

