### PR TITLE
Remove design section from docs

### DIFF
--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -243,10 +243,6 @@ To import just this base element into your project, copy the snippet below and i
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-## Design
-
-For more information [view the typography design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Typography), which includes the specification in markdown format and a PNG image.
-
 ## Related
 
 For more typographic related information view the [code](/docs/base/code) and [pull quote pattern](/docs/patterns/pull-quote) component or our [font settings](/docs/settings/font-settings).

--- a/templates/docs/patterns/breadcrumbs.md
+++ b/templates/docs/patterns/breadcrumbs.md
@@ -59,7 +59,3 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information [view the breadcrumbs design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Breadcrumbs), which includes the specification in markdown format and a PNG image.

--- a/templates/docs/patterns/heading-icon.md
+++ b/templates/docs/patterns/heading-icon.md
@@ -67,7 +67,3 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information view the [heading icon design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Heading%20icon), which includes the specification in Markdown format and a PNG image.

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -48,7 +48,3 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information view the [images design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Images) which includes the specification in markdown format and a PNG image.

--- a/templates/docs/patterns/list-tree.md
+++ b/templates/docs/patterns/list-tree.md
@@ -31,10 +31,6 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-## Design
-
-For more information view the [list tree design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/List%20tree) which includes the specification in markdown format and a PNG image.
-
 ## Related
 
 For alternative list style layouts [view our range of list components.](/docs/patterns/lists)

--- a/templates/docs/patterns/matrix.md
+++ b/templates/docs/patterns/matrix.md
@@ -37,7 +37,3 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information [view the matrix design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Matrix), which includes the specification in markdown format and a PNG image.

--- a/templates/docs/patterns/media-object.md
+++ b/templates/docs/patterns/media-object.md
@@ -45,7 +45,3 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information view the [media object design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Media%20object) which includes the specification in markdown format and a PNG image.

--- a/templates/docs/patterns/muted-heading.md
+++ b/templates/docs/patterns/muted-heading.md
@@ -29,7 +29,3 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information [view the muted heading design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Muted%20heading), which includes the specification in markdown format and a PNG image.

--- a/templates/docs/patterns/pull-quote.md
+++ b/templates/docs/patterns/pull-quote.md
@@ -54,10 +54,6 @@ To import just this component into your project, copy the snippet below and incl
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 
-## Design
-
-For more information [view the quotes design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Pull%20quote), which includes the specification in markdown format and a PNG image.
-
 ## Related
 
 For more typographic related information view the [blockquotes and citations](/docs/base/typography#blockquotes-and-citations) in base typography.

--- a/templates/docs/patterns/switch.md
+++ b/templates/docs/patterns/switch.md
@@ -52,7 +52,3 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information [view the switch design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Switch), which includes the specification in markdown format and a PNG image.

--- a/templates/docs/patterns/table-of-contents.md
+++ b/templates/docs/patterns/table-of-contents.md
@@ -31,7 +31,3 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information [view the table of contents design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Table%20of%20contents), which includes the specification in markdown format and a PNG image.

--- a/templates/docs/settings/animation-settings.md
+++ b/templates/docs/settings/animation-settings.md
@@ -82,7 +82,3 @@ If you require multiple properties then the list must be interpolated as shown i
 ```scss
 @include vf-animation(#{height, width}, brisk, out);
 ```
-
-## Design
-
-For more information view the [animations design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Animations) which includes the specification in markdown format and a PNG image.

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -180,7 +180,3 @@ To set the default theme to dark on any of the elements / components listed abov
 ### Invoking a theme that is not currently a default
 
 Besides setting the default, you can invoke the non-default theme by adding a class to your markup. For the list of themed elements above, add `is-dark` (if the default for the respective element or component is `light`, or `is-light` if the default is dark.
-
-## Design
-
-For more information [view the color design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Color), which includes the specification in markdown format and a PNG image.

--- a/templates/docs/settings/font-settings.md
+++ b/templates/docs/settings/font-settings.md
@@ -34,10 +34,6 @@ Vanilla uses three font weight settings in tandem with the Ubuntu font, which ca
 <br>
 <hr>
 
-## Design
-
-- [Typography design](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Typography)
-
 ## Related
 
 - [Base typography](/docs/base/typography)

--- a/templates/docs/utilities/image-position.md
+++ b/templates/docs/utilities/image-position.md
@@ -81,7 +81,3 @@ To import just this utility into your project, copy the snippet below and includ
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## Design
-
-For more information view the [image position design spec](https://github.com/canonical-web-and-design/design-vanilla-framework/tree/main/Image%20position) which includes the specification in markdown format and a PNG image.


### PR DESCRIPTION
## Done

- Remove the design section from the component docs pages

Fixes [#1312](https://github.com/canonical-web-and-design/vanilla-squad/issues/1312)

## QA

- Open [demo](https://github.com/canonical-web-and-design/vanilla-squad/issues/1312)
- Check there is no "Design" section on any of the docs pages

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

