### PR TITLE
Add fullscreen button for demo box

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -2,6 +2,7 @@
 
 {% block custom_head %}
   <link rel="stylesheet" href="{{ versioned_static('build/css/docs/site.css') }}" />
+  <link rel="stylesheet" href="{{ versioned_static('build/css/standalone/patterns_icons-additional.css') }}" />
 {% endblock %}
 
 {% block body %}

--- a/templates/docs/examples/patterns/code-snippet/codeSnippet.html
+++ b/templates/docs/examples/patterns/code-snippet/codeSnippet.html
@@ -81,9 +81,9 @@
   </code></pre>
   {%- endif %}
   {%- else %}
-  <pre id="stable-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-sh{% endif %}"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird' }}</code></pre>
-  <pre id="beta-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-sh{% endif %} u-hide" aria-hidden="true"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird --beta'}}</code></pre>
-  <pre id="edge-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-sh{% endif %} u-hide" aria-hidden="true"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird --edge'}}</code></pre>
+  <pre id="stable-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-bash{% endif %}"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird' }}</code></pre>
+  <pre id="beta-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-bash{% endif %} u-hide" aria-hidden="true"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird --beta'}}</code></pre>
+  <pre id="edge-panel" class="p-code-snippet__block{{ icons[style] }}{{ wrapping_class }}{% if highlight == 'true' %} language-bash{% endif %} u-hide" aria-hidden="true"><code>{{ 'https://ubuntu.com' if style == 'url' else 'sudo snap install thunderbird --edge'}}</code></pre>
   {%- endif %}
 </div>
 

--- a/templates/static/js/src/demobox/components/LiveDemoBox/Code.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/Code.tsx
@@ -50,8 +50,7 @@ const Code = ({ path }: Props) => {
     <>
       <div className="p-code-snippet u-no-margin--bottom">
         <div className="p-code-snippet__header">
-          <h5 className="p-code-snippet__title">Notifications</h5>
-          {isSuccess && (
+          {isSuccess && (js || css) && (
             <div className="p-code-snippet__dropdowns">
               <Select
                 className="p-code-snippet__dropdown"

--- a/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
+++ b/templates/static/js/src/demobox/components/LiveDemoBox/LiveDemoBox.tsx
@@ -93,7 +93,7 @@ const LiveDemoBox = () => {
   return (
     <section className="p-strip is-shallow">
       {configValues && configValues.dropdown && configValues.switch && (
-        <form>
+        <>
           <div className="row" style={{ gridGap: 0 }}>
             {dropdownOptions?.map((dropdownOption) => {
               const optionValues = configValues?.dropdown[dropdownOption].map(
@@ -102,6 +102,7 @@ const LiveDemoBox = () => {
               return (
                 <div className="col-2" key={dropdownOption}>
                   <Select
+                    className="u-no-margin--bottom"
                     id={dropdownOption}
                     label={
                       dropdownOption[0].toUpperCase() +
@@ -123,20 +124,33 @@ const LiveDemoBox = () => {
                   <iframe src={url} width="100%" height={300}></iframe>
                 </div>
               </div>
-              <div className="p-card__inner u-align--right">
-                {isSuccess && (
-                  <CodepenPrefill
-                    label="Edit on CodePen"
-                    className="p-button--link"
-                    target="_blank"
-                    title={`Vanilla framework ${patternName} example`}
-                    css_external="https://assets.ubuntu.com/v1/vanilla-framework-version-3.1.0.min.css;https://assets.ubuntu.com/v1/4653d9ba-example.css"
-                    html={html}
-                    css={css}
-                    js={js}
-                    editors="111"
-                  />
-                )}
+              <div className="p-card__inner u-align--right u-no-padding--top u-no-padding--bottom">
+                <ul className="p-inline-list u-no-margin--bottom">
+                  <li className="p-inline-list__item">
+                    {isSuccess && (
+                      <CodepenPrefill
+                        label="Edit on CodePen"
+                        className="p-button--link"
+                        target="_blank"
+                        title={`Vanilla framework ${patternName} example`}
+                        css_external="https://assets.ubuntu.com/v1/vanilla-framework-version-3.1.0.min.css;https://assets.ubuntu.com/v1/4653d9ba-example.css"
+                        html={html}
+                        css={css}
+                        js={js}
+                        editors="111"
+                      />
+                    )}
+                  </li>
+                  <li className="p-inline-list__item">
+                    <a
+                      className="p-icon--fullscreen"
+                      href={url}
+                      target="_blank"
+                    >
+                      Fullscreen
+                    </a>
+                  </li>
+                </ul>
               </div>
             </div>
             <div className="col-2 p-card u-no-margin--bottom">
@@ -151,7 +165,7 @@ const LiveDemoBox = () => {
               <Code path={url} />
             </div>
           </div>
-        </form>
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
## Done

- Added a button that, when clicked, opens the rendered example in a new tab
- Update some styling

## QA

- Open [demo](https://vanilla-framework-4340.demos.haus/docs/base/code)
- Click the button below the rendered example and verify that it opens in a new tab

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![demo-box](https://user-images.githubusercontent.com/995051/155572655-2eedcb44-39a3-4e92-a832-e892c7572dcc.png)
