### PR TITLE
Add accessibility card text

### DIFF
--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -50,8 +50,6 @@ Please ensure the `aria-control` attribute matches an ID of an element. If `aria
 
 ## Accessibility
 
-{# copy doc: https://docs.google.com/document/d/1UekmbTagZNVppuiuw3i9aoMpgQBJVdZnSHC2ciW6blY/edit# #}
-
 ### How it works
 
 Accordions are a vertically stacked list of headings. They reduce the need for users to scroll through a lot of content, as the headings act as interactive elements which show or hide the related content.

--- a/templates/docs/patterns/breadcrumbs.md
+++ b/templates/docs/patterns/breadcrumbs.md
@@ -20,8 +20,6 @@ View example of the breadcrumbs pattern
 
 ## Accessibility
 
-{# copy doc: https://docs.google.com/document/d/1qglleNv0WU-DLACF87fBkccYk49V2hwWnurTm_t1Ux4/edit#heading=h.tab4i4y8yac #}
-
 ### How it works
 
 It establishes a landmark on the page which assists the user in understanding where they currently are and which pages exist in the current page’s hierarchical order.

--- a/templates/docs/patterns/card.md
+++ b/templates/docs/patterns/card.md
@@ -58,6 +58,32 @@ The purpose of the overlay card is to make the text visible in conjunction with 
 View example of the patterns card overlay
 </a></div>
 
+## Accessibility
+
+{# copy doc: https://docs.google.com/document/d/1f_dJS0MquxNm9D6e1OaHohyqXBNG1GwnPfFdxFci60k/edit# #}
+
+### How it works
+
+Cards are content containers. They are useful for creating a responsive site, and help users scroll through similar content at ease. They are used as a teaser, and contain a link to more content.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- The headings in the cards should follow the heading hierarchy of the page.
+- Make sure the tab order makes sense, and that all appropriate elements are focusable.
+- There should also be a logical order within the card, heading first and related content to follow.
+- Headings should briefly and accurately describe the content of the card
+- Link text must be meaningful and clear.
+- Avoid wrapping the entire container in a link, as the entire content of the container will be read out as a link to by the screen reader.
+- Avoid multiple elements linking to the same place. Choose one element in the card to link from.
+- If an image is used as a link, then the `alt` text of the image should replace the link text. Alternatively, add `aria-label` to the link element wrapping the image.
+
+### Resources
+
+- [W3C Non-text content](https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv-all.html)
+- [What makes an accessible card](https://technica11y.org/what-makes-an-accessible-card)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.

--- a/templates/docs/patterns/card.md
+++ b/templates/docs/patterns/card.md
@@ -60,8 +60,6 @@ View example of the patterns card overlay
 
 ## Accessibility
 
-{# copy doc: https://docs.google.com/document/d/1f_dJS0MquxNm9D6e1OaHohyqXBNG1GwnPfFdxFci60k/edit# #}
-
 ### How it works
 
 Cards are content containers. They are useful for creating a responsive site, and help users scroll through similar content at ease. They are used as a teaser, and contain a link to more content.
@@ -75,7 +73,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - There should also be a logical order within the card, heading first and related content to follow.
 - Headings should briefly and accurately describe the content of the card
 - Link text must be meaningful and clear.
-- Avoid wrapping the entire container in a link, as the entire content of the container will be read out as a link to by the screen reader.
+- Avoid wrapping the entire container in a link, as the entire content of the container will be read out as a link by the screen reader.
 - Avoid multiple elements linking to the same place. Choose one element in the card to link from.
 - If an image is used as a link, then the `alt` text of the image should replace the link text. Alternatively, add `aria-label` to the link element wrapping the image.
 

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -140,8 +140,6 @@ View example of the divider list with an is-dark class
 
 ## Accessibility
 
-{# copy doc: https://docs.google.com/document/d/1pK4kmbo83pyfQ92DuRLCqVAJaY9HdRTWbaAI3yCg59I/edit# #}
-
 ### How it works
 
 Lists provide orientation for users by letting them know when a collection of items are related, and whether or not the items are sequential. They also let screen reader users know how many items are in each list, and allow users to jump between lists within the content.


### PR DESCRIPTION
## Done

- Add accessibility doc for Cards. Copy doc [here](https://docs.google.com/document/d/1f_dJS0MquxNm9D6e1OaHohyqXBNG1GwnPfFdxFci60k/edit#heading=h.qxwy2zql3yy7)

Fixes #4040 

## QA

- Open [demo](https://vanilla-framework-4237.demos.haus/docs/patterns/card#accessibility)
- Check the accessibility section of the card documentation

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

