### PR TITLE
Fix notifications in docs

### DIFF
--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -158,7 +158,8 @@ Adding the `disabled` attribute to an input will prevent user interaction.
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>All disabled inputs have an opacity of <code>0.5</code> and <code>not-allowed</code> cursor on hover.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">All disabled inputs have an opacity of <code>0.5</code> and <code>not-allowed</code> cursor on hover.</span>
   </p>
 </div>
 

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -79,7 +79,8 @@ View an example of the application layout structure
 
 <div class="p-notification--caution">
   <p class="p-notification__content">
-    <span class="p-notification__title">In progress:</span> The current implementation of the panel component is created to provide minimal consistent styling of panels, but is still work in progress and may change in the future.
+    <span class="p-notification__title">In progress:</span>
+    <span class="p-notification__message">The current implementation of the panel component is created to provide minimal consistent styling of panels, but is still work in progress and may change in the future.</span>
   </p>
 </div>
 

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -20,7 +20,8 @@ The wrapping element should either be a heading element or a `div` element with 
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>Clicking on the header toggles the display of accordion tabs. Accordion tabs should contain navigation or supplementary information, not main page content.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">Clicking on the header toggles the display of accordion tabs. Accordion tabs should contain navigation or supplementary information, not main page content.</span>
   </p>
 </div>
 

--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -12,7 +12,8 @@ Buttons are clickable elements used to perform an action, you can apply `button`
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>Do not use multiple button classes on one HTML element.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">Do not use multiple button classes on one HTML element.</span>
   </p>
 </div>
 

--- a/templates/docs/patterns/contextual-menu.md
+++ b/templates/docs/patterns/contextual-menu.md
@@ -37,7 +37,8 @@ If you require a drop-down button with a state indicator then the `p-contextual-
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Information:</span>This example makes use of additional components
+    <span class="p-notification__title">Information:</span>
+    <span class="p-notification__message">This example makes use of additional components</span>
   </p>
 </div>
 

--- a/templates/docs/patterns/labels.md
+++ b/templates/docs/patterns/labels.md
@@ -10,12 +10,6 @@ context:
 
 Labels are static elements which you can apply to signify status, tags or any other information you find useful.
 
-<div class="p-notification--information">
-  <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>These labels are used to inform <a href="/docs/whats-new">status</a> of components in Vanilla.
-  </p>
-</div>
-
 <div class="embedded-example"><a href="/docs/examples/patterns/labels/" class="js-example">
 View example of the labels pattern
 </a></div>

--- a/templates/docs/patterns/matrix.md
+++ b/templates/docs/patterns/matrix.md
@@ -14,7 +14,8 @@ Items will display in one column on small screens. At resolutions above `$breakp
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>To display correctly on large screens, you'll need to add list items in a multiple of three. If you do not have content for all the items, leave them empty but the list item must be present.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">To display correctly on large screens, you'll need to add list items in a multiple of three. If you do not have content for all the items, leave them empty but the list item must be present.</span>
   </p>
 </div>
 

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -18,7 +18,8 @@ displayed horizontally on larger screens.
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>By default, the width of the navigation is constrained to <code>$grid-max-width</code>. To make the navigation full width, replace <code>.p-navigation__row</code> with <code>.p-navigation__row--full-width</code>.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">By default, the width of the navigation is constrained to <code>$grid-max-width</code>. To make the navigation full width, replace <code>.p-navigation__row</code> with <code>.p-navigation__row--full-width</code>.</span>
   </p>
 </div>
 
@@ -78,7 +79,8 @@ To add icons on the left side of the items in side navigation use the `.p-side-n
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>Icons should only be used on the items in the first level of side navigation.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">Icons should only be used on the items in the first level of side navigation.</span>
   </p>
 </div>
 
@@ -91,7 +93,9 @@ View example of the side navigation pattern with icons
 On pages with content significantly longer than the side navigation contents you can make the navigation sticky to keep it visible when scrolling by adding `.is-sticky` class to the root element of `.p-side-navigation`.
 
 <div class="p-notification--caution">
-  <p class="p-notification__content"><span class="p-notification__title">Breaking change:</span>Side navigation used to be sticky by default, but since Vanilla 2.21.0 <code>.is-sticky</code> class is needed to add this functionality.</p>
+  <p class="p-notification__content">
+    <span class="p-notification__title">Breaking change:</span>
+    <span class="p-notification__message">Side navigation used to be sticky by default, but since Vanilla 2.21.0 <code>.is-sticky</code> class is needed to add this functionality.</p></span>
 </div>
 
 <div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/sticky" class="js-example">
@@ -117,12 +121,17 @@ Because of the limitations of raw HTML markup without class names, it's not poss
   <div class="row">
      <div class="col-4">
        <div class="p-notification--positive">
-        <p class="p-notification__content"><span class="p-notification__title">Do:</span>Use the  raw HTML variant when the backend serving the navigation content won't allow custom class names on HTML elements.</p>
+        <p class="p-notification__content">
+          <span class="p-notification__title">Do:</span>
+          <span class="p-notification__message">Use the  raw HTML variant when the backend serving the navigation content won't allow custom class names on HTML elements.</span>
+          </p>
        </div>
      </div>
     <div class="col-4">
       <div class="p-notification--negative">
-        <p class="p-notification__content"><span class="p-notification__title">Don't:</span>Use raw HTML variant when the markup can be fully controlled and class names can be properly added to all elements.</p>
+        <p class="p-notification__content">
+          <span class="p-notification__title">Don't:</span>
+          <span class="p-notification__message">Use raw HTML variant when the markup can be fully controlled and class names can be properly added to all elements.</span</p>
       </div>
     </div>
   </div>

--- a/templates/docs/patterns/search-and-filter.md
+++ b/templates/docs/patterns/search-and-filter.md
@@ -45,7 +45,9 @@ When a click event is triggered on the selected-count element you need need to t
 - Switch `.p-search-and-filter__search-container` aria-expanded attribute from false to true
 
 <div class="p-notification--information">
-  <p class="p-notification__content" role="status">You will have to handle the overflowing chip count yourself. Unfortunately that is out of scope for this example but this can be handled for you by the <a href="#react">React component</a>.</p>
+  <p class="p-notification__content">
+    <span class="p-notification__message">You will have to handle the overflowing chip count yourself. Unfortunately that is out of scope for this example but this can be handled for you by the <a href="#react">React component</a>.</span>
+  </p>
 </div>
 
 ## Search prompt
@@ -59,7 +61,9 @@ View example of the search and filter with search prompt pattern
 ### Functionality
 
 <div class="p-notification--information">
-  <p class="p-notification__content" role="status">You will have to handle filtering the available chips yourself by removing or hiding chips that do not match. Unfortunately that is out of scope for this example but this can be handled for you by the <a href="#react">React component</a>.</p>
+  <p class="p-notification__content">
+    <span class="p-notification__message">You will have to handle filtering the available chips yourself by removing or hiding chips that do not match. Unfortunately that is out of scope for this example but this can be handled for you by the <a href="#react">React component</a>.</span>
+  </p>
 </div>
 
 ## Import

--- a/templates/docs/patterns/search-box.md
+++ b/templates/docs/patterns/search-box.md
@@ -18,7 +18,7 @@ A cancel button is shown when the input has content, and a small amount of JavaS
 
 <div class="p-notification--caution">
   <div class="p-notification__content">
-    <h5 class="p-notification__title">Caution:</h5>
+    <h5 class="p-notification__title">Buttons in the search box:</h5>
     <p class="p-notification__message">Space is allocated for the <code>.p-search-box__reset</code> and <code>.p-search-box__button</code> buttons, so both must be included in the implementation to avoid the appearance of excess padding.</p>
   </div>
 </div>

--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -35,7 +35,8 @@ This pattern allows for an image background to be appear as a background on a st
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>Declare the background-image as an inline style attribute in the HTML.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">Declare the background-image as an inline style attribute in the HTML.</span>
   </p>
 </div>
 
@@ -52,7 +53,8 @@ This pattern is used to add a dividing border at the bottom of the strip.
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>This should be used when two strips of the same type are used after each other.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">This should be used when two strips of the same type are used after each other.</span>
   </p>
 </div>
 

--- a/templates/docs/patterns/tooltips.md
+++ b/templates/docs/patterns/tooltips.md
@@ -14,13 +14,15 @@ They can be used to provide information about concepts/terms/actions that are no
 
 <div class="p-notification--caution">
   <p class="p-notification__content">
-    <span class="p-notification__title">Avoid:</span>Using tooltips to provide instructions or guidance. They shouldn't be used to show rich information including images and formatted text and avoid placing over plain text or other places where they are not discoverable.
+    <span class="p-notification__title">Avoid:</span>
+    <span class="p-notification__message">Using tooltips to provide instructions or guidance. They shouldn't be used to show rich information including images and formatted text and avoid placing over plain text or other places where they are not discoverable.</span>
   </p>
 </div>
 
 <div class="p-notification--caution">
   <p class="p-notification__content">
-    <span class="p-notification__title">Avoid:</span>Tooltips shouldn't be used on disabled elements, such as buttons. It should be clear to the user why the button is disabled, without the tooltip needing to be revealed first.
+    <span class="p-notification__title">Avoid:</span>
+    <span class="p-notification__message">Tooltips shouldn't be used on disabled elements, such as buttons. It should be clear to the user why the button is disabled, without the tooltip needing to be revealed first.</span>
   </p>
 </div>
 

--- a/templates/docs/settings/animation-settings.md
+++ b/templates/docs/settings/animation-settings.md
@@ -66,7 +66,8 @@ The format is as follows:
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span> The list of valid `DURATION` and `EASING` options are shown in the <a href="#duration">duration</a> and <a href="#easing">easing</a> sections of the documentation.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">The list of valid <code>DURATION</code> and <code>EASING</code> options are shown in the <a href="#duration">duration</a> and <a href="#easing">easing</a> sections of the documentation.</span>
   </p>
 </div>
 

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -123,14 +123,19 @@ It’s important for us to meet all web accessibility standards. Vanilla encoura
   <div class="row">
      <div class="col-4">
        <div class="p-notification--positive">
-        <p class="p-notification__content"><span class="p-notification__title">Do:</span>Use a minimum contrast ratio of 4.5 for normal text and UI components</p>
+        <div class="p-notification__content">
+          <h5 class="p-notification__title">Do:</h5>
+          <span class="p-notification__message">Use a minimum contrast ratio of 4.5 for normal text and UI components.</span>
+        </div>
        </div>
        <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/e1183cd5-basics-text-color-do.png" alt="text-color-do">
        <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/92607803-basics-button-color-do.png" alt="button-color-do">
      </div>
     <div class="col-4">
       <div class="p-notification--negative">
-        <p class="p-notification__content"><span class="p-notification__title">Don't:</span>Use low-contrast text and background combinations.</p>
+        <div class="p-notification__content">
+          <h5 class="p-notification__title">Don't:</h5>
+          <span class="p-notification__message">Use low-contrast text and background combinations.</span></div>
       </div>
       <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/66aa056d-basics-text-color-don%27t.png" alt="text-color-don't">
       <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/0929f834-basics-button-color-don%27t.png" alt="button-color-don't">

--- a/templates/docs/utilities/image-position.md
+++ b/templates/docs/utilities/image-position.md
@@ -14,7 +14,8 @@ most cases it would be a strip.
 
 <div class="p-notification--information">
   <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>This only affects medium and large screen sizes.
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">This only affects medium and large screen sizes.</span>
   </p>
 </div>
 


### PR DESCRIPTION
## Done

Improve HTML structure of notifications in docs to fix missing space issue.

Fixes #4242 

## QA

- Code review - make sure notifications use both `p-notification__title` and `p-notification__message`
- Open [demo](https://vanilla-framework-4248.demos.haus/)
- Review updated docs pages, make sure notifications display correctly:
  - https://vanilla-framework-4248.demos.haus/docs/base/forms#disabled
  - https://vanilla-framework-4248.demos.haus/docs/patterns/accordion
  - https://vanilla-framework-4248.demos.haus/docs/patterns/buttons
  - https://vanilla-framework-4248.demos.haus/docs/patterns/contextual-menu#indicator
  - https://vanilla-framework-4248.demos.haus/docs/patterns/matrix
  - https://vanilla-framework-4248.demos.haus/docs/patterns/navigation
  - https://vanilla-framework-4248.demos.haus/docs/patterns/search-and-filter#search-prompt
  - https://vanilla-framework-4248.demos.haus/docs/patterns/search-box
  - https://vanilla-framework-4248.demos.haus/docs/patterns/strip#image-strip
  - https://vanilla-framework-4248.demos.haus/docs/patterns/tooltips
  - https://vanilla-framework-4248.demos.haus/docs/utilities/image-position
  - https://vanilla-framework-4248.demos.haus/docs/layouts/application#panels
  - https://vanilla-framework-4248.demos.haus/docs/settings/animation-settings#usage
  - https://vanilla-framework-4248.demos.haus/docs/settings/color-settings#accessibility


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.

## Screenshots

<img width="851" alt="Screenshot 2022-01-17 at 13 26 56" src="https://user-images.githubusercontent.com/83575/149769340-d4e3090c-b0cb-4de3-82f3-19076dbcb6ca.png">

