### PR TITLE
Update Code snippet docs

### DIFF
--- a/templates/_class-references/code-snippet.html
+++ b/templates/_class-references/code-snippet.html
@@ -1,0 +1,90 @@
+<div class="row">
+  <div class="col-2 col-medium-1"><h4 class="p-heading--5">Root element</h4></div>
+  <div class="col-7 col-medium-5">
+    <div class="row">
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet</code></p></div>
+      <div class="col-4 col-medium-3"><p>Main element of the code snippet component.</p></div>
+      <div class="col-7 col-medium-5"><hr/></div>
+      <div class="col-3 col-medium-2"><p><code>&.is-bordered</code></p></div>
+      <div class="col-4 col-medium-3"><p>Bordered variant, to be used when additional content (such as iframes) is used inside the code snippet component.</p></div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row">
+  <div class="col-2 col-medium-1"><h4 class="p-heading--5">Code block</h4></div>
+  <div class="col-7 col-medium-5">
+    <div class="row">
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet__block</code></p></div>
+      <div class="col-4 col-medium-3"><p>Code block without any additonal styling elements.</p></div>
+      <div class="col-7 col-medium-5"><hr/></div>
+      <div class="col-3 col-medium-2"><p><code>&.is-wrapped</code></p></div>
+      <div class="col-4 col-medium-3"><p>Code block with wrapped content in lines.</p></div>
+      <div class="col-7 col-medium-5"><hr/></div>
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet__block--icon</code></p></div>
+      <div class="col-4 col-medium-3"><p>Code block that starts with an icon. Default icon is a UNIX prompt. To be used with Linux CLI examples.</p></div>
+      <div class="col-7 col-medium-5"><hr/></div>
+      <div class="col-3 col-medium-2"><p><code>&.is-windows-prompt</code></p></div>
+      <div class="col-4 col-medium-3"><p>Changes the <code>.p-code-snippet__block--icon</code> to use a Windows prompt icon. To be used with Windows CLI examples.</p></div>
+      <div class="col-7 col-medium-5"><hr/></div>
+      <div class="col-3 col-medium-2"><p><code>&.is-url</code></p></div>
+      <div class="col-4 col-medium-3"><p>Changes the <code>.p-code-snippet__block--icon</code> to use a link icon. To be used with URLs.</p></div>
+      <div class="col-7 col-medium-5"><hr/></div>
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet__block--numbered</code></p></div>
+      <div class="col-4 col-medium-3"><p>Code block with numbered lines of code (to be used with longer pieces of code examples). Requires <code>.p-code-snippet__line</code>.</p></div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row">
+  <div class="col-2 col-medium-1"><h4 class="p-heading--5">Code line</h4></div>
+  <div class="col-7 col-medium-5">
+    <div class="row">
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet__line</code></p></div>
+      <div class="col-4 col-medium-3"><p>A wrapper around single line of code. Needed with numbered variant of a code block.</p></div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row">
+  <div class="col-2 col-medium-1"><h4 class="p-heading--5">Code block header</h4></div>
+  <div class="col-7 col-medium-5">
+    <div class="row">
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet__header</code></p></div>
+      <div class="col-4 col-medium-3"><p>A header of a code block. Contains a title and optional dropdowns.</p></div>
+      <div class="col-7 col-medium-5"><hr/></div>
+      <div class="col-3 col-medium-2"><p><code>&.is-stacked</code></p></div>
+      <div class="col-4 col-medium-3"><p>A stacked version of a header (with a title displayed above the dropdowns). To be used when there are multiple dropdowns with a long title.</p></div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row">
+  <div class="col-2 col-medium-1"><h4 class="p-heading--5">Code block title</h4></div>
+  <div class="col-7 col-medium-5">
+    <div class="row">
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet__title</code></p></div>
+      <div class="col-4 col-medium-3"><p>The title of a code block.</p></div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row">
+  <div class="col-2 col-medium-1"><h4 class="p-heading--5">Dropdowns container</h4></div>
+  <div class="col-7 col-medium-5">
+    <div class="row">
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet__dropdowns</code></p></div>
+      <div class="col-4 col-medium-3"><p>Container element for any dropdowns in the header.</p></div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row">
+  <div class="col-2 col-medium-1"><h4 class="p-heading--5">Dropdown</h4></div>
+  <div class="col-7 col-medium-5">
+    <div class="row">
+      <div class="col-3 col-medium-2"><p><code>.p-code-snippet__dropdown</code></p></div>
+      <div class="col-4 col-medium-3"><p>An individual dropdown in code block header.</p></div>
+    </div>
+  </div>
+</div>

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -76,6 +76,10 @@ It is also possible to include multiple selects, and an alternative layout is av
 View example of the code snippet
 </a></div>
 
+### JavaScript functionality
+
+When the code snippet contains dropdowns to switch the displayed code, the functionality of the dropdown menus needs to be provided via JavaScript. The contents of the code block should change based on the value selected in the dropdown. In a simpler case, there may be multiple code block elements in the code snippet component, but only one of them visible based on the user's choice in the dropdowns.
+
 ## Wrapping
 
 By default, `<pre>` elements do not wrap content, but this can be overridden by adding the `.is-wrapped` utility class to a `.p-code-snippet__block`:

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -108,6 +108,10 @@ Add the class `.is-bordered` to the `.p-code-snippet` element to visually group 
 View example of the code snippet with a border
 </a></div>
 
+## Class reference
+
+{% include "_class-references/code-snippet.html" %}
+
 ## React
 
 You can use code snippet in React by installing our react-component library and importing code snippet component.


### PR DESCRIPTION
## Done

Adds class reference and JavaScript sections to code snippet.

Fixes canonical-web-and-design/vanilla-squad#1198

## QA

- Review updated documentation:
  - Class reference https://vanilla-framework-4415.demos.haus/docs/base/code#class-reference
  - JavaScript functionality https://vanilla-framework-4415.demos.haus/docs/base/code#javascript-functionality

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


