### PR TITLE
Added min-height to close button

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -101,6 +101,7 @@ $notification-text-margin-bottom: $spv--large - $spv-nudge;
       background-repeat: no-repeat;
       background-size: unset;
       border: 0;
+      min-height: $spv--large	* 2;
       position: absolute;
       right: $sph--large * 0.5;
       top: $spv--small;

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -101,7 +101,8 @@ $notification-text-margin-bottom: $spv--large - $spv-nudge;
       background-repeat: no-repeat;
       background-size: unset;
       border: 0;
-      min-height: $spv--large * 2;
+      // set the height of the button to be size of an icon + padding on top and bottom
+      height: calc(2 * $spv--small + $default-icon-size);
       position: absolute;
       right: $sph--large * 0.5;
       top: $spv--small;

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -101,7 +101,7 @@ $notification-text-margin-bottom: $spv--large - $spv-nudge;
       background-repeat: no-repeat;
       background-size: unset;
       border: 0;
-      min-height: $spv--large	* 2;
+      min-height: $spv--large * 2;
       position: absolute;
       right: $sph--large * 0.5;
       top: $spv--small;


### PR DESCRIPTION
## Done

- Added min height to `.p-notification__close` to fix positioning issue when missing button text

- Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/4034

## QA

- Open [demo](https://vanilla-framework-4267.demos.haus)
- Go to patterns > notification > actions > buttons
- Edit on codepen or checkout current branch
- Remove close button text and ensure positioning is unchanged 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
