### PR TITLE
Live demo box iframe

### DIFF
--- a/templates/docs/examples/patterns/code-snippet/is-bordered.html
+++ b/templates/docs/examples/patterns/code-snippet/is-bordered.html
@@ -11,6 +11,6 @@
 
   <pre class="p-code-snippet__block"><code>&lt;button&gt;Button&lt;/button&gt;</code></pre>
 
-  <iframe src="/docs/examples/base/button"></iframe> 
+  <iframe src="/docs/examples/base/button"></iframe>
 </div>
 {% endblock %}

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -52,7 +52,7 @@ const LiveDemoBox = () => {
           <div className="row" style={{gridGap: 0}}>
             <div className="p-card col-6">
               <h3>Example</h3>
-              <p className="p-card__content">space for exmaple here</p>
+              <iframe src="/docs/examples/patterns/notifications/toast" width="100%" />
             </div>
             <div className="col-2 p-card">
               <Switch switchOptions={configValues.switch} />


### PR DESCRIPTION
## Done

Display example code in iframe

## QA

- Open  https://vanilla-framework-4313.demos.haus//docs/patterns/notification#live-demo-box
- Check that iframe is showing

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.

