### PR TITLE
Changed display property to fix raw-HTML side nav wrapping

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -38,6 +38,7 @@ $code-inline-padding: 0.25rem;
     direction: ltr;
     // stylelint-disable property-no-vendor-prefix
     -webkit-hyphens: none;
+    height: fit-content;
     hyphens: none;
     -moz-tab-size: 4;
     -o-tab-size: 4;

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -38,7 +38,6 @@ $code-inline-padding: 0.25rem;
     direction: ltr;
     // stylelint-disable property-no-vendor-prefix
     -webkit-hyphens: none;
-    height: fit-content;
     hyphens: none;
     -moz-tab-size: 4;
     -o-tab-size: 4;

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -288,6 +288,8 @@
     li > strong,
     li > a {
       @extend %side-navigation__text;
+
+      display: block;
     }
 
     li li > span,

--- a/templates/docs/examples/patterns/side-navigation/raw-html.html
+++ b/templates/docs/examples/patterns/side-navigation/raw-html.html
@@ -72,7 +72,7 @@
             <span>Second level text</span>
           </li>
           <li>
-            <span>Second level text with children</span>
+            <span>Second level text with <code>children</code> and has some code in the text</span>
             <ul>
               <li>
                 <span>Third level text</span>


### PR DESCRIPTION
## Done

- Set `display: block` for raw-HTML side nav list text to fix wrapping issue when using the `<code>` tag

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/3988

## QA

- Open [example demo](https://vanilla-framework-4266.demos.haus/docs/examples/patterns/side-navigation/raw-html)
- Open side nav and make sure everything wraps as expected where `<code>` tag is used

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots
![Screenshot 2022-01-20 at 16 05 53](https://user-images.githubusercontent.com/17607612/150365619-0264c5e3-edc2-493b-9fea-f90a7a140d9b.png)


