### PR TITLE
Add pagination accessibility docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -90,3 +90,4 @@ Heydon
 Pickering
 alt 
 WCAG
+A11y

--- a/templates/docs/patterns/pagination.md
+++ b/templates/docs/patterns/pagination.md
@@ -46,6 +46,36 @@ In some cases, providing information about the previous / next item in the set m
 View example of the article pagination pattern
 </a></div>
 
+## Accessibility
+
+### How it works
+
+Our pagination examples are wrapped in `nav` elements, each with an `aria-label=”Pagination”`. This helps distinguish the pagination from other `nav` elements on the page.
+
+An unordered list is used to list the pages, which allows screen readers to voice the number of elements in the Pagination component.
+
+Each page link has an `aria-label` including the word “page” along with the number. This helps orientate the user and clarify they are on a pagination button.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- It’s always recommended to use the native HTML elements where possible, but if you aren’t using a `nav` element to wrap the pagination, add `role=”navigation”` to the wrapping element.
+- Provide a descriptive `aria-label` for any Pagination component’s `nav` element that describes its purpose. For example, if the pagination component is used to navigate through a set of search results, an appropriate label could be `aria-label="search results page"`.
+- Do not use the landmark role as part of the label, as it will be repeated by the screen reader. For example if you use “Pagination navigation” as the `aria-label` value, then the screen reader will read out “Pagination navigation, navigation” . Use “Pagination” instead.
+- If you use more than one Pagination component on a page, each will need a unique `aria-label`.
+- Ensure you add `aria-current=”page”` to the current page.
+- It helps to add “first page, page x” to the first page and “last page, page x” to the final page in the list.
+- If you use chevrons without text labels to move to previous and next pages, make sure screen readers are reading “previous page” and “next page”.
+
+### Resources
+
+- [A11y style guide - Pagination navigation](https://a11y-style-guide.com/style-guide/section-navigation.html#kssref-navigation-pagination)
+- [Design system digital - Pagination](https://designsystem.digital.gov/components/pagination/)
+- Guidelines:
+  - [WAI-ARIA practices - General principles of landmark design](https://www.w3.org/TR/wai-aria-practices-1.1/#general-principles-of-landmark-design)
+  - [WAI-ARIA practices - Navigation](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_lh_navigation)
+
 ## Import
 
 ### Pagination component


### PR DESCRIPTION
## Done

- Add [accessibility doc](https://docs.google.com/document/d/1S1Wv8XjYL-q_yLzkmjebjRS1Pqvd4NDLOAyHI7x2Tzk/edit#) for the pagination component

Fixes #4059 

## QA

- Open [demo](https://vanilla-framework-4269.demos.haus/docs/patterns/pagination)
- Check the pagination accessibility docs

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

