### PR TITLE
Update accordion

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.3.0",
+  "version": "3.3.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -23,6 +23,7 @@
     @extend %single-border-text-vpadding--scaling;
     @include vf-focus;
 
+    background-color: inherit;
     border: 0;
     border-radius: 0;
     font-size: inherit;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -23,12 +23,6 @@
     @extend %single-border-text-vpadding--scaling;
     @include vf-focus;
 
-    background: {
-      color: inherit;
-      position: top $icon-top-position left $sph--large;
-      repeat: no-repeat;
-    }
-
     border: 0;
     border-radius: 0;
     font-size: inherit;
@@ -36,28 +30,37 @@
     margin-bottom: 0;
     padding-left: $sph--large + $icon-size + $sph--large;
     padding-right: $sph--large;
+    position: relative;
     text-align: left;
     transition-duration: 0s;
     width: 100%;
     z-index: 2;
 
+    &::before {
+      @include vf-icon-chevron($color-mid-dark);
+      @include vf-animation(transform);
+      content: '';
+      height: $icon-size;
+      left: $sph--large;
+      position: absolute;
+      top: $icon-top-position;
+      width: $icon-size;
+    }
+
     // aria-selected controls the open and closed state for the accordion tab
     &[aria-expanded='true'] {
-      @include vf-icon-minus($color-mid-dark);
-
       // override base expanded button styles
       background-color: inherit;
+
       &:hover {
         background-color: $colors--light-theme--background-hover;
       }
-
-      background-size: $icon-size;
     }
 
     &[aria-expanded='false'] {
-      @include vf-icon-plus($color-mid-dark);
-
-      background-size: $icon-size;
+      &::before {
+        transform: rotate(-90deg);
+      }
     }
   }
 
@@ -74,25 +77,22 @@
   }
 
   // stylelint-disable selector-max-type
-  h2.p-accordion__heading > .p-accordion__tab,
-  .p-heading--2 > .p-accordion__tab {
+  h2.p-accordion__heading > .p-accordion__tab::before,
+  .p-heading--2 > .p-accordion__tab::before {
     $icon-top-position: calc(#{$table-cell-vertical-padding + (map-get($line-heights, h2) - $icon-size) * 0.5});
-
-    background-position-y: $icon-top-position;
+    top: $icon-top-position;
   }
 
-  h3.p-accordion__heading > .p-accordion__tab,
-  .p-heading--3 > .p-accordion__tab {
+  h3.p-accordion__heading > .p-accordion__tab::before,
+  .p-heading--3 > .p-accordion__tab::before {
     $icon-top-position: calc(#{$table-cell-vertical-padding + (map-get($line-heights, h3) - $icon-size) * 0.5});
-
-    background-position-y: $icon-top-position;
+    top: $icon-top-position;
   }
 
-  h4.p-accordion__heading > .p-accordion__tab,
-  .p-heading--4 > .p-accordion__tab {
+  h4.p-accordion__heading > .p-accordion__tab::before,
+  .p-heading--4 > .p-accordion__tab::before {
     $icon-top-position: calc(#{$table-cell-vertical-padding + (map-get($line-heights, h4) - $icon-size) * 0.5});
-
-    background-position-y: $icon-top-position;
+    top: $icon-top-position;
   }
   // stylelint-enable selector-max-type
 

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -39,7 +39,7 @@
 
     &::before {
       @include vf-icon-chevron($color-mid-dark);
-      @include vf-animation(transform);
+      @include vf-animation($property: transform, $duration: fast);
       content: '';
       height: $icon-size;
       left: $sph--large;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -62,7 +62,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
-              {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
+              {{ side_nav_item("/docs/patterns/accordion", "Accordion", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
               {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
               {{ side_nav_item("/docs/patterns/card", "Cards") }}

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -20,6 +20,15 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 3.3.1 -->
+    <tr>
+      <th><a href="/docs/patterns/accordion">Accordion</a></th>
+      <td>
+        <span class="p-status-label--information">Updated</span>
+      </td>
+      <td>3.2.1</td>
+      <td>We changed the icon of the accordion tab.</td>
+    </tr>
     <!-- 3.3.0 -->
     <tr>
       <th><a href="/docs/patterns/segmented-control">Segmented control</a></th>


### PR DESCRIPTION
## Done

- Update accordion styling, according to #4397 

Fixes #4397 

## QA

- Open demo
- Find the accordion in the examples section an check it matches the design
e.g. https://vanilla-framework-4406.demos.haus/docs/examples/patterns/accordion/default

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.