### PR TITLE
Added a node.js script that creates a yaml file contains class reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "watch": "yarn build && yarn watch:scss",
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js",
-    "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
+    "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons",
+    "create-class-references": "node scripts/create-class-references.js"
   },
   "version": "3.1.1",
   "files": [
@@ -55,9 +56,10 @@
     "@canonical/cookie-policy": "3.4.0",
     "@canonical/latest-news": "1.3.0",
     "autoprefixer": "10.4.2",
-    "postcss": "8.4.6",
     "postcss-cli": "9.1.0",
-    "sass": "1.49.7"
+    "postcss-scss": "4.0.3",
+    "sass": "1.49.7",
+    "yaml": "1.10.2"
   },
   "devDependencies": {
     "@percy/script": "1.1.0",

--- a/scripts/create-class-references.js
+++ b/scripts/create-class-references.js
@@ -1,0 +1,51 @@
+const scssFolder = './scss';
+const fs = require('fs');
+const postcssScss = require('postcss-scss');
+const yaml = require('yaml');
+
+const patternFiles = [];
+fs.readdirSync(scssFolder).forEach((file) => {
+  const isPattern = file.match(/_patterns.*/, 'i');
+  if (isPattern) patternFiles.push(file);
+});
+
+// find the first comment
+function findComment(element) {
+  if (element.type === 'comment' && element.text.match(/class-reference.*/, 'i')) return element;
+
+  if (!element || !element.nodes) return;
+
+  for (let node of element.nodes) {
+    const foundElement = findComment(node);
+
+    if (foundElement) return foundElement;
+  }
+}
+
+let classReferences = [];
+
+patternFiles.forEach((fileName) => {
+  try {
+    const data = fs.readFileSync(`${scssFolder}/${fileName}`, 'utf8');
+    const root = postcssScss.parse(data);
+    const comment = findComment(root);
+
+    if (!comment) throw new Error(`class-reference does not exist in ${fileName}`);
+
+    const doc = yaml.parse(comment.text);
+    classReferences.push(doc['class-reference']);
+  } catch (error) {
+    const errorMessage = error.message;
+    console.error(errorMessage);
+  }
+});
+
+if (classReferences.length > 0) {
+  const parsedYaml = yaml.stringify({
+    'class-references': classReferences,
+  });
+  fs.writeFile('classreferences.yaml', parsedYaml, function (err) {
+    if (err) throw err;
+    console.log('Saved!');
+  });
+}

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -1,5 +1,21 @@
 @import 'settings';
 
+/*
+  class-reference:
+    component: "Accordion" 
+    references:
+      - reference-name: "Root element"
+        class-list:
+          - class-name: ".p-notification"
+            description: "Notification in default variant. Same as .p-notification--information"
+          - class-name: ".p-notification--information"
+            description: "Information notification. Same as default .p-notification."
+      - reference-name: "Content container"
+        class-list:
+          - class-name: ".p-notification__content"
+            description: "Container element for notification content (title and message)."
+*/
+
 @mixin vf-p-accordion {
   $icon-size: map-get($icon-sizes, default);
 

--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -1,5 +1,15 @@
 @import 'settings';
 
+/*
+  class-reference:
+    component: "Article Pagination" 
+    references:
+      - reference-name: "Root element"
+        class-list:
+          - class-name: ".p-article-pagination"
+            description: "Notification in default variant. Same as .p-notification--information"
+*/
+
 @mixin vf-p-article-pagination {
   %chevron-icon {
     color: $color-mid-dark;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,6 +2977,11 @@ postcss-safe-parser@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
+postcss-scss@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.3.tgz#36c23c19a804274e722e83a54d20b838ab4767ac"
+  integrity sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==
+
 postcss-scss@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.2.tgz#39ddcc0ab32f155d5ab328ee91353d67a52d537b"
@@ -3013,15 +3018,6 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.6, postcss@^8.4.5:
-  version "8.4.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.6.tgz#c5ff3c3c457a23864f32cb45ac9b741498a09ae1"
-  integrity sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==
-  dependencies:
-    nanoid "^3.2.0"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 postcss@^8.3.11:
   version "8.3.11"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
@@ -3030,6 +3026,15 @@ postcss@^8.3.11:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
+
+postcss@^8.4.5:
+  version "8.4.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.6.tgz#c5ff3c3c457a23864f32cb45ac9b741498a09ae1"
+  integrity sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==
+  dependencies:
+    nanoid "^3.2.0"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prepend-http@^2.0.0:
   version "2.0.0"
@@ -4151,7 +4156,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.0:
+yaml@1.10.2, yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
## Done

- Added a node.js script that creates a yaml file contains class reference

## QA

- Run `yarn create-class-references`
- Verify "classreferences.yaml" is created with correct values

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.

