### PR TITLE
Add lists accessibility doc

### DIFF
--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -138,6 +138,32 @@ For more details about themes in Vanilla refer to the [Color theming](/docs/sett
 View example of the divider list with an is-dark class
 </a></div>
 
+## Accessibility
+
+{# copy doc: https://docs.google.com/document/d/1pK4kmbo83pyfQ92DuRLCqVAJaY9HdRTWbaAI3yCg59I/edit# #}
+
+### How it works
+
+Lists provide orientation for users by letting them know when a collection of items are related, and whether or not the items are sequential. They also let screen reader users know how many items are in each list, and allow users to jump between lists within the content.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+Be sure to use the correct list type for your content:
+
+- Unordered lists (`<ul>`) can be used when the order of the content isn’t relevant.
+- Ordered lists (`<ol>`) are sequential, and are enumerated by the browser.
+
+It’s important to make sure that all content which is visibly a list has the correct HTML structure. Avoid making paragraphs look like lists by using bullet symbols or numbers, as these will not be read out as related content. Similarly, avoid using lists for indentation or layout purposes.
+
+### Resources
+
+- [WAI-ARIA practices: Lists ](https://www.w3.org/TR/wai-aria-1.1/#list)
+- [Web Accessibility Initiatives (WAI) page on the structure of Web content](https://www.w3.org/WAI/tutorials/page-structure/content/#lists)
+- Guidelines:
+  - [SC 1.3.1 Info and Relationships](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)
+
 ## Import
 
 To import list patterns into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Add accessibility notes for lists. copy doc [here](https://docs.google.com/document/d/1pK4kmbo83pyfQ92DuRLCqVAJaY9HdRTWbaAI3yCg59I/edit#)

Fixes #4051 

## QA

- Open [demo](https://vanilla-framework-4234.demos.haus/docs/patterns/lists#accessibility)
- Check the Accessibility notes on the lists page reads ok and isn't missing anything 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
