### PR TITLE
Upgrade warnings

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -6,6 +6,7 @@
 /css/(?P<path>.*): /static/css/{path}
 /js/(?P<path>.*): /static/js/{path}
 /docs/component-status: /docs/whats-new
+/docs/upgrade-guide-v3: /docs/migration-guide-to-v3
 
 # redirects based on class names
 /docs/patterns/code-snippet: /docs/base/code

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -47,7 +47,7 @@
               {{ side_nav_item("/docs/building-vanilla", "Building with Vanilla") }}
               {{ side_nav_item("/docs/customising-vanilla", "Customising Vanilla") }}
               {{ side_nav_item("/docs/whats-new", "What’s new in " ~ version) }}
-              {{ side_nav_item("/docs/upgrade-guide-v3", "Vanilla 3.0 upgrade guide", "new", "positive") }}
+              {{ side_nav_item("/docs/migration-guide-to-v3", "Migrating to v3.0", "new", "positive") }}
             </ul>
 
             <ul class="p-side-navigation__list">

--- a/templates/docs/migration-guide-to-v3.md
+++ b/templates/docs/migration-guide-to-v3.md
@@ -1,10 +1,10 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Vanilla 3.0 upgrade guide
+  title: Migrating to Vanilla 3.0
 ---
 
-# Vanilla 3.0 upgrade guide
+# Migrating to Vanilla 3.0
 
 <hr>
 

--- a/templates/docs/migration-guide-to-v3.md
+++ b/templates/docs/migration-guide-to-v3.md
@@ -112,7 +112,7 @@ The state initially implemented as "active" via `is-active` class name on the bu
 
 <div class="p-notification--caution">
   <div class="p-notification__content">
-    <p class="p-notification__message">We are using <code>is-active</code> class name in various components to denote the active state, so make sure you rename it <b>only</b> in context of buttons.</p>
+    <p class="p-notification__message">We use the <code>is-active</code> class name in various components to denote the active state, so make sure you rename it <b>only</b> in the context of buttons.</p>
   </div>
 </div>
 
@@ -191,7 +191,7 @@ We removed the inline images (`p-inline-images`) component. Please use the [logo
 
 <div class="p-notification--caution">
   <div class="p-notification__content">
-    <p class="p-notification__message">Logo section component requires images to have identical dimensions, so you will not only need to update the HTML markup of the component, but also change the URLs of logo images to new ones.</p>
+    <p class="p-notification__message">The logo section component requires images to have identical dimensions, so you will not only need to update the HTML markup of the component, but also change the URLs of logo images to new ones.</p>
   </div>
 </div>
 

--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -110,6 +110,12 @@ The state initially implemented as "active" via `is-active` class name on the bu
 | ------------------ | ---------------------- |
 | `button.is-active` | `button.is-processing` |
 
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <p class="p-notification__message">We are using <code>is-active</code> class name in various components to denote the active state, so make sure you rename it <b>only</b> in context of buttons.</p>
+  </div>
+</div>
+
 The previous `vf-button-active` mixin was renamed to `vf-button-processing`. Additionally the `vf-button-white-success-icon` mixin has been removed (it is not needed anymore as the `%vf-button-white-success-icon` placeholder it used to provide is part of the Vanilla base styles now).
 
 ## External Links
@@ -126,6 +132,12 @@ The scss maps defining grid margins and gutters have been simplified. In both `$
 | --------------- | ----------- |
 | `medium`        | `default`   |
 | `large`         | `default`   |
+
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <p class="p-notification__message">Sass will not throw errors or warn you if the key doesn't exist in the map. Please make sure you correctly search and replace any map keys and verify that affected styles render correctly in the browser.</p>
+  </div>
+</div>
 
 ### Column classes
 
@@ -175,7 +187,13 @@ The `p-icon--canonical` and `p-icon--ubuntu` from the social icon set have been 
 
 ## Inline images
 
-We removed the inline images (`p-inline-images`) component. Please use the [logo section component](/docs/patterns/logo-section) instead. As this pattern requires images to have identical dimensions, the height and width of any which currently use the `p-inline-images` pattern may need to be updated.
+We removed the inline images (`p-inline-images`) component. Please use the [logo section component](/docs/patterns/logo-section) instead.
+
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <p class="p-notification__message">Logo section component requires images to have identical dimensions, so you will not only need to update the HTML markup of the component, but also change the URLs of logo images to new ones.</p>
+  </div>
+</div>
 
 ## Navigation
 
@@ -323,6 +341,12 @@ The `accordion` key in map `$icon-sizes` has been renamed to `small`. It is curr
 | --------------------------------- | ----------------------------- |
 | `map-get($icon-sizes, accordion)` | `map-get($icon-sizes, small)` |
 
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <p class="p-notification__message">Sass will not throw errors or warn you if the key doesn't exist in the map. Please make sure you correctly search and replace any map keys and verify that affected styles render correctly in the browser.</p>
+  </div>
+</div>
+
 ### Grid margins
 
 `$grid-margin-width` is has been removed, as the grid margins differ at different breakpont. Use the values in `$grid-margin-widths` instead.
@@ -394,3 +418,9 @@ Full list of changed keys:
 | `nudge--p`            | `p`            |
 | `nudge--small`        | `small`        |
 | `nudge--x-small`      | `x-small`      |
+
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <p class="p-notification__message">Sass will not throw errors or warn you if the key doesn't exist in the map. Please make sure you correctly search and replace any map keys and verify that affected styles render correctly in the browser.</p>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Add warning alerts to crucial parts of the guide
- Rename the "Upgrade guide" to "Migration guide"

Fixes canonical-web-and-design/vanilla-squad#1184

## QA

- Open [demo](https://vanilla-framework-4215.demos.haus/docs/migration-guide-to-v3)
- Review updated documentation - focus on checking the warning notifications added, if they make sense in their context
- Make sure renamed page still works, that the URL is correct, side navigation works and redirect from all URL is in place

