### PR TITLE
Add accessibility accordion notes

### DIFF
--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -48,6 +48,42 @@ View example of the accordion pattern
 
 Please ensure the `aria-control` attribute matches an ID of an element. If `aria-expanded` is true, then the accordion will be open by default. When clicking on the `accordion__tab`, you must toggle the `aria-expanded` attribute on the toggle and the `aria-hidden` attribute on the panel.
 
+## Accessibility
+
+{# copy doc: https://docs.google.com/document/d/1UekmbTagZNVppuiuw3i9aoMpgQBJVdZnSHC2ciW6blY/edit# #}
+
+### How it works
+
+Accordions are a vertically stacked list of headings. They reduce the need for users to scroll through a lot of content, as the headings act as interactive elements which show or hide the related content.
+
+`Tab` and `Shift-Tab` are used to navigate forward and backward through each accordion header and all focusable elements in the accordion should be included in the tab order. `Enter` or `Space` expand and collapse each accordion panel.
+
+The two main components are:
+
+- Accordion heading which is the interactive title or thumbnail for each section. The headings can hide or show content.
+- Accordion panel is the content associated with an accordion heading.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- Accordion titles should be descriptive; it should be obvious what information the content will contain.
+- Ensure each tab button element is wrapped by a `div` element with a `p-accordion__heading` class and the `role=heading` attribute. This heading should have an appropriate `aria-level` label, depending on its position in the hierarchy of the page.
+- If the accordion panel associated with the heading is visible, then the button within the heading div must have `aria-expanded=”true”`
+- The heading button should have an `aria-controls` attribute set to the ID of the related accordion panel.
+- Add the `aria-labelledby` attribute to the accordion panel, set to the ID of the button heading.
+- Avoid keyboard traps when adding components to the accordion panel. For example, the user expands an accordion, but is unable to tab to the next focusable element.
+
+### Resources
+
+- [W3C WAI-ARIA Accordion (Sections With Show/Hide Functionality)](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion)
+- [WAI-ARIA Examples: Accordion](https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html)
+- [Carbon design systems - Accordion accessibility](https://carbondesignsystem.com/components/accordion/accessibility)
+- Guidelines:
+  - [1.3.1: Info and Relationships](https://www.w3.org/TR/WCAG21/#info-and-relationships)
+  - [2.1.1: Keyboard Accessible](https://www.w3.org/TR/WCAG21/#keyboard)
+  - [2.1.2: No Keyboard Trap](https://www.w3.org/TR/WCAG21/#no-keyboard-trap)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Added accessibility notes - google doc is [here](https://docs.google.com/document/d/1UekmbTagZNVppuiuw3i9aoMpgQBJVdZnSHC2ciW6blY/edit#) and has been QA'd by @sowasred2012 and @wgx 

Fixes #4037 

## QA

- Open [demo](https://vanilla-framework-4233.demos.haus/docs/patterns/accordion)
- Check the accessibility docs are the same as the doc

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

