### PR TITLE
Updated switch styling

### DIFF
--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -1,5 +1,5 @@
 @import 'settings';
-$knob-size: $sp-unit;
+$knob-size: $sp-unit * 2;
 
 @mixin vf-p-switch {
   .p-switch {
@@ -36,13 +36,13 @@ $knob-size: $sp-unit;
 
   .p-switch__slider {
     background: $color-mid-light;
-    border-radius: $knob-size * 1.5;
+    border-radius: $knob-size;
     box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
     display: inline-block;
-    height: $knob-size * 2;
+    height: $knob-size;
     margin: 0;
     position: relative;
-    width: $knob-size * 4;
+    width: $knob-size * 2;
 
     &::before {
       @extend %vf-has-round-corners;
@@ -53,9 +53,9 @@ $knob-size: $sp-unit;
       border: 1px solid $color-mid-dark;
       border-radius: 50%;
       content: '';
-      height: $knob-size * 2;
+      height: $knob-size;
       position: absolute;
-      width: $knob-size * 2;
+      width: $knob-size;
     }
   }
 

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -1,8 +1,9 @@
 @import 'settings';
-$knob-size: $sp-unit * 3;
+$knob-size: $sp-unit;
 
 @mixin vf-p-switch {
   .p-switch {
+    align-items: center;
     display: flex;
   }
 
@@ -35,13 +36,13 @@ $knob-size: $sp-unit * 3;
 
   .p-switch__slider {
     background: $color-mid-light;
-    border-radius: $knob-size * 0.5;
+    border-radius: $knob-size * 1.5;
     box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
     display: inline-block;
-    height: $knob-size - 0.5;
+    height: $knob-size * 2;
     margin: 0;
     position: relative;
-    width: $knob-size + 0.5;
+    width: $knob-size * 4;
 
     &::before {
       @extend %vf-has-round-corners;
@@ -49,12 +50,12 @@ $knob-size: $sp-unit * 3;
       @include vf-animation($duration: slow);
 
       background: $color-x-light;
-      border: 1px solid #757575;
+      border: 1px solid $color-mid-dark;
       border-radius: 50%;
       content: '';
-      height: $knob-size - 0.5;
+      height: $knob-size * 2;
       position: absolute;
-      width: $knob-size - 0.5;
+      width: $knob-size * 2;
     }
   }
 

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @import 'settings';
 $knob-size: $sp-unit * 3;
 
@@ -34,7 +33,7 @@ $knob-size: $sp-unit * 3;
   }
 
   .p-switch__slider {
-    border-radius: math.div($knob-size, 2);
+    border-radius: $knob-size * 0.5;
     box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
     display: inline-block;
     height: $knob-size;

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import 'settings';
 $knob-size: $sp-unit * 3;
 
@@ -19,7 +20,7 @@ $knob-size: $sp-unit * 3;
       @extend %vf-disabled-element;
     }
 
-    &:checked + .p-switch__slider{
+    &:checked + .p-switch__slider {
       background: $color-link;
     }
 
@@ -33,15 +34,13 @@ $knob-size: $sp-unit * 3;
   }
 
   .p-switch__slider {
-    @extend %vf-has-round-corners;
-
+    border-radius: math.div($knob-size, 2);
     box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
     display: inline-block;
     height: $knob-size;
     margin: 0;
     position: relative;
     width: $knob-size * 2;
-    border-radius: .7rem;
 
     &::before {
       @extend %vf-has-round-corners;
@@ -49,13 +48,12 @@ $knob-size: $sp-unit * 3;
       @include vf-animation($duration: slow);
 
       background: $color-x-light;
-
+      border-radius: 50%;
       content: '';
       height: $knob-size;
       left: 0;
       position: absolute;
       width: $knob-size;
-      border-radius: 50%;
     }
   }
 

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -19,6 +19,10 @@ $knob-size: $sp-unit * 3;
       @extend %vf-disabled-element;
     }
 
+    &:checked + .p-switch__slider{
+      background: $color-link;
+    }
+
     &:focus {
       outline: none;
 
@@ -31,13 +35,13 @@ $knob-size: $sp-unit * 3;
   .p-switch__slider {
     @extend %vf-has-round-corners;
 
-    background: linear-gradient(to right, $color-link 50%, $color-mid-light 50%);
     box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
     display: inline-block;
     height: $knob-size;
     margin: 0;
     position: relative;
     width: $knob-size * 2;
+    border-radius: .7rem;
 
     &::before {
       @extend %vf-has-round-corners;
@@ -45,11 +49,13 @@ $knob-size: $sp-unit * 3;
       @include vf-animation($duration: slow);
 
       background: $color-x-light;
+
       content: '';
       height: $knob-size;
       left: 0;
       position: absolute;
       width: $knob-size;
+      border-radius: 50%;
     }
   }
 

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -54,6 +54,7 @@ $knob-size: $sp-unit * 2;
       border-radius: 50%;
       content: '';
       height: $knob-size;
+      left: 0;
       position: absolute;
       width: $knob-size;
     }

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -12,6 +12,7 @@ $knob-size: $sp-unit * 3;
     position: absolute;
 
     &:checked + .p-switch__slider::before {
+      border: 1px solid $color-link;
       left: 50%;
     }
 
@@ -33,13 +34,14 @@ $knob-size: $sp-unit * 3;
   }
 
   .p-switch__slider {
+    background: $color-mid-light;
     border-radius: $knob-size * 0.5;
     box-shadow: inset 0 2px 5px 0 transparentize($color-dark, 0.8);
     display: inline-block;
-    height: $knob-size;
+    height: $knob-size - 0.5;
     margin: 0;
     position: relative;
-    width: $knob-size * 2;
+    width: $knob-size + 0.5;
 
     &::before {
       @extend %vf-has-round-corners;
@@ -47,12 +49,12 @@ $knob-size: $sp-unit * 3;
       @include vf-animation($duration: slow);
 
       background: $color-x-light;
+      border: 1px solid #757575;
       border-radius: 50%;
       content: '';
-      height: $knob-size;
-      left: 0;
+      height: $knob-size - 0.5;
       position: absolute;
-      width: $knob-size;
+      width: $knob-size - 0.5;
     }
   }
 


### PR DESCRIPTION
## Done

Updated switch styling as per [visual update](https://app.zenhub.com/workspaces/-design-system-tribe-59438c953747487777fbe484/issues/canonical-web-and-design/vanilla-framework/4036)

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/4249

## QA

- Open [demo](https://vanilla-framework-4254.demos.haus/docs/patterns/switch)
- See the the styling changes have been made accurately 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Screenshot 2022-01-19 at 09 56 14](https://user-images.githubusercontent.com/17607612/150097115-42a1434b-4868-4bf5-8600-0883c04e80e1.png)

