### PR TITLE
Added notification accessibility docs 

### DIFF
--- a/templates/docs/examples/patterns/notifications/action.html
+++ b/templates/docs/examples/patterns/notifications/action.html
@@ -4,11 +4,11 @@
 {% block standalone_css %}patterns_notifications{% endblock %}
 
 {% block content %}
-<div class="p-notification">
+<div class="p-notification" id="notification">
   <div class="p-notification__content">
     <h5 class="p-notification__title">Title</h5>
     <p class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</p>
-    <button class="p-notification__close">Close</button>
+    <button class="p-notification__close" aria-controls="notification">Close</button>
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">

--- a/templates/docs/examples/patterns/notifications/timestamp.html
+++ b/templates/docs/examples/patterns/notifications/timestamp.html
@@ -4,11 +4,11 @@
 {% block standalone_css %}patterns_notifications{% endblock %}
 
 {% block content %}
-<div class="p-notification">
+<div class="p-notification" id="notification">
   <div class="p-notification__content">
     <h5 class="p-notification__title">Title</h5>
     <p class="p-notification__message">Body lorem ipsum dolor sit amet consequiteor. Lorem ipsum dolor sit amet consequiteor.</p>
-    <button class="p-notification__close">Close</button>
+    <button class="p-notification__close" aria-controls="notification">Close</button>
   </div>
   <div class="p-notification__meta">
     <span class="p-notification__timestamp">1h ago</span>

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -90,7 +90,45 @@ View example of the time notification pattern
 
 ## Accessibility
 
-When adding notifications dynamically, it's important that the content of the notification is announced to users using assistive technology. If the notification is urgent, add `aria-live="assertive"` to the element, which will prompt assistive technology to announce it immediately, or use `aria-live="polite"`, which will cause assistive technology to wait for a pause before announcing the information.
+### How it works
+
+Notifications are messages used to communicate information and feedback to the user. Changes in content which are not interactive should be marked as live regions which are denoted by the `aria-live` attribute.  
+
+When the notification is time sensitive or critical `aria-live= “assertive”`, or its equivalent `role=”alert”`, should be used. Regions specified as assertive will be prioritized by assistive technologies and could potentially clear the speech queue of previous updates. For this reason, it should be used sparingly. Alternatively, when the notification is important, but not urgent, `aria-live=”polite”` should be used. This will notify the user of updates at the next graceful opportunity, without interrupting the current task.
+
+In dismissible notifications, an `aria-controls` attribute on the close button references the id on the parent div containing the notification. This makes it clear to screen reader users what the close button is targetting.
+
+Unless the alert from the screen reader is meant to break the user’s workflow, it is important that the notification does not affect keyboard focus. 
+
+Notifications should not disappear automatically.  
+
+
+### Considerations 
+
+This component strives to follow WCAG 2.1 (level AA guidelines), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect: 
+
+
+* Avoid adding both `aria-live=”assertive”` and `role=”alert”` to maximize compatibility as this causes double speaking issues in VoiceOver on iOS. 
+* Avoid frequent notifications as frequent interruptions may inhibit usability for people with visual and cognitive impairments. 
+* Place error notifications at the top of the page and use a distinctive heading so that they are easier to identify. 
+* Provide the user with clear instructions on how to correct errors and and explicitly remind them of any format requirements. 
+* Avoid creating a time limit, as making the notification disappear automatically can reduce accessibility for users who need longer to interact with the element.
+* An event listener should be added to hide notifications upon receiving a click on the close button. 
+
+
+### Resources
+
+
+
+* [Accessible Rich Internet Applications (WAI-ARIA) 1.1 : aria-live](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-live) 
+* [WAI-ARIA Authoring Practices 1.1: alert](https://www.w3.org/TR/wai-aria-practices-1.1/#alert) 
+* [User Notifications • Forms • WAI Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/forms/notifications/) 
+* [Accessible Rich Internet Applications (WAI-ARIA) 1.1: aria-controls](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-controls) 
+* [ARIA live regions - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) 
+* Applicable WCAG guidelines:
+    * [Guideline 2.2.3 - No timing](https://www.w3.org/WAI/WCAG21/quickref/#no-timing)
+    * [Guideline 3.2 - Predictable](https://www.w3.org/WAI/WCAG21/quickref/#predictable)
+    * [Guideline 3.3 - Input assistance](https://www.w3.org/WAI/WCAG21/quickref/#input-assistance)
 
 ## Import
 

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -94,7 +94,7 @@ View example of the time notification pattern
 
 Notifications are messages used to communicate information and feedback to the user. Changes in content which are not interactive should be marked as live regions which are denoted by the `aria-live` attribute.  
 
-When the notification is time sensitive or critical `aria-live= “assertive”`, or its equivalent `role=”alert”`, should be used. Regions specified as assertive will be prioritized by assistive technologies and could potentially clear the speech queue of previous updates. For this reason, it should be used sparingly. Alternatively, when the notification is important, but not urgent, `aria-live=”polite”` should be used. This will notify the user of updates at the next graceful opportunity, without interrupting the current task.
+When the notification is time sensitive or critical `aria-live= "assertive"`, or its equivalent `role="alert"`, should be used. Regions specified as assertive will be prioritized by assistive technologies and could potentially clear the speech queue of previous updates. For this reason, it should be used sparingly. Alternatively, when the notification is important, but not urgent, `aria-live="polite"` should be used. This will notify the user of updates at the next graceful opportunity, without interrupting the current task.
 
 In dismissible notifications, an `aria-controls` attribute on the close button references the id on the parent div containing the notification. This makes it clear to screen reader users what the close button is targetting.
 
@@ -108,7 +108,7 @@ Notifications should not disappear automatically.
 This component strives to follow WCAG 2.1 (level AA guidelines), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect: 
 
 
-* Avoid adding both `aria-live=”assertive”` and `role=”alert”` to maximize compatibility as this causes double speaking issues in VoiceOver on iOS. 
+* Avoid adding both `aria-live="assertive"` and `role="alert"` to maximize compatibility as this causes double speaking issues in VoiceOver on iOS. 
 * Avoid frequent notifications as frequent interruptions may inhibit usability for people with visual and cognitive impairments. 
 * Place error notifications at the top of the page and use a distinctive heading so that they are easier to identify. 
 * Provide the user with clear instructions on how to correct errors and and explicitly remind them of any format requirements. 

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -102,11 +102,9 @@ Unless the alert from the screen reader is meant to break the user’s workflow,
 
 Notifications should not disappear automatically.  
 
-
 ### Considerations 
 
 This component strives to follow WCAG 2.1 (level AA guidelines), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect: 
-
 
 * Avoid adding both `aria-live="assertive"` and `role="alert"` to maximize compatibility as this causes double speaking issues in VoiceOver on iOS. 
 * Avoid frequent notifications as frequent interruptions may inhibit usability for people with visual and cognitive impairments. 
@@ -115,10 +113,7 @@ This component strives to follow WCAG 2.1 (level AA guidelines), and care must b
 * Avoid creating a time limit, as making the notification disappear automatically can reduce accessibility for users who need longer to interact with the element.
 * An event listener should be added to hide notifications upon receiving a click on the close button. 
 
-
 ### Resources
-
-
 
 * [Accessible Rich Internet Applications (WAI-ARIA) 1.1 : aria-live](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-live) 
 * [WAI-ARIA Authoring Practices 1.1: alert](https://www.w3.org/TR/wai-aria-practices-1.1/#alert) 

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -98,10 +98,6 @@ When the notification is time sensitive or critical `aria-live= "assertive"`, or
 
 In dismissible notifications, an `aria-controls` attribute on the close button references the id on the parent div containing the notification. This makes it clear to screen reader users what the close button is targeting.
 
-Unless the alert from the screen reader is meant to break the user’s workflow, it is important that the notification does not affect keyboard focus.
-
-Notifications should not disappear automatically.
-
 ### Considerations
 
 This component strives to follow WCAG 2.1 (level AA guidelines), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
@@ -112,6 +108,8 @@ This component strives to follow WCAG 2.1 (level AA guidelines), and care must b
 - Provide the user with clear instructions on how to correct errors and and explicitly remind them of any format requirements.
 - Avoid creating a time limit, as making the notification disappear automatically can reduce accessibility for users who need longer to interact with the element.
 - An event listener should be added to hide notifications upon receiving a click on the close button.
+- Unless the alert from the screen reader is meant to break the user’s workflow, it is important that the notification does not affect keyboard focus.
+- Notifications should not disappear automatically.
 
 ### Resources
 

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -92,38 +92,38 @@ View example of the time notification pattern
 
 ### How it works
 
-Notifications are messages used to communicate information and feedback to the user. Changes in content which are not interactive should be marked as live regions which are denoted by the `aria-live` attribute.  
+Notifications are messages used to communicate information and feedback to the user. Changes in content which are not interactive should be marked as live regions which are denoted by the `aria-live` attribute.
 
 When the notification is time sensitive or critical `aria-live= "assertive"`, or its equivalent `role="alert"`, should be used. Regions specified as assertive will be prioritized by assistive technologies and could potentially clear the speech queue of previous updates. For this reason, it should be used sparingly. Alternatively, when the notification is important, but not urgent, `aria-live="polite"` should be used. This will notify the user of updates at the next graceful opportunity, without interrupting the current task.
 
 In dismissible notifications, an `aria-controls` attribute on the close button references the id on the parent div containing the notification. This makes it clear to screen reader users what the close button is targetting.
 
-Unless the alert from the screen reader is meant to break the user’s workflow, it is important that the notification does not affect keyboard focus. 
+Unless the alert from the screen reader is meant to break the user’s workflow, it is important that the notification does not affect keyboard focus.
 
-Notifications should not disappear automatically.  
+Notifications should not disappear automatically.
 
-### Considerations 
+### Considerations
 
-This component strives to follow WCAG 2.1 (level AA guidelines), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect: 
+This component strives to follow WCAG 2.1 (level AA guidelines), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
-* Avoid adding both `aria-live="assertive"` and `role="alert"` to maximize compatibility as this causes double speaking issues in VoiceOver on iOS. 
-* Avoid frequent notifications as frequent interruptions may inhibit usability for people with visual and cognitive impairments. 
-* Place error notifications at the top of the page and use a distinctive heading so that they are easier to identify. 
-* Provide the user with clear instructions on how to correct errors and and explicitly remind them of any format requirements. 
-* Avoid creating a time limit, as making the notification disappear automatically can reduce accessibility for users who need longer to interact with the element.
-* An event listener should be added to hide notifications upon receiving a click on the close button. 
+- Avoid adding both `aria-live="assertive"` and `role="alert"` to maximize compatibility as this causes double speaking issues in VoiceOver on iOS.
+- Avoid frequent notifications as frequent interruptions may inhibit usability for people with visual and cognitive impairments.
+- Place error notifications at the top of the page and use a distinctive heading so that they are easier to identify.
+- Provide the user with clear instructions on how to correct errors and and explicitly remind them of any format requirements.
+- Avoid creating a time limit, as making the notification disappear automatically can reduce accessibility for users who need longer to interact with the element.
+- An event listener should be added to hide notifications upon receiving a click on the close button.
 
 ### Resources
 
-* [Accessible Rich Internet Applications (WAI-ARIA) 1.1 : aria-live](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-live) 
-* [WAI-ARIA Authoring Practices 1.1: alert](https://www.w3.org/TR/wai-aria-practices-1.1/#alert) 
-* [User Notifications • Forms • WAI Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/forms/notifications/) 
-* [Accessible Rich Internet Applications (WAI-ARIA) 1.1: aria-controls](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-controls) 
-* [ARIA live regions - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) 
-* Applicable WCAG guidelines:
-    * [Guideline 2.2.3 - No timing](https://www.w3.org/WAI/WCAG21/quickref/#no-timing)
-    * [Guideline 3.2 - Predictable](https://www.w3.org/WAI/WCAG21/quickref/#predictable)
-    * [Guideline 3.3 - Input assistance](https://www.w3.org/WAI/WCAG21/quickref/#input-assistance)
+- [Accessible Rich Internet Applications (WAI-ARIA) 1.1 : aria-live](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-live)
+- [WAI-ARIA Authoring Practices 1.1: alert](https://www.w3.org/TR/wai-aria-practices-1.1/#alert)
+- [User Notifications • Forms • WAI Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/forms/notifications/)
+- [Accessible Rich Internet Applications (WAI-ARIA) 1.1: aria-controls](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-controls)
+- [ARIA live regions - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
+- Applicable WCAG guidelines:
+  - [Guideline 2.2.3 - No timing](https://www.w3.org/WAI/WCAG21/quickref/#no-timing)
+  - [Guideline 3.2 - Predictable](https://www.w3.org/WAI/WCAG21/quickref/#predictable)
+  - [Guideline 3.3 - Input assistance](https://www.w3.org/WAI/WCAG21/quickref/#input-assistance)
 
 ## Import
 

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -106,7 +106,7 @@ Notifications should not disappear automatically.
 
 This component strives to follow WCAG 2.1 (level AA guidelines), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
-- Avoid adding both `aria-live="assertive"` and `role="alert"` to maximize compatibility as this causes double speaking issues in VoiceOver on iOS.
+- Avoid adding both `aria-live="assertive"` and `role="alert"` to maximize compatibility as this causes double speaking issues in `VoiceOver` on iOS.
 - Avoid frequent notifications as frequent interruptions may inhibit usability for people with visual and cognitive impairments.
 - Place error notifications at the top of the page and use a distinctive heading so that they are easier to identify.
 - Provide the user with clear instructions on how to correct errors and and explicitly remind them of any format requirements.

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -96,7 +96,7 @@ Notifications are messages used to communicate information and feedback to the u
 
 When the notification is time sensitive or critical `aria-live= "assertive"`, or its equivalent `role="alert"`, should be used. Regions specified as assertive will be prioritized by assistive technologies and could potentially clear the speech queue of previous updates. For this reason, it should be used sparingly. Alternatively, when the notification is important, but not urgent, `aria-live="polite"` should be used. This will notify the user of updates at the next graceful opportunity, without interrupting the current task.
 
-In dismissible notifications, an `aria-controls` attribute on the close button references the id on the parent div containing the notification. This makes it clear to screen reader users what the close button is targetting.
+In dismissible notifications, an `aria-controls` attribute on the close button references the id on the parent div containing the notification. This makes it clear to screen reader users what the close button is targeting.
 
 Unless the alert from the screen reader is meant to break the user’s workflow, it is important that the notification does not affect keyboard focus.
 


### PR DESCRIPTION
## Done

- Added notification accessibility docs - google doc [here](https://docs.google.com/document/d/1iw5ZMMzDjnnz3oG1P4wwjj9JYsGOsTPfl6Kzp_H6NoU/edit#)
- Added `aria-controls` attribute to all dismissible example
- Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/4058

## QA

- Open [demo](insert-demo-url)
- Check that each dismissible notification has the aria-controls attribute on the close button
- QA the accessibility and considerations section of the notification docs  

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.
