### PR TITLE
Add template for Code Snippet

### DIFF
--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -14,7 +14,6 @@ Vanilla gives you multiple ways to display code using the standard HTML elements
 
 <div class="react-live-demo-box" data-id="/docs/examples/patterns/code-snippet/codeSnippet"></div>
 
-
 ## Inline
 
 When you refer to code inline with other text, use the <code>&lt;code></code> tag.

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -10,6 +10,11 @@ context:
 
 Vanilla gives you multiple ways to display code using the standard HTML elements.
 
+## Live Demo Box
+
+<div class="react-live-demo-box" data-id="/docs/examples/patterns/code-snippet/codeSnippet"></div>
+
+
 ## Inline
 
 When you refer to code inline with other text, use the <code>&lt;code></code> tag.

--- a/templates/docs/examples/patterns/code-snippet/codeSnippet.html
+++ b/templates/docs/examples/patterns/code-snippet/codeSnippet.html
@@ -1,0 +1,76 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Code Snippet{% endblock %}
+
+{% block standalone_css %}patterns_code-snippet{% endblock %}
+
+{% set type = request.args.get('type', 'default') %}
+{% set style = request.args.get('style', 'none') %}
+{% set wrapping = request.args.get('wrapping', 'false') %}
+{% set border = request.args.get('border', 'false') %}
+
+{% set icons = ({
+  'none': '',
+  'linux-prompt': '--icon',
+  'windows-prompt': '--icon is-windows-prompt',
+  'url': '--icon is-url',
+  'numbered': '--numbered'
+}) %}
+
+{% set wrapping_class = ' is-wrapped' if wrapping == 'true' else '' %}
+{% set border_class = ' is-bordered' if border == 'true' else '' %}
+
+
+{% block content %}
+<div class="p-code-snippet{{ border_class}}">
+  <div class="p-code-snippet__header">
+    <h5 class="p-code-snippet__title">Installing Thunderbird as a snap</h5>
+
+    {%- if type == 'dropdown' or type == 'multiple-dropdowns' %}
+    <div class="p-code-snippet__dropdowns">
+      <select class="p-code-snippet__dropdown" name="menu1-select" id="menu1-select">
+        <option value="">amd64</option>
+        <option value="">i386</option>
+      </select>
+      {%- if type == 'multiple-dropdowns' %}
+
+      <select class="p-code-snippet__dropdown" name="menu2-select" id="menu2-select">
+        <option value="stable-panel">stable</option>
+        <option value="beta-panel">beta</option>
+        <option value="edge-panel">edge</option>
+      </select>
+      {%- endif %}
+    </div>
+    {%- endif %}
+  </div>
+
+  {%- if style == 'numbered' %}
+  <pre id="stable-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}">
+    <code><span class="p-code-snippet__line">sudo snap install thunderbird</span></code>
+  </pre>
+
+  <pre id="beta-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }} u-hide" aria-hidden="true">
+    <code><span class="p-code-snippet__line">sudo snap install thunderbird --beta</span></code>
+  </pre>
+
+  <pre id="edge-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }} u-hide" aria-hidden="true">
+    <code><span class="p-code-snippet__line">sudo snap install thunderbird --edge</span></code>
+  </pre>
+  {%- else %}
+  <pre id="stable-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}">
+    <code>sudo snap install thunderbird</code>
+  </pre>
+
+  <pre id="beta-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }} u-hide" aria-hidden="true">
+    <code>sudo snap install thunderbird --beta</code>
+  </pre>
+
+  <pre id="edge-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }} u-hide" aria-hidden="true">
+    <code>sudo snap install thunderbird --edge</code>
+  </pre>
+  {%- endif %}
+</div>
+
+<script>
+  {% include 'docs/examples/patterns/code-snippet/_script.js' %}
+</script>
+{% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/codeSnippet.html
+++ b/templates/docs/examples/patterns/code-snippet/codeSnippet.html
@@ -3,10 +3,18 @@
 
 {% block standalone_css %}patterns_code-snippet{% endblock %}
 
+{% import 'docs/examples/patterns/code-snippet/example.py' as python_example %}
+{% import 'docs/examples/patterns/code-snippet/example.yaml' as yaml_example %}
+{% import 'docs/examples/patterns/code-snippet/example.sh' as bash_example %}
+{% set python_code = python_example | string %}
+{% set yaml_code = yaml_example | string %}
+{% set bash_code = bash_example | string %}
+
 {% set type = request.args.get('type', 'default') %}
 {% set style = request.args.get('style', 'none') %}
 {% set wrapping = request.args.get('wrapping', 'false') %}
 {% set border = request.args.get('border', 'false') %}
+{% set highlight = request.args.get('syntax-highlight', 'false') %}
 
 {% set icons = ({
   'none': '',
@@ -23,14 +31,23 @@
 {% block content %}
 <div class="p-code-snippet{{ border_class}}">
   <div class="p-code-snippet__header">
-    <h5 class="p-code-snippet__title">Installing Thunderbird as a snap</h5>
+    <h5 class="p-code-snippet__title">Example title</h5>
 
     {%- if type == 'dropdown' or type == 'multiple-dropdowns' %}
     <div class="p-code-snippet__dropdowns">
+
+      {%- if style == 'numbered' %}
+      <select class="p-code-snippet__dropdown" name="menu1-select" id="menu1-select">
+        <option value="python-panel">Python</option>
+        <option value="yaml-panel">YAML</option>
+        <option value="bash-panel">Bash</option>
+      </select>
+      {%- else %}
       <select class="p-code-snippet__dropdown" name="menu1-select" id="menu1-select">
         <option value="">amd64</option>
         <option value="">i386</option>
       </select>
+      {%- endif %}
       {%- if type == 'multiple-dropdowns' %}
 
       <select class="p-code-snippet__dropdown" name="menu2-select" id="menu2-select">
@@ -44,33 +61,38 @@
   </div>
 
   {%- if style == 'numbered' %}
-  <pre id="stable-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}">
-    <code><span class="p-code-snippet__line">sudo snap install thunderbird</span></code>
-  </pre>
+  <pre id="python-panel" class="p-code-snippet__block--numbered{{ wrapping_class }}{% if highlight == 'true' %} language-python{% endif %}"><code>
+  {%- for line in python_code.split('\n') %}
+<span class="p-code-snippet__line">{{ line }}</span>
+  {%- endfor -%}
+  </code></pre>
 
-  <pre id="beta-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }} u-hide" aria-hidden="true">
-    <code><span class="p-code-snippet__line">sudo snap install thunderbird --beta</span></code>
-  </pre>
+  <pre id="yaml-panel" class="p-code-snippet__block--numbered{{ wrapping_class }}{% if highlight == 'true' %} language-yaml{% endif %} u-hide" aria-hidden="true"><code>
+  {%- for line in yaml_code.split('\n') %}
+<span class="p-code-snippet__line">{{ line }}</span>
+  {%- endfor -%}
+  </code></pre>
 
-  <pre id="edge-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }} u-hide" aria-hidden="true">
-    <code><span class="p-code-snippet__line">sudo snap install thunderbird --edge</span></code>
-  </pre>
+  <pre id="bash-panel" class="p-code-snippet__block--numbered{{ wrapping_class }}{% if highlight == 'true' %} language-bash{% endif %} u-hide" aria-hidden="true"><code>
+  {%- for line in bash_code.split('\n') %}
+<span class="p-code-snippet__line">{{ line }}</span>
+  {%- endfor -%}
+  </code></pre>
   {%- else %}
-  <pre id="stable-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}">
-    <code>sudo snap install thunderbird</code>
-  </pre>
-
-  <pre id="beta-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }} u-hide" aria-hidden="true">
-    <code>sudo snap install thunderbird --beta</code>
-  </pre>
-
-  <pre id="edge-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }} u-hide" aria-hidden="true">
-    <code>sudo snap install thunderbird --edge</code>
-  </pre>
+  <pre id="stable-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-sh{% endif %}"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird' }}</code></pre>
+  <pre id="beta-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-sh{% endif %} u-hide" aria-hidden="true"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird --beta'}}</code></pre>
+  <pre id="edge-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-sh{% endif %} u-hide" aria-hidden="true"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird --edge'}}</code></pre>
   {%- endif %}
 </div>
 
+{%- if type == 'dropdown' or type == 'multiple-dropdowns' %}
 <script>
   {% include 'docs/examples/patterns/code-snippet/_script.js' %}
 </script>
+{%- endif %}
+{%- if highlight == 'true' %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-core.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/keep-markup/prism-keep-markup.min.js"></script>
+{%- endif %}
 {% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/codeSnippet.json
+++ b/templates/docs/examples/patterns/code-snippet/codeSnippet.json
@@ -19,6 +19,7 @@
   },
   "switch": [
     {"key": "wrapping", "label": "with wrapping"},
-    {"key": "border", "label": "with border"}
+    {"key": "border", "label": "with border"},
+    {"key": "syntax-highlight", "label": "Syntax highlighting"}
   ]
 }

--- a/templates/docs/examples/patterns/code-snippet/codeSnippet.json
+++ b/templates/docs/examples/patterns/code-snippet/codeSnippet.json
@@ -5,10 +5,7 @@
       {"key": "dropdown", "label": "Dropdown"},
       {"key": "multiple-dropdowns", "label": "Multiple dropdowns"}
     ],
-    "theme": [
-      {"key": "light", "label": "Light", "default": true},
-      {"key": "dark", "label": "Dark"}
-    ],
+    "theme": [{"key": "light", "label": "Light", "default": true}],
     "style": [
       {"key": "none", "label": "None", "default": true},
       {"key": "linux-prompt", "label": "Linux prompt"},

--- a/templates/docs/examples/patterns/code-snippet/codeSnippet.json
+++ b/templates/docs/examples/patterns/code-snippet/codeSnippet.json
@@ -3,7 +3,7 @@
     "type": [
       {"key": "default", "label": "Default", "default": true},
       {"key": "dropdown", "label": "Dropdown"},
-      {"key": "mutiple-dropdowns", "label": "Mutliple dropdowns"}
+      {"key": "multiple-dropdowns", "label": "Multiple dropdowns"}
     ],
     "theme": [
       {"key": "light", "label": "Light", "default": true},

--- a/templates/docs/examples/patterns/code-snippet/codeSnippet.json
+++ b/templates/docs/examples/patterns/code-snippet/codeSnippet.json
@@ -1,0 +1,24 @@
+{
+  "dropdown": {
+    "type": [
+      {"key": "default", "label": "Default", "default": true},
+      {"key": "dropdown", "label": "Dropdown"},
+      {"key": "mutiple-dropdowns", "label": "Mutliple dropdowns"}
+    ],
+    "theme": [
+      {"key": "light", "label": "Light", "default": true},
+      {"key": "dark", "label": "Dark"}
+    ],
+    "style": [
+      {"key": "none", "label": "None", "default": true},
+      {"key": "linux-prompt", "label": "Linux prompt"},
+      {"key": "windows-prompt", "label": "Windows prompt"},
+      {"key": "url", "label": "URL"},
+      {"key": "numbered", "label": "Numbered"}
+    ]
+  },
+  "switch": [
+    {"key": "wrapping", "label": "with wrapping"},
+    {"key": "border", "label": "with border"}
+  ]
+}

--- a/templates/docs/examples/patterns/code-snippet/example.py
+++ b/templates/docs/examples/patterns/code-snippet/example.py
@@ -1,0 +1,19 @@
+class DiscourseAPI:
+  """
+  Retrieve information from a Discourse installation
+  through its API
+  """
+
+  def __init__(self, base_url, session, api_key=None, api_username=None):
+      """
+      @param base_url: The Discourse URL (e.g. https://discourse.example.com)
+      """
+
+      self.base_url = base_url.rstrip("/")
+      self.session = session
+
+      if api_key and api_username:
+          self.session.headers = {
+              "Api-Key": api_key,
+              "Api-Username": api_username,
+          }

--- a/templates/docs/examples/patterns/code-snippet/example.sh
+++ b/templates/docs/examples/patterns/code-snippet/example.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu
+. $CONJURE_UP_SPELLSDIR/sdk/common.sh
+
+if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then
+    debug "Running pre-deploy for $CONJURE_UP_SPELL"
+    sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" || exposeResult "Failed to set profile" $? "false"
+fi
+
+exposeResult "Successful pre-deploy." 0 "true"

--- a/templates/docs/examples/patterns/code-snippet/example.yaml
+++ b/templates/docs/examples/patterns/code-snippet/example.yaml
@@ -1,0 +1,16 @@
+name: super-cool-app
+version: "1.0"
+summary: Super Cool App
+description: |
+    Super Cool App that does everything! […]
+confinement: strict
+base: core18
+parts:
+  super-cool-app:
+    plugin: flutter
+    source: https://github.com/kenvandine/super-cool-app.git
+    flutter-target: lib/main.dart
+apps:
+  super-cool-app:
+    command: super_cool_app
+    extensions: [flutter-dev]

--- a/templates/docs/examples/patterns/notifications/toast.json
+++ b/templates/docs/examples/patterns/notifications/toast.json
@@ -6,10 +6,7 @@
       {"key": "negative", "label": "Negative"},
       {"key": "positive", "label": "Positive"}
     ],
-    "theme": [
-      {"key": "light", "label": "Light", "default": true},
-      {"key": "dark", "label": "Dark"}
-    ],
+    "theme": [{"key": "light", "label": "Light", "default": true}],
     "style": [
       {"key": "block", "label": "Block", "default": true},
       {"key": "inline", "label": "Inline"}

--- a/templates/docs/patterns/notification.md
+++ b/templates/docs/patterns/notification.md
@@ -12,7 +12,7 @@ Notifications are used to attract the user's attention. They offer four separate
 
 ## Live Demo Box
 
-<div id="react-live-demo-box"></div>
+<div class="react-live-demo-box" data-id="/docs/examples/patterns/notifications/toast"></div>
 
 ## Severity levels
 

--- a/templates/static/js/src/demobox/app.tsx
+++ b/templates/static/js/src/demobox/app.tsx
@@ -6,4 +6,4 @@ const App = () => {
   return <LiveDemoBox />;
 };
 
-ReactDOM.render(<App />, document.getElementById("react-live-demo-box"));
+ReactDOM.render(<App />, document.querySelector(".react-live-demo-box"));

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -23,6 +23,8 @@ type SelectValueType = {
 };
 
 const LiveDemoBox = () => {
+  const element = document.querySelector(".react-live-demo-box") 
+  const jsonUrl = element?.getAttribute("data-id")
   const [configValues, setConfigValues] = useState<InitialState>();
   const [selectValue, setSelectValues] = useState<SelectValueType>({
     type: "",
@@ -34,7 +36,7 @@ const LiveDemoBox = () => {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          "/docs/examples/patterns/notifications/toast.json"
+          `${jsonUrl}.json`
         );
         const json = await response.json();
         setConfigValues({ dropdown: json.dropdown, switch: json.switch });
@@ -83,8 +85,8 @@ const LiveDemoBox = () => {
     }
   };
 
-  const url = `/docs/examples/patterns/notifications/toast?type=${selectValue.type}&style=${selectValue.style}&actions=${selectValue.actions}&dismiss=${selectValue.dismiss}&timestamp=${selectValue.timestamp}`;
-
+  const url = `${jsonUrl}?type=${selectValue.type}&style=${selectValue.style}&actions=${selectValue.actions}&dismiss=${selectValue.dismiss}&timestamp=${selectValue.timestamp}`;
+  console.log(url)
   return (
     <section className="p-strip--light">
       {configValues && configValues.dropdown && configValues.switch && (

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -84,7 +84,7 @@ const LiveDemoBox = () => {
   const dropdownOptions = configValues && Object.keys(configValues.dropdown);
 
   return (
-    <section className="p-strip--light">
+    <section className="p-strip--light is-shallow">
       {configValues && configValues.dropdown && configValues.switch && (
         <form>
           <div className="row" style={{ gridGap: 0 }}>
@@ -110,11 +110,10 @@ const LiveDemoBox = () => {
             })}
           </div>
           <div className="row" style={{ gridGap: 0 }}>
-            <div className="p-card col-6">
-              <h3>Example</h3>
+            <div className="p-card col-6 u-no-padding">
               <div className="p-card__content">
                 <div>
-                  <iframe src={url} width="100%"></iframe>
+                  <iframe src={url} width="100%" height={300}></iframe>
                 </div>
               </div>
             </div>

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -7,15 +7,13 @@ export type InputOptions = {
   label: string;
 };
 
-type DropDown = {
-  type: [InputOptions];
-  theme: [InputOptions];
-  style: [InputOptions];
+type DropDownType = {
+  [key: string]: InputOptions[];
 };
 
 type InitialState = {
-  dropdown: DropDown;
-  switch: [InputOptions];
+  dropdown: DropDownType;
+  switch: InputOptions[];
 };
 
 type SelectValueType = {
@@ -26,11 +24,7 @@ const LiveDemoBox = () => {
   const element = document.querySelector(".react-live-demo-box");
   const jsonUrl = element?.getAttribute("data-id");
   const [configValues, setConfigValues] = useState<InitialState>();
-  const [selectValue, setSelectValues] = useState<SelectValueType>({
-    type: "",
-    theme: "",
-    style: "",
-  });
+  const [selectValue, setSelectValues] = useState<SelectValueType>({});
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -38,34 +32,30 @@ const LiveDemoBox = () => {
         const json = await response.json();
         setConfigValues({ dropdown: json.dropdown, switch: json.switch });
 
+        const object = {};
+
         const setDefaultDropdownValues = (dropdownOption: any) => {
-          json.dropdown[dropdownOption].map((dropdownValue: any) => {
-            return (
-              "default" in dropdownValue &&
-              setSelectValues({
-                ...selectValue,
-                [dropdownValue]: dropdownValue.key,
-              })
-            );
+          json.dropdown[dropdownOption].forEach((dropdownValue: any) => {
+            "default" in dropdownValue &&
+              (object[dropdownOption] = dropdownValue.key);
           });
         };
+
         Object.keys(json.dropdown).forEach((key) =>
           setDefaultDropdownValues(key)
         );
 
-        const setDefaultSwitchValues = () => {
-          json.switch.map((switchOption: any) => {
-            setSelectValues({ ...selectValue, [switchOption.query]: false });
-          });
-        };
-        setDefaultSwitchValues();
+        json.switch.forEach((switchOption: any) => {
+          object[switchOption.key] = false;
+        });
+
+        setSelectValues(object);
       } catch (error) {
         console.log("error", error);
       }
     };
     fetchData();
   }, []);
-
   const handleChange = (
     e: React.ChangeEvent<HTMLSelectElement | HTMLInputElement>
   ) => {
@@ -81,7 +71,6 @@ const LiveDemoBox = () => {
       });
     }
   };
-
   const constructUrl = () => {
     let url = `${jsonUrl}?`;
     const arrayOfKeys = Object.keys(selectValue);
@@ -90,8 +79,10 @@ const LiveDemoBox = () => {
     });
     return url;
   };
-  const url = constructUrl();
+
+  let url = constructUrl();
   const dropdownOptions = configValues && Object.keys(configValues.dropdown);
+
   return (
     <section className="p-strip--light">
       {configValues && configValues.dropdown && configValues.switch && (

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -98,7 +98,9 @@ const LiveDemoBox = () => {
         <form>
           <div className="row" style={{ gridGap: 0 }}>
             {dropdownOptions?.map((dropdownOption) => {
-              const optionValue = configValues?.dropdown[dropdownOption];
+              const optionValue = configValues?.dropdown[dropdownOption].map(
+                (item) => ({ ...item, value: item.key })
+              );
               return (
                 <div className="col-2" key={dropdownOption}>
                   <Select

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -23,8 +23,8 @@ type SelectValueType = {
 };
 
 const LiveDemoBox = () => {
-  const element = document.querySelector(".react-live-demo-box") 
-  const jsonUrl = element?.getAttribute("data-id")
+  const element = document.querySelector(".react-live-demo-box");
+  const jsonUrl = element?.getAttribute("data-id");
   const [configValues, setConfigValues] = useState<InitialState>();
   const [selectValue, setSelectValues] = useState<SelectValueType>({
     type: "",
@@ -35,9 +35,7 @@ const LiveDemoBox = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await fetch(
-          `${jsonUrl}.json`
-        );
+        const response = await fetch(`${jsonUrl}.json`);
         const json = await response.json();
         setConfigValues({ dropdown: json.dropdown, switch: json.switch });
 
@@ -85,8 +83,18 @@ const LiveDemoBox = () => {
     }
   };
 
-  const url = `${jsonUrl}?type=${selectValue.type}&style=${selectValue.style}&actions=${selectValue.actions}&dismiss=${selectValue.dismiss}&timestamp=${selectValue.timestamp}`;
-  console.log(url)
+  const constructUrl = () => {
+    let url = `${jsonUrl}?`;
+
+    const arrayOfKeys = Object.keys(selectValue);
+
+    arrayOfKeys.forEach((key) => {
+      url += `${key}=${selectValue[key]}&`;
+    });
+    return url;
+  };
+  const url = constructUrl();
+
   return (
     <section className="p-strip--light">
       {configValues && configValues.dropdown && configValues.switch && (

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -31,7 +31,6 @@ const LiveDemoBox = () => {
     theme: "",
     style: "",
   });
-
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -50,13 +49,13 @@ const LiveDemoBox = () => {
             );
           });
         };
-        setDefaultDropdownValues("type");
-        setDefaultDropdownValues("theme");
-        setDefaultDropdownValues("style");
+        Object.keys(json.dropdown).forEach((key) =>
+          setDefaultDropdownValues(key)
+        );
 
         const setDefaultSwitchValues = () => {
           json.switch.map((switchOption: any) => {
-            setSelectValues({ ...selectValue, [switchOption.key]: false });
+            setSelectValues({ ...selectValue, [switchOption.query]: false });
           });
         };
         setDefaultSwitchValues();
@@ -85,49 +84,36 @@ const LiveDemoBox = () => {
 
   const constructUrl = () => {
     let url = `${jsonUrl}?`;
-
     const arrayOfKeys = Object.keys(selectValue);
-
     arrayOfKeys.forEach((key) => {
       url += `${key}=${selectValue[key]}&`;
     });
     return url;
   };
   const url = constructUrl();
-
+  const dropdownOptions = configValues && Object.keys(configValues.dropdown);
   return (
     <section className="p-strip--light">
       {configValues && configValues.dropdown && configValues.switch && (
         <form>
           <div className="row" style={{ gridGap: 0 }}>
-            <div className="col-2">
-              <Select
-                id="type"
-                label="Type"
-                name="type"
-                onChange={handleChange}
-                options={configValues.dropdown.type}
-              />
-            </div>
-            <div className="col-2">
-              <Select
-                id="theme"
-                label="Theme"
-                name="theme"
-                onChange={handleChange}
-                options={configValues.dropdown.theme}
-                disabled
-              />
-            </div>
-            <div className="col-2">
-              <Select
-                id="style"
-                label="Style"
-                name="style"
-                onChange={handleChange}
-                options={configValues.dropdown.style}
-              />
-            </div>
+            {dropdownOptions?.map((dropdownOption) => {
+              const optionValue = configValues?.dropdown[dropdownOption];
+              return (
+                <div className="col-2" key={dropdownOption}>
+                  <Select
+                    id={dropdownOption}
+                    label={
+                      dropdownOption[0].toUpperCase() +
+                      dropdownOption.substring(1)
+                    }
+                    name={dropdownOption}
+                    onChange={handleChange}
+                    options={optionValue}
+                  />
+                </div>
+              );
+            })}
           </div>
           <div className="row" style={{ gridGap: 0 }}>
             <div className="p-card col-6">

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -17,7 +17,7 @@ type InitialState = {
 };
 
 type SelectValueType = {
-  [key: string]: string | boolean;
+  [key: string]: string | boolean | InputOptions[];
 };
 
 const LiveDemoBox = () => {
@@ -32,7 +32,7 @@ const LiveDemoBox = () => {
         const json = await response.json();
         setConfigValues({ dropdown: json.dropdown, switch: json.switch });
 
-        const object = {};
+        const object: SelectValueType = {};
 
         const setDefaultDropdownValues = (dropdownOption: any) => {
           json.dropdown[dropdownOption].forEach((dropdownValue: any) => {
@@ -89,7 +89,7 @@ const LiveDemoBox = () => {
         <form>
           <div className="row" style={{ gridGap: 0 }}>
             {dropdownOptions?.map((dropdownOption) => {
-              const optionValue = configValues?.dropdown[dropdownOption].map(
+              const optionValues = configValues?.dropdown[dropdownOption].map(
                 (item) => ({ ...item, value: item.key })
               );
               return (
@@ -102,7 +102,8 @@ const LiveDemoBox = () => {
                     }
                     name={dropdownOption}
                     onChange={handleChange}
-                    options={optionValue}
+                    options={optionValues}
+                    disabled={optionValues.length === 1}
                   />
                 </div>
               );

--- a/templates/static/js/src/demobox/components/LiveDemoBox/Switch.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/Switch.tsx
@@ -6,7 +6,7 @@ export type SwitchInfo = {
 };
 
 type SwitchProps = {
-  switchOptions?: [SwitchInfo];
+  switchOptions?: SwitchInfo[];
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 


### PR DESCRIPTION
## Done

- Added HTML template for Code Snippet
- Fix bug where select options were missing the `value` attribute

## QA

- Open [demo](https://vanilla-framework-4334.demos.haus/docs/base/code)
- Verify that the code snippet renders

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![demo-box-code-snippet](https://user-images.githubusercontent.com/995051/155355748-fbfdf437-c9de-4a12-8a48-a747805499c1.gif)
