### PR TITLE
Added empty state - Variant 2

### DIFF
--- a/scss/standalone/patterns_empty-state.scss
+++ b/scss/standalone/patterns_empty-state.scss
@@ -7,3 +7,11 @@
 @include vf-u-align;
 @include vf-p-buttons;
 @include vf-p-strip;
+
+// dependencies for user action triggered empty state example
+@include vf-p-strip;
+@include vf-p-lists;
+@include vf-p-search-box;
+@include vf-p-icons-common;
+@include vf-p-icon-search;
+@include vf-u-layout;

--- a/templates/docs/examples/patterns/empty-state/no-content.html
+++ b/templates/docs/examples/patterns/empty-state/no-content.html
@@ -1,33 +1,33 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Empty State / No content {% endblock %}
+{% block title %}Empty State / No content{% endblock %}
 
 {% block standalone_css %}patterns_empty-state{% endblock %}
 
 {% block content %}
 <table aria-label="Vanilla framework no content empty state">
-    <thead>
-        <tr>
-            <th>Vendor ID</th>
-            <th>Product</th>
-            <th>ProductID</th>
-            <th>Driver</th>
-            <th>Huma Node</th>
-            <th>PCI Address</th>
-        </tr>
-    </thead>
-    <caption>
-        <div class="p-strip">
-            <div class="row">
-                <div class="u-align--right col-4 col-medium-2 col-small-1">
-                    <img src="https://assets.ubuntu.com/v1/263e7c5d-iot_orange.svg" alt="empty state"/>
-                </div>
-                <div class="u-align--left col-8 col-medium-4 col-small-3">
-                    <p class="p-heading--4 u-no-margin--bottom">PCI information not available</p>
-                    <p>Commission this machine to load PCI and USB device information</p>
-                    <button class="p-button--positive">Commission</button>
-                </div>
-            </div>
+  <thead>
+    <tr>
+      <th>Vendor ID</th>
+      <th>Product</th>
+      <th>ProductID</th>
+      <th>Driver</th>
+      <th>Huma Node</th>
+      <th>PCI Address</th>
+    </tr>
+  </thead>
+  <caption>
+    <div class="p-strip">
+      <div class="row">
+        <div class="u-align--right col-4 col-medium-2 col-small-1">
+          <img src="https://assets.ubuntu.com/v1/263e7c5d-iot_orange.svg" alt="empty state"/>
         </div>
-    </caption>
+        <div class="u-align--left col-8 col-medium-4 col-small-3">
+          <p class="p-heading--4 u-no-margin--bottom">PCI information not available</p>
+          <p>Commission this machine to load PCI and USB device information</p>
+          <button class="p-button--positive">Commission</button>
+        </div>
+      </div>
+    </div>
+  </caption>
 </table>
 {% endblock %}

--- a/templates/docs/examples/patterns/empty-state/user-triggered.html
+++ b/templates/docs/examples/patterns/empty-state/user-triggered.html
@@ -1,0 +1,52 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Empty State / User action triggered{% endblock %}
+
+{% block standalone_css %}patterns_empty-state{% endblock %}
+
+{% block content %}
+<section id="search" class="p-strip is-shallow">
+  <div class="u-fixed-width">
+    <h2>Search results for "flibberdygibbery"</h2>
+  </div>
+
+  <div class="u-fixed-width">
+    <form class="p-search-box">
+      <input type="search" aria-label="search" class="p-search-box__input" name="search" required="" value="flibberdygibbery">
+      <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+    </form>
+  </div>
+</section>
+<section id="search-results" class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-4 col-medium-3">
+      <div class="p-heading--4">
+        Why not try widening your search?<br> You can do this by:
+      </div>
+    </div>
+    <div class="col-4 col-medium-3">
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
+        <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
+        <li class="p-list__item is-ticked">Trying a different spelling</li>
+      </ul>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr>
+  </div>
+  <div class="row">
+    <div class="col-4 col-medium-3">
+      <div class="p-heading--4">Still no luck?</div>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p class="u-no-margin--bottom">
+        <a href="#">Visit the Ubuntu homepage</a>
+      </p>
+      <p class="u-no-margin--bottom">
+        <a href="#">Contact us</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+{% endblock %}

--- a/templates/docs/patterns/empty-state.md
+++ b/templates/docs/patterns/empty-state.md
@@ -18,6 +18,14 @@ No data available denotes the empty state scenario for when we cannot display da
 View example of the first variation of no content state
 </a></div>
 
+## User action triggers empty state
+
+This scenario describes when there is no content available to show as a result of an action. For instance, searching or filtering items in a list, table, page, or results that shows up in cards.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/empty-state/user-triggered" class="js-example">
+View example of the second variation of no content state
+</a></div>
+
 ## Import
 
 To import either or all of these components into your project, copy the snippets below and include it in your main Sass file.
@@ -33,6 +41,14 @@ To import either or all of these components into your project, copy the snippets
 @include vf-u-align;
 @include vf-p-buttons;
 @include vf-p-strip;
+
+// dependencies for user action triggered empty state example
+@include vf-p-strip;
+@include vf-p-lists;
+@include vf-p-search-box;
+@include vf-p-icons-common;
+@include vf-p-icon-search;
+@include vf-u-layout;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
Should be merged after https://github.com/canonical-web-and-design/vanilla-framework/pull/4274

## Done

-  Variant 2 empty state is added.

Fixes #1010

## QA

- Open [second variant of the empty state](https://vanilla-framework-4276.demos.haus/docs/examples/layouts/empty-state/user-triggered)
- Verify its implemented according to [design](https://discourse.ubuntu.com/t/variant-b-user-action-triggers-empty-state/24620)
- Open [docs](https://vanilla-framework-4276.demos.haus/docs/layouts/empty-state#user-action-triggers-empty-state).
- Verify empty state's second variant is documented correctly.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.