### PR TITLE
Added empty state - Variant 3

### DIFF
--- a/scss/standalone/patterns_empty-state.scss
+++ b/scss/standalone/patterns_empty-state.scss
@@ -15,3 +15,6 @@
 @include vf-p-icons-common;
 @include vf-p-icon-search;
 @include vf-u-layout;
+
+// dependencies for user action triggered empty state example
+@include vf-u-vertically-center;

--- a/templates/docs/examples/patterns/empty-state/error-management.html
+++ b/templates/docs/examples/patterns/empty-state/error-management.html
@@ -1,0 +1,20 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Empty State / Error management{% endblock %}
+
+{% block standalone_css %}patterns_empty-state{% endblock %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6 col-medium-3 u-vertically-center u-align--center">
+      <img src="https://assets.ubuntu.com/v1/03c7318e-image-404.svg" alt="Page not found" width="360" height="365">
+    </div>
+    <div class="col-6 col-medium-3 u-vertically-center">
+      <div>
+        <h1>404: Page not found</h1>
+        <p class="p-heading--4">Sorry, we couldn’t find that page.</p>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/docs/patterns/empty-state.md
+++ b/templates/docs/patterns/empty-state.md
@@ -15,7 +15,7 @@ State zero or the empty state is a state where there is no data to display in th
 No data available denotes the empty state scenario for when we cannot display data.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/empty-state/no-content" class="js-example">
-View example of the first variation of no content state
+View example of the empty state caused by no content
 </a></div>
 
 ## User action triggers empty state
@@ -23,7 +23,15 @@ View example of the first variation of no content state
 This scenario describes when there is no content available to show as a result of an action. For instance, searching or filtering items in a list, table, page, or results that shows up in cards.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/empty-state/user-triggered" class="js-example">
-View example of the second variation of no content state
+View example of the empty state caused by user action
+</a></div>
+
+## Error management empty state
+
+This scenario describes when there is no content available to show as a result of errors such as no server connection, entering the wrong page, or something went wrong with the http requests.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/empty-state/error-management" class="js-example">
+View example of the empty state caused by error
 </a></div>
 
 ## Import
@@ -49,6 +57,9 @@ To import either or all of these components into your project, copy the snippets
 @include vf-p-icons-common;
 @include vf-p-icon-search;
 @include vf-u-layout;
+
+// dependencies for user action triggered empty state example
+@include vf-u-vertically-center;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
Should be merged after https://github.com/canonical-web-and-design/vanilla-framework/pull/4276

## Done

-  Variant 3 empty state is added.

Fixes #1010

## QA

- Open [third variant of the empty state]( https://vanilla-framework-4279.demos.haus/docs/examples/layouts/empty-state/error-management)
- Verify its implemented according to [design](https://discourse.ubuntu.com/t/variant-c-error-management-empty-state/24621)
- Open [docs]( https://vanilla-framework-4279.demos.haus/docs/layouts/empty-state#error-management-empty-state).
- Verify empty state's third variant is documented correctly.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.