### PR TITLE
Deprecate label pattern

### DIFF
--- a/guides/pull-requests.md
+++ b/guides/pull-requests.md
@@ -52,7 +52,7 @@ Any affected examples in your PR should have an appropriate label, either `new`,
 An example's documentation should then also include a status label within the body of the page, using the appropriate label:
 
 ```
-<span class="p-label--positive">New</span>
-<span class="p-label--information">Updated</span>
-<span class="p-label--negative">Deprecated</span>
+<span class="p-status-label--positive">New</span>
+<span class="p-status-label--information">Updated</span>
+<span class="p-status-label--negative">Deprecated</span>
 ```

--- a/scss/_patterns_status-label.scss
+++ b/scss/_patterns_status-label.scss
@@ -56,7 +56,6 @@
   }
 }
 
-
 // Deprecated mixin kept for compatibility
 @mixin vf-p-label {
   @include vf-p-status-label;

--- a/scss/_patterns_status-label.scss
+++ b/scss/_patterns_status-label.scss
@@ -55,3 +55,9 @@
     color: $color-x-light;
   }
 }
+
+
+// Deprecated mixin kept for compatibility
+@mixin vf-p-label {
+  @include vf-p-status-label;
+}

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -32,7 +32,7 @@
                     {{ title }}
                     {% if label %}
                       <span class="p-side-navigation__status">
-                        <span class="p-label--{{ type|lower }}">
+                        <span class="p-status-label--{{ type|lower }}">
                           {{ label|capitalize }}
                         </span>
                       </span>

--- a/templates/docs/changelog-v2.md
+++ b/templates/docs/changelog-v2.md
@@ -22,7 +22,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms#datalist">Forms / Datalist</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.37.0</td>
       <td>We've added documentation for datalist</td>
@@ -31,7 +31,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/accordion#with-tick-elements">Accordion / Tick elements</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.36.0</td>
       <td>We've added a variation of the accordion using tick elements</td>
@@ -39,7 +39,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/card#content-bleed">Card / Content Bleed</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.36.0</td>
       <td>We added a <code>.p-card__inner</code> element so that it's possible to have a mix of padded and not padded content within a card.</td>
@@ -47,7 +47,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms#help-text">Form / Help text</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.36.0</td>
       <td>We added a class name to aligned help text with checkboxes or radio buttons</td>
@@ -56,7 +56,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms#validation">Forms / Validation</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.35.0</td>
       <td>We've updated the styling of the form validation and required patterns</td>
@@ -65,7 +65,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms#password-showhide">Forms / Password toggle</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.34.0</td>
       <td>Password fields now have a show/hide toggle.</td>
@@ -73,7 +73,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/lists#status">Lists / Crossed</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.34.0</td>
       <td>We added a <code>is-crossed</code> modifier class for lists, to complement the existing <code>is-ticked</code> modifier.</td>
@@ -81,7 +81,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/lists#status">Lists / Ticked</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.34.0</td>
       <td>We updated the color of the <code>is-ticked</code> icon on lists to <code>$color-positive</code>, where previously it was <code>$color-accent</code>.</td>
@@ -89,7 +89,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/tabs#tab-buttons">Tabs / Tab Buttons</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.34.0</td>
       <td>We added a new type of tab pattern, `p-tab-buttons`, which can display tabs like a group of buttons.</td>
@@ -98,7 +98,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/links#skip-link">Links / Skip Link</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.33.0</td>
       <td>We added a new link variant, <code>.p-link--skip</code>, that places a link offscreen and is revealed on focus.</td>
@@ -106,7 +106,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/notification">Notifications</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.33.0</td>
       <td>Notifications have been updated with a new appearance, requiring a new HTML structure.</td>
@@ -114,7 +114,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/notification#deprecated">Notifications structure</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.33.0</td>
       <td>The following notification classes have been deprecated: <code>.p-notification__response</code>, <code>.p-notification__status</code></td>
@@ -123,7 +123,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/chip">Labels / Default</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.32.0</td>
       <td>We've added a default label <code>p-label</code></td>
@@ -131,7 +131,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/buttons#theming">Button / Dark</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.32.0</td>
       <td>We added the dark theme to the buttons.</td>
@@ -139,7 +139,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/buttons#neutral">Button / Neutral</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.32.0</td>
       <td>The neutral button variant <code>p-button--neutral</code> is deprecated, please use default <code>p-button</code> instead.</td>
@@ -147,7 +147,7 @@ context:
     <tr>
       <th><a href="/docs/base/tables#overflow">Tables / Overflow</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.32.0</td>
       <td>We introduced the <code>.has-overflow</code> utility for table cells, to aid with the display of components that need to overflow the cell, such as tooltips and contextual menus.</td>
@@ -155,7 +155,7 @@ context:
     <tr>
       <th><a href="/docs/base/tables#responsive">Tables / Responsive</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.32.0</td>
       <td>The <code>.p-table--mobile-card</code> previously contained style overrides for the <a href="https://vanillaframework.io/docs/examples/patterns/contextual-menu/default">contextual menu pattern</a>, these have been removed so that contextual menus within responsive tables look and behave the same as they do elsewhere.</td>
@@ -164,7 +164,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Dropdown</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.31.0</td>
       <td>We introduced the <code>.p-navigation__item--dropdown-toggle</code> class, as a replacement for the now deprecated <code>.p-subnav</code> class.</td>
@@ -172,7 +172,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation#dropdown">Navigation / Sub-navigation</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.31.0</td>
       <td>The <code>.p-subnav</code> class previously could theoretically be used outside of the main <code>.p-navigation</code> component, which was not intended. It has been deprecated, and succeeded by the <code>.p-navigation__item--dropdown-toggle</code> class.</td>
@@ -181,7 +181,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/buttons#link">Button / Link</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.30.0</td>
       <td>Buttons can now assume the appearance of a standard link.</td>
@@ -189,7 +189,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/lists#theming">Lists / spanider</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.30.0</td>
       <td>We added a dark theme to responsive spanider lists.</td>
@@ -197,7 +197,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/tabs#content">Tabs / Content</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.30.0</td>
       <td>The tab pattern can now be used either as a navigation list, or as controls for panes of content.</td>
@@ -206,7 +206,7 @@ context:
     <tr>
       <th><a href="/docs/layouts/fluid-breakout#toolbar">Fluid breakout - toolbar</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.29.0</td>
       <td>We added support for a toolbar within the fluid-breakout layout.</td>
@@ -215,7 +215,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/modal">Modal footer</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added the optional footer to the modal pattern.</td>
@@ -223,7 +223,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/logo-section">Logo section</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.28.0</td>
       <td>A new logo section</td>
@@ -231,7 +231,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/logo-section">Inline images</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.28.0</td>
       <td>The inline images component has now been deprecated. Please use the logo section component instead.</td>
@@ -239,7 +239,7 @@ context:
     <tr>
       <th><a href="/docs/base/tables#empty">Table - empty</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added a basic styling for the table <code>&lt;caption&gt;</code> in empty tables</td>
@@ -247,7 +247,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/tooltips#detached">Tooltips - detached</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.28.0</td>
       <td>We added the <code>.is-detached</code> utility, providing a way for tooltips to exist separately from their associated element.</td>
@@ -256,7 +256,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/icons#social">GitHub icon</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.27.0</td>
       <td>We added the GitHub icon <code>.p-icon--github</code> to our social icons set.</td>
@@ -264,7 +264,7 @@ context:
     <tr>
       <th><a href="/docs/base/code#bordered">Code snippet - bordered</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.27.0</td>
       <td>We added the utility class <code>.is-bordered</code> to the code snippet.</td>
@@ -273,7 +273,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/search-and-filter">Search and filter</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added the new Search and filter component.</td>
@@ -281,7 +281,7 @@ context:
     <tr>
       <th><a href="/docs/layouts/application#aside-area">Application layout - animations</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.26.0</td>
       <td>We added <code>is-collapsed</code> class that allows animating the application layout aside panel.</td>
@@ -289,7 +289,7 @@ context:
     <tr>
       <th><a href="/docs/base/tables#expanding">Tables expanding</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We renamed and deprecated <code>p-table-expanding</code> and <code>p-table-expanding__panel</code>. Use <code>p-table--expanding</code> and <code>p-table__expanding-panel</code> instead.</td>
@@ -297,7 +297,7 @@ context:
     <tr>
       <th><a href="/docs/base/tables#sortable">Tables sorting</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We removed <code>p-table--sortable</code> class name. Sorting can be enabled on any table by adding <code>aria-sort</code> attributes.</td>
@@ -305,7 +305,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms#indeterminate-state-checkbox">Forms / Checkbox indeterminate</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added indeterminate state checkboxes. If a checkbox has <code>checkbox.indeterminate = true;</code> set via JavaScript, the checkbox will show a state between checked and unchecked.</td>
@@ -313,7 +313,7 @@ context:
     <tr>
       <th><a href="/docs/layouts/sticky-footer">Sticky footer</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.26.0</td>
       <td>We added a new <code>.l-site</code> layout, which can accommodate a sticky footer.</td>
@@ -321,7 +321,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/accordion">Accordions</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.26.0</td>
       <td>We deprecated the previous accordion tab patterns, <code>.p-accordion__tab</code> and <code>.p-accordion__tab--with-title .p-accordion__title</code>, in favour of a more accessible pattern. Please use <code>.p-accordion__heading .p-accordion__tab</code>.</td>
@@ -330,7 +330,7 @@ context:
     <tr>
       <th><a href="/docs/base/typography#extra-small-capitalised-text">Typography / Extra small caps</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new extra small capitalised text <code>p-text--x-small-capitalised</code>.</td>
@@ -338,7 +338,7 @@ context:
     <tr>
       <th><a href="/docs/base/typography#baseline-alignment-small-extra-small-and-paragraph-text">Typography / Baseline alignment</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added a couple of util classes to help aligning small text on the baseline along default text size.</td>
@@ -346,7 +346,7 @@ context:
     <tr>
       <th><a href="/docs/base/separators#muted-horizontal-rule">Separators / Muted</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new muted variant of horizontal rule.</td>
@@ -354,7 +354,7 @@ context:
     <tr>
       <th><a href="/docs/base/separators#fixed-width-horizontal-rule">Separators / Fixed width</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.25.0</td>
       <td>We added new fixed width variant of horizontal rule to allow aligning it with full 12-column grid layouts.</td>
@@ -362,7 +362,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/lists#middot">Lists / Middot</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.25.0</td>
       <td>We added a dark theme to middot lists.</td>
@@ -371,7 +371,7 @@ context:
     <tr>
       <th><a href="/docs/base/code#dropdowns">Code snippet - Dropdowns</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.24.0</td>
       <td>We added the ability to accommodate multiple selects within a <code>.p-code-snippet__header</code>, either inline, using the <code>.is-stacked</code> utility to class to have the dropdowns below the title.</td>
@@ -379,7 +379,7 @@ context:
     <tr>
       <th><a href="/docs/base/code#inline">Code inline - dark</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.24.0</td>
       <td>We've updated inline <code>code</code> elements to support being nested within a <code>.p-strip--dark</code> element, and to support an <code>.is-dark</code> utility class.</td>
@@ -387,7 +387,7 @@ context:
     <tr>
       <th><a href="/docs/layouts/fluid-breakout">Fluid breakout</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.24.0</td>
       <td>We added a new <code>l-fluid-breakout</code> layout that can be used to break out of the constraints of a 12-column grid and allow content to bleed into the page margins on larger screens.</td>
@@ -395,7 +395,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/grid">Grid - "orphan" columns</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.24.0</td>
       <td>We deprecated the use of `.col` classes without a direct parent with a class `.row`.</td>
@@ -404,7 +404,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/buttons#active">Active button</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.23.0</td>
       <td>The <code>is-active</code> class was deprecated and given a more appropriate name: <code>is-processing</code>.</td>
@@ -412,7 +412,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/buttons#processing">Processing button</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.23.0</td>
       <td>We renamed <code>is-active</code> button state class to <code>is-processing</code>, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
@@ -420,7 +420,7 @@ context:
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet - Dropdowns</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.23.0</td>
       <td>We add the ability to include a select within in a code snippet, allowing users to switch between related code examples.</td>
@@ -428,7 +428,7 @@ context:
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.23.0</td>
       <td>We added a utility class for <code>.p-code-snippet__block</code> that allows content to wrap, rather than horizontally scroll: <code>.is-wrapped</code>.</td>
@@ -437,7 +437,7 @@ context:
     <tr>
       <th><a href="/docs/base/separators">Separator</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.22.0</td>
       <td>The new <code>p-separator</code> component has been added to be used as a separator between content blocks.</td>
@@ -445,7 +445,7 @@ context:
     <tr>
       <th><a href="/docs/base/code#code-snippet">Code snippet</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.22.0</td>
       <td>The new <code>.p-code-snippet</code> component has been added, to be used to display code examples in a number of different formats.</td>
@@ -453,7 +453,7 @@ context:
     <tr>
       <th><a href="/docs/base/code#copyable">Code copyable</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.22.0</td>
       <td><code>.p-code-copyable</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>
@@ -461,7 +461,7 @@ context:
     <tr>
       <th><a href="/docs/base/code#numbered">Code numbered</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.22.0</td>
       <td><code>.p-code-numbered</code> has been deprecated and will be removed in the v3.0 release. Please use <code>.p-code-snippet .p-code-snippet__block--numbered</code> instead.</td>
@@ -470,7 +470,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Contextual Menu</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.21.0</td>
       <td>The <code>p-icon--contextual-menu</code> has been deprecated and will be removed in future release v3.0. Please use existing <code>.p-icon--chevron-down</code> and <code>.p-icon--chevron-up</code> icons instead.</td>
@@ -478,7 +478,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/icons#additional">Icons - Additional</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.21.0</td>
       <td>We added many more icons, outside of the base icon set. These icons are not included in Vanilla by default, but can be inspanidually included as needed.</td>
@@ -486,7 +486,7 @@ context:
     <tr>
       <th><a href="/docs/layouts/application#panels">Application layout - panels</a></th>
       <td>
-        <span class="p-label--caution">In progress</span>
+        <span class="p-status-label--caution">In progress</span>
       </td>
       <td>2.21.0</td>
       <td>We continue working on application layout panels styling. We improved the positioning of the logo, title and controls in panel headers.</td>
@@ -494,7 +494,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation#application-layout">Application layout - side navigation</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.21.0</td>
       <td>We implemented and documented improvements for <a href="/docs/patterns/navigation#application-layout">side navigation component</a> for the <a href="/docs/layouts/application#side-navigation">application layout</a>.</td>
@@ -502,7 +502,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation#sticky">Side navigation - Sticky</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.21.0</td>
       <td>Side navigation component used to be sticky by default. We now introduced new <code>is-sticky</code> variant that should be used to optionally make side navigation sticky.</td>
@@ -511,7 +511,7 @@ context:
     <tr>
       <th><a href="/docs/layouts/application#responsive-application-layout">Application layout panels</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.20.0</td>
       <td>We updated the responsive styles of application layout panels and introduced some class names and variables for more flexible customization options.</td>
@@ -519,7 +519,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/buttons#small">Small buttons</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.20.0</td>
       <td>We added an <code>is-small</code> modifier class for buttons, which can be combined with <code>is-dense</code>.</td>
@@ -527,7 +527,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/buttons#small">Active buttons</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.20.0</td>
       <td>We added an <code>is-active</code> state class for buttons, which can be combined with <code>disabled</code> when a button needs to indicate a process is occurring while also preventing user interaction.</td>
@@ -536,7 +536,7 @@ context:
     <tr>
       <th><a href="/docs/base/tables#expanding">Expanding table column placeholder</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.19.2</td>
       <td>We started using <code>aria-hidden="true"</code> attribute to hide the placeholder table header in place of previously used <code>u-hide</code> utility.</td>
@@ -544,7 +544,7 @@ context:
     <tr>
       <th><a href="/docs/base/tables#icons">Table icons</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.19.0</td>
       <td>We added a <code>p-table__cell--icon-placeholder</code> class to properly align icons in table cells.</td>
@@ -553,7 +553,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/breadcrumbs">Breadcrumbs</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.18.0</td>
       <td>We updated the markup of the breadcrumbs component to comply with accessibility requirements. The class <code>.p-breadcrumbs</code> is now moved onto a <code>&lt;nav&gt;</code> element, the unordered list has been changed to an ordered one that has a class <code>.p-breadcrumbs__items</code>. </td>
@@ -561,7 +561,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/breadcrumbs#deprecated-markup">Breadcrumbs</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.18.0</td>
       <td>Top level <code>&lt;ul&gt;</code> with a class <code>.p-breadcrumbs</code> is now deprecated for the Breadcrumbs pattern.</td>
@@ -570,7 +570,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms#checkbox">Checkbox and radio buttons components</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.17.0</td>
       <td>We introduced new <code>.p-checkbox</code> and <code>.p-radio</code> components. They replace the existing styling of base form inputs.</td>
@@ -578,7 +578,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms#deprecated-base-checkboxes">Checkbox and radio buttons elements</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.17.0</td>
       <td>Base styled checkboxes and radio buttons (on <code>&lt;input type="checkbox"&gt;</code> or <code>&lt;input type="radio"&gt;</code> elements) are deprecated and they will be reverted to native browser inputs in future version of Vanilla. Please use on bWe added new layout styles for building responsive full-screen applications.</td>
@@ -587,7 +587,7 @@ context:
     <tr>
       <th><a href="/docs/layouts/application">Application layout</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.16.0</td>
       <td>We added new layout styles for building responsive full-screen applications.</td>
@@ -595,7 +595,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/strip#suru-strip">Suru strip</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.16.0</td>
       <td>We added new strip variants <code>.p-strip--suru</code> and <code>.p-strip--suru-topped</code>.</td>
@@ -604,7 +604,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/chip">Chip</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.15.0</td>
       <td>We added the new <code>.p-chip</code> component to be used to display small actionable pieces of information.</td>
@@ -613,7 +613,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/lists#inline-stretched">List inline stretched</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.14.0</td>
       <td>We added the new <code>.p-inline-list--stretch</code> list variant that arranges items so they span the full width of the parent container.</td>
@@ -622,7 +622,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/accordion#headings">Accordion</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.13.0</td>
       <td>We updated the accordion component with a new <code>.p-accordion__tab--with-title</code> variant that allows using headings in accordion buttons.</td>
@@ -631,7 +631,7 @@ context:
     <tr>
       <th><a href="/docs/base/typography#muted-text">Muted text</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.12.0</td>
       <td>New <code>u-text--muted</code> utility class has been added.</td>
@@ -639,7 +639,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/icons">Icons</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.12.0</td>
       <td>The icons have been updated to new style.</td>
@@ -647,7 +647,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/icons#standard">Icons - Question</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.12.0</td>
       <td>The <code>p-icon--question</code> has been deprecated will be removed in future release v3.0. Please use existing `.p-icon--help` icon instead.</td>
@@ -656,7 +656,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.11.0</td>
       <td>A no-JS fallback was added for the side navigation toggle functionality on small screens.</td>
@@ -664,7 +664,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation#raw-html">Side navigation</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.11.0</td>
       <td>A new raw HTML variant of the side navigation component.</td>
@@ -673,7 +673,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.10.0</td>
       <td>Update to the responsive styling of the side navigation.</td>
@@ -682,7 +682,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.9.0</td>
       <td>New side navigation component was added.</td>
@@ -691,7 +691,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.8.0</td>
       <td>New navigation classes (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) were added to replace existing (<code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code>).</td>
@@ -699,7 +699,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.8.0</td>
       <td>Navigation classes <code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code> are deprecated and will be removed in future release v3.0. Please use new class names (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) instead.</td>
@@ -708,7 +708,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/contextual-menu#theming">Contextual menu</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.7.0</td>
       <td>Added dark theme to contextual menu.</td>
@@ -716,7 +716,7 @@ context:
     <tr>
       <th><a href="/docs/base/typography#heading-classes">Heading classes</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.7.0</td>
       <td>New heading classes with numbers (<code>p-heading--1</code>, ...) were added for consistency with other class names we use.</td>
@@ -724,7 +724,7 @@ context:
     <tr>
       <th><a href="/docs/base/typography#heading-classes">Heading classes</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.7.0</td>
       <td>Heading classes with numbers as words (<code>p-heading--one</code>, <code>--two</code>, ...) are deprecated and will be removed in future release v3.0. Please use class names with numbers (<code>p-heading--1</code>, <code>--2</code>, ...) instead.</td>
@@ -732,7 +732,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms/#range">Range input</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.6.0</td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
@@ -740,7 +740,7 @@ context:
     <tr>
       <th><a href="/docs/base/forms/#checkbox">Checkbox, radio button</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.6.0</td>
       <td>New `is-table-header` added to properly align checkboxes and radio buttons used in table headers.</td>
@@ -748,7 +748,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/slider">Slider</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.6.0</td>
       <td>Styling of Slider component was added to all <code>&lt;input type="range"&gt;</code> elements by default. This makes <code>p-slider</code> class optional for styling range inputs.</td>
@@ -756,7 +756,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/contextual-menu/#indicator">Contextual menu</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Optional state indicator was added to contextual menu</td>
@@ -764,7 +764,7 @@ context:
     <tr>
       <th><a href="/docs/utilities/font-metrics/">Font metrics</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-visualise-font-metrics</code> utility to visualise font metrics</td>
@@ -772,7 +772,7 @@ context:
     <tr>
       <th><a href="/docs/base/typography/#line-length">Line length</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>$max-width--default</code> variable and <code>u-no-max-width</code> utility to control line length</td>
@@ -780,7 +780,7 @@ context:
     <tr>
       <th><a href="/docs/utilities/table-cell-padding-overlap/">Table cell padding overlap</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-table-cell-padding-overlap</code> utility to overlap table cell padding</td>
@@ -788,7 +788,7 @@ context:
     <tr>
       <th><a href="/docs/utilities/truncate/">Truncation</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>2.5.0</td>
       <td>Added <code>u-truncate</code> utility to truncate text with ellipsis</td>
@@ -796,7 +796,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/icons/#social">Social icons</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>2.5.0</td>
       <td>Updated style of social icons. Added new <code>.p-icon--rss</code> and <code>p-icon--email</code> icons.</td>
@@ -804,7 +804,7 @@ context:
     <tr>
       <th><a href="/docs/patterns/icons/#social">Social icons</a></th>
       <td>
-        <span class="p-label--negative">Deprecated</span>
+        <span class="p-status-label--negative">Deprecated</span>
       </td>
       <td>2.5.0</td>
       <td>We will be removing <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from social icon set in future release v3.0</td>
@@ -817,25 +817,25 @@ context:
 <div class="row">
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--positive">New</span>
+      <span class="p-status-label--positive">New</span>
       <p class="p-card__content">Newly released components, utilities or settings that are safe to use in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--negative">Deprecated</span>
+      <span class="p-status-label--negative">Deprecated</span>
       <p class="p-card__content">These components, utilities or settings are in the process of being removed and should no longer be used in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--caution">In progress</span>
+      <span class="p-status-label--caution">In progress</span>
       <p class="p-card__content">Design spec and code implementation are not yet finished.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--information">Updated</span>
+      <span class="p-status-label--information">Updated</span>
       <p class="p-card__content">These are existing components, utilities or settings that have been updated either through design or code.</p>
     </div>
   </div>

--- a/templates/docs/examples/patterns/labels.html
+++ b/templates/docs/examples/patterns/labels.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Labels / Default{% endblock %}
+{% block title %}Labels (deprecated) / Default{% endblock %}
 
 {% block standalone_css %}patterns_label{% endblock %}
 

--- a/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
+++ b/templates/docs/examples/patterns/lists/lists-inline-stretch-align.html
@@ -7,7 +7,7 @@
 <ul class="p-inline-list--stretch">
   <li class="p-inline-list__item"><h3>Documentation</h3></li>
   <li class="p-inline-list__item u-vertically-center u-align--right">
-    <span class="p-label--positive">New</span>
+    <span class="p-status-label--positive">New</span>
   </li>
 </ul>
 {% endblock %}

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -40,7 +40,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-label--caution">In progress</span>
+                  <span class="p-status-label--caution">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -58,17 +58,17 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <span class="p-label--positive">New</span>
+          <span class="p-status-label--positive">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <span class="p-label--information">Updated</span>
+          <span class="p-status-label--information">Updated</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-label--positive">Validated</span>
+          <span class="p-status-label--positive">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_docs.html
+++ b/templates/docs/examples/patterns/side-navigation/_docs.html
@@ -24,7 +24,7 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Quick start<span class="p-side-navigation__status">
-          <span class="p-label--positive">New</span>
+          <span class="p-status-label--positive">New</span>
         </span></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -43,7 +43,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-label--caution">In progress</span>
+                  <span class="p-status-label--caution">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -61,17 +61,17 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
-          <span class="p-label--positive">New</span>
+          <span class="p-status-label--positive">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
-          <span class="p-label--information">Updated</span>
+          <span class="p-status-label--information">Updated</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-label--positive">Validated</span>
+          <span class="p-status-label--positive">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
@@ -33,7 +33,7 @@
       <span class="p-side-navigation__text">
         Version 0.4.0
         <div class="p-side-navigation__status">
-          <span class="p-label--caution">Beta</span>
+          <span class="p-status-label--caution">Beta</span>
         </div>
       </span>
     </li>

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -29,7 +29,7 @@
               </li>
               <li class="p-side-navigation__item">
                 <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">Third level link with label that is truncated because it's long long long long long</span><div class="p-side-navigation__status">
-                  <span class="p-label--caution">In progress</span>
+                  <span class="p-status-label--caution">In progress</span>
                 </div></a>
               </li>
               <li class="p-side-navigation__item">
@@ -47,17 +47,17 @@
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="p-side-navigation__label">First level link with a label</span><div class="p-side-navigation__status">
-          <span class="p-label--positive">New</span>
+          <span class="p-status-label--positive">New</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i><span class="p-side-navigation__label">First level link with a label is long and wraps wraps wraps wraps wraps wraps</span><div class="p-side-navigation__status">
-          <span class="p-label--information">Updated</span>
+          <span class="p-status-label--information">Updated</span>
         </div></a>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><span class="u-truncate p-side-navigation__label">First level link with label that is truncated because it's long long long long long long long</span><div class="p-side-navigation__status">
-          <span class="p-label--information">Validated</span>
+          <span class="p-status-label--information">Validated</span>
         </div></a>
       </li>
     </ul>

--- a/templates/docs/examples/patterns/side-navigation/icons.html
+++ b/templates/docs/examples/patterns/side-navigation/icons.html
@@ -38,7 +38,7 @@
           <i class="p-icon--help p-side-navigation__icon"></i>
           Get help
           <span class="p-side-navigation__status">
-            <span class="p-label--information">Updated</span>
+            <span class="p-status-label--information">Updated</span>
           </span>
         </a>
       </li>

--- a/templates/docs/migration-guide-to-v3.md
+++ b/templates/docs/migration-guide-to-v3.md
@@ -440,7 +440,11 @@ The colour variants of the label pattern have been renamed to use consistent sem
 
 The individual mixins for label variants have been removed. All necessary styles are included in main `vf-p-label` mixin. If you use any of the following individual mixins you can remove them from your code: `vf-p-label-new`, `vf-p-label-updated`, `vf-p-label-deprecated`, `vf-p-label-in-progress` and `vf-p-label-validated`.
 
-Refer to [the label component documentation](/docs/patterns/labels) page for more details and code examples.
+<div class="p-notification--information">
+  <div class="p-notification__content">
+    <p class="p-notification__message">Since Vanilla 3.2 the label component has been renamed to status label. Refer to the <a href="/docs/patterns/status-labels">status label component</a> page for more details and code examples. 
+  </div>
+</div>
 
 ## Notifications
 

--- a/templates/docs/patterns/navigation.md
+++ b/templates/docs/patterns/navigation.md
@@ -249,7 +249,7 @@ To import side navigation, copy snippet below:
 @include vf-p-side-navigation;
 
 // optionally add icons and/or labels if you use them in side navigation__nav
-@include vf-p-label;
+@include vf-p-status-label;
 @include vf-p-icons;
 ```
 

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -24,7 +24,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation#expanding-search-box">Navigation - Search</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>3.2.0</td>
       <td>We added new dropdown for expanding search on small screens.</td>
@@ -32,7 +32,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation">Navigation</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>3.2.0</td>
       <td>We added new style of the logos to main navigation.</td>
@@ -72,7 +72,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/empty-state">Empty state</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>3.1.0</td>
       <td>We've added examples for empty state scenarios.</td>
@@ -80,7 +80,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/lists#nested-count">Ordered list nested counter</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>3.1.0</td>
       <td>We've updated lists by adding a new class name. It can be used when nested items numbers are required to be set according to their parents.</td>
@@ -88,7 +88,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/slider">Slider</a> and <a href="/docs/patterns/switch">Switch</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>3.1.0</td>
       <td>We've updated the styling of the Switch and Slider components.</td>
@@ -97,7 +97,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/navigation">Expanding search box</a></th>
       <td>
-        <span class="p-label--positive">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>3.0.0</td>
       <td>We've added an expandable search box, to be used in top navigation.</td>
@@ -105,7 +105,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/labels">Labels</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>3.0.0</td>
       <td>We've updated the labels component by introducing new semantic class names consistend with tinted chips.</td>
@@ -113,7 +113,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/chip">Chips</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>3.0.0</td>
       <td>We've added tinted chips. The tints are based on the semantic colours (positive, caution, negative) plus a dark blue one that matches the blue used in the information flavour of the notification component.</td>
@@ -121,7 +121,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <tr>
       <th><a href="/docs/patterns/switch">Switch</a></th>
       <td>
-        <span class="p-label--information">Updated</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
       <td>3.0.0</td>
       <td>We've updated the HTML structure of the switch component. The <code>p-switch</code> class should be placed on the the wrapping label element instead of on the input.</td>
@@ -147,7 +147,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#notifications">Notifications structure</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>The classes <code>.p-notification__response</code>, <code>.p-notification__status</code><code>.p-icon--close</code> have been removed and replaced.</td>
@@ -155,7 +155,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#buttons">Button / Neutral</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>The neutral button variant <code>p-button--neutral</code> has been removed, please use default <code>p-button</code> instead.</td>
@@ -163,7 +163,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#navigation-title">Navigation / Sub-navigation</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>The <code>.p-subnav</code> class has been removed and succeeded by the <code>.p-navigation__item--dropdown-toggle</code> class. The children of <code>.p-subnav</code> have been removed and replaced.</td>
@@ -171,7 +171,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#inline-images">Inline images</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>The inline images component has now been removed. Please use the logo section component instead.</td>
@@ -179,7 +179,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#tables">Tables expanding</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>We renamed and removed <code>p-table-expanding</code> and <code>p-table-expanding__panel</code>. Use <code>p-table--expanding</code> and <code>p-table__expanding-panel</code> instead.</td>
@@ -187,7 +187,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#tables">Tables sorting</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>We removed <code>p-table--sortable</code> class name. Sorting can be enabled on any table by adding <code>aria-sort</code> attributes.</td>
@@ -195,7 +195,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#accordion">Accordions</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>We removed the previous accordion tab patterns, <code>.p-accordion__tab</code> and <code>.p-accordion__tab--with-title .p-accordion__title</code>, in favour of a more accessible pattern. Please use <code>.p-accordion__heading .p-accordion__tab</code>.</td>
@@ -203,7 +203,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#grid">Grid - "orphan" columns</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>We removed the ability to use <code>.col</code> classes without a direct parent with a class <code>.row</code>.</td>
@@ -211,7 +211,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#buttons">Active button</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>The <code>is-active</code> class was removed and given a more appropriate name: <code>is-processing</code>.</td>
@@ -219,7 +219,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#code">Code copyable</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td><code>.p-code-copyable</code> has been removed. Please use <code>.p-code-snippet .p-code-snippet__block--icon</code> instead.</td>
@@ -227,7 +227,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#code">Code numbered</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td><code>.p-code-numbered</code> has been removed. Please use <code>.p-code-snippet .p-code-snippet__block--numbered</code> instead.</td>
@@ -235,7 +235,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#icons">Icons - Contextual Menu</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>The <code>p-icon--contextual-menu</code> has been removed. Please use existing <code>.p-icon--chevron-down</code> and <code>.p-icon--chevron-up</code> icons instead.</td>
@@ -243,7 +243,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#breadcrumbs">Breadcrumbs</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>Top level <code>&lt;ul&gt;</code> with a class <code>.p-breadcrumbs</code> has been removed and replaced by the breadcrumbs pattern.</td>
@@ -251,7 +251,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#form-elements">Checkbox and radio buttons elements</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>Base styled checkboxes and radio buttons (on <code>&lt;input type="checkbox"&gt;</code> or <code>&lt;input type="radio"&gt;</code> elements) have been removed. Please use checkbox and radio components.</td>
@@ -259,7 +259,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#icons">Icons - Question</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>The <code>p-icon--question</code> has been removed. Please use existing <code>.p-icon--help</code> icon instead.</td>
@@ -267,7 +267,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#navigation-title">Navigation</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>Navigation classes <code>p-navigation__links</code>, <code>p-navigation__link</code>, and classless <code>&lt;a&gt;</code> have been removed. Please use new class names (<code>p-navigation__items</code>, <code>p-navigation__item</code>, <code>p-navigation__link</code>) instead.</td>
@@ -275,7 +275,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#headings">Heading classes</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>Heading classes with numbers as words (<code>p-heading--one</code>, <code>--two</code>, ...) have been removed. Please use class names with numbers (<code>p-heading--1</code>, <code>--2</code>, ...) instead.</td>
@@ -283,7 +283,7 @@ The table below lists all the removed components and utilities in 3.0. For more 
     <tr>
       <th><a href="/docs/migration-guide-to-v3#social-icons">Social icons</a></th>
       <td>
-        <span class="p-label--negative">Removed</span>
+        <span class="p-status-label--negative">Removed</span>
       </td>
       <td>3.0.0</td>
       <td>We've removed <code>p-icon--canonical</code> and <code>p-icon--ubuntu</code> from social icon set.</td>
@@ -298,31 +298,31 @@ To see what changed in Vanilla v2, see the [changelog for v2](/docs/changelog-v2
 <div class="row">
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--positive">New</span>
+      <span class="p-status-label--positive">New</span>
       <p class="p-card__content">Newly released components, utilities or settings that are safe to use in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--negative">Deprecated</span>
+      <span class="p-status-label--negative">Deprecated</span>
       <p class="p-card__content">These components, utilities or settings are in the process of being removed and should no longer be used in projects.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--caution">In progress</span>
+      <span class="p-status-label--caution">In progress</span>
       <p class="p-card__content">Design spec and code implementation are not yet finished.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--information">Updated</span>
+      <span class="p-status-label--information">Updated</span>
       <p class="p-card__content">These are existing components, utilities or settings that have been updated either through design or code.</p>
     </div>
   </div>
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
-      <span class="p-label--negative">Removed</span>
+      <span class="p-status-label--negative">Removed</span>
       <p class="p-card__content">These components, variants or utilities have been removed from Vanilla. They should be removed from projects or updated to their new recommended versions.</p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Bring `vf-p-label` mixin back due to compatibility reasons
- Flag the label component as deprecated in the examples section
- Add a notification in the migration to 3.0 guide
- Rename `p-label` to `p-status-label` in the markup

Fixes https://github.com/canonical-web-and-design/vanilla-framework/issues/4411