### PR TITLE
Add tooltip accessibility doc

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -86,3 +86,5 @@ div
 u-no-padding--top
 datalist
 WAI-ARIA
+Heydon
+Pickering

--- a/templates/docs/patterns/links.md
+++ b/templates/docs/patterns/links.md
@@ -52,8 +52,6 @@ View example of the back to skip link pattern
 
 ## Accessibility
 
-{# copy doc: https://docs.google.com/document/d/1DcYBpmuLKZGLIWR6jgjYfZc1X64d8HtDt9uKMoB0POE/edit#heading=h.6xtxk46lmbik #}
-
 ### How it works
 
 Links are used as navigational elements and can be used on their own or inline with text. It's possible to use the `Tab` key to navigate to the link, and the `Enter` key activates the link.

--- a/templates/docs/patterns/tooltips.md
+++ b/templates/docs/patterns/tooltips.md
@@ -36,6 +36,29 @@ In some cases you may need the tooltip element to exist outside of the element i
 View example of the detached tooltips pattern
 </a></div>
 
+## Accessibility
+
+### How it works
+
+A tooltip is text that appears in a small overlay on demand, usually when hovering over the thing it describes. It is hidden by default, and becomes available on hover or focus of the control it describes. It should provide information that isn’t self explanatory or well known.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- Be sure to include the `aria-describedby` attribute with the `id` of the description.
+- They should be discoverable, avoid placing them in over a word in a sentence for example.
+- Avoid using tooltips to provide instructions or guidance, or any rich information.
+- They shouldn’t be used on disabled elements. It should be clear to the user why the button is disabled without the tooltip.
+
+### Resources
+
+- Inclusive Components by Heydon Pickering
+- Guidelines
+  - [WCAG21 - Content on hover or focus](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus)
+  - [WCAG21 Techniques - aria](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1)
+  - [WAI-ARIA practices - Tooltip](https://www.w3.org/TR/wai-aria-practices-1.1/#tooltip)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Add accessibility notes for tooltips
- Filed an [issue](https://github.com/canonical-web-and-design/vanilla-framework/issues/4240) as on our example currently the description is read out twice

Fixes #4068 

## QA

- Open [demo](insert-demo-url)
- Check the tooltips accessibility section

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
