### PR TITLE
Update modal accessibility docs

### DIFF
--- a/templates/docs/patterns/modal.md
+++ b/templates/docs/patterns/modal.md
@@ -32,9 +32,30 @@ View example of the modal with a footer
 
 ## Accessibility
 
-JavaScript should be used with the modal pattern to trap focus within an open modal, preventing elements behind the modal from unintentionally receiving focus via keyboard input. The examples on this page include JavaScript that can help to achieve this.
+### How it works
 
-See [WCAG Success Criterion 2.1.2](https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-trapping.html) for further information.
+Modal is used to overlay an area of the screen with a prompt, dialog or interaction and prevents users from interacting with content outside of it until it’s closed.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- The element that serves as the modal container should have a role of dialog and `aria-modal` set to `true`.
+- The dialog has a label specified by `aria-labelledby` property that refers to a visible modal title.
+
+JavaScript needs to be used to ensure:
+
+- When a modal opens, focus moves to the first focusable element inside the modal.
+- Focus is trapped within an open modal preventing any elements outside of the modal from receiving focus
+- Tab, Shift+Tab move focus within the modal
+- Escape closes the modal
+- When a modal closes, focus returns to the element that triggered the modal
+
+### Resources
+
+- [Modal Dialog Example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html)
+- [WAI-ARIA practices: Dialog (Modal)](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal)
+- [No Keyboard Trap: Understanding SC 2.1.2](https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-trapping.html)
 
 ## Import
 


### PR DESCRIPTION
## Done

- Update modal accessibility docs

Fixes #4055 

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
