### PR TITLE
Add role=switch to switch component

### DIFF
--- a/templates/docs/examples/patterns/switch.html
+++ b/templates/docs/examples/patterns/switch.html
@@ -5,22 +5,22 @@
 
 {% block content %}
 <label class="p-switch">
-    <input type="checkbox" class="p-switch__input" checked/>
+    <input type="checkbox" class="p-switch__input" checked role="switch"/>
     <span class="p-switch__slider"></span>
     <span class="p-switch__label">On</span>
 </label>
 <label class="p-switch">
-    <input type="checkbox" class="p-switch__input" />
+    <input type="checkbox" class="p-switch__input" role="switch"/>
     <span class="p-switch__slider"></span>
     <span class="p-switch__label">Off</span>
 </label>
 <label class="p-switch">
-    <input type="checkbox" class="p-switch__input" checked disabled/>
+    <input type="checkbox" class="p-switch__input" checked role="switch" disabled/>
     <span class="p-switch__slider"></span>
     <span class="p-switch__label">On disabled</span>
 </label>
 <label class="p-switch">
-    <input type="checkbox" class="p-switch__input" disabled/>
+    <input type="checkbox" class="p-switch__input" role="switch" disabled/>
     <span class="p-switch__slider"></span>
     <span class="p-switch__label">Off disabled</span>
 </label>


### PR DESCRIPTION
## Done

- Add `role=switch` to switch component. Without this the screen reader describes this as a checkbox being checked and unchecked. 
- We mention using aria-checked in the description but don't include it in the example. Should we include it as default? https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role

## QA

- Open [demo](https://vanilla-framework-4260.demos.haus/docs/patterns/switch)
- Use VoiceOver and check the switch component. It should read out the label, then the status, then switch. It sounds a little strange with our example but that's because our labels are on and off.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

