### PR TITLE
Fix sass deprecation warning

### DIFF
--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import 'settings';
 
 @mixin vf-p-chip {
@@ -54,7 +55,7 @@
       flex: 0 0 auto;
       margin-left: $sph--x-small;
       @media (min-width: $breakpoint-x-large) {
-        background-size: map-get($icon-sizes, small) / $font-size-ratio--largescreen; //ensure no rounding happens as it positions the icon off center
+        background-size: math.div(map-get($icon-sizes, small), $font-size-ratio--largescreen); //ensure no rounding happens as it positions the icon off center
       }
     }
 


### PR DESCRIPTION
## Done
- replaced division with `math.div`

Fixes #4206 

## QA

- Pull this branch
- run dotrun
- check there are no more deprecation warnings in the terminal

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
