### PR TITLE
Improve accessibility in the pagination component

### DIFF
--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -5,7 +5,8 @@
     @extend %vf-button-base;
     @include vf-button-pattern;
 
-    &.is-active {
+    &.is-active,
+    &[aria-current='page'] {
       background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-amount * 100%);
       color: $color-dark;
       text-decoration: none;

--- a/templates/docs/examples/patterns/pagination/pagination-disabled.html
+++ b/templates/docs/examples/patterns/pagination/pagination-disabled.html
@@ -4,27 +4,29 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<ol class="p-pagination">
-  <li class="p-pagination__item">
-    <span class="p-pagination__link--previous is-disabled"><i class="p-icon--chevron-down">Previous page</i></span>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link is-active" href="#1">1</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#2">2</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#3">3</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#4">4</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#5">5</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
-  </li>
-</ol>
+<nav aria-label="Pagination">
+  <ol class="p-pagination">
+    <li class="p-pagination__item">
+      <span class="p-pagination__link--previous is-disabled" aria-disabled="true"><i class="p-icon--chevron-down">Previous page</i></span>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link is-active" aria-current="page" aria-label="Page 1" href="#1">1</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#2" aria-label="Page 2">2</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#3" aria-label="Page 3">3</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#4" aria-label="Page 4">4</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#5" aria-label="Page 5">5</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
+    </li>
+  </ol>
+</nav>
 {% endblock %}

--- a/templates/docs/examples/patterns/pagination/pagination-truncated.html
+++ b/templates/docs/examples/patterns/pagination/pagination-truncated.html
@@ -4,33 +4,35 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<ol class="p-pagination">
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#1">1</a>
-  </li>
-  <li class="p-pagination__item p-pagination__item--truncation">
-    &hellip;
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#33">33</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link is-active" href="#34">34</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#35">35</a>
-  </li>
-  <li class="p-pagination__item p-pagination__item--truncation">
-    &hellip;
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#7">100</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
-  </li>
-</ol>
+<nav aria-label="Pagination">
+  <ol class="p-pagination">
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#1" aria-label="Page 1">1</a>
+    </li>
+    <li class="p-pagination__item p-pagination__item--truncation" aria-label="Ellipses representing truncated pages">
+      &hellip;
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#33" aria-label="Page 33">33</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link is-active" href="#34" aria-current="page" aria-label="Page 34"></a>>34</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#35" aria-label="Page 35"></a>>35</a>
+    </li>
+    <li class="p-pagination__item p-pagination__item--truncation" aria-label="Ellipses representing truncated pages">
+      &hellip;
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#7">100</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
+    </li>
+  </ol>
+</nav>
 {% endblock %}

--- a/templates/docs/examples/patterns/pagination/pagination-truncated.html
+++ b/templates/docs/examples/patterns/pagination/pagination-truncated.html
@@ -12,19 +12,19 @@
     <li class="p-pagination__item">
       <a class="p-pagination__link" href="#1" aria-label="Page 1">1</a>
     </li>
-    <li class="p-pagination__item p-pagination__item--truncation" aria-label="Ellipses representing truncated pages">
+    <li class="p-pagination__item p-pagination__item--truncation">
       &hellip;
     </li>
     <li class="p-pagination__item">
       <a class="p-pagination__link" href="#33" aria-label="Page 33">33</a>
     </li>
     <li class="p-pagination__item">
-      <a class="p-pagination__link is-active" href="#34" aria-current="page" aria-label="Page 34"></a>>34</a>
+      <a class="p-pagination__link is-active" href="#34" aria-current="page" aria-label="Page 34">34</a>
     </li>
     <li class="p-pagination__item">
-      <a class="p-pagination__link" href="#35" aria-label="Page 35"></a>>35</a>
+      <a class="p-pagination__link" href="#35" aria-label="Page 35">35</a>
     </li>
-    <li class="p-pagination__item p-pagination__item--truncation" aria-label="Ellipses representing truncated pages">
+    <li class="p-pagination__item p-pagination__item--truncation">
       &hellip;
     </li>
     <li class="p-pagination__item">

--- a/templates/docs/examples/patterns/pagination/pagination-verbose.html
+++ b/templates/docs/examples/patterns/pagination/pagination-verbose.html
@@ -4,12 +4,14 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<ol class="p-pagination">
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down"></i><span>Previous page</span></a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><span>Next page</span><i class="p-icon--chevron-down"></i></a>
-  </li>
-</ol>
+<nav aria-label="Pagination">
+  <ol class="p-pagination">
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down"></i><span>Previous page</span></a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--next" href="#next" title="Next page"><span>Next page</span><i class="p-icon--chevron-down"></i></a>
+    </li>
+  </ol>
+</nav>
 {% endblock %}

--- a/templates/docs/examples/patterns/pagination/pagination.html
+++ b/templates/docs/examples/patterns/pagination/pagination.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<nav aria-label="pagination">
+<nav aria-label="Pagination">
   <ol class="p-pagination">
     <li class="p-pagination__item">
       <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>

--- a/templates/docs/examples/patterns/pagination/pagination.html
+++ b/templates/docs/examples/patterns/pagination/pagination.html
@@ -4,27 +4,29 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<ol class="p-pagination">
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#1">1</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#2">2</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link is-active" href="#3">3</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#4">4</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link" href="#5">5</a>
-  </li>
-  <li class="p-pagination__item">
-    <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
-  </li>
-</ol>
+<nav aria-label="pagination">
+  <ol class="p-pagination">
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#1" aria-label="Page 1">1</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#2" aria-label="Page 2">2</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link is-active" aria-current="page" href="#3" aria-label="Page 3">3</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#4" aria-label="Page 4">4</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#5" aria-label="Page 5">5</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
+    </li>
+  </ol>
+</nav>
 {% endblock %}


### PR DESCRIPTION
## Done

Improvements to the accessibility of our pagination component:
- Added `&[aria-current='page']` to the `is-active` styles
- Wrapped all pagination examples in a `<nav>` with an aria-label so users know it's the pagination navigation
- Added `aria-label="page x"` to each of the pages, to be more descriptive about what the number means
- Added `aria-current="page"` to the active pages


Fixes #4256 

## QA

- Open [demo](insert-demo-url)
- Check nothing has broken on the pagination examples/docs
- Check with voiceover the pagination examples
- Accessibility documentation is currently being written so will be in a separate PR
- The `p-navigation` class should be on the `<nav>` element, but this will be addressed in this [issue](https://github.com/canonical-web-and-design/vanilla-framework/issues/4257)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
