### PR TITLE
Add heading icon accessibility docs

### DIFF
--- a/templates/docs/patterns/heading-icon.md
+++ b/templates/docs/patterns/heading-icon.md
@@ -31,6 +31,28 @@ The icon for this component is also available at a smaller size of 32 × 32 pixe
 View example of the pattern heading icon small
 </a></div>
 
+## Accessibility
+
+### How it works
+
+The heading icon pattern includes an icon next to the heading to add emphasis. It includes an image element alongside a title wrapped in a `div` for the header, and a paragraph wrapped in an outer `div` for the content which follows.
+
+### Considerations
+
+- The content of the heading should make sense without the icon present, the icon should not convey information on its own.
+- The image should always include an `alt` attribute.
+- If the image or logo is considered decorative (which is likely in this case), the `alt` attribute’s value should be blank i.e. `alt=""`.
+- If the image provides information not otherwise available to users of assistive technology, the value of the `alt` attribute should provide that information in a concise way.
+- Avoid using words and phrases like “logo” or “image of"; in most cases the information that needs to be conveyed is, for example, who the logo belongs to or what the image contains, rather than that the element itself is an image.
+
+### Resources
+
+- [WAI-ARIA practices - naming effectively](https://www.w3.org/TR/wai-aria-practices-1.1/#naming_effectively)
+- [WAI tutorials - Images](https://www.w3.org/WAI/tutorials/images/)
+- [An alt Decision Tree](https://www.w3.org/WAI/tutorials/images/decision-tree/)
+- Applicable WCAG guidelines:
+  - [WCAG 2.1 - 1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=111#non-text-content)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Added accessibility doc for the heading icon - copy doc [here](https://docs.google.com/document/d/1-pph5kexTYURof_M1WgYbouPUxElhPbubgQq5hbuiXs/edit#)

Fixes #4044 

## QA

- Open [demo](https://vanilla-framework-4277.demos.haus)
- The google doc has been reviewed, please just QA the docs on the site


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
