### PR TITLE
Update side nav for 3.2

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -47,7 +47,7 @@
               {{ side_nav_item("/docs/building-vanilla", "Building with Vanilla") }}
               {{ side_nav_item("/docs/customising-vanilla", "Customising Vanilla") }}
               {{ side_nav_item("/docs/whats-new", "What’s new in " ~ version) }}
-              {{ side_nav_item("/docs/migration-guide-to-v3", "Migrating to v3.0", "new", "positive") }}
+              {{ side_nav_item("/docs/migration-guide-to-v3", "Migrating to v3.0") }}
             </ul>
 
             <ul class="p-side-navigation__list">
@@ -69,29 +69,29 @@
               {{ side_nav_item("/docs/patterns/chip", "Chips") }}
               {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}
               {{ side_nav_item("/docs/patterns/divider", "Divider") }}
-              {{ side_nav_item("/docs/patterns/empty-state", "Empty state", 'new', 'positive') }}
+              {{ side_nav_item("/docs/patterns/empty-state", "Empty state") }}
               {{ side_nav_item("/docs/patterns/grid", "Grid") }}
               {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}
               {{ side_nav_item("/docs/patterns/icons", "Icons") }}
               {{ side_nav_item("/docs/patterns/images", "Images") }}
               {{ side_nav_item("/docs/patterns/links", "Links") }}
               {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
               {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}
               {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}
               {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
-              {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
+              {{ side_nav_item("/docs/patterns/navigation", "Navigation", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
               {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
               {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
-              {{ side_nav_item("/docs/patterns/slider", "Slider", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/slider", "Slider") }}
               {{ side_nav_item("/docs/patterns/status-labels", "Status labels", 'new', 'positive') }}
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}
-              {{ side_nav_item("/docs/patterns/switch", "Switch", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/switch", "Switch") }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
               {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}
               {{ side_nav_item("/docs/patterns/tooltips", "Tooltips") }}


### PR DESCRIPTION
## Done

Make sure side nav in Vanilla docs only shows latest relevant status labels.

## QA

- Open [demo](https://vanilla-framework-4409.demos.haus/docs)
- Make sure docs side nav only shows relevant status labels (compare with what's new table)





## Screenshots

<img width="329" alt="image" src="https://user-images.githubusercontent.com/83575/163125688-26ad043c-5883-4056-8b2e-560f150e0e1e.png">

