### PR TITLE
Add tab accessibility doc

### DIFF
--- a/templates/docs/patterns/tabs.md
+++ b/templates/docs/patterns/tabs.md
@@ -87,6 +87,44 @@ The pattern also supports the use of icons within each button.
 View examples of the tab buttons pattern with icons
 </a></div>
 
+## Accessibility
+
+### How it works
+
+Tabs are a set of layered sections of content, known as tab panels, that display one panel of content at a time. Each tab panel has an associated tab element, that when activated, displays the panel. The list of tab elements is arranged along one edge of the currently displayed panel, most commonly the top edge.
+
+The component can be navigated to via the keyboard: pressing the `Tab` key will highlight the active tab, and navigating between the tabs is achieved by pressing the `Left` and `Right` keys. When a new tab is selected, the corresponding panel is automatically shown.
+
+This component does not have a semantic counterpart in HTML, so it uses several WAI-ARIA tools to aid assistive technology:
+
+- The tabs are contained within a wrapper that has `role=”tablist”`, indicating to assistive technology that this component is not just a series of buttons or links.
+- Individual tabs use several `aria` attributes:
+  - `role=”tab”`
+  - `aria-selected`, which takes a boolean value to indicate whether it is the currently selected tab.
+  - `aria-controls`, which references the ID of the tab panel it controls
+- Tab panels also have several `aria` attributes:
+  - `role=”tabpanel”`,
+  - `aria-labelledby`, which references the ID of the tab it is controlled by
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- Tab text should be concise and make it clear what content they link to/nest.
+- There should be a clear relationship between the tabs and the tab panels.
+- JavaScript should be used to handle both mouse and keyboard interactions.
+- Content included in tab panels should also be accessible, i.e. images should include appropriate `alt` text.
+- Avoid tabs that wrap over more than one line. This can make it harder for users to distinguish the selected tab from its content.
+
+### Resources
+
+- [Example of Tabs with Automatic Activation](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html)
+- [WAI-ARIA practices: Tabs](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel)
+- Guidelines:
+  - [1.3.1: Info and Relationships](https://www.w3.org/TR/WCAG21/#info-and-relationships)
+  - [2.1.1: Keyboard Accessible](https://www.w3.org/TR/WCAG21/#keyboard)
+  - [2.1.2: No Keyboard Trap](https://www.w3.org/TR/WCAG21/#no-keyboard-trap)
+
 ## Import
 
 To import just the standard tab component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Add [accessibility doc](https://docs.google.com/document/d/1NYZ7l_f2K3hhi8euPyJncSHpG2_RBiequyraakQuDq0/edit#heading=h.tityw67q1sgi) for Tab component

Fixes #4067 

## QA

- Open [demo](insert-demo-url)
- Review Tab accessibility section - the doc has had +1 from dev and ux, just the formatting needs reviewing 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
