### PR TITLE
Fix visited links in dark side navigation

### DIFF
--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -431,11 +431,11 @@
     border-color: $color-sidenav-list-border;
   }
 
-  %theme-side-navigation__list {
+  .p-side-navigation__list::after {
     background: $color-sidenav-list-border;
   }
 
-  %theme-side-navigation__link {
+  .p-side-navigation__link {
     &,
     &:visited {
       color: $color-sidenav-text-default;
@@ -460,14 +460,6 @@
     &[aria-current='true'] {
       @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
     }
-  }
-
-  .p-side-navigation__list::after {
-    @extend %theme-side-navigation__list;
-  }
-
-  .p-side-navigation__link {
-    @extend %theme-side-navigation__link;
   }
 
   .p-side-navigation__item--title,


### PR DESCRIPTION
## Done

Fixes color of visited links in dark themed side-nav

Fixes #4341 

## QA

- Open [demo](https://vanilla-framework-4342.demos.haus/docs/examples/patterns/side-navigation/dark)
- Click some links in dark theme side nav and make sure visited links don't change color
  - https://vanilla-framework-4342.demos.haus/docs/examples/patterns/side-navigation/dark

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.



