### PR TITLE
Update Vanilla website to new mobile search dropdown 

### DIFF
--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -8,8 +8,16 @@
           <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/94d962aa-vanilla_white-orange_hex.svg" style="height:1.5rem" alt="Vanilla framework">
         </a>
       </div>
-      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+      <ul class="p-navigation__items">
+        <li class="p-navigation__item">
+          <button class="js-search-button p-navigation__link--search-toggle">
+            <span class="p-navigation__search-label">Search</span>
+          </button>
+        </li>
+        <li class="p-navigation__item">
+          <button class="js-menu-button p-navigation__link">Menu</button>
+        </li>
+      </ul>
     </div>
     <nav class="p-navigation__nav" aria-label="Main">
       <ul class="p-navigation__items">
@@ -21,9 +29,9 @@
       </ul>
       <ul class="p-navigation__items">
         <li class="p-navigation__item">
-          <a href="#" class="js-search-button p-navigation__link--search-toggle">
+          <button class="js-search-button p-navigation__link--search-toggle">
             <span class="p-navigation__search-label">Search</span>
-          </a>
+          </button>
         </li>
       </ul>
       <div class="p-navigation__search">

--- a/templates/docs/examples/patterns/navigation/search-dark.html
+++ b/templates/docs/examples/patterns/navigation/search-dark.html
@@ -22,9 +22,9 @@
           <button class="js-search-button p-navigation__link--search-toggle">
             <span class="p-navigation__search-label">Search</span>
           </button>
-          <li class="p-navigation__item">
-            <button class="js-menu-button p-navigation__link">Menu</button>
-          </li>
+        </li>
+        <li class="p-navigation__item">
+          <button class="js-menu-button p-navigation__link">Menu</button>
         </li>
       </ul>
     </div>
@@ -42,9 +42,9 @@
       </ul>
       <ul class="p-navigation__items">
         <li class="p-navigation__item">
-          <a href="#" class="js-search-button p-navigation__link--search-toggle">
+          <button class="js-search-button p-navigation__link--search-toggle">
             <span class="p-navigation__search-label">Search</span>
-          </a>
+          </button>
         </li>
       </ul>
       <div class="p-navigation__search">

--- a/templates/docs/examples/patterns/navigation/search-light.html
+++ b/templates/docs/examples/patterns/navigation/search-light.html
@@ -22,11 +22,12 @@
           <button class="js-search-button p-navigation__link--search-toggle">
             <span class="p-navigation__search-label">Search</span>
           </button>
-          <li class="p-navigation__item">
-            <button class="js-menu-button p-navigation__link">Menu</button>
-          </li>
         </li>
-      </ul>    </div>
+        <li class="p-navigation__item">
+          <button class="js-menu-button p-navigation__link">Menu</button>
+        </li>
+      </ul>
+    </div>
     <nav class="p-navigation__nav" aria-label="Example main">
       <ul class="p-navigation__items">
         <li class="p-navigation__item is-selected">
@@ -41,9 +42,9 @@
       </ul>
       <ul class="p-navigation__items">
         <li class="p-navigation__item">
-          <a href="#" class="js-search-button p-navigation__link--search-toggle">
+          <button href="#" class="js-search-button p-navigation__link--search-toggle">
             <span class="p-navigation__search-label">Search</span>
-          </a>
+          </button>
         </li>
       </ul>
       <div class="p-navigation__search">

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -150,38 +150,120 @@
 
 (function () {
   function initNavigationSearch(element) {
-    const searchButton = element.querySelector('.js-search-button');
-    if (searchButton) {
-      searchButton.addEventListener('click', openSearch);
+    const searchButtons = element.querySelectorAll('.js-search-button');
+
+    searchButtons.forEach((searchButton) => {
+      searchButton.addEventListener('click', toggleSearch);
+    });
+
+    const menuButton = element.querySelector('.js-menu-button');
+    if (menuButton) {
+      menuButton.addEventListener('click', toggleMenu);
     }
 
     const overlay = element.querySelector('.p-navigation__search-overlay');
     if (overlay) {
-      overlay.addEventListener('click', closeSearch);
+      overlay.addEventListener('click', closeAll);
+    }
+
+    function toggleMenu(e) {
+      e.preventDefault();
+
+      var navigation = e.target.closest('.p-navigation');
+      if (navigation.classList.contains('has-menu-open')) {
+        closeAll();
+      } else {
+        closeAll();
+        openMenu(e);
+      }
+    }
+
+    function toggleSearch(e) {
+      e.preventDefault();
+
+      var navigation = e.target.closest('.p-navigation');
+      if (navigation.classList.contains('has-search-open')) {
+        closeAll();
+      } else {
+        closeAll();
+        openSearch(e);
+      }
     }
 
     function openSearch(e) {
       e.preventDefault();
       var navigation = e.target.closest('.p-navigation');
+      var nav = navigation.querySelector('.p-navigation__nav');
+
       var searchInput = navigation.querySelector('.p-search-box__input');
+      var buttons = document.querySelectorAll('.js-search-button');
+
+      buttons.forEach((searchButton) => {
+        searchButton.setAttribute('aria-pressed', true);
+      });
+
       navigation.classList.add('has-search-open');
       searchInput.focus();
       document.addEventListener('keyup', keyPressHandler);
     }
 
+    function openMenu(e) {
+      e.preventDefault();
+      var navigation = e.target.closest('.p-navigation');
+      var nav = navigation.querySelector('.p-navigation__nav');
+
+      var buttons = document.querySelectorAll('.js-menu-button');
+
+      buttons.forEach((searchButton) => {
+        searchButton.setAttribute('aria-pressed', true);
+      });
+
+      navigation.classList.add('has-menu-open');
+      document.addEventListener('keyup', keyPressHandler);
+    }
+
     function closeSearch() {
-      var navigation = document.querySelector('.p-navigation.has-search-open');
+      var navigation = document.querySelector('.p-navigation');
+      var nav = navigation.querySelector('.p-navigation__nav');
+
       var banner = document.querySelector('.p-navigation__banner');
+      var buttons = document.querySelectorAll('.js-search-button');
+
+      buttons.forEach((searchButton) => {
+        searchButton.removeAttribute('aria-pressed');
+      });
+
       navigation.classList.remove('has-search-open');
       document.removeEventListener('keyup', keyPressHandler);
     }
 
+    function closeMenu() {
+      var navigation = document.querySelector('.p-navigation');
+      var nav = navigation.querySelector('.p-navigation__nav');
+
+      var banner = document.querySelector('.p-navigation__banner');
+      var buttons = document.querySelectorAll('.js-menu-button');
+
+      buttons.forEach((searchButton) => {
+        searchButton.removeAttribute('aria-pressed');
+      });
+
+      navigation.classList.remove('has-menu-open');
+      document.removeEventListener('keyup', keyPressHandler);
+    }
+
+    function closeAll() {
+      closeSearch();
+      closeMenu();
+    }
+
     function keyPressHandler(e) {
       if (e.key === 'Escape') {
-        closeSearch();
+        closeAll();
       }
     }
   }
+
   var navigation = document.querySelector('#navigation');
   initNavigationSearch(navigation);
 })();


### PR DESCRIPTION

## Done

Update Vanilla website to new mobile search dropdown

Drive-by: fix wrongly nested HTML in the search examples

## QA

- Open [demo](https://vanilla-framework-4408.demos.haus/)
- make sure vanilla docs website uses new search dropdown on mobile
