### PR TITLE
Add grid accessibility notes

### DIFF
--- a/templates/docs/patterns/grid.md
+++ b/templates/docs/patterns/grid.md
@@ -95,6 +95,30 @@ View example of the incorrect column offset within a nested grid
 
 In some cases, there might be a good reason to break out of the constraints of a 12 column grid and allow content to bleed into the page margins. Vanilla provides a separate [fluid breakout layout](/docs/layouts/fluid-breakout) for this purpose.
 
+## Accessibility
+
+### How it works
+
+The grid gives the ability to maintain semantic meaning in the page, while placing the content in whatever visual way required. The distinguishing feature of the grid that enables it to be used for grouping other widgets, is that its cells are containers that preserve the semantics of their descendant elements.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- Each column containing text should span a minimum of 3 columns.
+- Only columns should be direct children of rows.
+- The starting point of your page should be a well structured and accessible source document. Ensure the document remains in a logical order for screen readers, irrespective of how the content looks visually.
+- Ensure to use order and the grid-placement properties only for visual, not logical, reordering of content.
+
+## Resources
+
+- [CSS Grid Layout and Accessibility - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility)
+- [CSS Grid Layout Module Level 2 - Order accessibility](https://drafts.csswg.org/css-grid/#order-accessibility)
+- [WAI-ARIA examples - Grid layout ](https://www.w3.org/TR/wai-aria-practices/examples/grid/LayoutGrids.html)
+- [WAI-ARIA practices - Grid](https://www.w3.org/TR/wai-aria-practices-1.1/#grid)
+- Guidelines
+  - [WCAG 2.1 - 2.4.3 Focus order](https://www.w3.org/TR/WCAG21/#focus-order)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Add accessibility notes for the Grid component - google doc [here](https://docs.google.com/document/d/1cPgsBMHdS0_3fhaLReiN830Ni8uJSNIM-frqvpZTB8E/edit#)

Fixes #4043 

## QA

- Open [demo](https://vanilla-framework-4275.demos.haus/docs/patterns/grid)
- Doc text has already been reviewed, just QA on page 


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
