### PR TITLE
Button's processing state's width and height is set to initial width and height

### DIFF
--- a/templates/docs/examples/patterns/buttons/_script.js
+++ b/templates/docs/examples/patterns/buttons/_script.js
@@ -1,0 +1,26 @@
+(function () {
+  const button = document.querySelector(".p-button--positive");
+
+  button.addEventListener('click', function () {
+    const hideClass = "u-hide";
+    const processingClass = "is-processing";
+    const spinner = document.querySelector(".p-icon--spinner");
+    const buttonLabel = document.getElementById("button-label");
+
+    if (!spinner.classList.contains(hideClass)) {
+      spinner.classList.add(hideClass);
+      buttonLabel.classList.remove(hideClass);
+      button.classList.remove(processingClass);
+      button.disabled = false;
+    } else { 
+      const buttonRect = button.getBoundingClientRect();
+      button.style.width = buttonRect.width + "px";
+      button.style.height = buttonRect.height + "px";
+
+      button.classList.add(processingClass);
+      spinner.classList.remove(hideClass);
+      buttonLabel.classList.add(hideClass);
+      button.disabled = true;
+    }
+  });
+})();

--- a/templates/docs/examples/patterns/buttons/_script.js
+++ b/templates/docs/examples/patterns/buttons/_script.js
@@ -1,26 +1,18 @@
 (function () {
   const button = document.querySelector(".p-button--positive");
+  const hideClass = "u-hide";
+  const processingClass = "is-processing";
+  const spinner = document.querySelector(".p-icon--spinner");
+  const buttonLabel = document.getElementById("button-label");
+  const buttonRect = button.getBoundingClientRect();
 
   button.addEventListener('click', function () {
-    const hideClass = "u-hide";
-    const processingClass = "is-processing";
-    const spinner = document.querySelector(".p-icon--spinner");
-    const buttonLabel = document.getElementById("button-label");
+    button.style.width = buttonRect.width + "px";
+    button.style.height = buttonRect.height + "px";
+    button.disabled = true;
 
-    if (!spinner.classList.contains(hideClass)) {
-      spinner.classList.add(hideClass);
-      buttonLabel.classList.remove(hideClass);
-      button.classList.remove(processingClass);
-      button.disabled = false;
-    } else { 
-      const buttonRect = button.getBoundingClientRect();
-      button.style.width = buttonRect.width + "px";
-      button.style.height = buttonRect.height + "px";
-
-      button.classList.add(processingClass);
-      spinner.classList.remove(hideClass);
-      buttonLabel.classList.add(hideClass);
-      button.disabled = true;
-    }
+    button.classList.add(processingClass);
+    spinner.classList.remove(hideClass);
+    buttonLabel.classList.add(hideClass);
   });
 })();

--- a/templates/docs/examples/patterns/buttons/processing.html
+++ b/templates/docs/examples/patterns/buttons/processing.html
@@ -4,5 +4,12 @@
 {% block standalone_css %}patterns_buttons{% endblock %}
 
 {% block content %}
-<button class="p-button--positive is-processing" disabled><i class="p-icon--spinner u-animation--spin is-light"></i></button>
+<button class="p-button--positive">
+    <i class="p-icon--spinner u-animation--spin is-light u-hide"></i>
+    <span id="button-label">Click</span>
+</button>
+<script>
+  {% include 'docs/examples/patterns/buttons/_script.js' %}
+</script>
 {% endblock %}
+


### PR DESCRIPTION
## Done

- Added script that sets width and height of the button in processing state

Fixes #3713 

## QA

- Open [demo](insert-demo-url)
- Click on the button
- Verify button's width and height does not change

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.

