### PR TITLE
Add switch accessibility docs

### DIFF
--- a/templates/docs/patterns/switch.md
+++ b/templates/docs/patterns/switch.md
@@ -14,6 +14,30 @@ You can use this switch component to display on and off content, such as for set
 View example of the switch pattern
 </a></div>
 
+## Accessibility
+
+### How it works
+
+The switch component is used to display on and off content. It includes the `role=”switch”` attribute so the screen reader distinguishes it from a checkbox. The `span` with class name `p-switch__label` acts as the label, and is associated with the status of the switch input.
+
+The element is focusable, and the `Spacebar` changes the state of the switch the same way a click would.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- Each switch should have a clear and concise label
+- Adding `aria-checked=”true”` or `aria-checked=”false”` will set the switch to on or off respectively.
+- `aria-readonly` is set to false as default, meaning the user can change the value of the switch. Change this to true if the switch is meant to be read only (i.e. disabled).
+
+### Resources
+
+- [WAI-ARIA names and descriptions definition](https://www.w3.org/TR/wai-aria-practices-1.1/#names_and_descriptions_definition)
+- [MDN Web accessibility - Switch role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role)
+- Guidelines:
+  - [4.1.2 Name, Role, Value](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html)
+  - [ 3.2.2 On Input](https://www.w3.org/WAI/WCAG21/Understanding/on-input)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Add [accessibility doc](https://docs.google.com/document/d/1mvRvpEwtxUQAVRrfMiEgS-QgsWCm4-QsmWFfg6y5NZ0/edit#) to switch component docs

Fixes #4065 

## QA

- Open [demo](https://vanilla-framework-4271.demos.haus/docs/patterns/switch)
- Check the accessibility section of the Switch component - the text has already been QA +1'd.


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
