### PR TITLE
Add search box accessibility doc

### DIFF
--- a/templates/docs/patterns/search-box.md
+++ b/templates/docs/patterns/search-box.md
@@ -47,6 +47,27 @@ When search box is expanded the overlay element (`p-navigation__search-overlay`)
 
 <div class="embedded-example"><a href="/docs/examples/patterns/navigation/search-light" class="js-example"> View example of the search navigation </a></div>
 
+## Accessibility
+
+### How it works
+
+The search box allows users to search for content by typing in the input, without needing to use the navigation. The input element has a descriptive `aria-label` for screen reader users.
+
+It's a focusable component, and in the expanding search box where only the icon is visible, the search box has an appropriate `aria-label`. If `required` is included in the input, then the browser will display an accessible error message instructing the user to fill out the field.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- Make sure to have a descriptive `aria-label` for the search input.
+- Usually, it shouldn’t be possible to search with an empty input field, so indicate this with the `required` attribute on the input.
+- If a page includes more than one search landmark, each should have a unique label.
+
+### Resources
+
+- [W3C WAI-ARIA Landmarks Example](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/search.html)
+- [Accessible search - handling form errors](https://www.a11ymatters.com/pattern/accessible-search/#handling-form-errors)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Add search box accessibility doc

Fixes #4062 

## QA

- Open [demo](https://vanilla-framework-4239.demos.haus/docs/patterns/search-box#accessibility)
- Check the accessibility section of the search box docs page.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

