### PR TITLE
Add link accessibility doc

### DIFF
--- a/templates/docs/patterns/links.md
+++ b/templates/docs/patterns/links.md
@@ -50,6 +50,47 @@ The `.p-link--skip` link is used to help keyboard users navigate quickly to the 
 View example of the back to skip link pattern
 </a></div>
 
+## Accessibility
+
+{# copy doc: https://docs.google.com/document/d/1DcYBpmuLKZGLIWR6jgjYfZc1X64d8HtDt9uKMoB0POE/edit#heading=h.6xtxk46lmbik #}
+
+### How it works
+
+Links are used as navigational elements and can be used on their own or inline with text. It's possible to use the `Tab` key to navigate to the link, and the `Enter` key activates the link.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+#### Link text
+
+- As screen reader users can choose to read link text in isolation, avoid using non descriptive text like “Read more”, “Learn more”, “Click here” etc. Out of context, it isn’t obvious where these links take you.
+- Use unique link text where possible. Speech recognition software users may have a bad experience with duplicated link text.
+- Avoid using anything longer than a full sentence for a link.
+- Use judgement when linking URLs, think about how these may be read out.
+
+#### Images
+
+- Using images as links should be avoided where possible, but if they are used, the `alt` text should be a replacement for the link text instead of describing the image.
+
+#### Adjacent links
+
+- Having adjacent links to the same place (e.g. header, image and link in text of card) should be avoided. Choose one element, or wrap all the elements together.
+
+#### ARIA attributes
+
+- `aria-describedby` can be used to add some additional information about the link. It will be read out directly after the link text.
+- Be aware when using `aria-label` or `aria-labelledby`, the screen reader will skip the link text completely and read out these values only.
+
+Note: It’s important to use button and link elements accurately. Controls with button-like behaviour (e.g. opening models, submitting forms) should be designed like buttons using the button element, and regular text links (e.g. going to an external page) should be designed like text links using the link element.
+
+### Resources
+
+- [WAI-ARIA practices: Links ](https://www.w3.org/TR/wai-aria-practices/#link)
+- [Yale usability & Web Accessibility - Links](https://usability.yale.edu/web-accessibility/articles/links)
+- Guidelines:
+  - [2.4.4: Link Purpose in Context](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Add accessibility notes for Links. copy doc [here](https://docs.google.com/document/d/1DcYBpmuLKZGLIWR6jgjYfZc1X64d8HtDt9uKMoB0POE/edit#heading=h.6xtxk46lmbik)

Fixes #4049 

## QA

- Open [demo](https://vanilla-framework-4235.demos.haus/docs/patterns/links#accessibility)
- Check the accessibility notes for links

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

