### PR TITLE
Use query parameters to change notification example

### DIFF
--- a/templates/docs/examples/patterns/notifications/toast.html
+++ b/templates/docs/examples/patterns/notifications/toast.html
@@ -1,0 +1,36 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Notifications / Toast{% endblock %}
+
+{% block standalone_css %}patterns_notifications{% endblock %}
+
+{% set type = request.args.get('type') %}
+{% set theme = request.args.get('theme') %}
+{% set style = request.args.get('style') %}
+{% set dismiss = request.args.get('dismiss') %}
+{% set actions = request.args.get('actions') %}
+{% set timestamp = request.args.get('timestamp') %}
+
+{% block content %}
+<div class="p-notification{{ '--' ~ type if type else '' }} {% if theme == 'dark' %}is-dark{% endif %} {% if style == 'inline' %}is-inline{% endif %}">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Permissions changed</h5>
+    <p class="p-notification__message">Anyone with access can view your invited users.</p>
+    {% if dismiss == 'true' %}
+    <button class="p-notification__close" aria-controls="notification">Close</button>
+    {% endif %}
+  </div>
+  {% if actions == 'true' or timestamp == 'true' %}
+  <div class="p-notification__meta">
+    {% if timestamp == 'true' %}
+    <span class="p-notification__timestamp">1h ago</span>
+    {% endif %}
+    {% if actions == 'true' %}
+    <div class="p-notification__actions">
+      <a class="p-notification__action" href="#">Action 1</a>
+      <a class="p-notification__action" href="#">Action 2</a>
+    </div>
+    {% endif %}
+  </div>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Done

- Added notification template that renders HTML based on query parameters in the URL

## QA

- Open [demo](https://vanilla-framework-4318.demos.haus/docs/examples/patterns/notifications/toast)
- Add query parameters to the URL -- e.g. https://vanilla-framework-4318.demos.haus/docs/examples/patterns/notifications/toast?type=caution&style=inline&actions=true&dismiss=true&timestamp=true
- Verify that the example changes based on the given query parameters

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.

## Issue

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/4319

## Screenshots

![notification-example](https://user-images.githubusercontent.com/995051/154277632-a7e32ddd-3f47-4659-9f4a-2c76765fa050.png)
