### PR TITLE
Add label accessibility doc

### DIFF
--- a/templates/docs/patterns/labels.md
+++ b/templates/docs/patterns/labels.md
@@ -14,6 +14,28 @@ Labels are static elements which you can apply to signify status, tags or any ot
 View example of the labels pattern
 </a></div>
 
+## Accessibility
+
+### How it works
+
+Labels are used to signify status, tags or any other information. The colours have semantic meaning, reflected by the name given in the code example.
+
+Semantic colour can help users recognise and recall meaning more quickly, especially when scanning a view, for example. It’s important that labels still convey the same meaning without colour information.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- Select an appropriately coloured label which makes sense semantically for your use case.
+- Ensure you don’t use colour as the only visual means of conveying information or an action - the text within the label should be descriptive enough.
+
+### Resources
+
+Applicable WCAG guidelines:
+
+- [WCAG21 - Use of color](https://www.w3.org/TR/WCAG21/#use-of-color)
+- [WCAG21 - Sensory characteristics](https://www.w3.org/TR/WCAG21/#sensory-characteristics)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Add accessibility notes for labels 

Fixes #4048 

## QA

- Open [demo](https://vanilla-framework-4268.demos.haus/docs/patterns/labels)
- Check formatting of accessibility notes on labels. Text has already been reviewed by dev and design. 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

