### PR TITLE
Replace `<cite>` with `<span>` pull-quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.1.0",
+  "version": "3.1.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -29,6 +29,7 @@
     .p-pull-quote__citation {
       @extend %vf-heading-6;
 
+      display: block;
       margin-top: $spv--small;
     }
   }

--- a/templates/docs/examples/patterns/pull-quotes/default-image.html
+++ b/templates/docs/examples/patterns/pull-quotes/default-image.html
@@ -7,6 +7,6 @@
 <blockquote class="p-pull-quote has-image">
   <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="" />
   <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
-  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
+  <span class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</span>
 </blockquote>
 {% endblock %}

--- a/templates/docs/examples/patterns/pull-quotes/default.html
+++ b/templates/docs/examples/patterns/pull-quotes/default.html
@@ -6,6 +6,6 @@
 {% block content %}
 <blockquote class="p-pull-quote">
   <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+  <span class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</span>
 </blockquote>
 {% endblock %}

--- a/templates/docs/examples/patterns/pull-quotes/large.html
+++ b/templates/docs/examples/patterns/pull-quotes/large.html
@@ -6,6 +6,6 @@
 {% block content %}
 <blockquote class="p-pull-quote--large">
   <p class="p-pull-quote__quote">The support has been fabulous. The whole team stepped up and helped us work through issues.</p>
-  <cite class="p-pull-quote__citation">Director of Web Engineering, Best Buy Corp</cite>
+  <span class="p-pull-quote__citation">Director of Web Engineering, Best Buy Corp</span>
 </blockquote>
 {% endblock %}

--- a/templates/docs/examples/patterns/pull-quotes/small.html
+++ b/templates/docs/examples/patterns/pull-quotes/small.html
@@ -6,6 +6,6 @@
 {% block content %}
 <blockquote class="p-pull-quote--small">
   <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+  <span class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</span>
 </blockquote>
 {% endblock %}

--- a/templates/docs/examples/patterns/pull-quotes/variants.html
+++ b/templates/docs/examples/patterns/pull-quotes/variants.html
@@ -8,14 +8,14 @@
 <h3>Default variant - 1 paragraph with cite:</h3>
 <blockquote class="p-pull-quote">
   <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+  <span class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</span>
 </blockquote>
 
 <h3>Default variant - 2 paragraphs with cite:</h3>
 <blockquote class="p-pull-quote">
   <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
   <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+  <span class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</span>
 </blockquote>
 
 <h3>Default variant - 1 paragraph, no cite:</h3>
@@ -33,7 +33,7 @@
 <blockquote class="p-pull-quote has-image">
   <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
   <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
-  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
+  <span class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</span>
 </blockquote>
 
 <h3>Default variant - image, 1 paragraph, no cite:</h3>
@@ -46,14 +46,14 @@
 <h3>Small variant - 1 paragraph with cite:</h3>
 <blockquote class="p-pull-quote--small">
   <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+  <span class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</span>
 </blockquote>
 
 <h3>Small variant - 2 paragraphs with cite:</h3>
 <blockquote class="p-pull-quote--small">
   <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
   <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+  <span class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</span>
 </blockquote>
 
 <h3>Small variant - 1 paragraph, no cite:</h3>
@@ -71,7 +71,7 @@
 <blockquote class="p-pull-quote--small has-image">
   <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
   <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
-  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
+  <span class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</span>
 </blockquote>
 
 <h3>Small variant - image, 1 paragraph, no cite:</h3>
@@ -85,14 +85,14 @@
 <h3>Large variant - 1 paragraph with cite:</h3>
 <blockquote class="p-pull-quote--large">
   <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+  <span class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</span>
 </blockquote>
 
 <h3>Large variant - 2 paragraphs with cite:</h3>
 <blockquote class="p-pull-quote--large">
   <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms.</p>
   <p class="p-pull-quote__quote">Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
-  <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
+  <span class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</span>
 </blockquote>
 
 <h3>Large variant - 1 paragraph, no cite:</h3>
@@ -110,7 +110,7 @@
 <blockquote class="p-pull-quote--large has-image">
   <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c7881d6c-spiculelogo-spacingx2-01.svg" alt="spiculelogo" />
   <p class="p-pull-quote__quote">Using the modelling ethos brought by Juju allows me to quickly run big data applications in a multitude of places. Be it locally on my laptop, on bare metal or in the Cloud, Juju lets me reuse the same models and code without changing any aspects of my deployment.</p>
-  <cite class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</cite>
+  <span class="p-pull-quote__citation">Tom Barber, CTO, Spicule LTD</span>
 </blockquote>
 
 <h3>Large variant - image, 1 paragraph, no cite:</h3>


### PR DESCRIPTION
## Done

- Replace `<cite>` with `<span>` pull-quotes. Semantically, cites should only be used to refer to someone's work, not their name

Fixes #4263 

## QA

- Open [demo](https://vanilla-framework-4300.demos.haus/)
- Check there are no visual changes in the pull quote examples
- Check VoiceOver works as expected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
