### PR TITLE
Add updated labels to side navigation

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -53,7 +53,7 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
               {{ side_nav_item("/docs/base/code", "Code") }}
-              {{ side_nav_item("/docs/base/forms", "Forms", 'new', 'positive') }}
+              {{ side_nav_item("/docs/base/forms", "Forms") }}
               {{ side_nav_item("/docs/base/reset", "Reset") }}
               {{ side_nav_item("/docs/base/separators", "Separators") }}
               {{ side_nav_item("/docs/base/tables", "Tables") }}
@@ -72,7 +72,7 @@
               {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}
               {{ side_nav_item("/docs/patterns/icons", "Icons") }}
               {{ side_nav_item("/docs/patterns/images", "Images") }}
-              {{ side_nav_item("/docs/patterns/labels", "Labels") }}
+              {{ side_nav_item("/docs/patterns/labels", "Labels", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
               {{ side_nav_item("/docs/patterns/lists", "Lists") }}
@@ -86,10 +86,10 @@
               {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
-              {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
+              {{ side_nav_item("/docs/patterns/search-box", "Search box", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/slider", "Slider") }}
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}
-              {{ side_nav_item("/docs/patterns/switch", "Switch") }}
+              {{ side_nav_item("/docs/patterns/switch", "Switch", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
               {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}
               {{ side_nav_item("/docs/patterns/tooltips", "Tooltips") }}

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -86,7 +86,7 @@
               {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
-              {{ side_nav_item("/docs/patterns/search-box", "Search box", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/search-box", "Search box", 'new', 'positive') }}
               {{ side_nav_item("/docs/patterns/slider", "Slider") }}
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}
               {{ side_nav_item("/docs/patterns/switch", "Switch", 'updated', 'information') }}

--- a/templates/docs/patterns/search-box.md
+++ b/templates/docs/patterns/search-box.md
@@ -35,6 +35,18 @@ This component integrates with `.p-navigation__nav` for both small and large scr
 View examples of search box navigation patterns
 </a></div>
 
+## Expanding search box
+
+Expanding search in main navigation consists of couple of elements: search toggle link (`.p-navigation__link--search-toggle`), expanding search box (`.p-navigation__search`) and an overlay that covers whole screen when search is expanded (`.p-navigation__search-overlay`).
+
+The `.p-navigation__link--search-toggle` class name is used to add a search toggle link to navigation items. The label text of this toggle element should be wrapped in `.p-navigation__search-label` element to make sure it's hidden on smaller screen sizes. Click event handler attached to the toggle element should add `.has-search-open` class on main `.p-navigation` element to expand the search box and show the overlay.
+
+Vanilla Search box component is used for the search field, but it's wrapped into an element with `.p-navigation__search` class name. The search will be hidden by default and only expands when the navigation element has `.has-search-open` class name.
+
+When search box is expanded the overlay element (`p-navigation__search-overlay`) is faded in to cover all the contents of the page (except the search box itself). Clicking anywhere on the overlay (or hitting Escape key) closes the search box.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/navigation/search-light" class="js-example"> View example of the search navigation </a></div>
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -22,6 +22,14 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 3.00 -->
     <tr>
+      <th><a href="/docs/patterns/navigation">Expanding search box</a></th>
+      <td>
+        <span class="p-label--positive">New</span>
+      </td>
+      <td>3.0.0</td>
+      <td>We've added an expandable search box, to be used in top navigation.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/labels">Labels</a></th>
       <td>
         <span class="p-label--information">Updated</span>
@@ -36,14 +44,6 @@ When we add, make significant updates, or deprecate a component we update their 
       </td>
       <td>3.0.0</td>
       <td>We've added tinted chips. The tints are based on the semantic colours (positive, caution, negative) plus a dark blue one that matches the blue used in the information flavour of the notification component.</td>
-    </tr>
-    <tr>
-      <th><a href="/docs/patterns/navigation">Expanding search box</a></th>
-      <td>
-        <span class="p-label--information">Updated</span>
-      </td>
-      <td>3.0.0</td>
-      <td>We've added an expandable search box, to be used in top navigation.</td>
     </tr>
     <tr>
       <th><a href="/docs/patterns/switch">Switch</a></th>


### PR DESCRIPTION
## Done

- Added updated labels to components in side navigation
- Added expanding search box example to search box docs

Fixes #4220 

## QA

- Open [demo](https://vanilla-framework-4221.demos.haus/docs)
- Check the labels are on correct components - chips, labels, search box and switch
- Check search box docs with expanding search box example

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
