### PR TITLE
Update README on vanilla website

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,44 +30,42 @@ You can link to the latest build to add directly into your markup like so, by re
 <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-x.x.x.min.css" />
 ```
 
-### Including Vanilla in your project via NPM
+### Including Vanilla in your project via NPM or yarn
 
-Pull down the latest version of Vanilla into your local `node_modules` folder
-and save it into your project's dependencies (`package.json`) as follows:
+To get set up with Sass, add the `sass` and `vanilla-framework` packages to your project dependencies:
 
 ```bash
-npm install --save-dev vanilla-framework
+yarn add sass vanilla-framework
 ```
 
-Now ensure that your SASS builder is including modules from `node_modules`. E.g. for Gulp:
+In the script that builds the CSS in your `package.json`, you should include the path to `node_modules` when looking for `@imports`. In this example, we have called the build script `"build-css"`:
 
-```javascript
-// gulpfile.js
-gulp.task('sass', function () {
-  return gulp.src('[your-sass-directory]/**/*.scss').pipe(
-    sass({
-      includePaths: ['node_modules'],
-    })
-  );
-});
+```
+"build-css": "sass -w --load-path=node_modules src:dist --style=compressed"
 ```
 
-Please note, that to provide the best browser support you should also include [autoprefixer](https://www.npmjs.com/package/autoprefixer) as a build step.
-
-Then reference it from your own Sass files, with optional settings:
+Make a folder `src/`, create a file inside called `style.scss` and import Vanilla:
 
 ```sass
-// Optionally override some settings
-$color-brand: #ffffff;
-
 // Import the theme
 @import 'vanilla-framework';
 @include vanilla;
+
+// Optionally override some settings
+$color-brand: #ffffff;
 
 // Add theme if applicable
 ```
 
 If you don't want the whole framework, you can just `@include` specific [parts](scss) - e.g. `@include vf-b-forms`.
+
+Now run `yarn build-css`, which will convert any Sass files in the `src/` folder to CSS in the `dist/` folder.
+
+To watch for changes in your Sass files, add the following script to your `package.json`
+
+```
+"watch-css":  "yarn build-css && sass --load-path=node_modules -w src:dist --style=compressed"
+```
 
 ## Developing Vanilla
 


### PR DESCRIPTION
## Done

- Remove gulp instructions and add instructions with Sass

Fixes #4222 

## QA

- Open [demo](insert-demo-url)
- Check readme text is correct

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

