### PR TITLE
Update slider style

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.0.1",
+  "version": "3.0.2",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -1,8 +1,8 @@
 @mixin vf-b-range {
   $thumb-shadow: 0 0 $bar-thickness 1px rgba(0, 0, 0, 0.2);
-  $thumb-size: 24px;
+  $thumb-size: 1.5rem;
   $thumb-radius: 50%;
-  $track-height: 3px;
+  $track-height: $bar-thickness;
   $track-radius: $bar-thickness;
 
   // stylelint-disable selector-max-type -- base styles can use type selectors

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -2,7 +2,7 @@
   $thumb-shadow: 0 0 $bar-thickness 1px rgba(0, 0, 0, 0.2);
   $thumb-size: 24px;
   $thumb-radius: 50%;
-  $track-height: 2px;
+  $track-height: 3px;
   $track-radius: $bar-thickness;
 
   // stylelint-disable selector-max-type -- base styles can use type selectors
@@ -20,7 +20,7 @@
     // Chrome
     &::-webkit-slider-runnable-track {
       border-radius: $track-radius + 1;
-      height: $track-height + 1;
+      height: $track-height;
     }
 
     &::-webkit-slider-thumb {
@@ -44,15 +44,15 @@
 
     // Firefox
     &::-moz-range-track {
-      background: $color-x-light;
+      background: $color-mid;
       border-radius: $track-radius;
-      height: $track-height - 1;
+      height: $track-height;
     }
 
     &::-moz-range-progress {
-      background-color: $color-information;
+      background-color: $color-link;
       border-radius: $track-radius;
-      height: $track-height - 1;
+      height: $track-height;
     }
 
     &::-moz-range-thumb {

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -1,10 +1,8 @@
 @mixin vf-b-range {
   $thumb-shadow: 0 0 $bar-thickness 1px rgba(0, 0, 0, 0.2);
   $thumb-size: 24px;
-  $thumb-radius: $bar-thickness;
-  $track-height: 5px;
-  $track-border-size: 1px;
-  $track-border: $track-border-size solid $colors--light-theme--border-high-contrast;
+  $thumb-radius: 50%;
+  $track-height: 2px;
   $track-radius: $bar-thickness;
 
   // stylelint-disable selector-max-type -- base styles can use type selectors
@@ -21,7 +19,6 @@
 
     // Chrome
     &::-webkit-slider-runnable-track {
-      border: $track-border;
       border-radius: $track-radius + 1;
       height: $track-height + 1;
     }
@@ -37,7 +34,7 @@
       border-radius: $thumb-radius;
       box-shadow: $thumb-shadow;
       height: $thumb-size;
-      margin-top: ((-$thumb-size + $track-height) * 0.5) - $track-border-size;
+      margin-top: (-$thumb-size + $track-height) * 0.5;
       width: $thumb-size;
 
       &:hover {
@@ -48,7 +45,6 @@
     // Firefox
     &::-moz-range-track {
       background: $color-x-light;
-      border: $track-border;
       border-radius: $track-radius;
       height: $track-height - 1;
     }

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -1,6 +1,6 @@
 @mixin vf-b-range {
   $thumb-shadow: 0 0 $bar-thickness 1px rgba(0, 0, 0, 0.2);
-  $thumb-size: 1.5rem;
+  $thumb-size: 1rem;
   $thumb-radius: 50%;
   $track-height: $bar-thickness;
   $track-radius: $bar-thickness;
@@ -12,14 +12,14 @@
     -moz-appearance: none;
     appearance: none;
     // stylelint-enable property-no-vendor-prefix
-    border-radius: $track-radius + 1;
+    border-radius: $track-radius;
     margin: $sp-small 0;
     padding: 0;
     width: 100%;
 
     // Chrome
     &::-webkit-slider-runnable-track {
-      border-radius: $track-radius + 1;
+      border-radius: $track-radius; 
       height: $track-height;
     }
 

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -2,6 +2,7 @@
   $thumb-shadow: 0 0 $bar-thickness 1px rgba(0, 0, 0, 0.2);
   $thumb-size: 1rem;
   $thumb-radius: 50%;
+  $thumb-border: 1px solid $color-mid-dark;
   $track-height: $bar-thickness;
   $track-radius: $bar-thickness;
 
@@ -19,7 +20,7 @@
 
     // Chrome
     &::-webkit-slider-runnable-track {
-      border-radius: $track-radius; 
+      border-radius: $track-radius;
       height: $track-height;
     }
 
@@ -30,7 +31,7 @@
       appearance: none;
       // stylelint-enable property-no-vendor-prefix
       background: $color-x-light;
-      border: 0;
+      border: $thumb-border;
       border-radius: $thumb-radius;
       box-shadow: $thumb-shadow;
       height: $thumb-size;
@@ -44,7 +45,7 @@
 
     // Firefox
     &::-moz-range-track {
-      background: $color-mid;
+      background: $color-mid-light;
       border-radius: $track-radius;
       height: $track-height;
     }
@@ -57,7 +58,7 @@
 
     &::-moz-range-thumb {
       background: $color-x-light;
-      border: 0;
+      border: $thumb-border;
       border-radius: $thumb-radius;
       box-shadow: $thumb-shadow;
       height: $thumb-size;

--- a/templates/docs/examples/base/forms/range.html
+++ b/templates/docs/examples/base/forms/range.html
@@ -11,7 +11,7 @@
 var isWebkit =
   /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
 var PROGRESS_COLOUR = '#06c';
-var EMPTY_COLOUR = '#999';
+var EMPTY_COLOUR = '#D9D9D9';
 
 /**
  Renders gradient to fake progress color in webkit browsers.

--- a/templates/docs/examples/base/forms/range.html
+++ b/templates/docs/examples/base/forms/range.html
@@ -11,7 +11,7 @@
 var isWebkit =
   /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
 var PROGRESS_COLOUR = '#06c';
-var EMPTY_COLOUR = '#fff';
+var EMPTY_COLOUR = '#999';
 
 /**
  Renders gradient to fake progress color in webkit browsers.

--- a/templates/docs/examples/patterns/slider/slider-input.html
+++ b/templates/docs/examples/patterns/slider/slider-input.html
@@ -43,7 +43,7 @@ var isWebkit =
   /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
 
 var PROGRESS_COLOUR = '#06c';
-var EMPTY_COLOUR = '#fff';
+var EMPTY_COLOUR = '#999';
 
 /**
  Renders gradient to fake progress color in webkit browsers.

--- a/templates/docs/examples/patterns/slider/slider-input.html
+++ b/templates/docs/examples/patterns/slider/slider-input.html
@@ -43,7 +43,7 @@ var isWebkit =
   /Chrome/i.test(navigator.userAgent) || /Safari/i.test(navigator.userAgent);
 
 var PROGRESS_COLOUR = '#06c';
-var EMPTY_COLOUR = '#999';
+var EMPTY_COLOUR = '#D9D9D9';
 
 /**
  Renders gradient to fake progress color in webkit browsers.


### PR DESCRIPTION
## Done
Update slider's style.

Fixes #4250 

## QA

- Open [demo](https://vanilla-framework-4253.demos.haus/docs/patterns/slider)
- Check doc page of slider
- Verify it's style matches with the [design](https://app.zeplin.io/project/6166f0f9aad348b734b978bb/screen/6166f160f367a9bb84e0c02d)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

## Screenshots


<img width="1123" alt="Screenshot 2022-01-18 at 14 50 57" src="https://user-images.githubusercontent.com/83575/149949944-4f9910f8-f502-4672-b670-23c6d1226023.png">
