### PR TITLE
Logo section accessibility doc

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -88,3 +88,5 @@ datalist
 WAI-ARIA
 Heydon
 Pickering
+alt 
+WCAG

--- a/templates/docs/examples/patterns/logo-section/logo-section.html
+++ b/templates/docs/examples/patterns/logo-section/logo-section.html
@@ -10,18 +10,18 @@
       Partners
     </p>
     <div class="p-logo-section__items">
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/4c6fb640-logo-verizon.png" alt="verizon logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/252e2017-logo-ea.png" alt="ea logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/e7dd8cc4-logo-at%26t.png" alt="AT&amp;T logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/add4119e-logo-sandia.png" alt="SNL logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/afb5991e-logo-ubisoft.png" alt="ubisoft logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/ab9074df-logo-tele2.png" alt="tele2 logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/56c03384-logo-nec.png" alt="nec logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/822701bb-logo-tmobile.png" alt="tmobile logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/673fa219-logo-ntt.png" alt="ntt logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png" alt="bt logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/a59ea622-logo-liberty-global.png" alt="liberty-global logo"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/9bb88cf6-logo-barclays+copy.png" alt="barclays logo"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/4c6fb640-logo-verizon.png" alt="verizon"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/252e2017-logo-ea.png" alt="ea"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/e7dd8cc4-logo-at%26t.png" alt="AT&amp;T"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/add4119e-logo-sandia.png" alt="SNL"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/afb5991e-logo-ubisoft.png" alt="ubisoft"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/ab9074df-logo-tele2.png" alt="tele2"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/56c03384-logo-nec.png" alt="nec"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/822701bb-logo-tmobile.png" alt="tmobile"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/673fa219-logo-ntt.png" alt="ntt"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png" alt="bt"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/a59ea622-logo-liberty-global.png" alt="liberty-global"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/9bb88cf6-logo-barclays+copy.png" alt="barclays"></div>
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/logo-section/logo-section.html
+++ b/templates/docs/examples/patterns/logo-section/logo-section.html
@@ -10,18 +10,18 @@
       Partners
     </p>
     <div class="p-logo-section__items">
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/4c6fb640-logo-verizon.png" alt="verizon"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/252e2017-logo-ea.png" alt="ea"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/4c6fb640-logo-verizon.png" alt="Verizon"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/252e2017-logo-ea.png" alt="EA"></div>
       <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/e7dd8cc4-logo-at%26t.png" alt="AT&amp;T"></div>
       <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/add4119e-logo-sandia.png" alt="SNL"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/afb5991e-logo-ubisoft.png" alt="ubisoft"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/ab9074df-logo-tele2.png" alt="tele2"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/56c03384-logo-nec.png" alt="nec"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/822701bb-logo-tmobile.png" alt="tmobile"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/673fa219-logo-ntt.png" alt="ntt"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png" alt="bt"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/a59ea622-logo-liberty-global.png" alt="liberty-global"></div>
-      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/9bb88cf6-logo-barclays+copy.png" alt="barclays"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/afb5991e-logo-ubisoft.png" alt="Ubisoft"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/ab9074df-logo-tele2.png" alt="Tele2"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/56c03384-logo-nec.png" alt="NEC"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/822701bb-logo-tmobile.png" alt="T-Mobile"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/673fa219-logo-ntt.png" alt="NTT"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png" alt="BT"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/a59ea622-logo-liberty-global.png" alt="Liberty Global"></div>
+      <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/9bb88cf6-logo-barclays+copy.png" alt="Barclays"></div>
     </div>
   </div>
 </div>

--- a/templates/docs/patterns/logo-section.md
+++ b/templates/docs/patterns/logo-section.md
@@ -39,7 +39,7 @@ The logo section showcases a group of related images or logos. It works by ensur
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
 - Images should always contain an `alt` attribute.
-- If the image or logo is considered decorative, the `alt` attribute’s value should be blank i.e. `alt=””`.
+- If the image or logo is considered decorative, the `alt` attribute’s value should be blank i.e. `alt=""`.
 - If the image provides information not otherwise available to users of assistive technology, the value of the `alt` attribute should provide that information in a concise way.
 - Avoid using words and phrases like “logo” or “image of''; in most cases the information that needs to be conveyed is, for example, who the logo belongs to or what the image contains, rather than that the element itself is an image.
 

--- a/templates/docs/patterns/logo-section.md
+++ b/templates/docs/patterns/logo-section.md
@@ -28,6 +28,29 @@ View example of the logo section pattern
 View example of the logo section pattern inside a six column parent container
 </a></div>
 
+## Accessibility
+
+### How it works
+
+The logo section showcases a group of related images or logos. It works by ensuring each image matches the width of either one or two grid columns.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- Images should always contain an `alt` attribute.
+- If the image or logo is considered decorative, the `alt` attribute’s value should be blank i.e. `alt=””`.
+- If the image provides information not otherwise available to users of assistive technology, the value of the `alt` attribute should provide that information in a concise way.
+- Avoid using words and phrases like “logo” or “image of''; in most cases the information that needs to be conveyed is, for example, who the logo belongs to or what the image contains, rather than that the element itself is an image.
+
+### Resources
+
+- [WAI-ARIA practices - naming effectively](https://www.w3.org/TR/wai-aria-practices-1.1/#naming_effectively)
+- [WAI tutorials - Images](https://www.w3.org/WAI/tutorials/images/)
+- [An alt Decision Tree](https://www.w3.org/WAI/tutorials/images/decision-tree/)
+- Applicable WCAG guidelines:
+  - [WCAG 2.1 - 1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=111#non-text-content)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Removed redundant "logo" from each alt attribute in logo section example

Fixes #4052 

## QA

- Open [demo](https://vanilla-framework-4262.demos.haus/docs/patterns/logo-section)
- Check the formatting of the accessibility doc, the content has already been reviewed in the doc

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels
