### PR TITLE
Add accessibility docs for strip

### DIFF
--- a/templates/docs/patterns/strip.md
+++ b/templates/docs/patterns/strip.md
@@ -98,6 +98,30 @@ The colours of the solid gradient are based on `$color-brand` by default. The gr
 View example of the topped Suru strip pattern
 </a></div>
 
+## Accessibility
+
+### How it works
+
+A Strip is a full-width content container. They provide visual interest and break up long scrolling pages into sections.
+
+### Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- The starting point of your page should be a well structured and accessible source document. Ensure the document remains in a logical order for screen readers, irrespective of how the content looks visually
+- The headings in the Strips should follow the heading hierarchy of the page.
+- Make sure the tab order makes sense, and that all appropriate elements are focusable.
+- There should be a logical order within the Strip, heading first and related content to follow.
+- Headings should briefly and accurately describe the content of the Strip
+- Link text must be meaningful and clear.
+- Avoid wrapping the entire container in a link, as the entire content of the container will be read out as a link to by the screen reader.
+- Image strips should ensure image accessibility is maintained with appropriate descriptive text for relevant images
+- If the image is the link, then the alt text of the image should replace the link text Alternatively, add aria-label to the link element wrapping the image
+
+### Resources
+
+[W3C Non-text content](https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv-all.html)
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

Added the[ accessibility doc](https://docs.google.com/document/d/1cEkDcilw5irLRLEqkJcozx_-WORdm3Ihu4dPtg8mO2o/edit#) to the website for Strips

Fixes #4316 

## QA

- Open [demo](https://vanilla-framework-4358.demos.haus/docs/patterns/strip) of Strip doc
- Check the formatting of the accessibility doc. The text has already been reviewed by UX and Dev

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
