### PR TITLE
Removed right alignment in card example

### DIFF
--- a/scss/standalone/patterns_card.scss
+++ b/scss/standalone/patterns_card.scss
@@ -5,5 +5,6 @@
 @include vf-p-grid;
 @include vf-p-strip;
 
-@include vf-u-vertical-spacing;
 @include vf-u-align;
+@include vf-u-padding-collapse;
+@include vf-u-vertical-spacing;

--- a/templates/docs/examples/patterns/card/content-bleed.html
+++ b/templates/docs/examples/patterns/card/content-bleed.html
@@ -13,7 +13,7 @@
         <p>From robots learning to encourage social participation to detect serious environmental problems, it was a learning month.</p>
       </div>
       <hr class="u-no-margin--bottom" />
-      <div class="p-card__inner u-align-text--right">
+      <div class="p-card__inner">
         by <a href="#">Bartek Szopka</a> on 21st August 2021
       </div>
     </div>


### PR DESCRIPTION
## Done

- Removed right alignment 

- Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/4175

## QA

- Open [demo](https://vanilla-framework-4261.demos.haus)
- See that the `u-align-text--right` has been removed from doc example
- Check that footer is aligned correctly in [examples](https://vanilla-framework-4261.demos.haus/docs/examples/patterns/card/content-bleed) and [patterns](https://vanilla-framework-4261.demos.haus/docs/patterns/card) for all screen sizes

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="402" alt="Screenshot 2022-01-19 at 14 43 25" src="https://user-images.githubusercontent.com/17607612/150142489-d0fbdbe4-20be-466f-beec-3bed0adda961.png">

