### PR TITLE
Align accordion's icon with heading

### DIFF
--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -33,18 +33,12 @@
     z-index: 2;
 
     &::before {
-      $vertical-offset: 0.5px;
       @include vf-icon-chevron($color-mid-dark);
       @include vf-animation($property: transform, $duration: fast);
+      @extend %icon;
 
-      background-position: center;
       content: '';
-      display: inline-block;
-      font-size: inherit;
-      height: $icon-size;
       margin-right: $sph--large;
-      vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $default-icon-size});
-      width: $icon-size;
     }
 
     // aria-selected controls the open and closed state for the accordion tab
@@ -84,12 +78,8 @@
   }
 
   .p-heading--3 > .p-accordion__tab::before,
-  h3.p-accordion__heading > .p-accordion__tab::before {
-    @include vf-icon-size($default-icon-size);
-    vertical-align: 0;
-  }
-
   .p-heading--4 > .p-accordion__tab::before,
+  h3.p-accordion__heading > .p-accordion__tab::before,
   h4.p-accordion__heading > .p-accordion__tab::before {
     vertical-align: 0;
   }

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -1,5 +1,11 @@
 @import 'settings';
 
+@mixin align-icon($icon-size: 1rem, $line-height: default-text) {
+  // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
+  // and offset to align it with baseline of accordion tab text element
+  top: $table-cell-vertical-padding + 0.5 * (map-get($line-heights, $line-height) - $icon-size);
+}
+
 @mixin vf-p-accordion {
   $icon-size: map-get($icon-sizes, default);
 
@@ -16,10 +22,6 @@
   }
 
   .p-accordion__tab {
-    // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
-    // and offset to align it with baseline of accordion tab text element
-    $icon-top-position: calc(#{$table-cell-vertical-padding + (map-get($line-heights, default-text) - $icon-size) * 0.5});
-
     @extend %single-border-text-vpadding--scaling;
     @include vf-focus;
 
@@ -39,12 +41,15 @@
 
     &::before {
       @include vf-icon-chevron($color-mid-dark);
+
+      background-position: center;
       @include vf-animation($property: transform, $duration: fast);
+      @include align-icon($icon-size);
+
       content: '';
       height: $icon-size;
       left: $sph--large;
       position: absolute;
-      top: $icon-top-position;
       width: $icon-size;
     }
 
@@ -77,25 +82,18 @@
     }
   }
 
-  // stylelint-disable selector-max-type
-  h2.p-accordion__heading > .p-accordion__tab::before,
-  .p-heading--2 > .p-accordion__tab::before {
-    $icon-top-position: calc(#{$table-cell-vertical-padding + (map-get($line-heights, h2) - $icon-size) * 0.5});
-    top: $icon-top-position;
-  }
+  $heading-levels: 2, 3, 4;
+  @each $level in $heading-levels {
+    .p-heading--#{$level} > .p-accordion__tab::before,
+    h#{$level}.p-accordion__heading > .p-accordion__tab::before {
+      @include align-icon($icon-size, h#{$level}-mobile);
 
-  h3.p-accordion__heading > .p-accordion__tab::before,
-  .p-heading--3 > .p-accordion__tab::before {
-    $icon-top-position: calc(#{$table-cell-vertical-padding + (map-get($line-heights, h3) - $icon-size) * 0.5});
-    top: $icon-top-position;
+      // Adjust icon position due to font-size increase of the headings
+      @media (min-width: $breakpoint-heading-threshold) {
+        @include align-icon($icon-size, h#{$level});
+      }
+    }
   }
-
-  h4.p-accordion__heading > .p-accordion__tab::before,
-  .p-heading--4 > .p-accordion__tab::before {
-    $icon-top-position: calc(#{$table-cell-vertical-padding + (map-get($line-heights, h4) - $icon-size) * 0.5});
-    top: $icon-top-position;
-  }
-  // stylelint-enable selector-max-type
 
   .p-accordion__panel {
     margin: 0;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -1,11 +1,5 @@
 @import 'settings';
 
-@mixin align-icon($icon-size: 1rem, $line-height: default-text) {
-  // calculate icon top position based on top padding (from %single-border-text-vpadding--scaling)
-  // and offset to align it with baseline of accordion tab text element
-  top: $table-cell-vertical-padding + 0.5 * (map-get($line-heights, $line-height) - $icon-size);
-}
-
 @mixin vf-p-accordion {
   $icon-size: map-get($icon-sizes, default);
 
@@ -31,7 +25,6 @@
     font-size: inherit;
     justify-content: flex-start;
     margin-bottom: 0;
-    padding-left: $sph--large + $icon-size + $sph--large;
     padding-right: $sph--large;
     position: relative;
     text-align: left;
@@ -40,16 +33,17 @@
     z-index: 2;
 
     &::before {
+      $vertical-offset: 0.5px;
       @include vf-icon-chevron($color-mid-dark);
+      @include vf-animation($property: transform, $duration: fast);
 
       background-position: center;
-      @include vf-animation($property: transform, $duration: fast);
-      @include align-icon($icon-size);
-
       content: '';
+      display: inline-block;
+      font-size: inherit;
       height: $icon-size;
-      left: $sph--large;
-      position: absolute;
+      margin-right: $sph--large;
+      vertical-align: calc(#{$vertical-offset} + #{0.5 * $cap-height} - #{0.5 * $default-icon-size});
       width: $icon-size;
     }
 
@@ -82,18 +76,24 @@
     }
   }
 
-  $heading-levels: 2, 3, 4;
-  @each $level in $heading-levels {
-    .p-heading--#{$level} > .p-accordion__tab::before,
-    h#{$level}.p-accordion__heading > .p-accordion__tab::before {
-      @include align-icon($icon-size, h#{$level}-mobile);
-
-      // Adjust icon position due to font-size increase of the headings
-      @media (min-width: $breakpoint-heading-threshold) {
-        @include align-icon($icon-size, h#{$level});
-      }
-    }
+  // stylelint-disable selector-max-type
+  .p-heading--2 > .p-accordion__tab::before,
+  h2.p-accordion__heading > .p-accordion__tab::before {
+    @include vf-icon-size($x-height);
+    vertical-align: 0;
   }
+
+  .p-heading--3 > .p-accordion__tab::before,
+  h3.p-accordion__heading > .p-accordion__tab::before {
+    @include vf-icon-size($default-icon-size);
+    vertical-align: 0;
+  }
+
+  .p-heading--4 > .p-accordion__tab::before,
+  h4.p-accordion__heading > .p-accordion__tab::before {
+    vertical-align: 0;
+  }
+  // stylelint-enable selector-max-type
 
   .p-accordion__panel {
     margin: 0;


### PR DESCRIPTION
## Done

~~- Add a media query to change the alignment of the icon when next to a heading, so we use a different line-height to calculate the icon's position depending on the screen size.~~

Update the styling of the accordion.

Fixes #4418 

## QA

- Open demo
- Go to the example with headings (https://vanilla-framework-4424.demos.haus/docs/examples/patterns/accordion/headings) and check that the icon looks aligned no matter the screen size. (The problem we had was that the icon was misaligned in small screens).

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
