### PR TITLE
add react components doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+scripts/generate-react-docs.js
+
 # [generated] Bracketed sections updated by Yeoman generator
 # generator-canonical-webteam@3.4.1
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "watch": "yarn build && yarn watch:scss",
     "clean": "rm -rf build docs/static/css node_modules/ yarn-error.log",
     "percy": "percy exec -- node snapshots.js",
-    "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
+    "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons",
+    "generate-react-docs": "tsc --esModuleInterop true ./scripts/generate-react-docs.ts && node ./scripts/generate-react-docs.js https://canonical-web-and-design.github.io/react-components/iframe.html"
   },
   "version": "3.1.2",
   "files": [
@@ -65,11 +66,13 @@
     "markdown-spellcheck": "1.3.1",
     "parker": "0.0.10",
     "prettier": "2.5.1",
+    "puppeteer": "^13.5.1",
     "stylelint": "14.5.3",
     "stylelint-config-prettier": "9.0.3",
     "stylelint-config-recommended-scss": "5.0.2",
     "stylelint-order": "5.0.0",
     "stylelint-prettier": "2.0.0",
-    "svgo": "2.8.0"
+    "svgo": "2.8.0",
+    "typescript": "^4.6.2"
   }
 }

--- a/react-components.json
+++ b/react-components.json
@@ -1,0 +1,2730 @@
+{
+  "accordion": {
+    "name": "Accordion",
+    "stories": [
+      {
+        "id": "accordion--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "accordion--external-state",
+        "name": "External state"
+      },
+      {
+        "id": "accordion--headings",
+        "name": "Headings"
+      }
+    ],
+    "props": [
+      {
+        "name": "sections",
+        "description": "An array of sections and content.",
+        "type": "Section[]",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional classes applied to the parent element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "expanded",
+        "description": "An optional value to set the expanded section. The value must match a\nsection key. This value will only set the expanded section on first render\nif externallyControlled is not set to `true`.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "externallyControlled",
+        "description": "Whether the expanded section will be controlled via external state.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "onExpandedChange",
+        "description": "Optional function that is called when the expanded section is changed.\nThe function is provided the section title or null.",
+        "type": "(id: any, title: string) => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "titleElement",
+        "description": "Optional string describing heading element that should be used for the section titles.",
+        "type": "\"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\"",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "actionbutton": {
+    "name": "ActionButton",
+    "stories": [
+      {
+        "id": "actionbutton--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "actionbutton--loading",
+        "name": "Loading"
+      }
+    ],
+    "props": [
+      {
+        "name": "appearance",
+        "description": "The appearance of the button.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "children",
+        "description": "The content of the button.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the button element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "disabled",
+        "description": "Whether the button should be disabled.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "inline",
+        "description": "Whether the button should display inline.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "loading",
+        "description": "Whether the button should be in the loading state.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "success",
+        "description": "Whether the button should be in the success state.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      }
+    ]
+  },
+  "articlepagination": {
+    "name": "ArticlePagination",
+    "stories": [
+      {
+        "id": "articlepagination--default-story",
+        "name": "Default"
+      }
+    ],
+    "props": [
+      {
+        "name": "nextLabel",
+        "description": "The label for the next link.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "nextURL",
+        "description": "The URL for the next link.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "previousLabel",
+        "description": "The label for the previous link.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "previousURL",
+        "description": "The URL for the previous link.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional classes to add to the wrapping element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "button": {
+    "name": "Button",
+    "stories": [
+      {
+        "id": "button--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "button--default-disabled",
+        "name": "Default disabled"
+      },
+      {
+        "id": "button--base",
+        "name": "Base"
+      },
+      {
+        "id": "button--base-disabled",
+        "name": "Base disabled"
+      },
+      {
+        "id": "button--link",
+        "name": "Link"
+      },
+      {
+        "id": "button--link-disabled",
+        "name": "Link disabled"
+      },
+      {
+        "id": "button--positive",
+        "name": "Positive"
+      },
+      {
+        "id": "button--positive-disabled",
+        "name": "Positive disabled"
+      },
+      {
+        "id": "button--negative",
+        "name": "Negative"
+      },
+      {
+        "id": "button--negative-disabled",
+        "name": "Negative disabled"
+      },
+      {
+        "id": "button--brand",
+        "name": "Brand"
+      },
+      {
+        "id": "button--brand-disabled",
+        "name": "Brand disabled"
+      },
+      {
+        "id": "button--inline",
+        "name": "Inline"
+      },
+      {
+        "id": "button--dense",
+        "name": "Dense"
+      },
+      {
+        "id": "button--small",
+        "name": "Small"
+      },
+      {
+        "id": "button--icon",
+        "name": "Icon"
+      },
+      {
+        "id": "button--icon-text",
+        "name": "Icon & text"
+      }
+    ],
+    "props": [
+      {
+        "name": "children",
+        "description": "The content of the button.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "appearance",
+        "description": "The appearance of the button.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the button element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "dense",
+        "description": "Whether the button should have dense padding.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "disabled",
+        "description": "Whether the button should be disabled.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "element",
+        "description": "Optional element or component to use instead of `button`.",
+        "type": "ElementType<any> | ComponentType<P>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "hasIcon",
+        "description": "Whether the button has an icon in the content.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "inline",
+        "description": "Whether the button should display inline.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "onClick",
+        "description": "Function for handling button click event.",
+        "type": "MouseEventHandler<HTMLButtonElement>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "small",
+        "description": "Whether the button should be small.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "card": {
+    "name": "Card",
+    "stories": [
+      {
+        "id": "card--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "card--header",
+        "name": "Header"
+      },
+      {
+        "id": "card--highlighted",
+        "name": "Highlighted"
+      },
+      {
+        "id": "card--overlay",
+        "name": "Overlay"
+      }
+    ],
+    "props": [
+      {
+        "name": "children",
+        "description": "The content of the card.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "title",
+        "description": "The title of the card.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping div element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "highlighted",
+        "description": "Whether the card should have highlighted styling.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "overlay",
+        "description": "Whether the card should have overlay styling.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "thumbnail",
+        "description": "The path to a thumbnail image.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "checkboxinput": {
+    "name": "CheckboxInput",
+    "stories": [
+      {
+        "id": "checkboxinput--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "checkboxinput--children",
+        "name": "Children"
+      },
+      {
+        "id": "checkboxinput--disabled",
+        "name": "Disabled"
+      },
+      {
+        "id": "checkboxinput--required",
+        "name": "Required"
+      },
+      {
+        "id": "checkboxinput--inline",
+        "name": "Inline"
+      },
+      {
+        "id": "checkboxinput--indeterminate",
+        "name": "Indeterminate"
+      }
+    ],
+    "props": [
+      {
+        "name": "label",
+        "description": "The label for the input element.",
+        "type": "ReactNode",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "labelClassName",
+        "description": "Optional class(es) to pass to the label element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "inline",
+        "description": "Ensures the input and the label text are properly aligned with other inline text.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "indeterminate",
+        "description": "Whether the input element should display in indeterminate state.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      }
+    ]
+  },
+  "chip": {
+    "name": "Chip",
+    "stories": [
+      {
+        "id": "chip--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "chip--lead-value",
+        "name": "Lead-value"
+      },
+      {
+        "id": "chip--appearance",
+        "name": "Appearance"
+      },
+      {
+        "id": "chip--dismissible",
+        "name": "Dismissible"
+      }
+    ],
+    "props": [
+      {
+        "name": "value",
+        "description": "The value of the chip.",
+        "type": "string",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "appearance",
+        "description": "The appearance of the chip.",
+        "type": "\"caution\" | \"information\" | \"negative\" | \"positive\"",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "lead",
+        "description": "The lead for the chip.",
+        "type": "string",
+        "required": false,
+        "defaultValue": "\"\""
+      },
+      {
+        "name": "onClick",
+        "description": "Function for handling chip div click event.",
+        "type": "(event: MouseEvent<HTMLButtonElement, MouseEvent> | { lead: string; value: string; }) => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "onDismiss",
+        "description": "Function for handling dismissing a chip.",
+        "type": "() => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "selected",
+        "description": "Whether the chip is selected.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "subString",
+        "description": "A substring to emphasise if it is part of the chip's value,\ne.g. \"sit\" => poSITive",
+        "type": "string",
+        "required": false,
+        "defaultValue": "\"\""
+      },
+      {
+        "name": "quoteValue",
+        "description": "Whether to wrap the value in quotation marks.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "codesnippet": {
+    "name": "CodeSnippet",
+    "stories": [
+      {
+        "id": "codesnippet--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "codesnippet--title",
+        "name": "Title"
+      },
+      {
+        "id": "codesnippet--multiple-blocks",
+        "name": "Multiple blocks"
+      },
+      {
+        "id": "codesnippet--appearance",
+        "name": "Appearance"
+      },
+      {
+        "id": "codesnippet--wrap-lines",
+        "name": "Wrap lines"
+      },
+      {
+        "id": "codesnippet--dropdown",
+        "name": "Dropdown"
+      },
+      {
+        "id": "codesnippet--dropdowns",
+        "name": "Dropdowns"
+      },
+      {
+        "id": "codesnippet--dropdowns-stacked",
+        "name": "DropdownsStacked"
+      },
+      {
+        "id": "codesnippet--content",
+        "name": "Content"
+      }
+    ],
+    "props": [
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping div element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "blocks",
+        "description": "A list of code blocks to display.",
+        "type": "Props[]",
+        "required": true,
+        "defaultValue": null
+      }
+    ]
+  },
+  "col": {
+    "name": "Col",
+    "stories": [
+      {
+        "id": "col--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "col--grid",
+        "name": "Grid"
+      },
+      {
+        "id": "col--nested-columns",
+        "name": "Nested columns"
+      },
+      {
+        "id": "col--empty-columns",
+        "name": "Empty columns"
+      }
+    ],
+    "props": [
+      {
+        "name": "children",
+        "description": "The content of the column.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "size",
+        "description": "The number of columns the content occupies.",
+        "type": "1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "element",
+        "description": "Optional element type to give the wrapper if not \"div\".",
+        "type": "ElementType<any>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "emptyLarge",
+        "description": "The number of columns to skip before starting on large screens.",
+        "type": "1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "emptyMedium",
+        "description": "The number of columns to skip before starting on medium screens.",
+        "type": "1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "emptySmall",
+        "description": "The number of columns to skip before starting on small screens.",
+        "type": "1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "large",
+        "description": "Override for the number of columns the content occupies on large screens.",
+        "type": "1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "medium",
+        "description": "Override for the number of columns the content occupies on medium screens.",
+        "type": "1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "small",
+        "description": "Override for the number of columns the content occupies on small screens.",
+        "type": "1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "contextualmenu": {
+    "name": "ContextualMenu",
+    "stories": [
+      {
+        "id": "contextualmenu--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "contextualmenu--toggle",
+        "name": "Toggle"
+      }
+    ],
+    "props": [
+      {
+        "name": "children",
+        "description": "The menu content (if the links prop is not supplied).",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "closeOnOutsideClick",
+        "description": "Whether the menu should close when clicking outside the menu.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "true"
+      },
+      {
+        "name": "constrainPanelWidth",
+        "description": "Whether the menu's width should match the toggle's width.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "position",
+        "description": "The position of the menu.",
+        "type": "\"left\" | \"right\" | \"center\"",
+        "required": false,
+        "defaultValue": "\"right\""
+      },
+      {
+        "name": "visible",
+        "description": "Whether the menu should be visible.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "autoAdjust",
+        "description": "Whether the menu should adjust to fit in the screen.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "true"
+      },
+      {
+        "name": "className",
+        "description": "An optional class to apply to the wrapping element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "closeOnEsc",
+        "description": "Whether the menu should close when the escape key is pressed.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "true"
+      },
+      {
+        "name": "dropdownClassName",
+        "description": "An optional class to apply to the dropdown.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "dropdownProps",
+        "description": "Additional props to pass to the dropdown.",
+        "type": "SubComponentProps<Props<null>>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "hasToggleIcon",
+        "description": "Whether the toggle should display a chevron icon.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "links",
+        "description": "A list of links to display in the menu (if the children prop is not supplied.)",
+        "type": "MenuLink<L>[]",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "onToggleMenu",
+        "description": "A function to call when the menu is toggled.",
+        "type": "(isOpen: boolean) => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "positionNode",
+        "description": "An element to make the menu relative to.",
+        "type": "HTMLElement",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "toggleAppearance",
+        "description": "The appearance of the toggle button.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "toggleClassName",
+        "description": "A class to apply to the toggle button.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "toggleDisabled",
+        "description": "Whether the toggle button should be disabled.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "toggleLabel",
+        "description": "The toggle button's label.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "toggleLabelFirst",
+        "description": "Whether the toggle lable or icon should appear first.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "true"
+      },
+      {
+        "name": "toggleProps",
+        "description": "Additional props to pass to the toggle button.",
+        "type": "SubComponentProps<Props<null>>",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "form": {
+    "name": "Form",
+    "stories": [
+      {
+        "id": "form--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "form--fieldset",
+        "name": "Fieldset"
+      },
+      {
+        "id": "form--inline",
+        "name": "Inline"
+      },
+      {
+        "id": "form--stacked",
+        "name": "Stacked"
+      },
+      {
+        "id": "form--disabled",
+        "name": "Disabled"
+      },
+      {
+        "id": "form--validation",
+        "name": "Validation"
+      },
+      {
+        "id": "form--required",
+        "name": "Required"
+      }
+    ],
+    "props": [
+      {
+        "name": "children",
+        "description": "The content of the form.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the form element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "inline",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "stacked",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "icon": {
+    "name": "Icon",
+    "stories": [
+      {
+        "id": "icon--base",
+        "name": "Base"
+      },
+      {
+        "id": "icon--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "icon--custom",
+        "name": "Custom"
+      },
+      {
+        "id": "icon--social",
+        "name": "Social"
+      }
+    ],
+    "props": [
+      {
+        "name": "name",
+        "description": "The name of the icon.",
+        "type": "string",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional classes to add to the icon element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "light",
+        "description": "Whether to show the light variant of the icon.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "input": {
+    "name": "Input",
+    "stories": [
+      {
+        "id": "input--text-input",
+        "name": "Text input"
+      },
+      {
+        "id": "input--stacked",
+        "name": "Stacked"
+      },
+      {
+        "id": "input--disabled",
+        "name": "Disabled"
+      },
+      {
+        "id": "input--error",
+        "name": "Error"
+      },
+      {
+        "id": "input--success",
+        "name": "Success"
+      },
+      {
+        "id": "input--caution",
+        "name": "Caution"
+      },
+      {
+        "id": "input--required",
+        "name": "Required"
+      },
+      {
+        "id": "input--checkbox",
+        "name": "Checkbox"
+      },
+      {
+        "id": "input--radio-button",
+        "name": "Radio button"
+      }
+    ],
+    "props": [
+      {
+        "name": "id",
+        "description": "The id of the input.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "label",
+        "description": "The label for the field.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "caution",
+        "description": "The content for caution validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the input element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "error",
+        "description": "The content for error validation message. Controls the value of aria-invalid attribute.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "help",
+        "description": "Help text to show below the field.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "labelClassName",
+        "description": "Optional class(es) to pass to the label component.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "required",
+        "description": "Whether the field is required.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "stacked",
+        "description": "Whether the form field should have a stacked appearance.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "success",
+        "description": "The content for success validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "takeFocus",
+        "description": "Whether to focus on the input on initial render.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "wrapperClassName",
+        "description": "Optional class(es) to pass to the wrapping Field component",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "link": {
+    "name": "Link",
+    "stories": [
+      {
+        "id": "link--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "link--soft",
+        "name": "Soft"
+      },
+      {
+        "id": "link--inverted",
+        "name": "Inverted"
+      },
+      {
+        "id": "link--back-to-top",
+        "name": "Back to top"
+      }
+    ],
+    "props": [
+      {
+        "name": "children",
+        "description": "The content of the link.",
+        "type": "ReactNode",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping anchor element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "inverted",
+        "description": "Whether the link should have inverted styling.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "soft",
+        "description": "Whether the link should have soft styling.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "top",
+        "description": "Whether the link should have \"back to top\" styling.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      }
+    ]
+  },
+  "list": {
+    "name": "List",
+    "stories": [
+      {
+        "id": "list--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "list--ticked",
+        "name": "Ticked"
+      },
+      {
+        "id": "list--horizontal-divider",
+        "name": "Horizontal divider"
+      },
+      {
+        "id": "list--ticked-with-horizontal-divider",
+        "name": "Ticked with horizontal divider"
+      },
+      {
+        "id": "list--inline",
+        "name": "Inline"
+      },
+      {
+        "id": "list--middot",
+        "name": "Middot"
+      },
+      {
+        "id": "list--stretch",
+        "name": "Stretch"
+      },
+      {
+        "id": "list--vertical-stepped",
+        "name": "Vertical stepped"
+      },
+      {
+        "id": "list--horizontal-stepped",
+        "name": "Horizontal stepped"
+      },
+      {
+        "id": "list--split",
+        "name": "Split"
+      }
+    ],
+    "props": [
+      {
+        "name": "items",
+        "description": "The list's items.",
+        "type": "ListItem[] | SteppedListItem[]",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "detailed",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "divided",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "inline",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "isDark",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "middot",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "split",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "stepped",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "stretch",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "ticked",
+        "description": "",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "loader": {
+    "name": "Loader",
+    "stories": [
+      {
+        "id": "loader--default-story",
+        "name": "Default"
+      }
+    ],
+    "props": [
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping span element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "isLight",
+        "description": "Whether the spinner should have a light appearance.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "text",
+        "description": "Text to display next to the spinner.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "role",
+        "description": "What the role of the spinner should be.",
+        "type": "string & AriaRole",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "ariaLive",
+        "description": "The politeness setting of the spinner alert.",
+        "type": "\"off\" | \"assertive\" | \"polite\"",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "maintable": {
+    "name": "MainTable",
+    "stories": [
+      {
+        "id": "maintable--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "maintable--sortable",
+        "name": "Sortable"
+      },
+      {
+        "id": "maintable--expanding",
+        "name": "Expanding"
+      },
+      {
+        "id": "maintable--overflow",
+        "name": "Overflow"
+      },
+      {
+        "id": "maintable--responsive",
+        "name": "Responsive"
+      },
+      {
+        "id": "maintable--paginated",
+        "name": "Paginated"
+      },
+      {
+        "id": "maintable--empty",
+        "name": "Empty"
+      }
+    ],
+    "props": [
+      {
+        "name": "headers",
+        "description": "The header columns for this table.",
+        "type": "MainTableHeader[]",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "rows",
+        "description": "The rows to display in the table.",
+        "type": "MainTableRow[]",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "defaultSort",
+        "description": "The default key to sort the rows by.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "defaultSortDirection",
+        "description": "The default direction the row data should be sorted by.",
+        "type": "\"none\" | \"ascending\" | \"descending\"",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "emptyStateMsg",
+        "description": "A message to display when there are no table rows.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "onUpdateSort",
+        "description": "A function that is called when the sort key is changed.",
+        "type": "(sortKey: string) => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "paginate",
+        "description": "A number of rows to paginate by.",
+        "type": "number",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "sortable",
+        "description": "Whether this table should be sortable.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "sortFunction",
+        "description": "A function to be used when sorting.",
+        "type": "(a: MainTableRow, b: MainTableRow, currentSortDirection: SortDirection, currentSortKey: string) => 0 | 1 | -1",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping table element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "children",
+        "description": "The content of the table.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "expanding",
+        "description": "Whether the table can expand hidden cells.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "responsive",
+        "description": "Whether the table should show card styling on smaller screens.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "modal": {
+    "name": "Modal",
+    "stories": [
+      {
+        "id": "modal--default-story",
+        "name": "Default"
+      }
+    ],
+    "props": [
+      {
+        "name": "buttonRow",
+        "description": "Buttons to display underneath the main modal content.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to apply to the wrapping element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "children",
+        "description": "The content of the modal.",
+        "type": "ReactNode",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "close",
+        "description": "Function to handle closing the modal.",
+        "type": "() => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "title",
+        "description": "The title of the modal.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "modulartable": {
+    "name": "ModularTable",
+    "stories": [
+      {
+        "id": "modulartable--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "modulartable--empty",
+        "name": "Empty"
+      },
+      {
+        "id": "modulartable--load-more",
+        "name": "Load more"
+      }
+    ],
+    "props": [
+      {
+        "name": "columns",
+        "description": "The columns of the table.",
+        "type": "Column<Record<string, unknown>>[]",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "data",
+        "description": "The data of the table.",
+        "type": "Record<string, unknown>[]",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "emptyMsg",
+        "description": "A message to display if data is empty.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "footer",
+        "description": "Optional extra row to display underneath the main table content.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "getHeaderProps",
+        "description": "This function is used to resolve any props needed for a particular column's header cell.",
+        "type": "(header: HeaderGroup<Record<string, unknown>>) => Partial<TableHeaderProps & HTMLProps<HTMLTableHeaderCellElement>>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "getRowProps",
+        "description": "This function is used to resolve any props needed for a particular row.",
+        "type": "(row: Row<Record<string, unknown>>) => Partial<TableRowProps & HTMLProps<HTMLTableRowElement>>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "getCellProps",
+        "description": "This function is used to resolve any props needed for a particular cell.",
+        "type": "(cell: Cell<Record<string, unknown>, any>) => Partial<TableCellProps & HTMLProps<HTMLTableCellElement>>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "getRowId",
+        "description": "",
+        "type": "(originalRow: Record<string, unknown>, relativeIndex: number, parent?: Row<Record<string, unknown>>) => string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "notification": {
+    "name": "Notification",
+    "stories": [
+      {
+        "id": "notification--information",
+        "name": "Information"
+      },
+      {
+        "id": "notification--caution",
+        "name": "Caution"
+      },
+      {
+        "id": "notification--negative",
+        "name": "Negative"
+      },
+      {
+        "id": "notification--positive",
+        "name": "Positive"
+      },
+      {
+        "id": "notification--inline",
+        "name": "Inline"
+      },
+      {
+        "id": "notification--borderless",
+        "name": "Borderless"
+      },
+      {
+        "id": "notification--actions",
+        "name": "Actions"
+      },
+      {
+        "id": "notification--dismissible",
+        "name": "Dismissible"
+      },
+      {
+        "id": "notification--timeout",
+        "name": "Timeout"
+      },
+      {
+        "id": "notification--timestamp",
+        "name": "Timestamp"
+      }
+    ],
+    "props": [
+      {
+        "name": "children",
+        "description": "The notification message content.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "severity",
+        "description": "The severity of the notification.",
+        "type": "\"caution\" | \"information\" | \"negative\" | \"positive\"",
+        "required": false,
+        "defaultValue": "\"information\""
+      },
+      {
+        "name": "title",
+        "description": "The title of the notification.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "actions",
+        "description": "A list of up to two actions that the notification can perform.",
+        "type": "NotificationAction[]",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "borderless",
+        "description": "Whether the notification should not have a border.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to apply to the parent notification element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "close",
+        "description": "**Deprecated**. Use `onDismiss` instead.",
+        "type": "never",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "inline",
+        "description": "Whether the title should display inline with the message.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "onDismiss",
+        "description": "The function to run when dismissing/closing the notification.",
+        "type": "() => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "status",
+        "description": "**Deprecated**. Use `title` instead.",
+        "type": "never",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "timeout",
+        "description": "The amount of time (in ms) until the notification is automatically dismissed.",
+        "type": "number",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "timestamp",
+        "description": "A relevant timestamp for the notification, e.g. when it was created.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "type",
+        "description": "**Deprecated**. Use `severity` instead.",
+        "type": "never",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "pagination": {
+    "name": "Pagination",
+    "stories": [
+      {
+        "id": "pagination--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "pagination--truncated",
+        "name": "Truncated"
+      },
+      {
+        "id": "pagination--disabled-controls",
+        "name": "Disabled controls"
+      }
+    ],
+    "props": [
+      {
+        "name": "itemsPerPage",
+        "description": "The number of items to show per page.",
+        "type": "number",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "totalItems",
+        "description": "The total number of items.",
+        "type": "number",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "paginate",
+        "description": "Function to handle paginating the items.",
+        "type": "(page: number) => void",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "currentPage",
+        "description": "The current page being viewed.",
+        "type": "number",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "scrollToTop",
+        "description": "Whether to scroll to the top of the list on page change.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "truncateThreshold",
+        "description": "The number of pages at which to truncate the pagination items.",
+        "type": "number",
+        "required": false,
+        "defaultValue": "10"
+      }
+    ]
+  },
+  "passwordtoggle": {
+    "name": "PasswordToggle",
+    "stories": [
+      {
+        "id": "passwordtoggle--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "passwordtoggle--read-only",
+        "name": "Read only"
+      },
+      {
+        "id": "passwordtoggle--error",
+        "name": "Error"
+      },
+      {
+        "id": "passwordtoggle--success",
+        "name": "Success"
+      },
+      {
+        "id": "passwordtoggle--caution",
+        "name": "Caution"
+      },
+      {
+        "id": "passwordtoggle--help",
+        "name": "Help"
+      },
+      {
+        "id": "passwordtoggle--disabled",
+        "name": "Disabled"
+      }
+    ],
+    "props": [
+      {
+        "name": "caution",
+        "description": "The content for caution validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the input element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "error",
+        "description": "The content for error validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "help",
+        "description": "Help text to show below the field.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "id",
+        "description": "The id of the input.",
+        "type": "string",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "label",
+        "description": "The label for the field.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "readOnly",
+        "description": "Whether the field is read only.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "required",
+        "description": "Whether the field is required.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "success",
+        "description": "The content for success validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "type",
+        "description": "The content for success validation.",
+        "type": "\"button\" | \"submit\" | \"reset\"",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "wrapperClassName",
+        "description": "Optional class(es) to pass to the wrapping Field component",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "radioinput": {
+    "name": "RadioInput",
+    "stories": [
+      {
+        "id": "radioinput--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "radioinput--children",
+        "name": "Children"
+      },
+      {
+        "id": "radioinput--disabled",
+        "name": "Disabled"
+      },
+      {
+        "id": "radioinput--required",
+        "name": "Required"
+      },
+      {
+        "id": "radioinput--inline",
+        "name": "Inline"
+      }
+    ],
+    "props": [
+      {
+        "name": "label",
+        "description": "The label for the input element.",
+        "type": "ReactNode",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "labelClassName",
+        "description": "Optional class(es) to pass to the label element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "inline",
+        "description": "Ensures the input and the label text are properly aligned with other inline text.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "indeterminate",
+        "description": "Whether the input element should display in indeterminate state.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "row": {
+    "name": "Row",
+    "stories": [
+      {
+        "id": "row--default-story",
+        "name": "Default"
+      }
+    ],
+    "props": [
+      {
+        "name": "children",
+        "description": "The content of the row.",
+        "type": "ReactNode",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping div element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "search-and-filter": {
+    "name": "Search and Filter",
+    "stories": [
+      {
+        "id": "search-and-filter--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "search-and-filter--with-data-set",
+        "name": "With data set"
+      },
+      {
+        "id": "search-and-filter--with-existing-search-data",
+        "name": "With existing search data"
+      }
+    ],
+    "props": [
+      {
+        "name": "returnSearchData",
+        "description": "A function that is called when the search data changes.",
+        "type": "(searchData: SearchAndFilterChip[]) => void",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "filterPanelData",
+        "description": "The data for the filter panel.",
+        "type": "SearchAndFilterData[]",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "existingSearchData",
+        "description": "A list of chips to initialise inside the input.",
+        "type": "SearchAndFilterChip[]",
+        "required": false,
+        "defaultValue": "[]"
+      }
+    ]
+  },
+  "searchbox": {
+    "name": "SearchBox",
+    "stories": [
+      {
+        "id": "searchbox--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "searchbox--disabled",
+        "name": "Disabled"
+      },
+      {
+        "id": "searchbox--external-state",
+        "name": "External state"
+      },
+      {
+        "id": "searchbox--navigation",
+        "name": "Navigation"
+      }
+    ],
+    "props": [
+      {
+        "name": "autocomplete",
+        "description": "Whether autocomplete should be enabled for the search input.",
+        "type": "\"on\" | \"off\"",
+        "required": false,
+        "defaultValue": "\"on\""
+      },
+      {
+        "name": "className",
+        "description": "Optional classes to pass to the form element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "disabled",
+        "description": "Whether the input and buttons should be disabled.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "externallyControlled",
+        "description": "Whether the input value will be controlled via external state.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "onChange",
+        "description": "A function that will be called when the input value changes.",
+        "type": "(inputValue: string) => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "onSearch",
+        "description": "A function that is called when the user clicks the search icon",
+        "type": "() => void",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "placeholder",
+        "description": "A search input placeholder message.",
+        "type": "string",
+        "required": false,
+        "defaultValue": "\"Search\""
+      },
+      {
+        "name": "value",
+        "description": "The value of the search input when the state is externally controlled.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "select": {
+    "name": "Select",
+    "stories": [
+      {
+        "id": "select--select",
+        "name": "Select"
+      },
+      {
+        "id": "select--select-multiple",
+        "name": "Select multiple"
+      }
+    ],
+    "props": [
+      {
+        "name": "id",
+        "description": "The id of the input.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "options",
+        "description": "Array of options that the select can choose from.",
+        "type": "Option[]",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "label",
+        "description": "The label for the field.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "caution",
+        "description": "The content for caution validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the input element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "error",
+        "description": "The content for error validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "help",
+        "description": "Help text to show below the field.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "labelClassName",
+        "description": "Optional class(es) to pass to the label component.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "onChange",
+        "description": "Function to run when select value changes.",
+        "type": "ChangeEventHandler<HTMLSelectElement>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "required",
+        "description": "Whether the field is required.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "stacked",
+        "description": "Whether the form field should have a stacked appearance.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "success",
+        "description": "The content for success validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "takeFocus",
+        "description": "Whether to focus on the input on initial render.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "wrapperClassName",
+        "description": "Optional class(es) to pass to the wrapping Field component",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "slider": {
+    "name": "Slider",
+    "stories": [
+      {
+        "id": "slider--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "slider--with-input",
+        "name": "With input"
+      }
+    ],
+    "props": [
+      {
+        "name": "disabled",
+        "description": "Whether to disable the slider and input (if showInput is true).",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "label",
+        "description": "Field label.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "max",
+        "description": "Maximum value of the slider.",
+        "type": "number",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "min",
+        "description": "Minimum value of the slider.",
+        "type": "number",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "showInput",
+        "description": "Whether to show a number input with the numerical value next to the slider.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "caution",
+        "description": "Field caution message.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "error",
+        "description": "Field error message.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "help",
+        "description": "Field help message.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "id",
+        "description": "Field id. Only passed to range input, not to number input.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "inputDisabled",
+        "description": "Whether to disable only the input, but not the slider.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "onChange",
+        "description": "Change event handler.",
+        "type": "ChangeEventHandler<HTMLInputElement>",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "required",
+        "description": "Whether the field is required for the form to submit.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      }
+    ]
+  },
+  "spinner": {
+    "name": "Spinner",
+    "stories": [
+      {
+        "id": "spinner--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "spinner--text",
+        "name": "Text"
+      },
+      {
+        "id": "spinner--assertive",
+        "name": "Assertive"
+      }
+    ],
+    "props": [
+      {
+        "name": "isLight",
+        "description": "Whether the spinner should have a light appearance.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "text",
+        "description": "Text to display next to the spinner.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "role",
+        "description": "What the role of the spinner should be.",
+        "type": "string & AriaRole",
+        "required": false,
+        "defaultValue": "alert"
+      },
+      {
+        "name": "ariaLive",
+        "description": "The politeness setting of the spinner alert.",
+        "type": "\"off\" | \"assertive\" | \"polite\"",
+        "required": false,
+        "defaultValue": "\"polite\""
+      }
+    ]
+  },
+  "strip": {
+    "name": "Strip",
+    "stories": [
+      {
+        "id": "strip--light-strip",
+        "name": "Light strip"
+      },
+      {
+        "id": "strip--dark-strip",
+        "name": "Dark strip"
+      },
+      {
+        "id": "strip--accent-strip",
+        "name": "Accent strip"
+      },
+      {
+        "id": "strip--image-strip",
+        "name": "Image strip"
+      },
+      {
+        "id": "strip--bordered-strip",
+        "name": "Bordered strip"
+      },
+      {
+        "id": "strip--deep-strip",
+        "name": "Deep strip"
+      },
+      {
+        "id": "strip--shallow-strip",
+        "name": "Shallow strip"
+      }
+    ],
+    "props": [
+      {
+        "name": "type",
+        "description": "The type of the strip (e.g. \"accent\" or \"image\").",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "children",
+        "description": "The content of the strip.",
+        "type": "ReactNode",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "background",
+        "description": "A background images for the strip.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "bordered",
+        "description": "Whether the strip should display borders.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "className",
+        "description": "Optional classes for the strip.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "colSize",
+        "description": "The width of the column if `includeCol` has been set.",
+        "type": "1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12",
+        "required": false,
+        "defaultValue": "12"
+      },
+      {
+        "name": "dark",
+        "description": "Whether the strip should be dark.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "deep",
+        "description": "Whether the strip should be deep.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "element",
+        "description": "The base HTML element of the strip.",
+        "type": "ElementType<any>",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "includeCol",
+        "description": "Whether the strip should wrap the content in a column.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "true"
+      },
+      {
+        "name": "light",
+        "description": "Whether the strip should be light.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "rowClassName",
+        "description": "Optional classes to apply to the row.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "shallow",
+        "description": "Whether the strip should be shallow.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      }
+    ]
+  },
+  "summarybutton": {
+    "name": "SummaryButton",
+    "stories": [
+      {
+        "id": "summarybutton--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "summarybutton--action-only",
+        "name": "Action only"
+      },
+      {
+        "id": "summarybutton--summary-only",
+        "name": "Summary only"
+      },
+      {
+        "id": "summarybutton--loading",
+        "name": "Loading"
+      }
+    ],
+    "props": [
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the wrapping element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "isLoading",
+        "description": "Whether the summary button is loading.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "label",
+        "description": "The label of the summary button.",
+        "type": "string",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "onClick",
+        "description": "Function to handle clicking the summary button.",
+        "type": "MouseEventHandler<HTMLButtonElement>",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "summary",
+        "description": "The summary content.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "switch": {
+    "name": "Switch",
+    "stories": [
+      {
+        "id": "switch--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "switch--disabled",
+        "name": "Disabled"
+      }
+    ],
+    "props": [
+      {
+        "name": "label",
+        "description": "The label name for the switch",
+        "type": "ReactNode",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "disabled",
+        "description": "Whether the switch is disabled or not",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      }
+    ]
+  },
+  "tabs": {
+    "name": "Tabs",
+    "stories": [
+      {
+        "id": "tabs--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "tabs--horizontally-aligned",
+        "name": "Horizontally aligned"
+      }
+    ],
+    "props": [
+      {
+        "name": "links",
+        "description": "An array of tab link objects.",
+        "type": "TabLink<P>[]",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional classes applied to the parent \"nav\" element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "listClassName",
+        "description": "Optional classes applied to the \"ul\" element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "textarea": {
+    "name": "Textarea",
+    "stories": [
+      {
+        "id": "textarea--default-story",
+        "name": "Default"
+      }
+    ],
+    "props": [
+      {
+        "name": "label",
+        "description": "The label for the field.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "id",
+        "description": "The id of the textarea.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "caution",
+        "description": "The content for caution validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "Optional class(es) to pass to the textarea element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "error",
+        "description": "The content for error validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "grow",
+        "description": "Whether the textarea should grow to fit the content automatically.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "help",
+        "description": "Help text to show below the field.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "labelClassName",
+        "description": "Optional class(es) to pass to the label component.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "required",
+        "description": "Whether the field is required.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "stacked",
+        "description": "Whether the form field should have a stacked appearance.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "success",
+        "description": "The content for success validation.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "takeFocus",
+        "description": "Whether to focus on the input on initial render.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "wrapperClassName",
+        "description": "Optional class(es) to pass to the wrapping Field component",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  },
+  "tooltip": {
+    "name": "Tooltip",
+    "stories": [
+      {
+        "id": "tooltip--default-story",
+        "name": "Default"
+      },
+      {
+        "id": "tooltip--follow-mouse",
+        "name": "Follow mouse"
+      },
+      {
+        "id": "tooltip--targeting-elements",
+        "name": "Targeting elements"
+      }
+    ],
+    "props": [
+      {
+        "name": "message",
+        "description": "Message to display when the element is hovered.",
+        "type": "ReactNode",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "autoAdjust",
+        "description": "Whether the tooltip should adjust to fit in the screen.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "true"
+      },
+      {
+        "name": "children",
+        "description": "Element on which to apply the tooltip.",
+        "type": "ReactNode",
+        "required": true,
+        "defaultValue": null
+      },
+      {
+        "name": "className",
+        "description": "An optional class to apply to the wrapping element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "followMouse",
+        "description": "Whether the tooltip should follow the mouse.",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": "false"
+      },
+      {
+        "name": "position",
+        "description": "Position of the tooltip relative to the element.",
+        "type": "\"btm-center\" | \"btm-left\" | \"btm-right\" | \"left\" | \"right\" | \"top-center\" | \"top-left\" | \"top-right\"",
+        "required": false,
+        "defaultValue": "\"top-left\""
+      },
+      {
+        "name": "positionElementClassName",
+        "description": "An optional class to apply to the element that wraps the children.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      },
+      {
+        "name": "tooltipClassName",
+        "description": "An optional class to apply to the tooltip message element.",
+        "type": "string",
+        "required": false,
+        "defaultValue": null
+      }
+    ]
+  }
+}

--- a/scripts/generate-react-docs.ts
+++ b/scripts/generate-react-docs.ts
@@ -1,0 +1,125 @@
+import express from 'express';
+import {stat, writeFile} from 'fs/promises';
+import {AddressInfo} from 'net';
+import path from 'path';
+import {argv} from 'process';
+import puppeteer from 'puppeteer';
+
+const read = async (url: string) => {
+  console.log(`connecting to: ${url}`);
+  const browser = await puppeteer.launch({args: ['--no-sandbox']});
+  const page = await browser.newPage();
+
+  await page.goto(url);
+
+  console.log('extracting the data...');
+  await page.waitForFunction('window.__STORYBOOK_ADDONS.channel.data');
+  const data = JSON.parse(
+    await page.evaluate(() => {
+      return JSON.stringify(window['__STORYBOOK_ADDONS'], null, 2);
+    })
+  );
+  await browser.close();
+
+  if (!data?.channel?.data?.setStories) throw new Error('failed to find the storybook variable: window.__STORYBOOK_ADDONS');
+
+  const stories = data.channel.data.setStories[0].stories;
+  const components = {};
+  Object.keys(stories).forEach((storySlug) => {
+    const name = storySlug.split('--')[0];
+    const story = stories[storySlug];
+    const storyRef = {
+      id: story.id,
+      name: story.name,
+    };
+
+    if (components[name]) {
+      components[name].stories.push(storyRef);
+    } else {
+      components[name] = {
+        name: story.title,
+        stories: [storyRef],
+        props: parseProp(story.argTypes),
+      };
+    }
+  });
+
+  // special case: this isn't a component, it's added by storybook
+  // as main point to the page
+  delete components['getting-started'];
+  return components;
+};
+type ArgTypes = {
+  [k: string]: {
+    name: string;
+    description: string;
+    type?: {
+      name: string;
+      value?: string;
+      required?: boolean;
+    };
+    table?: {
+      type: {summary: string} | null;
+      defaultValue: {summary: string} | null;
+    };
+  };
+};
+
+const parseProp = (argTypes: ArgTypes) => {
+  return Object.keys(argTypes)
+    .filter((propName) => argTypes[propName].table)
+    .map((propName) => argTypes[propName])
+    .map((prop) => ({
+      name: prop.name,
+      description: prop.description,
+      type: prop.table.type.summary,
+      required: prop.type?.required || false,
+      defaultValue: prop.table.defaultValue?.summary || null,
+    }));
+};
+
+const serveLocation: (location: string) => Promise<[string, () => void]> = async (location: string) => {
+  if (location.match(/^http/)) {
+    return [location, async () => {}];
+  }
+
+  // check for location's existence
+  await stat(path.resolve(location));
+
+  const app = express();
+
+  app.use(express.static(location));
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const address: AddressInfo = server.address() as AddressInfo;
+      const result = `http://localhost:${address.port}/iframe.html`;
+
+      console.log(`serving the data on: ${result}`);
+
+      resolve([result, server.close.bind(server)]);
+    });
+  });
+};
+
+async function extract(input: string, targetPath: string) {
+  if (input && targetPath) {
+    const [location, exit] = await serveLocation(input);
+
+    const data = await read(location);
+
+    await writeFile(targetPath, JSON.stringify(data, null, 2));
+
+    await exit();
+  } else {
+    throw new Error('Extract: please specify a path where your built-storybook is (can be a public url) and a target directory');
+  }
+}
+
+async function main(storybookOutputDir, targetPath) {
+  targetPath = path.resolve(targetPath);
+  await extract(storybookOutputDir, targetPath);
+  console.log(`data exported to: ${targetPath}`);
+}
+const location = argv[2];
+main(location, 'react-components1.json');

--- a/templates/_layouts/_react_component.html
+++ b/templates/_layouts/_react_component.html
@@ -1,0 +1,160 @@
+<section>
+  <h3>React component <code>{{component['name']}}</code></h3>
+  <h4>props:</h4>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for prop in component['props'] %}
+      <tr>
+        <td>
+          {{prop['name']}}
+          {% if prop['required'] %}
+          <span style="color:red">*</span>
+          {% endif %}
+        </td>
+        <td>
+          {{prop['description']}}
+          <br />
+          <code>{{prop['type']}}</code>
+        </td>
+        <td>
+          {% if prop['defaultValue'] %}
+          <code>{{prop['defaultValue']}}</code>
+          {% else %}
+          -
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <h4>Variants</h4>
+  <div class="p-tabs">
+    <div class="p-tabs__list" role="tablist" aria-label="Component variants">
+      {% for story in component['stories'] %}
+      <div class="p-tabs__item">
+        <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="{{ story['id'] }}">
+          {{story['name']}}
+        </button>
+      </div>
+      {% endfor %}
+    </div>
+
+    {% for story in component['stories'] %}
+    <div tabindex="0" role="tabpanel" id="{{ story['id'] }}" aria-labelledby="{{ story['name'] }}" hidden>
+      <iframe
+        src="https://canonical-web-and-design.github.io/react-components/iframe.html?id={{story['id']}}&viewMode=story&shortcuts=false&singleStory=true"
+        width="100%" height="400"></iframe>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+
+
+<script>
+  (function () {
+    var keys = {
+      left: 'ArrowLeft',
+      right: 'ArrowRight',
+    };
+
+    var direction = {
+      ArrowLeft: -1,
+      ArrowRight: 1,
+    };
+
+    /**
+      Attaches a number of events that each trigger
+      the reveal of the chosen tab content
+      @param {Array} tabs an array of tabs within a container
+    */
+    function attachEvents(tabs) {
+      tabs.forEach(function (tab, index) {
+        tab.addEventListener('keyup', function (e) {
+          if (e.code === keys.left || e.code === keys.right) {
+            switchTabOnArrowPress(e, tabs);
+          }
+        });
+
+        tab.addEventListener('click', function (e) {
+          e.preventDefault();
+          setActiveTab(tab, tabs);
+        });
+
+        tab.addEventListener('focus', function () {
+          setActiveTab(tab, tabs);
+        });
+
+        tab.index = index;
+      });
+    }
+
+    /**
+      Determine which tab to show when an arrow key is pressed
+      @param {KeyboardEvent} event
+      @param {Array} tabs an array of tabs within a container
+    */
+    function switchTabOnArrowPress(event, tabs) {
+      var pressed = event.code;
+
+      if (direction[pressed]) {
+        var target = event.target;
+        if (target.index !== undefined) {
+          if (tabs[target.index + direction[pressed]]) {
+            tabs[target.index + direction[pressed]].focus();
+          } else if (pressed === keys.left) {
+            tabs[tabs.length - 1].focus();
+          } else if (pressed === keys.right) {
+            tabs[0].focus();
+          }
+        }
+      }
+    }
+
+    /**
+      Cycles through an array of tab elements and ensures 
+      only the target tab and its content are selected
+      @param {HTMLElement} tab the tab whose content will be shown
+      @param {Array} tabs an array of tabs within a container
+    */
+    function setActiveTab(tab, tabs) {
+      tabs.forEach(function (tabElement) {
+        var tabContent = document.getElementById(tabElement.getAttribute('aria-controls'));
+
+        if (tabElement === tab) {
+          tabElement.setAttribute('aria-selected', true);
+          tabContent.removeAttribute('hidden');
+        } else {
+          tabElement.setAttribute('aria-selected', false);
+          tabContent.setAttribute('hidden', true);
+        }
+      });
+    }
+
+    /**
+      Attaches events to tab links within a given parent element,
+      and sets the active tab if the current hash matches the id
+      of an element controlled by a tab link
+      @param {String} selector class name of the element 
+      containing the tabs we want to attach events to
+    */
+    function initTabs(selector) {
+      var tabContainers = [].slice.call(document.querySelectorAll(selector));
+
+      tabContainers.forEach(function (tabContainer) {
+        var tabs = [].slice.call(tabContainer.querySelectorAll('[aria-controls]'));
+        attachEvents(tabs);
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      initTabs('[role="tablist"]');
+    });
+  })();
+</script>

--- a/templates/docs/patterns/accordion.md
+++ b/templates/docs/patterns/accordion.md
@@ -102,4 +102,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use accordion in React by installing our react-component library and importing `Accordion` component.
 
+{{react_component('accordion')}}
+
 [See the documentation for our React `Accordion` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/accordion--default-story#accordion)

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,6 +271,13 @@
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/yauzl@^2.9.1":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.2.tgz#c48e5d56aff1444409e39fa164b0b4d4552a7b7a"
+  integrity sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
+  dependencies:
+    "@types/node" "*"
+
 accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz"
@@ -283,6 +290,13 @@ agent-base@5:
   version "5.1.1"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz"
   integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.12.3:
   version "6.12.6"
@@ -506,6 +520,11 @@ balanced-match@^2.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
@@ -517,6 +536,15 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bluebird-retry@^0.11.0:
   version "0.11.0"
@@ -584,6 +612,14 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@^5.2.1, buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 bytes@3.1.0:
   version "3.1.0"
@@ -721,6 +757,11 @@ chokidar@^3.3.0:
     readdirp "~3.5.0"
   optionalDependencies:
     fsevents "~2.3.1"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -983,6 +1024,13 @@ create-thenable@~1.0.0:
     object.omit "~2.0.0"
     unique-concat "~0.2.2"
 
+cross-fetch@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz"
@@ -1072,6 +1120,13 @@ debug@4, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
+debug@4.3.3, debug@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
 debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
@@ -1085,13 +1140,6 @@ debug@^3.0.0:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
-  dependencies:
-    ms "2.1.2"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -1142,6 +1190,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+devtools-protocol@0.0.969999:
+  version "0.0.969999"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.969999.tgz#3d6be0a126b3607bb399ae2719b471dda71f3478"
+  integrity sha512-6GfzuDWU0OFAuOvBokXpXPLxjOJ5DZ157Ue3sGQQM3LgAamb8m0R0ruSfN0DDu+XG5XJgT50i6zZ/0o8RglreQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1240,7 +1293,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -1412,6 +1465,17 @@ extract-stack@^1.0.0:
   resolved "https://registry.npmjs.org/extract-stack/-/extract-stack-1.0.0.tgz"
   integrity sha1-uXrK+UQe6iMyUpYktzL8WhyBZfo=
 
+extract-zip@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 extract-zip@^1.6.6:
   version "1.7.0"
   resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz"
@@ -1545,7 +1609,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-up@^4.1.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -1630,6 +1694,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-extra@^10.0.0:
   version "10.0.0"
@@ -1942,6 +2011,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 https-proxy-agent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz"
@@ -1966,6 +2043,11 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.8"
@@ -2056,6 +2138,11 @@ inherits@2, inherits@2.0.3, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@^1.3.5:
   version "1.3.8"
@@ -2601,6 +2688,11 @@ minimist@^1.2.5:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 mkdirp@^0.5.4:
   version "0.5.5"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz"
@@ -2662,6 +2754,13 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-releases@^2.0.1:
   version "2.0.1"
@@ -2934,6 +3033,13 @@ pinkie@^2.0.0:
   resolved "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
+pkg-dir@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
 postcss-cli@9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/postcss-cli/-/postcss-cli-9.1.0.tgz#1a86404cbe848e370127b4bdf5cd2be83bc45ebe"
@@ -3068,7 +3174,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-progress@^2.0.1:
+progress@2.0.3, progress@^2.0.1:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -3081,7 +3187,7 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@1.1.0, proxy-from-env@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -3103,6 +3209,24 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+puppeteer@^13.5.1:
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-13.5.1.tgz#d0f751bf36120efc2ebf74c7562a204a84e500e9"
+  integrity sha512-wWxO//vMiqxlvuzHMAJ0pRJeDHvDtM7DQpW1GKdStz2nZo2G42kOXBDgkmQ+zqjwMCFofKGesBeeKxIkX9BO+w==
+  dependencies:
+    cross-fetch "3.1.5"
+    debug "4.3.3"
+    devtools-protocol "0.0.969999"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.0"
+    pkg-dir "4.2.0"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.5.0"
 
 puppeteer@^2.0.0:
   version "2.1.1"
@@ -3196,7 +3320,7 @@ readable-stream@^2.2.2, readable-stream@^2.3.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.4.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -3340,17 +3464,17 @@ reusify@^1.0.4:
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@3.0.2, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.6.1:
   version "2.6.3"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -3843,12 +3967,33 @@ table@^6.8.0:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
+tar-fs@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 text-hex@1.0.x:
   version "1.0.0"
   resolved "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz"
   integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
 
-through@^2.3.6:
+through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -3892,6 +4037,11 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   dependencies:
     psl "^1.1.28"
     punycode "^2.1.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 treeify@^1.1.0:
   version "1.1.0"
@@ -3967,6 +4117,19 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
+unbzip2-stream@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
 
 unique-concat@~0.2.2:
   version "0.2.2"
@@ -4056,6 +4219,19 @@ walk@^2.3.14:
   dependencies:
     foreachasync "^3.0.0"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
@@ -4137,6 +4313,11 @@ write-file-atomic@^4.0.1:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+ws@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
 ws@^6.1.0:
   version "6.2.2"


### PR DESCRIPTION
## Done

- Add React components docs generator script
- Add React component template
- Test it on the component accordion

## QA

- [demo](https://vanilla-framework-4369.demos.haus/docs/patterns/accordion)
- Make sure that the props and different variants are shown properly
- Delete the file: `react-components.json`
- Run the following script to regenerate the data:
```bash
yarn run generate-react-docs
```
- Make sure that the file `react-components.json` is created

## Screenshots

### example of react component documentation in the component accordion
![image](https://user-images.githubusercontent.com/36013798/159713636-6fcb4eb4-a445-4b67-84fb-6b5217f39d43.png)
