### PR TITLE
Add nested counter to order lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.0.2",
+  "version": "3.1.0",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -30,9 +30,12 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
   }
 
   %nested-counter {
+    // Counter is named and it will be reset for each "ol" element.
     counter-reset: list-item;
-
     li::marker {
+      // "counters" function returns a string representing the current value of the named counter ("list-item").
+      // It is used to insert a string between different levels of nested counters.
+      // Source: https://www.w3schools.com/css/css_counters.asp
       content: counters(list-item, '.') '. ';
       counter-increment: list-item;
     }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -29,6 +29,15 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     }
   }
 
+  %nested-counter {
+    counter-reset: list-item;
+
+    li::marker {
+      content: counters(list-item, '.') '. ';
+      counter-increment: list-item;
+    }
+  }
+
   // Mixin for list items
   %vf-list-item {
     padding-bottom: $spv--x-small;
@@ -395,6 +404,12 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
   }
 }
 
+@mixin vf-p-list-nested-counter {
+  .p-list--nested-counter {
+    @extend %nested-counter;
+  }
+}
+
 @mixin vf-p-lists {
   @include vf-p-list-placeholders;
 
@@ -407,4 +422,5 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
   @include vf-p-stepped-list;
   @include vf-p-stepped-list-detailed;
   @include vf-p-list-split;
+  @include vf-p-list-nested-counter;
 }

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -75,7 +75,7 @@
               {{ side_nav_item("/docs/patterns/labels", "Labels", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
+              {{ side_nav_item("/docs/patterns/lists", "Lists", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}

--- a/templates/docs/examples/patterns/lists/list-nested-count.html
+++ b/templates/docs/examples/patterns/lists/list-nested-count.html
@@ -1,0 +1,17 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Lists / Nested Count{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<ol class="p-list--nested-counter">
+  <li>Install LXD using the instructions for your OS</li>
+  <li>Install Conjure up using the instructions for your OS
+    <ol>
+      <li>Ubuntu</li>
+      <li>macOS</li>
+    </ol>
+  </li>
+  <li>Proceed with the relevant steps from the install instructions and choose localhost in the CHOOSE A CLOUD step.</li>
+</ol>
+{% endblock %}

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -123,6 +123,14 @@ If you wish to split the items in a list into two columns above `$breakpoint-sma
 View example of the patterns list split
 </a></div>
 
+## Nested Count
+
+If you want nested ordered lists to have numbers based on their parents, you can add the class `p-list--nested-counter` to the ordered list element.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/list-nested-count/" class="js-example">
+View example of the pattern nested counter
+</a></div>
+
 ## Theming
 
 The responsive divider is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_settings_colors.scss).

--- a/templates/docs/patterns/lists.md
+++ b/templates/docs/patterns/lists.md
@@ -20,6 +20,14 @@ items than the basic lists.
 View example of the list pattern
 </a></div>
 
+## Nested Count
+
+If you want nested ordered lists to have numbers based on their parents, you can add the class `p-list--nested-counter` to the ordered list element.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/list-nested-count/" class="js-example">
+View example of the pattern nested counter
+</a></div>
+
 ## Status
 
 Add the `.is-ticked` or `.is-crossed` classes to each list item to display tick/cross icons.
@@ -121,14 +129,6 @@ If you wish to split the items in a list into two columns above `$breakpoint-sma
 
 <div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-split/" class="js-example">
 View example of the patterns list split
-</a></div>
-
-## Nested Count
-
-If you want nested ordered lists to have numbers based on their parents, you can add the class `p-list--nested-counter` to the ordered list element.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/lists/list-nested-count/" class="js-example">
-View example of the pattern nested counter
 </a></div>
 
 ## Theming

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -22,7 +22,7 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 3.00 -->
     <tr>
-      <th><a href="/docs/patterns/lists">Ordered list nested counter</a></th>
+      <th><a href="/docs/patterns/lists#nested-count">Ordered list nested counter</a></th>
       <td>
         <span class="p-label--information">Updated</span>
       </td>

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -22,6 +22,14 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
     <!-- 3.00 -->
     <tr>
+      <th><a href="/docs/patterns/lists">Ordered list nested counter</a></th>
+      <td>
+        <span class="p-label--information">Updated</span>
+      </td>
+      <td>3.1.0</td>
+      <td>We've updated lists by adding a new class name. It can be used when nested items numbers are required to be set according to their parents.</td>
+    </tr>
+    <tr>
       <th><a href="/docs/patterns/navigation">Expanding search box</a></th>
       <td>
         <span class="p-label--positive">New</span>


### PR DESCRIPTION
## Done
- Added nested counter to order lists

Fixes #4074 

## QA

- Open [docs](https://vanilla-framework-4264.demos.haus/docs/patterns/lists)
- Open "Nested Count" section
- Verify item numbers are displayed correctly
- Open [examples](https://vanilla-framework-4264.demos.haus/docs/examples/patterns/lists/list-nested-count)
- Verify item numbers are displayed correctly

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![image](https://user-images.githubusercontent.com/24393395/150190002-86c2dd3f-5742-4a18-b282-b2c0b50dd014.png)