### PR TITLE
Make top nav adjustments (size and highlight colour)

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -2,8 +2,10 @@
 
 $lightness-threshold: 70;
 $navigation-logo-tag-width: 1.5rem;
-$navigation-logo-tag-height: 2.4rem;
-$navigation-logo-tag-height-mobile: 2.2rem;
+$navigation-logo-tag-height: 2.2rem;
+$navigation-logo-tag-height-desktop: 2.4rem;
+$navigation-logo-height: 3rem;
+$navigation-logo-height-desktop: 3.5rem;
 $navigation-logo-width: 1.1rem;
 $sph-navigation-link: 0.3rem;
 $spv-navigation-logo: 0.3125rem;
@@ -11,12 +13,12 @@ $spv-navigation-logo: 0.3125rem;
 @mixin vf-p-navigation {
   // placeholders
   %navigation-link-responsive-padding-vertical {
-    padding-bottom: $spv--large;
-    padding-top: $spv--large;
+    padding-bottom: $spv--medium;
+    padding-top: $spv--medium;
 
-    @media (max-width: $breakpoint-navigation-threshold) {
-      padding-bottom: $spv--medium;
-      padding-top: $spv--medium;
+    @media (min-width: $breakpoint-navigation-threshold) {
+      padding-bottom: $spv--large;
+      padding-top: $spv--large;
     }
   }
 
@@ -194,8 +196,12 @@ $spv-navigation-logo: 0.3125rem;
   .p-navigation__logo {
     display: flex;
     flex: 0 0 auto;
-    height: 3.5rem;
+    height: $navigation-logo-height;
     margin: 0 $sph--large 0 0;
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      height: $navigation-logo-height-desktop;
+    }
 
     .p-navigation__item {
       @include vf-focus;
@@ -215,8 +221,8 @@ $spv-navigation-logo: 0.3125rem;
       top: 0;
       width: $navigation-logo-tag-width;
 
-      @media (max-width: $breakpoint-navigation-threshold) {
-        height: $navigation-logo-tag-height-mobile;
+      @media (min-width: $breakpoint-navigation-threshold) {
+        height: $navigation-logo-tag-height-desktop;
       }
     }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -3,6 +3,7 @@
 $lightness-threshold: 70;
 $navigation-logo-tag-width: 1.5rem;
 $navigation-logo-tag-height: 2.4rem;
+$navigation-logo-tag-height-mobile: 2.2rem;
 $navigation-logo-width: 1.1rem;
 $sph-navigation-link: 0.3rem;
 $spv-navigation-logo: 0.3125rem;
@@ -12,6 +13,11 @@ $spv-navigation-logo: 0.3125rem;
   %navigation-link-responsive-padding-vertical {
     padding-bottom: $spv--large;
     padding-top: $spv--large;
+
+    @media (max-width: $breakpoint-navigation-threshold) {
+      padding-bottom: $spv--medium;
+      padding-top: $spv--medium;
+    }
   }
 
   %navigation-link-responsive-padding-left {
@@ -208,6 +214,10 @@ $spv-navigation-logo: 0.3125rem;
       position: absolute;
       top: 0;
       width: $navigation-logo-tag-width;
+
+      @media (max-width: $breakpoint-navigation-threshold) {
+        height: $navigation-logo-tag-height-mobile;
+      }
     }
 
     .p-navigation__logo-icon {
@@ -633,7 +643,7 @@ $spv-navigation-logo: 0.3125rem;
     $color-navigation-background: $colors--light-theme--background-default,
     $color-navigation-background--hover: $colors--light-theme--background-alt,
     $color-navigation-background--active: $colors--light-theme--background-active,
-    $color-navigation-highlight: $color-accent,
+    $color-navigation-highlight: $colors--light-theme--text-default,
     $color-navigation-separator: $colors--light-theme--border-low-contrast,
     $color-navigation-icon: $colors--light-theme--text-muted
   );
@@ -645,7 +655,7 @@ $spv-navigation-logo: 0.3125rem;
     $color-navigation-background: $colors--dark-theme--background-default,
     $color-navigation-background--hover: $colors--dark-theme--background-hover,
     $color-navigation-background--active: $colors--dark-theme--background-active,
-    $color-navigation-highlight: $color-accent,
+    $color-navigation-highlight: $colors--dark-theme--text-default,
     $color-navigation-separator: $colors--dark-theme--border-low-contrast,
     $color-navigation-icon: $colors--dark-theme--text-muted
   );

--- a/templates/docs/examples/patterns/navigation/deprecated.html
+++ b/templates/docs/examples/patterns/navigation/deprecated.html
@@ -10,7 +10,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
@@ -52,12 +52,9 @@
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
-      <div class="p-navigation__tagged-logo">
-        <a class="p-navigation__link" href="#">
-          <div class="p-navigation__logo-tag">
-            <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="" >
-          </div>
-          <span class="p-navigation__logo-title">LXD</span>
+      <div class="p-navigation__logo">
+        <a class="p-navigation__item" href="#">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/20673d9f-lxd_primary--for-dark-bg.svg" alt="LXD" width="95">
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/deprecated.html
+++ b/templates/docs/examples/patterns/navigation/deprecated.html
@@ -10,14 +10,13 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95">
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-
-    <nav class="p-navigation__nav" aria-label="Example main">
+    <nav class="p-navigation__nav" aria-label="Example main navigation">
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
           <a class="p-navigation__link" href="#">Products</a>
@@ -32,15 +31,33 @@
           <a class="p-navigation__link" href="#">About</a>
         </li>
       </ul>
+      <ul class="p-navigation__items">
+        <li class="p-navigation__item">
+          <a href="#" class="js-search-button p-navigation__link--search-toggle">
+            <span class="p-navigation__search-label">Search</span>
+          </a>
+        </li>
+      </ul>
+      <div class="p-navigation__search">
+        <form class="p-search-box">
+          <input type="search" class="p-search-box__input" name="q" placeholder="Search our sites" required="" aria-label="Search our sites">
+          <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
+          <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+        </form>
+      </div>
     </nav>
   </div>
+  <div class="p-navigation__search-overlay"></div>
 </header>
 <header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
-      <div class="p-navigation__logo">
-        <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/3c7954dd-logo-canonical-white.svg" alt="" width="95" />
+      <div class="p-navigation__tagged-logo">
+        <a class="p-navigation__link" href="#">
+          <div class="p-navigation__logo-tag">
+            <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="" >
+          </div>
+          <span class="p-navigation__logo-title">LXD</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
@@ -48,20 +65,75 @@
     </div>
     <nav class="p-navigation__nav" aria-label="Example main">
       <ul class="p-navigation__items">
-        <li class="p-navigation__item is-selected">
-          <a class="p-navigation__link" href="#">Products</a>
+        <li class="p-navigation__item--dropdown-toggle" id="link-1">
+          <a href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">LXC</a>
+          <ul class="p-navigation__dropdown" id="link-1-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+            </li>
+          </ul>
         </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="#">Services</a>
+        <li class="p-navigation__item--dropdown-toggle" id="link-2">
+          <a href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link">LXD</a>
+          <ul class="p-navigation__dropdown" id="link-2-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started - Command line</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenStack</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenNebula</a>
+            </li>
+          </ul>
         </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="#">Partners</a>
+        <li class="p-navigation__item--dropdown-toggle is-active" id="link-3">
+          <a href="#link-3-menu" aria-controls="link-3-menu" class="p-navigation__link">LXCFS</a>
+          <ul class="p-navigation__dropdown" id="link-3-menu" aria-hidden="false">
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+            </li>
+          </ul>
         </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="#">About</a>
+      </ul>
+      <ul class="p-navigation__items">
+        <li class="p-navigation__item--dropdown-toggle" id="link-4">
+          <a class="p-navigation__link" aria-controls="account-menu">
+            My account
+          </a>
+          <ul class="p-navigation__dropdown--right" id="account-menu" aria-hidden="true">
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Sign out</a>
+            </li>
+          </ul>
         </li>
       </ul>
     </nav>
   </div>
 </header>
+
+<script>
+  {% include 'docs/examples/patterns/navigation/_script-search.js' %}
+  {% include 'docs/examples/patterns/navigation/_script.js' %}
+
+  initNavDropdowns('.p-navigation__item--dropdown-toggle')
+</script>
 {% endblock %}


### PR DESCRIPTION
## Done

- Update deprecated example to include more features
- Adjust the size of the top nav bar from `3.5rem` to `3rem` on small screens as per [design](https://www.figma.com/file/BSP7FqnRMcMvO7kCozJKUa/Ubuntu.com-navigation-update-Iteration-9?node-id=0%3A1832)
- Make the highlight the same as text instead of ubuntu orange

Fixes #4383 

## QA

- Open [demo](https://vanilla-framework-4386.demos.haus/)
- Go to the Navigation deprecated example and check they work as expected
- Check the highlight colour of the top nav is correct on light and dark themes
- Check on mobile the height of the top nav is correct (3rem)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Screenshot 2022-03-31 at 12 11 51](https://user-images.githubusercontent.com/58959073/161042442-c69cd090-1aaf-4240-8cc9-0c178a215726.png)
![Screenshot 2022-03-31 at 12 12 16](https://user-images.githubusercontent.com/58959073/161042495-18689c87-85dd-420c-a251-b5d28ad28d24.png)

