### PR TITLE
Add accessibility docs for navigation

### DIFF
--- a/templates/docs/examples/patterns/search-box/navigation-dark.html
+++ b/templates/docs/examples/patterns/search-box/navigation-dark.html
@@ -15,7 +15,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example main navigation with a search box component">
+    <nav class="p-navigation__nav" aria-label="Example with a search box component">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>

--- a/templates/docs/examples/patterns/search-box/navigation.html
+++ b/templates/docs/examples/patterns/search-box/navigation.html
@@ -15,7 +15,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example main navigation with a search box component">
+    <nav class="p-navigation__nav" aria-label="Example with a search box component">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>

--- a/templates/docs/examples/patterns/tabs/navigation.html
+++ b/templates/docs/examples/patterns/tabs/navigation.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_tabs{% endblock %}
 
 {% block content %}
-<nav class="p-tabs" aria-label="Example tabs navigation">
+<nav class="p-tabs" aria-label="Tabs example">
   <ul class="p-tabs__list">
     <li class="p-tabs__item">
       <a href="/docs" class="p-tabs__link" aria-selected="true">Docs</a>

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -175,6 +175,44 @@ For more details about themes in Vanilla refer to the [Color theming](/docs/sett
 
 [See example of side navigation with dark theme](/docs/examples/patterns/side-navigation/dark).
 
+## Accessibility
+
+### How it works
+
+Navigation allows users to navigate different pages or content in a website. The list of navigation items can be displayed on the top or left edge of the viewport.
+
+The component can be navigated to via the keyboard. Pressing the `Tab` key will highlight the navigation items. When an element is highlighted, pressing the `Enter` key will open the corresponding view.
+
+The navigation component has the `<nav>` HTML tag to aid assistive technology. Also it uses several WAI-ARIA tools to aid assistive technology:
+
+- Navigation component uses `aria-label`, which is the description of it.
+- Individual items use several `aria` attributes:
+  - `aria-control`, which references the ID of the navigation panel it controls.
+  - `aria-hidden`, which takes a boolean value to control the dropdown navigation items.
+  - `aria-current="page"`, which is passed to the currently selected item.
+
+Care should be taken to ensure that the label makes sense out of context of the content around it.
+
+Consider the size that navigation elements are displayed at. They should be easily reachable and tappable on mobile views and easy to locate with the pointer on desktop views. Consider that users with reduced mobility may find it harder to locate and operate controls that appear too small on screen.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- The visual order of the UI objects that is read by assistive technologies should match with the source code.
+- Each navigation element should have a unique and clear label. Be sure not to include the word “navigation” in the `aria-label`, as this would be repeated by the screen reader.
+- Javascript will be needed to show/hide a collapsible element. The toggle element should have an `aria-controls` attribute that matches with the collapsible element’s `id`.
+- The target element is shown/hidden by changing `aria-hidden` to `true` or `false` accordingly.
+- Javascript will be needed to indicate which navigation element is active. `aria-current="page"` attribute should be given to the navigation item.
+- JavaScript should be used to handle both mouse and keyboard interactions.
+
+### Resources
+
+- [Carbon Design System - Navigation](https://www.carbondesignsystem.com/patterns/global-header/#accessibility)
+- Guidelines:
+  - [WAI-ARIA practices - General principles of landmark design](https://www.w3.org/TR/wai-aria-practices-1.1/#general-principles-of-landmark-design)
+  - [WAI-ARIA practices - Navigation](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_lh_navigation)
+
 ## Import
 
 To import just navigation component into your project, copy snippets below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Remove mention of navigation in aria-labels to avoid repetition
- Add accessibility docs for navigation

Fixes #4057 

## QA

- Open [demo](https://vanilla-framework-4287.demos.haus/docs/patterns/navigation#accessibility)
- Google doc has been reviewed. Check docs page for final QA please

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
