### PR TITLE
Make after element transparent

### DIFF
--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -82,5 +82,13 @@
 
       // stylelint-enable selector-max-type
     }
+
+    @media (min-width: 410px) and (max-width: 440px) {
+      td, tbody th {
+        &:nth-child(2)::after {
+          background-color: transparent;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Done

- Unnecessary border like element of the mobile card element is removed.

Fixes #4103 

## QA

- Open [demo](insert-demo-url)
- Reduce the screen size between 440 - 410px.
- Verify unnecessary border is not displayed for the second element.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots
![image](https://user-images.githubusercontent.com/24393395/150337096-feed4bc0-1de6-489b-b053-a6f3b7428ecf.png)
