### PR TITLE
Update table docs with empty state

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -66,14 +66,14 @@
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
               {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
               {{ side_nav_item("/docs/patterns/card", "Cards") }}
-              {{ side_nav_item("/docs/patterns/chip", "Chips", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/chip", "Chips") }}
               {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}
               {{ side_nav_item("/docs/patterns/empty-state", "Empty state", 'new', 'positive') }}
               {{ side_nav_item("/docs/patterns/grid", "Grid") }}
               {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}
               {{ side_nav_item("/docs/patterns/icons", "Icons") }}
               {{ side_nav_item("/docs/patterns/images", "Images") }}
-              {{ side_nav_item("/docs/patterns/labels", "Labels", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/labels", "Labels") }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
               {{ side_nav_item("/docs/patterns/lists", "Lists", 'updated', 'information') }}
@@ -87,8 +87,8 @@
               {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
-              {{ side_nav_item("/docs/patterns/search-box", "Search box", 'new', 'positive') }}
-              {{ side_nav_item("/docs/patterns/slider", "Slider") }}
+              {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
+              {{ side_nav_item("/docs/patterns/slider", "Slider", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}
               {{ side_nav_item("/docs/patterns/switch", "Switch", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -33,10 +33,10 @@ You can find out more about the [truncation](/docs/utilities/truncate) and
 
 ## Empty
 
-A `<caption>` element can be used to provide a description when there is no data to display in the table.
+A `<caption>` element can be used to provide a description when there is no data to display in the table. For more examples, see the [Empty states documentation](/docs/patterns/empty-state).
 
-<div class="embedded-example"><a href="/docs/examples/base/table-empty/" class="js-example">
-View example of empty table
+<div class="embedded-example"><a href="/docs/examples/patterns/empty-state/no-content" class="js-example">
+View example of the empty state caused by no content
 </a></div>
 
 ## Icons

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -37,6 +37,29 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>3.1.0</td>
       <td>We've updated lists by adding a new class name. It can be used when nested items numbers are required to be set according to their parents.</td>
     </tr>
+    <tr>
+      <th><a href="/docs/patterns/slider">Slider</a> and <a href="/docs/patterns/switch">Switch</a></th>
+      <td>
+        <span class="p-label--information">Updated</span>
+      </td>
+      <td>3.1.0</td>
+      <td>We've updated the styling of the Switch and Slider components.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Previously in Vanilla v3
+
+<table aria-label="Previously in Vanilla v3">
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 3.0.0 -->
     <tr>
       <th><a href="/docs/patterns/navigation">Expanding search box</a></th>


### PR DESCRIPTION
## Done

- Added the new empty state pattern to the Table docs
- Updated the side navigation with correct labels
- Updated what's new 

Fixes #4292 

## QA

- Open [demo](https://vanilla-framework-4297.demos.haus/)
- Review updated documentation:
  - What's new
  - Table docs

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
