### PR TITLE
Close contextual menu when focus leaves

### DIFF
--- a/templates/docs/examples/patterns/contextual-menu/_script.js
+++ b/templates/docs/examples/patterns/contextual-menu/_script.js
@@ -24,47 +24,42 @@ function toggleMenu(element, show, top) {
 
 /**
   Attaches event listeners for the menu toggle open and close click events.
-  @param {HTMLElement} menuToggle The menu container element.
+  @param {HTMLElement} menu The menu container element.
 */
-function setupContextualMenu(menuToggle) {
-  menuToggle.addEventListener('click', function (event) {
-    event.preventDefault();
-    var menuAlreadyOpen = menuToggle.getAttribute('aria-expanded') === 'true';
 
-    var top = menuToggle.offsetHeight;
+function setupContextualMenu(menu) {
+  const toggle = menu.querySelector('.p-contextual-menu__toggle');
+  const dropdown = menu.querySelector('.p-contextual-menu__dropdown');
+
+  toggle.addEventListener('click', function (event) {
+    event.preventDefault();
+    var menuAlreadyOpen = toggle.getAttribute('aria-expanded') === 'true';
+
+    var top = toggle.offsetHeight;
     // for inline elements leave some space between text and menu
-    if (window.getComputedStyle(menuToggle).display === 'inline') {
+    if (window.getComputedStyle(toggle).display === 'inline') {
       top += 5;
     }
 
-    toggleMenu(menuToggle, !menuAlreadyOpen, top);
+    toggleMenu(toggle, !menuAlreadyOpen, top);
   });
-}
-
-/**
-  Attaches event listeners for all the menu toggles in the document and
-  listeners to handle close when clicking outside the menu or using ESC key.
-  @param {String} contextualMenuToggleSelector The CSS selector matching menu toggle elements.
-*/
-function setupAllContextualMenus(contextualMenuToggleSelector) {
-  // Setup all menu toggles on the page.
-  var toggles = document.querySelectorAll(contextualMenuToggleSelector);
-
-  for (var i = 0, l = toggles.length; i < l; i++) {
-    setupContextualMenu(toggles[i]);
-  }
 
   // Add handler for clicking outside the menu.
   document.addEventListener('click', function (event) {
-    for (var i = 0, l = toggles.length; i < l; i++) {
-      var toggle = toggles[i];
-      var contextualMenu = document.getElementById(toggle.getAttribute('aria-controls'));
-      var clickOutside = !(toggle.contains(event.target) || contextualMenu.contains(event.target));
+    var contextualMenu = document.getElementById(toggle.getAttribute('aria-controls'));
+    var clickOutside = !(toggle.contains(event.target) || contextualMenu.contains(event.target));
 
-      if (clickOutside) {
-        toggleMenu(toggle, false);
-      }
+    if (clickOutside) {
+      toggleMenu(toggle, false);
     }
+  });
+
+  //Add event listener to close menu when tab focus leaves
+  dropdown.addEventListener('focusout', function (e) {
+    // Check if where you have tabbed to is in the dropdown
+    if (dropdown.contains(e.relatedTarget)) return;
+
+    toggleMenu(toggle, false);
   });
 
   // Add handler for closing menus using ESC key.
@@ -72,11 +67,23 @@ function setupAllContextualMenus(contextualMenuToggleSelector) {
     e = e || window.event;
 
     if (e.keyCode === 27) {
-      for (var i = 0, l = toggles.length; i < l; i++) {
-        toggleMenu(toggles[i], false);
-      }
+      toggleMenu(toggle, false);
     }
   });
 }
 
-setupAllContextualMenus('.p-contextual-menu__toggle');
+/**
+  @param {String} contextualMenuSelector The CSS selector matching menu toggle elements.
+*/
+function setupAllContextualMenus(contextualMenuSelector) {
+  // Setup all contextual menus on the page.
+  var menus = document.querySelectorAll(contextualMenuSelector);
+
+  for (var i = 0, l = menus.length; i < l; i++) {
+    setupContextualMenu(menus[i]);
+  }
+}
+
+setupAllContextualMenus('.p-contextual-menu');
+setupAllContextualMenus('.p-contextual-menu--left');
+setupAllContextualMenus('.p-contextual-menu--center');

--- a/templates/docs/examples/patterns/contextual-menu/_script.js
+++ b/templates/docs/examples/patterns/contextual-menu/_script.js
@@ -84,6 +84,4 @@ function setupAllContextualMenus(contextualMenuSelector) {
   }
 }
 
-setupAllContextualMenus('.p-contextual-menu');
-setupAllContextualMenus('.p-contextual-menu--left');
-setupAllContextualMenus('.p-contextual-menu--center');
+setupAllContextualMenus('.p-contextual-menu, [class*="p-contextual-menu--"]');


### PR DESCRIPTION
## Done

- Close contextual menu when the focus leaves

Fixes #4284 

## QA

- Open [demo](https://vanilla-framework-4359.demos.haus/docs/patterns/contextual-menu)
- Open the "Take action" contextual menu
- Tab through the dropdown, check when the focus leaves the menu it closes
- Compare this to [live](https://vanillaframework.io/docs/patterns/contextual-menu). See how the menu remains open after the focus leaves.


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
