### PR TITLE
Fix spacing issues with chips in search and filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.0.0",
+  "version": "3.0.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -153,9 +153,11 @@
       border: 0;
     }
 
-    // hide chips lead when there are in panel
-    // FIXME: this should be handled in HTML/React, not CSS
     .p-chip {
+      margin-bottom: $spv--small;
+
+      // hide chips lead when there are in panel
+      // FIXME: this should be handled in HTML/React, not CSS
       .p-chip__lead {
         display: none;
       }
@@ -177,7 +179,7 @@
       position: relative;
 
       &[aria-expanded='false'] {
-        max-height: 4rem;
+        max-height: 5rem; // 2 rows of chips
       }
     }
 


### PR DESCRIPTION
## Done

Fixes spacing issues in search and filter panel

## QA

- Open [demo](https://vanilla-framework-4246.demos.haus/docs/examples/patterns/search-and-filter/expanded)
- Check search and filter examples (make screen smaller for chips to wrap in 2 lines)
  - https://vanilla-framework-4246.demos.haus/docs/examples/patterns/search-and-filter/expanded
- Make sure chips are visible as expected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

### Before

<img width="607" alt="Screenshot 2022-01-13 at 13 36 03" src="https://user-images.githubusercontent.com/83575/149332881-afe93ac7-956f-485b-a4bf-c6cff2bac0f0.png">

### After

<img width="608" alt="Screenshot 2022-01-13 at 13 35 43" src="https://user-images.githubusercontent.com/83575/149332873-4b4770ed-d1dc-445b-8c4b-cf01436fe815.png">

