### PR TITLE
Separate Tab buttons from tabs

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -93,6 +93,7 @@
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}
               {{ side_nav_item("/docs/patterns/switch", "Switch", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
+              {{ side_nav_item("/docs/patterns/tab-buttons", "Tab buttons") }}
               {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}
               {{ side_nav_item("/docs/patterns/tooltips", "Tooltips") }}
             </ul>

--- a/templates/docs/patterns/tab-buttons.md
+++ b/templates/docs/patterns/tab-buttons.md
@@ -1,0 +1,70 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Segmented control | Components
+---
+
+# Tab buttons
+
+<hr>
+
+Tab buttons can be used in two ways:
+
+**Secondary tabs:** if the page already has a set of primary tabs used as navigation, these can be used as a sub-navigation of those primary tabs.
+
+**View switcher:** in the case of a page in which the same piece of content is shown in more than one format, this component can be used as a switcher between the different views.
+
+At smaller breakpoints, this pattern should be swapped out for one more suited to the available width, such as a <a href="https://vanillaframework.io/docs/base/forms#select">select</a>.
+
+<div class="p-notification--information is-inline">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Accessibility:</h5>
+    <p class="p-notification__message">This pattern requires the use of JS to handle navigating between tabs using keyboard events i.e. arrow keys. For more information, see <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html">the W3's tab pattern recommendations</a>.</p>
+  </div>
+</div>
+
+## Default
+
+Use the class `p-tab-buttons` to make your tabs appear as a group of buttons.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tab-buttons/default" class="js-example">
+View examples of the tab buttons pattern
+</a></div>
+
+## Dense
+
+By adding the `is-dense` modifier to the `p-tab-buttons` element, the buttons will take on a more compact appearance.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tab-buttons/dense" class="js-example">
+View examples of the dense tab buttons pattern
+</a></div>
+
+## With Icons
+
+The pattern also supports the use of icons within each button.
+
+<div class="p-notification--caution is-inline">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Icons:</h5>
+    <p class="p-notification__message">If any icons are used, all buttons within the pattern should have an icon, to avoid any potential confusion that could arise from a mix of buttons with and without an icon.</p>
+  </div>
+</div>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tab-buttons/icons" class="js-example">
+View examples of the tab buttons pattern with icons
+</a></div>
+
+## Import
+
+To import the tab button component into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework';
+@include vf-base;
+
+@include vf-p-tab-buttons;
+```
+
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/patterns/tabs.md
+++ b/templates/docs/patterns/tabs.md
@@ -102,3 +102,9 @@ To import the tab button component into your project, copy the snippet below and
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+
+## React
+
+You can use tabs in React by installing our react-component library and importing `Tab` component.
+
+[See the documentation for our React `Tab` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/tabs--default-story#tabs)

--- a/templates/docs/patterns/tabs.md
+++ b/templates/docs/patterns/tabs.md
@@ -39,54 +39,6 @@ When you need to group a number of related blocks of content within an area on t
 View example of the tabs content pattern
 </a></div>
 
-## Tab Buttons
-
-Tab buttons can be used in two ways:
-
-**Secondary tabs:** if the page already has a set of primary tabs used as navigation, as described above, these can be used as a sub-navigation of those primary tabs.
-
-**View switcher:** in the case of a page in which the same piece of content is shown in more than one format, this component can be used as a switcher between the different views.
-
-At smaller breakpoints, this pattern should be swapped out for one more suited to the available width, such as a <a href="https://vanillaframework.io/docs/base/forms#select">select</a>.
-
-<div class="p-notification--information is-inline">
-  <div class="p-notification__content">
-    <h5 class="p-notification__title">Accessibility:</h5>
-    <p class="p-notification__message">This pattern requires the use of JS to handle navigating between tabs using keyboard events i.e. arrow keys. For more information, see <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html">the W3's tab pattern recommendations</a>.</p>
-  </div>
-</div>
-
-### Default
-
-Use the class `p-tab-buttons` to make your tabs appear as a group of buttons.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/tab-buttons/default" class="js-example">
-View examples of the tab buttons pattern
-</a></div>
-
-### Dense
-
-By adding the `is-dense` modifier to the `p-tab-buttons` element, the buttons will take on a more compact appearance.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/tab-buttons/dense" class="js-example">
-View examples of the dense tab buttons pattern
-</a></div>
-
-### With Icons
-
-The pattern also supports the use of icons within each button.
-
-<div class="p-notification--caution is-inline">
-  <div class="p-notification__content">
-    <h5 class="p-notification__title">Icons:</h5>
-    <p class="p-notification__message">If any icons are used, all buttons within the pattern should have an icon, to avoid any potential confusion that could arise from a mix of buttons with and without an icon.</p>
-  </div>
-</div>
-
-<div class="embedded-example"><a href="/docs/examples/patterns/tab-buttons/icons" class="js-example">
-View examples of the tab buttons pattern with icons
-</a></div>
-
 ## Accessibility
 
 ### How it works
@@ -150,9 +102,3 @@ To import the tab button component into your project, copy the snippet below and
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
-
-## React
-
-You can use tabs in React by installing our react-component library and importing `Tab` component.
-
-[See the documentation for our React `Tab` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/tabs--default-story#tabs)


### PR DESCRIPTION
## Done

- Separate Tab buttons from tabs
- I didn't include the accessibility docs for now as we might need to take a look at the [spec](https://discourse.ubuntu.com/t/segmented-control/26835) for segmental control and check what applies
- NOTE: Renaming will be done in a separate PR 

Fixes [#1310](https://github.com/canonical-web-and-design/vanilla-squad/issues/1310)

## QA

- Open [demo](https://vanilla-framework-4401.demos.haus/docs/patterns/tab-buttons)
- Check the content in the tab buttons docs page makes sense 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
