### PR TITLE
Add component to display example code

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,10 @@
     "esbuild": "^0.14.21",
     "postcss": "8.4.6",
     "postcss-cli": "9.1.0",
+    "prismjs": "^1.26.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-query": "^3.34.15",
     "sass": "1.49.7",
     "typescript": "^4.5.5"
   },

--- a/templates/docs/examples/patterns/code-snippet/codeSnippet.html
+++ b/templates/docs/examples/patterns/code-snippet/codeSnippet.html
@@ -67,6 +67,7 @@
   {%- endfor -%}
   </code></pre>
 
+  {%- if type == 'dropdown' or type == 'multiple-dropdowns' %}
   <pre id="yaml-panel" class="p-code-snippet__block--numbered{{ wrapping_class }}{% if highlight == 'true' %} language-yaml{% endif %} u-hide" aria-hidden="true"><code>
   {%- for line in yaml_code.split('\n') %}
 <span class="p-code-snippet__line">{{ line }}</span>
@@ -78,6 +79,7 @@
 <span class="p-code-snippet__line">{{ line }}</span>
   {%- endfor -%}
   </code></pre>
+  {%- endif %}
   {%- else %}
   <pre id="stable-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-sh{% endif %}"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird' }}</code></pre>
   <pre id="beta-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-sh{% endif %} u-hide" aria-hidden="true"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird --beta'}}</code></pre>

--- a/templates/docs/examples/patterns/notifications/toast.html
+++ b/templates/docs/examples/patterns/notifications/toast.html
@@ -11,26 +11,51 @@
 {% set timestamp = request.args.get('timestamp') %}
 
 {% block content %}
-<div class="p-notification{{ '--' ~ type if type else '' }} {% if theme == 'dark' %}is-dark{% endif %} {% if style == 'inline' %}is-inline{% endif %}">
+<div class="p-notification{{ '--' ~ type if type else '' }}{% if theme == 'dark' %} is-dark{% endif %}{% if style == 'inline' %} is-inline{% endif %}" id="notification">
   <div class="p-notification__content">
     <h5 class="p-notification__title">Permissions changed</h5>
     <p class="p-notification__message">Anyone with access can view your invited users.</p>
-    {% if dismiss == 'true' %}
+    {%- if dismiss == 'true' %}
     <button class="p-notification__close" aria-controls="notification">Close</button>
-    {% endif %}
+    {%- endif %}
   </div>
-  {% if actions == 'true' or timestamp == 'true' %}
+  {%- if actions == 'true' or timestamp == 'true' %}
   <div class="p-notification__meta">
-    {% if timestamp == 'true' %}
+    {%- if timestamp == 'true' %}
     <span class="p-notification__timestamp">1h ago</span>
-    {% endif %}
-    {% if actions == 'true' %}
+    {%- endif %}
+    {%- if actions == 'true' %}
     <div class="p-notification__actions">
       <a class="p-notification__action" href="#">Action 1</a>
       <a class="p-notification__action" href="#">Action 2</a>
     </div>
-    {% endif %}
+    {%- endif %}
   </div>
-  {% endif %}
+  {%- endif %}
 </div>
+{%- if dismiss == 'true' %}
+<script>
+/**
+  Attaches event listener for hide notification on close button click.
+  @param {HTMLElement} closeButton The notification close button element.
+*/
+function setupCloseButton(closeButton) {
+  closeButton.addEventListener('click', function(event) {
+    var target = event.target.getAttribute('aria-controls');
+    var notification = document.getElementById(target);
+
+    if (notification) {
+      notification.classList.add('u-hide');
+    }
+  });
+}
+
+// Set up all notification close buttons.
+var closeButtons = document.querySelectorAll('.p-notification__close');
+
+for (var i = 0, l = closeButtons.length; i < l; i++) {
+  setupCloseButton(closeButtons[i]);
+}
+</script>
+{%- endif %}
 {% endblock %}

--- a/templates/static/js/src/demobox/app.tsx
+++ b/templates/static/js/src/demobox/app.tsx
@@ -1,9 +1,26 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { QueryClient, QueryClientProvider } from "react-query";
 import LiveDemoBox from "./components/LiveDemoBox";
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      staleTime: 60 * 60 * 1000, // 1 hour
+      retryOnMount: false,
+    },
+  },
+});
+
 const App = () => {
-  return <LiveDemoBox />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <LiveDemoBox />
+    </QueryClientProvider>
+  );
 };
 
 ReactDOM.render(<App />, document.querySelector(".react-live-demo-box"));

--- a/templates/static/js/src/demobox/components/LiveDemoBox/Code.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/Code.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import { Select } from "@canonical/react-components";
+import Prism from "prismjs";
+import useCode from "../../hooks/useCode";
+
+type Props = {
+  path: string;
+};
+
+const Code = ({ path }: Props) => {
+  const [language, setLanguage] = useState("html");
+
+  const { html, js, css, isLoading, isSuccess } = useCode(path);
+
+  useEffect(() => {
+    if (
+      !isLoading &&
+      isSuccess &&
+      ((language === "js" && !js) || (language === "css" && !css))
+    ) {
+      setLanguage("html");
+    }
+
+    Prism.highlightAll();
+  }, [html, js, css, language, isLoading, isSuccess]);
+
+  const selectOptions = [
+    {
+      value: "html",
+      label: "HTML",
+      disabled: !html,
+    },
+    {
+      value: "js",
+      label: "JS",
+      disabled: !js,
+    },
+    {
+      value: "css",
+      label: "CSS",
+      disabled: !css,
+    },
+  ];
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setLanguage(e.target.value);
+  };
+
+  return (
+    <>
+      <div className="p-code-snippet">
+        <div className="p-code-snippet__header">
+          <h5 className="p-code-snippet__title">Notifications</h5>
+          {isSuccess && (
+            <div className="p-code-snippet__dropdowns">
+              <Select
+                className="p-code-snippet__dropdown"
+                options={selectOptions}
+                onChange={handleChange}
+                value={language}
+              />
+            </div>
+          )}
+        </div>
+        <pre
+          className={`p-code-snippet__block u-no-margin language-${language}`}
+          data-lang={language}
+          style={{ maxHeight: "300px" }}
+        >
+          <code className={`language-${language}`}>
+            {(language == "html" && html) ||
+              (language == "js" && js) ||
+              (language == "css" && css)}
+          </code>
+        </pre>
+      </div>
+    </>
+  );
+};
+
+export default Code;

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Switch from "./Switch";
 import { Select } from "@canonical/react-components";
+import Code from "./Code";
 
 export type InputOptions = {
   key: string;
@@ -122,6 +123,11 @@ const LiveDemoBox = () => {
                 switchOptions={configValues.switch}
                 handleChange={handleChange}
               />
+            </div>
+          </div>
+          <div className="row" style={{ gridGap: 0 }}>
+            <div className="p-card col-8 u-no-padding">
+              <Code path={url} />
             </div>
           </div>
         </form>

--- a/templates/static/js/src/demobox/hooks/useCode.ts
+++ b/templates/static/js/src/demobox/hooks/useCode.ts
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { useQuery } from "react-query";
+import { getHtml, getJs, getCss } from "../utils/code";
+
+type CodeRecord = Record<string, string | null>;
+
+const useCode = (path: string) => {
+  const [html, setHtml] = useState<CodeRecord>({});
+  const [js, setJs] = useState<CodeRecord>({});
+  const [css, setCss] = useState<CodeRecord>({});
+
+  const { isLoading, isSuccess, isError, error } = useQuery(
+    path,
+    async () => {
+      const response = await fetch(path);
+      const responseText = await response.text();
+
+      const responseHtml = getHtml(responseText);
+      const responseJs = getJs(responseText);
+      const responseCss = getCss(responseText);
+
+      setHtml({ ...html, [path]: responseHtml });
+      setJs({ ...js, [path]: responseJs });
+      setCss({ ...css, [path]: responseCss });
+    },
+    { enabled: true }
+  );
+
+  return {
+    html: html[path],
+    js: js[path],
+    css: css[path],
+    isLoading,
+    isSuccess,
+    isError,
+    error,
+  };
+};
+
+export default useCode;

--- a/templates/static/js/src/demobox/utils/code.ts
+++ b/templates/static/js/src/demobox/utils/code.ts
@@ -1,0 +1,41 @@
+export const getHeadHtml = (code: string) => {
+  const headPattern = /<head[^>]*>((.|[\n\r])*)<\/head>/im;
+  const parsed = headPattern.exec(code);
+  const headHtml = parsed ? parsed[1].trim() : "";
+  return headHtml;
+};
+
+export const getBodyHtml = (code: string) => {
+  const bodyPattern = /<body[^>]*>((.|[\n\r])*)<\/body>/im;
+  const parsed = bodyPattern.exec(code);
+  const bodyHtml = parsed ? parsed[1].trim() : "";
+  return bodyHtml;
+};
+
+export const getHtml = (code: string) => {
+  const div = document.createElement("div");
+  div.innerHTML = getBodyHtml(code);
+  const scripts = div.getElementsByTagName("script");
+  let i = scripts.length;
+  while (i--) {
+    const parentNode = scripts[i].parentNode;
+    if (parentNode) {
+      parentNode.removeChild(scripts[i]);
+    }
+  }
+  return div.innerHTML.trim();
+};
+
+export const getJs = (code: string) => {
+  const div = document.createElement("div");
+  div.innerHTML = getBodyHtml(code);
+  const script = div.querySelector("script");
+  return script ? script.innerHTML.trim() : null;
+};
+
+export const getCss = (code: string) => {
+  const div = document.createElement("div");
+  div.innerHTML = getHeadHtml(code);
+  const style = div.querySelector("style");
+  return style ? style.innerHTML.trim() : null;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,13 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@canonical/cookie-policy@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.4.0.tgz#0d6708da340df5867fd2cc9dbd95538c46f20cf8"
@@ -585,6 +592,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
@@ -635,6 +647,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browserslist@^4.19.1:
   version "4.19.1"
@@ -1255,6 +1281,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 diff-sequences@^27.5.1:
   version "27.5.1"
@@ -2510,6 +2541,11 @@ jest-get-type@^27.5.1:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
   integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -2770,6 +2806,14 @@ marked@^0.3.5:
   resolved "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz"
   integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mathml-tag-names@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz"
@@ -2852,6 +2896,11 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.44.0:
   version "1.44.0"
@@ -2945,6 +2994,13 @@ mute-stream@0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
   integrity sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@3.2.0, nanoid@^3.1.30, nanoid@^3.2.0:
   version "3.2.0"
@@ -3050,6 +3106,11 @@ object.omit@~2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -3385,6 +3446,11 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
+prismjs@^1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.26.0.tgz#16881b594828bb6b45296083a8cbab46b0accd47"
+  integrity sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
@@ -3507,6 +3573,15 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-query@^3.34.15:
+  version "3.34.15"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.15.tgz#9e143b7d0aa39c515102a35120d5518ad91b10f6"
+  integrity sha512-dOhGLB5RT3p+wWj0rVdAompSg+R9t6oMRk+JhU8DP0tpJM2UyIv3r4Kk0zUkHSxT+QG34hFdrgdqxVWxgeNq4g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-table@7.7.0:
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
@@ -3609,6 +3684,16 @@ regenerator-runtime@^0.13.1:
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
+regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 request-promise-core@1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz"
@@ -3710,17 +3795,17 @@ reusify@^1.0.4:
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@3.0.2, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.6.1:
   version "2.6.3"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -4415,6 +4500,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Done

- Add component to display example code

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/4320

## QA

- Open [demo](https://vanilla-framework-4321.demos.haus/docs/patterns/notification)
- Verify that the code is updated when different options are selected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

