### PR TITLE
Add icon accessibility docs

### DIFF
--- a/templates/docs/patterns/icons.md
+++ b/templates/docs/patterns/icons.md
@@ -44,12 +44,6 @@ If an icon needs to act as a link, `p-icon--` classes can instead be applied to 
 View example of icons as links
 </a></div>
 
-## Accessibility
-
-For accessibility purposes, you can add text inside the icon element which will not be displayed to the user. E.g.
-
-`<i class="p-icon--chevron-down">This text will not be displayed</i>`
-
 ## Standard
 
 Our icons have two predefined color styles: light and dark. The light variant is the default style.
@@ -101,6 +95,33 @@ If you wish to add share icons for Twitter, Facebook or LinkedIn, we recommend u
     </ul>
   </div>
 </div>
+
+## Accessibility
+
+### How it works
+
+Icons are used to enhance usability and provide clarity. `<i>` elements are used for our icons, and text should be added unless the icon is purely decorative. This text won’t be displayed visually. e.g.
+
+`<i class="p-icon--chevron-down">This text will not be displayed</i>`
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- If the icon is purely decorative with accompanying text, don’t include any text within the `<i>` element.
+- If there is no text with the icon, then the text within the `<i>` element must be clear and concise conveying the meaning of the icon.
+- Choose well known icons where possible, the more commonly used the icon is, the more likely it is the user will know what it represents.
+- Be consistent. The first time users encounter an icon, they learn the meaning or function associated with it. Using that same icon elsewhere or for a different purpose will disorient them.
+- If the icon is actionable e.g. a menu icon, make sure it is focusable and it has a meaningful, clear and concise `alt` attribute.
+- The colour contrast from the icon to the background should be at least 3:1, as mentioned in the [WCAG techniques](https://www.w3.org/WAI/WCAG21/Techniques/general/G207).
+
+### Resources
+
+- [Are your icons accessible?](https://www.system-concepts.com/insights/are-your-icons-usable-and-accessible/)
+- [Keyboard - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard)
+- Guidelines
+  - [WCAG21 - 1.1.1 Non text content](https://www.w3.org/TR/WCAG21/#non-text-content)
+  - [WCAG21 - 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html)
 
 ## Import
 


### PR DESCRIPTION
## Done

- Add [accessibility doc](https://docs.google.com/document/d/1B3JqDWU25pGuVdmETeM5DCxQog-9aQSciF4_wWPDAaY/edit#heading=h.gd4zn0ids0xg) for icons

Fixes #4045 

## QA

- Open [demo](https://vanilla-framework-4286.demos.haus/docs/patterns/icons#accessibility)
- Google doc has had UX and dev +1. Please just review formatting on docs page 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
