### PR TITLE
Merge Button Accessibility sections into one

### DIFF
--- a/templates/docs/patterns/buttons.md
+++ b/templates/docs/patterns/buttons.md
@@ -118,14 +118,6 @@ View example of the buttons with an is-dark class
 
 ## Accessibility
 
-In some contexts, it may be necessary to indicate to the user that a button is in a pressed state, such as when a button opens a contextual menu. This can be done by adding `aria-pressed="true"` to the button with JavaScript when the button is clicked, and removed when necessary.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/buttons/pressed" class="js-example" data-height="270">
-View example of the contextual menu pattern
-</a></div>
-
-## Accessibility
-
 ### How it works
 
 The button component is used to trigger an action or event - this could be opening or closing a modal, navigating to the next page, or cancelling an action. Rather than adding `role=button` to links, it’s always advisable to use the native HTML button element, as native HTML buttons provide keyboard and focus requirements by default and are best supported by assistive technologies.
@@ -137,8 +129,12 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - A button, once focussed should be activated by using the `Space` or `Enter` keys.
 - The button should have an accurate description. This can be as text in the button, or by using `aria-label` or `aria-labelledby`.
 - If there is a description of the button, the button should have an `aria-describedby` which matches the ID of the description.
-- If the button is a toggle and it needs to be indicated to the user when it’s in a pressed state, add `aria-pressed=true` and `aria-pressed=false` accordingly.
 - After the button is activated ensure the focus is set correctly based on the type of action the button performs. See [W3C WAI-ARIA Authoring Practices Button Design Pattern](https://www.w3.org/TR/wai-aria-practices/#button) for a list of examples.
+- In some contexts, it may be necessary to indicate to the user that a button is in a pressed state, such as when a button opens a contextual menu. This can be done by adding `aria-pressed="true"` to the button with JavaScript when the button is clicked, and removed when necessary.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/buttons/pressed" class="js-example" data-height="270">
+View example of the contextual menu pattern
+</a></div>
 
 Note: It’s important to use button and link elements accurately. Controls with button-like behaviour (e.g. opening models, submitting forms) should be designed like buttons using the button element, and regular text links (e.g. going to an external page) should be designed like text links using the link element.
 


### PR DESCRIPTION
## Done

- Included the previous accessibility section as a bullet point in the new section with the example below it. 

Fixes #4251 

## QA

- Open [demo]( https://vanilla-framework-4252.demos.haus/docs/patterns/buttons)
- Check the accessibility section of the Button docs

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

