### PR TITLE
Update aria-labels on landmarks

### DIFF
--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -2,7 +2,7 @@
   <div class="row p-content__row">
     <div class="col-12">
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-      <nav aria-label="Footer navigation">
+      <nav aria-label="Footer">
         <ul class="p-inline-list--middot u-no-margin--bottom">
           <li class="p-inline-list__item">
             <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -11,7 +11,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Main navigation">
+    <nav class="p-navigation__nav" aria-label="Main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item {% if path.startswith('/docs') and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
         <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -12,7 +12,7 @@
     <div class="p-strip">
     <div class="row">
       <aside class="col-3">
-        <nav class="p-side-navigation" id="side-navigation-drawer">
+        <nav class="p-side-navigation" id="side-navigation-drawer" aria-label="Side">
           <a href="#side-navigation-drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation-drawer">
             Toggle side navigation
           </a>

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -24,7 +24,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Main navigation">
+    <nav class="p-navigation__nav" aria-label="Main">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
@@ -260,7 +260,7 @@
 </div>
 
 <footer class="p-strip--light">
-  <nav class="row" aria-label="Footer navigation">
+  <nav class="row" aria-label="Footer">
     <div class="has-cookie">
       <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
       <ul class="p-inline-list--middot">

--- a/templates/docs/examples/layouts/sticky-footer.html
+++ b/templates/docs/examples/layouts/sticky-footer.html
@@ -26,7 +26,7 @@
   </div>
 
   <footer class="l-footer--sticky p-strip--light">
-    <nav class="row" aria-label="Footer navigation">
+    <nav class="row" aria-label="Footer">
       <div class="has-cookie">
         <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
         <ul class="p-inline-list--middot">

--- a/templates/docs/examples/patterns/links/links-skip.html
+++ b/templates/docs/examples/patterns/links/links-skip.html
@@ -18,7 +18,7 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
 
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/default-dark.html
+++ b/templates/docs/examples/patterns/navigation/default-dark.html
@@ -15,7 +15,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/default.html
+++ b/templates/docs/examples/patterns/navigation/default.html
@@ -16,7 +16,7 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
 
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/dropdown-dark.html
+++ b/templates/docs/examples/patterns/navigation/dropdown-dark.html
@@ -15,7 +15,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item--dropdown-toggle" id="link-1">
           <a href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">LXC</a>

--- a/templates/docs/examples/patterns/navigation/full-width.html
+++ b/templates/docs/examples/patterns/navigation/full-width.html
@@ -15,7 +15,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example of full-width main navigation">
+    <nav class="p-navigation__nav" aria-label="Example of full-width main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/search-dark.html
+++ b/templates/docs/examples/patterns/navigation/search-dark.html
@@ -17,7 +17,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/examples/patterns/navigation/search-light.html
+++ b/templates/docs/examples/patterns/navigation/search-light.html
@@ -17,7 +17,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -6,7 +6,7 @@
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer{% if is_sticky %}-sticky{% endif %}"></div>
 
-  <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
+  <nav class="p-side-navigation__drawer" aria-label="Example side">
     <div class="p-side-navigation__drawer-header">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer{% if is_sticky %}-sticky{% endif %}">
         Toggle side navigation

--- a/templates/docs/examples/patterns/side-navigation/_docs.html
+++ b/templates/docs/examples/patterns/side-navigation/_docs.html
@@ -5,7 +5,7 @@
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
 
-  <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
+  <nav class="p-side-navigation__drawer" aria-label="Example side">
     <div class="p-side-navigation__drawer-header">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
         Toggle side navigation

--- a/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
@@ -1,6 +1,6 @@
 {# used by the application layout example #}
 
-<nav class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" aria-label="Main navigation">
+<nav class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" aria-label="Main">
   <ul class="p-side-navigation__list">
     <li class="p-side-navigation__item">
       <a class="p-side-navigation__link" href="#" aria-current="page">

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -1,7 +1,7 @@
 {# used by the application layout example #}
 
 <div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
-  <nav aria-label="Main navigation">
+  <nav aria-label="Main">
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title">
         <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">Title that is a link</span></a>

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -29,7 +29,7 @@
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
 
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <ul id="main-navigation" class="p-navigation__items u-clearfix">
         <li class="p-navigation__item"><a class="p-navigation__link" href="#install">Install</a></li>
         <li class="p-navigation__item"><a class="p-navigation__link" href="#how-it-works">How it works</a></li>
@@ -56,7 +56,7 @@
 <div class="p-strip is-shallow">
   <div class="row">
     <aside class="col-3">
-      <nav class="p-side-navigation" id="drawer" aria-label="Example side navigation">
+      <nav class="p-side-navigation" id="drawer" aria-label="Example side">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </button>
@@ -320,7 +320,7 @@
 </div>
 
 <footer class="p-strip">
-  <nav class="row" aria-label="Footer navigation">
+  <nav class="row" aria-label="Footer">
     <div class="has-cookie">
       <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
       <ul class="p-inline-list--middot">

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -13,7 +13,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav u-image-position" aria-label="Example main navigation">
+    <nav class="p-navigation__nav u-image-position" aria-label="Example main">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
@@ -75,7 +75,7 @@
   </div>
 </div>
 <div class="p-strip is-shallow">
-  <nav class="p-tabs" aria-label="Example tabs navigation">
+  <nav class="p-tabs" aria-label="Example tabs">
     <div class="row">
       <ul class="p-tabs__list" role="tablist">
         <li class="p-tabs__item" role="presentation">
@@ -209,7 +209,7 @@
 <footer class="p-strip">
   <div class="row">
     <p>© 2017 Company name and logo are registered trademarks of Company Ltd.</p>
-    <nav aria-label="Example footer navigation">
+    <nav aria-label="Example footer">
       <ul class="p-inline-list--middot">
         <li class="p-inline-list__item">
           <a href="#">Footer link 1</a>

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -36,7 +36,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>

--- a/templates/docs/examples/templates/z-index.html
+++ b/templates/docs/examples/templates/z-index.html
@@ -10,7 +10,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" aria-label="Example main navigation">
+    <nav class="p-navigation__nav" aria-label="Example main">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
@@ -146,7 +146,7 @@
 
   <hr class="u-no-margin--bottom" />
 
-  <nav class="p-tabs" aria-label="Example tabs navigation">
+  <nav class="p-tabs" aria-label="Example tabs">
     <ul class="p-tabs__list" role="tablist">
       <li class="p-tabs__item" role="presentation">
         <a href="#section1" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1" aria-selected="true">Machine summary</a>


### PR DESCRIPTION
## Done

- Removed the word "navigation" from all `aria-label`'s on `<nav>` elements, to fix duplication with screen readers. 
- Checked all `<header>` and `<main>` tags too

Fixes #4133 

## QA

- Open [demo](https://vanilla-framework-4361.demos.haus/)
- Use VoiceOver on the navigation landmarks such as pagination or side navigation to check duplication has been removed
- Check out this PR, in VsCode search for `navigation"` and there should be no more instances of the word navigation in nav elements


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
