### PR TITLE
Add menu to all patterns

### DIFF
--- a/component_tabs.yaml
+++ b/component_tabs.yaml
@@ -1,3 +1,63 @@
 patterns/accordion:
   accessibility: True
   design_guidelines: False
+patterns/breadcrumbs:
+  accessibility: True
+  design_guidelines: False
+patterns/buttons:
+  accessibility: True
+  design_guidelines: False
+patterns/card:
+  accessibility: True
+  design_guidelines: False
+patterns/contextual-menu:
+  accessibility: True
+  design_guidelines: False
+patterns/grid:
+  accessibility: True
+  design_guidelines: False
+patterns/heading-icon:
+  accessibility: True
+  design_guidelines: False
+patterns/icon:
+  accessibility: True
+  design_guidelines: False
+patterns/links:
+  accessibility: True
+  design_guidelines: False
+patterns/lists:
+  accessibility: True
+  design_guidelines: False
+patterns/logo-section:
+  accessibility: True
+  design_guidelines: False
+patterns/modal:
+  accessibility: True
+  design_guidelines: False
+patterns/navigation:
+  accessibility: True
+  design_guidelines: False
+patterns/notification:
+  accessibility: True
+  design_guidelines: False
+patterns/pagination:
+  accessibility: True
+  design_guidelines: False
+patterns/search-box:
+  accessibility: True
+  design_guidelines: False
+patterns/status-labels:
+  accessibility: True
+  design_guidelines: False
+patterns/strip:
+  accessibility: True
+  design_guidelines: False
+patterns/switch:
+  accessibility: True
+  design_guidelines: False
+patterns/tabs:
+  accessibility: True
+  design_guidelines: False
+patterns/tooltips:
+  accessibility: True
+  design_guidelines: False

--- a/component_tabs.yaml
+++ b/component_tabs.yaml
@@ -1,63 +1,45 @@
+# Settings: accessibility, desing_guidelines
+
 patterns/accordion:
   accessibility: True
-  design_guidelines: False
 patterns/breadcrumbs:
   accessibility: True
-  design_guidelines: False
 patterns/buttons:
   accessibility: True
-  design_guidelines: False
 patterns/card:
   accessibility: True
-  design_guidelines: False
 patterns/contextual-menu:
-  accessibility: True
-  design_guidelines: False
 patterns/grid:
   accessibility: True
-  design_guidelines: False
 patterns/heading-icon:
   accessibility: True
-  design_guidelines: False
 patterns/icon:
   accessibility: True
-  design_guidelines: False
 patterns/links:
   accessibility: True
-  design_guidelines: False
 patterns/lists:
   accessibility: True
-  design_guidelines: False
 patterns/logo-section:
   accessibility: True
-  design_guidelines: False
 patterns/modal:
   accessibility: True
-  design_guidelines: False
 patterns/navigation:
   accessibility: True
-  design_guidelines: False
 patterns/notification:
   accessibility: True
-  design_guidelines: False
 patterns/pagination:
   accessibility: True
-  design_guidelines: False
 patterns/search-box:
   accessibility: True
-  design_guidelines: False
+patterns/segmented-control:
+  design_guidelines: True
 patterns/status-labels:
   accessibility: True
-  design_guidelines: False
 patterns/strip:
   accessibility: True
-  design_guidelines: False
 patterns/switch:
   accessibility: True
-  design_guidelines: False
 patterns/tabs:
   accessibility: True
-  design_guidelines: False
 patterns/tooltips:
   accessibility: True
-  design_guidelines: False

--- a/templates/docs/patterns/breadcrumbs/accessibility.md
+++ b/templates/docs/patterns/breadcrumbs/accessibility.md
@@ -4,9 +4,7 @@ context:
   title: Breadcrumbs | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 It establishes a landmark on the page which assists the user in understanding where they currently are and which pages exist in the current page’s hierarchical order.
 
@@ -14,7 +12,7 @@ It comprises a set of links structured using an ordered list. A `nav` element us
 
 To prevent screen reader announcement of the visual separators between links, they are added via CSS. The separators are part of the visual presentation that signifies the breadcrumb trail, which is already semantically represented by the `nav` element.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -23,7 +21,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - The breadcrumb indicating the current page should be visually distinct from the preceding breadcrumbs.
 - If the breadcrumb reflecting the current page is a link, it should have an `aria-current="page" `attribute.
 
-### Resources
+## Resources
 
 - [WAI-ARIA practices: Breadcrumbs](https://www.w3.org/TR/wai-aria-practices/#breadcrumb)
 - [WAI-ARIA practices: Breadcrumb example](https://www.w3.org/TR/wai-aria-practices/#breadcrumb)

--- a/templates/docs/patterns/breadcrumbs/index.md
+++ b/templates/docs/patterns/breadcrumbs/index.md
@@ -4,10 +4,6 @@ context:
   title: Breadcrumbs | Components
 ---
 
-# Breadcrumbs
-
-<hr>
-
 You can use the breadcrumbs pattern to indicate where the current page sits in the site's navigation.
 
 - A `<nav>` element with an `aria-label` "Breadcrumb" identifies the structure as a breadcrumb trail

--- a/templates/docs/patterns/buttons/accessibility.md
+++ b/templates/docs/patterns/buttons/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Buttons | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 The button component is used to trigger an action or event - this could be opening or closing a modal, navigating to the next page, or cancelling an action. Rather than adding `role=button` to links, it’s always advisable to use the native HTML button element, as native HTML buttons provide keyboard and focus requirements by default and are best supported by assistive technologies.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -26,7 +24,7 @@ View example of the contextual menu pattern
 
 Note: It’s important to use button and link elements accurately. Controls with button-like behaviour (e.g. opening models, submitting forms) should be designed like buttons using the button element, and regular text links (e.g. going to an external page) should be designed like text links using the link element.
 
-### Resources
+## Resources
 
 - [W3C WAI-ARIA Authoring Practices Button Design Pattern](https://www.w3.org/TR/wai-aria-practices/#button)
 - [WAI-ARIA Examples: Button](https://www.w3.org/TR/wai-aria-practices-1.1/examples/button/button.html)

--- a/templates/docs/patterns/buttons/index.md
+++ b/templates/docs/patterns/buttons/index.md
@@ -4,10 +4,6 @@ context:
   title: Buttons | Components
 ---
 
-# Buttons
-
-<hr>
-
 Buttons are clickable elements used to perform an action, you can apply `button` classes on buttons and link elements.
 
 <div class="p-notification--information">

--- a/templates/docs/patterns/card/accessibility.md
+++ b/templates/docs/patterns/card/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Card | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Cards are content containers. They are useful for creating a responsive site, and help users scroll through similar content at ease. They are used as a teaser, and contain a link to more content.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -23,7 +21,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - Avoid multiple elements linking to the same place. Choose one element in the card to link from.
 - If an image is used as a link, then the `alt` text of the image should replace the link text. Alternatively, add `aria-label` to the link element wrapping the image.
 
-### Resources
+## Resources
 
 - [W3C Non-text content](https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv-all.html)
 - [What makes an accessible card](https://technica11y.org/what-makes-an-accessible-card)

--- a/templates/docs/patterns/card/index.md
+++ b/templates/docs/patterns/card/index.md
@@ -4,10 +4,6 @@ context:
   title: Cards | Components
 ---
 
-# Cards
-
-<hr>
-
 There are four card styles available to use in Vanilla: default, header, highlighted and overlay. Our card component will expand to fill the full width of its parent container.
 
 ## Default

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Chip | Components
+  title: Chips | Components
 ---
 
 # Chips

--- a/templates/docs/patterns/contextual-menu/accessibility.md
+++ b/templates/docs/patterns/contextual-menu/accessibility.md
@@ -4,8 +4,6 @@ context:
   title: Contextual menu | Components
 ---
 
-## Accessibility
-
 When using the `p-contextual-menu__toggle` class on a `button` element, please ensure that the button label contains a trailing ellipsis `…`, e.g. "Take action&hellip;". This is a convention used to indicate that the button launches a dialog.
 
 In cases where a contextual menu is shown on click, focus should be set within the menu element, using JavaScript.

--- a/templates/docs/patterns/contextual-menu/index.md
+++ b/templates/docs/patterns/contextual-menu/index.md
@@ -5,10 +5,6 @@ context:
   title: Contextual menu | Components
 ---
 
-# Contextual menu
-
-<hr>
-
 A contextual menu can be applied to any button, link or navigation item that requires a secondary menu. To interact with the menu it will require some javascript to hide/show each pattern. This is achieved by finding the toggle element `p-contextual-menu__toggle` and what it controls `aria-controls`.
 
 The target element will be hidden or shown with `aria-hidden="true"` or `false`. The control element will change to `aria-expanded` so screen readers will know it's active.

--- a/templates/docs/patterns/grid/accessibility.md
+++ b/templates/docs/patterns/grid/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Grid | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 The grid gives the ability to maintain semantic meaning in the page, while placing the content in whatever visual way required. The distinguishing feature of the grid that enables it to be used for grouping other widgets, is that its cells are containers that preserve the semantics of their descendant elements.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -4,10 +4,6 @@ context:
   title: Grid | Components
 ---
 
-# Grid
-
-<hr>
-
 Vanilla has a responsive grid with the following columns and gutters:
 
 <table>

--- a/templates/docs/patterns/heading-icon/accessibility.md
+++ b/templates/docs/patterns/heading-icon/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Heading icon | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 The heading icon pattern includes an icon next to the heading to add emphasis. It includes an image element alongside a title wrapped in a `div` for the header, and a paragraph wrapped in an outer `div` for the content which follows.
 
-### Considerations
+## Considerations
 
 - The content of the heading should make sense without the icon present, the icon should not convey information on its own.
 - The image should always include an `alt` attribute.
@@ -18,7 +16,7 @@ The heading icon pattern includes an icon next to the heading to add emphasis. I
 - If the image provides information not otherwise available to users of assistive technology, the value of the `alt` attribute should provide that information in a concise way.
 - Avoid using words and phrases like “logo” or “image of"; in most cases the information that needs to be conveyed is, for example, who the logo belongs to or what the image contains, rather than that the element itself is an image.
 
-### Resources
+## Resources
 
 - [WAI-ARIA practices - naming effectively](https://www.w3.org/TR/wai-aria-practices-1.1/#naming_effectively)
 - [WAI tutorials - Images](https://www.w3.org/WAI/tutorials/images/)

--- a/templates/docs/patterns/heading-icon/index.md
+++ b/templates/docs/patterns/heading-icon/index.md
@@ -5,10 +5,6 @@ context:
   title: Heading icon | Components
 ---
 
-# Heading icon
-
-<hr>
-
 A heading can be emphasised by adding an icon alongside the text.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/heading-icon/heading-icon/" class="js-example">

--- a/templates/docs/patterns/icons/accessibility.md
+++ b/templates/docs/patterns/icons/accessibility.md
@@ -4,15 +4,13 @@ context:
   title: Icons | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Icons are used to enhance usability and provide clarity. `<i>` elements are used for our icons, and text should be added unless the icon is purely decorative. This text won’t be displayed visually. e.g.
 
 `<i class="p-icon--chevron-down">This text will not be displayed</i>`
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -23,7 +21,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - If the icon is actionable e.g. a menu icon, make sure it is focusable and it has a meaningful, clear and concise `alt` attribute.
 - The colour contrast from the icon to the background should be at least 3:1, as mentioned in the [WCAG techniques](https://www.w3.org/WAI/WCAG21/Techniques/general/G207).
 
-### Resources
+## Resources
 
 - [Are your icons accessible?](https://www.system-concepts.com/insights/are-your-icons-usable-and-accessible/)
 - [Keyboard - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard)

--- a/templates/docs/patterns/icons/index.md
+++ b/templates/docs/patterns/icons/index.md
@@ -26,10 +26,6 @@ context:
 
 {% set social_icons = ['facebook', 'instagram', 'twitter', 'linkedin', 'youtube', 'github', 'rss', 'email'] %}
 
-# Icons
-
-<hr>
-
 Icons provide visual context and enhance usability, they can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/icons/icons-light" class="js-example">

--- a/templates/docs/patterns/links/accessibility.md
+++ b/templates/docs/patterns/links/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Links | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Links are used as navigational elements and can be used on their own or inline with text. It's possible to use the `Tab` key to navigate to the link, and the `Enter` key activates the link.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -36,7 +34,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 
 Note: It’s important to use button and link elements accurately. Controls with button-like behaviour (e.g. opening models, submitting forms) should be designed like buttons using the button element, and regular text links (e.g. going to an external page) should be designed like text links using the link element.
 
-### Resources
+## Resources
 
 - [WAI-ARIA practices: Links ](https://www.w3.org/TR/wai-aria-practices/#link)
 - [Yale usability & Web Accessibility - Links](https://usability.yale.edu/web-accessibility/articles/links)

--- a/templates/docs/patterns/links/index.md
+++ b/templates/docs/patterns/links/index.md
@@ -4,10 +4,6 @@ context:
   title: Links | Components
 ---
 
-# Links
-
-<hr>
-
 Links are used to embed actions or pathways to more information, allowing users to click their way from page to page.
 
 ## Default

--- a/templates/docs/patterns/lists/accessibility.md
+++ b/templates/docs/patterns/lists/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Lists | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Lists provide orientation for users by letting them know when a collection of items are related, and whether or not the items are sequential. They also let screen reader users know how many items are in each list, and allow users to jump between lists within the content.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -21,7 +19,7 @@ Be sure to use the correct list type for your content:
 
 It’s important to make sure that all content which is visibly a list has the correct HTML structure. Avoid making paragraphs look like lists by using bullet symbols or numbers, as these will not be read out as related content. Similarly, avoid using lists for indentation or layout purposes.
 
-### Resources
+## Resources
 
 - [WAI-ARIA practices: Lists ](https://www.w3.org/TR/wai-aria-1.1/#list)
 - [Web Accessibility Initiatives (WAI) page on the structure of Web content](https://www.w3.org/WAI/tutorials/page-structure/content/#lists)

--- a/templates/docs/patterns/lists/index.md
+++ b/templates/docs/patterns/lists/index.md
@@ -4,10 +4,6 @@ context:
   title: Lists | Components
 ---
 
-# Lists
-
-<hr>
-
 If you want to display lists in a way that is more visually distinctive than the
 standard `<ol>` and `<ul>`, we have 7 list styles at your disposal.
 

--- a/templates/docs/patterns/logo-section/accessibility.md
+++ b/templates/docs/patterns/logo-section/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Logo section | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 The logo section showcases a group of related images or logos. It works by ensuring each image matches the width of either one or two grid columns.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -19,7 +17,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - If the image provides information not otherwise available to users of assistive technology, the value of the `alt` attribute should provide that information in a concise way.
 - Avoid using words and phrases like “logo” or “image of''; in most cases the information that needs to be conveyed is, for example, who the logo belongs to or what the image contains, rather than that the element itself is an image.
 
-### Resources
+## Resources
 
 - [WAI-ARIA practices - naming effectively](https://www.w3.org/TR/wai-aria-practices-1.1/#naming_effectively)
 - [WAI tutorials - Images](https://www.w3.org/WAI/tutorials/images/)

--- a/templates/docs/patterns/logo-section/index.md
+++ b/templates/docs/patterns/logo-section/index.md
@@ -4,10 +4,6 @@ context:
   title: Logo section | Components
 ---
 
-# Logo section
-
-<hr>
-
 The logo section pattern can be used to showcase a group of related images, such as a group of customer or partner logos.
 For best results, ensure that the images have identical dimensions.
 

--- a/templates/docs/patterns/modal/accessibility.md
+++ b/templates/docs/patterns/modal/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Modal | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Modal is used to overlay an area of the screen with a prompt, dialog or interaction and prevents users from interacting with content outside of it until it’s closed.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -25,7 +23,7 @@ JavaScript needs to be used to ensure:
 - Escape closes the modal
 - When a modal closes, focus returns to the element that triggered the modal
 
-### Resources
+## Resources
 
 - [Modal Dialog Example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html)
 - [WAI-ARIA practices: Dialog (Modal)](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal)

--- a/templates/docs/patterns/modal/index.md
+++ b/templates/docs/patterns/modal/index.md
@@ -4,10 +4,6 @@ context:
   title: Modal | Components
 ---
 
-# Modal
-
-<hr>
-
 The modal component can be used to overlay an area of the screen which can contain a prompt, dialog or interaction.
 
 On `p-modal` set display to `display:flex` or `display:none` to toggle the visibility of the modal.

--- a/templates/docs/patterns/navigation/accessibility.md
+++ b/templates/docs/patterns/navigation/accessibility.md
@@ -4,9 +4,7 @@ context:
   title: Navigation | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Navigation allows users to navigate different pages or content in a website. The list of navigation items can be displayed on the top or left edge of the viewport.
 
@@ -24,7 +22,7 @@ Care should be taken to ensure that the label makes sense out of context of the 
 
 Consider the size that navigation elements are displayed at. They should be easily reachable and tappable on mobile views and easy to locate with the pointer on desktop views. Consider that users with reduced mobility may find it harder to locate and operate controls that appear too small on screen.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -35,7 +33,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - Javascript will be needed to indicate which navigation element is active. `aria-current="page"` attribute should be given to the navigation item.
 - JavaScript should be used to handle both mouse and keyboard interactions.
 
-### Resources
+## Resources
 
 - [Carbon Design System - Navigation](https://www.carbondesignsystem.com/patterns/global-header/#accessibility)
 - Guidelines:

--- a/templates/docs/patterns/navigation/index.md
+++ b/templates/docs/patterns/navigation/index.md
@@ -4,10 +4,6 @@ context:
   title: Navigation | Components
 ---
 
-# Navigation
-
-<hr>
-
 ## Global navigation
 
 Vanilla includes a simple navigation bar that you can add to the top of your

--- a/templates/docs/patterns/notification/accessibility.md
+++ b/templates/docs/patterns/notification/accessibility.md
@@ -4,9 +4,7 @@ context:
   title: Nofitication | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Notifications are messages used to communicate information and feedback to the user. Changes in content which are not interactive should be marked as live regions which are denoted by the `aria-live` attribute.
 
@@ -14,7 +12,7 @@ When the notification is time sensitive or critical `aria-live= "assertive"`, or
 
 In dismissible notifications, an `aria-controls` attribute on the close button references the id on the parent div containing the notification. This makes it clear to screen reader users what the close button is targeting.
 
-### Considerations
+## Considerations
 
 This component strives to follow WCAG 2.1 (level AA guidelines), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -27,7 +25,7 @@ This component strives to follow WCAG 2.1 (level AA guidelines), and care must b
 - Unless the alert from the screen reader is meant to break the user’s workflow, it is important that the notification does not affect keyboard focus.
 - Notifications should not disappear automatically.
 
-### Resources
+## Resources
 
 - [Accessible Rich Internet Applications (WAI-ARIA) 1.1 : aria-live](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-live)
 - [WAI-ARIA Authoring Practices 1.1: alert](https://www.w3.org/TR/wai-aria-practices-1.1/#alert)

--- a/templates/docs/patterns/notification/index.md
+++ b/templates/docs/patterns/notification/index.md
@@ -4,10 +4,6 @@ context:
   title: Notification | Components
 ---
 
-# Notification
-
-<hr>
-
 Notifications are used to attract the user's attention. They offer four separate severity levels, and can also be modified for use in different contexts.
 
 ## Severity levels

--- a/templates/docs/patterns/pagination/accessibility.md
+++ b/templates/docs/patterns/pagination/accessibility.md
@@ -4,9 +4,7 @@ context:
   title: Pagination | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Our pagination examples are wrapped in `nav` elements, each with an `aria-label=”Pagination”`. This helps distinguish the pagination from other `nav` elements on the page.
 
@@ -14,7 +12,7 @@ An unordered list is used to list the pages, which allows screen readers to voic
 
 Each page link has an `aria-label` including the word “page” along with the number. This helps orientate the user and clarify they are on a pagination button.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -26,7 +24,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - It helps to add “first page, page x” to the first page and “last page, page x” to the final page in the list.
 - If you use chevrons without text labels to move to previous and next pages, make sure screen readers are reading “previous page” and “next page”.
 
-### Resources
+## Resources
 
 - [A11y style guide - Pagination navigation](https://a11y-style-guide.com/style-guide/section-navigation.html#kssref-navigation-pagination)
 - [Design system digital - Pagination](https://designsystem.digital.gov/components/pagination/)

--- a/templates/docs/patterns/pagination/index.md
+++ b/templates/docs/patterns/pagination/index.md
@@ -4,10 +4,6 @@ context:
   title: Pagination | Components
 ---
 
-# Pagination
-
-<hr>
-
 Use the pagination component to paginate large sets of data:
 
 <div class="embedded-example"><a href="/docs/examples/patterns/pagination/pagination" class="js-example">

--- a/templates/docs/patterns/search-box/accessibility.md
+++ b/templates/docs/patterns/search-box/accessibility.md
@@ -4,15 +4,13 @@ context:
   title: Search box | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 The search box allows users to search for content by typing in the input, without needing to use the navigation. The input element has a descriptive `aria-label` for screen reader users.
 
 It's a focusable component, and in the expanding search box where only the icon is visible, the search box has an appropriate `aria-label`. If `required` is included in the input, then the browser will display an accessible error message instructing the user to fill out the field.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -20,7 +18,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - Usually, it shouldn’t be possible to search with an empty input field, so indicate this with the `required` attribute on the input.
 - If a page includes more than one search landmark, each should have a unique label.
 
-### Resources
+## Resources
 
 - [W3C WAI-ARIA Landmarks Example](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/search.html)
 - [Accessible search - handling form errors](https://www.a11ymatters.com/pattern/accessible-search/#handling-form-errors)

--- a/templates/docs/patterns/search-box/index.md
+++ b/templates/docs/patterns/search-box/index.md
@@ -4,10 +4,6 @@ context:
   title: Search box | Components
 ---
 
-# Search box
-
-<hr>
-
 Search boxes enable search functionality on a page and are typically used in a navigation bar.
 
 ## Default

--- a/templates/docs/patterns/segmented-control.md
+++ b/templates/docs/patterns/segmented-control.md
@@ -4,10 +4,6 @@ context:
   title: Segmented control | Components
 ---
 
-# Segmented control
-
-<hr>
-
 Segmented control can be used in two ways:
 
 **Secondary tabs:** if the page already has a set of primary tabs used as navigation, this can be used as a sub-navigation of those primary tabs.

--- a/templates/docs/patterns/status-labels/accessibility.md
+++ b/templates/docs/patterns/status-labels/accessibility.md
@@ -4,22 +4,20 @@ context:
   title: Status labels | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Status labels are used to signify status, tags or any other information. The colours have semantic meaning, reflected by the name given in the code example.
 
 Semantic colour can help users recognise and recall meaning more quickly, especially when scanning a view, for example. It’s important that status labels still convey the same meaning without colour information.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
 - Select an appropriately coloured label which makes sense semantically for your use case.
 - Ensure you don’t use colour as the only visual means of conveying information or an action - the text within the label should be descriptive enough.
 
-### Resources
+## Resources
 
 Applicable WCAG guidelines:
 

--- a/templates/docs/patterns/status-labels/index.md
+++ b/templates/docs/patterns/status-labels/index.md
@@ -4,10 +4,6 @@ context:
   title: Status labels | Components
 ---
 
-# Status labels
-
-<hr>
-
 Status labels are static elements which you can apply to signify status, tags or any other information you find useful.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/status-labels/" class="js-example">

--- a/templates/docs/patterns/strip/accessibility.md
+++ b/templates/docs/patterns/strip/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Strip | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 A Strip is a full-width content container. They provide visual interest and break up long scrolling pages into sections.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -24,6 +22,6 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - Image strips should ensure image accessibility is maintained with appropriate descriptive text for relevant images
 - If the image is the link, then the alt text of the image should replace the link text Alternatively, add aria-label to the link element wrapping the image
 
-### Resources
+## Resources
 
 [W3C Non-text content](https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv-all.html)

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -4,10 +4,6 @@ context:
   title: Strip | Components
 ---
 
-# Strip
-
-<hr>
-
 The strip pattern provides a full width strip container in which to wrap a row. A strip can have light (`.p-strip--light`) or dark (`.p-strip--dark`) grey background.
 
 A `.p-strip` container should always be the parent of a `.row` (from the [Grid pattern](/docs/patterns/grid/)) and never the other way around.

--- a/templates/docs/patterns/switch/accessibility.md
+++ b/templates/docs/patterns/switch/accessibility.md
@@ -4,15 +4,13 @@ context:
   title: Switch | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 The switch component is used to display on and off content. It includes the `role=”switch”` attribute so the screen reader distinguishes it from a checkbox. The `span` with class name `p-switch__label` acts as the label, and is associated with the status of the switch input.
 
 The element is focusable, and the `Spacebar` changes the state of the switch the same way a click would.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -20,7 +18,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - Adding `aria-checked=”true”` or `aria-checked=”false”` will set the switch to on or off respectively.
 - `aria-readonly` is set to false as default, meaning the user can change the value of the switch. Change this to true if the switch is meant to be read only (i.e. disabled).
 
-### Resources
+## Resources
 
 - [WAI-ARIA names and descriptions definition](https://www.w3.org/TR/wai-aria-practices-1.1/#names_and_descriptions_definition)
 - [MDN Web accessibility - Switch role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role)

--- a/templates/docs/patterns/switch/index.md
+++ b/templates/docs/patterns/switch/index.md
@@ -4,10 +4,6 @@ context:
   title: Switch | Components
 ---
 
-# Switch
-
-<hr>
-
 You can use this switch component to display on and off content, such as for settings or simple controls. By changing the `aria-checked` attribute from true or false will animate the switch on/off.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/switch/" class="js-example">

--- a/templates/docs/patterns/tabs/accessibility.md
+++ b/templates/docs/patterns/tabs/accessibility.md
@@ -4,9 +4,7 @@ context:
   title: Tabs | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 Tabs are a set of layered sections of content, known as tab panels, that display one panel of content at a time. Each tab panel has an associated tab element, that when activated, displays the panel. The list of tab elements is arranged along one edge of the currently displayed panel, most commonly the top edge.
 
@@ -23,7 +21,7 @@ This component does not have a semantic counterpart in HTML, so it uses several 
   - `role=”tabpanel”`,
   - `aria-labelledby`, which references the ID of the tab it is controlled by
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -33,7 +31,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - Content included in tab panels should also be accessible, i.e. images should include appropriate `alt` text.
 - Avoid tabs that wrap over more than one line. This can make it harder for users to distinguish the selected tab from its content.
 
-### Resources
+## Resources
 
 - [Example of Tabs with Automatic Activation](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html)
 - [WAI-ARIA practices: Tabs](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel)

--- a/templates/docs/patterns/tabs/index.md
+++ b/templates/docs/patterns/tabs/index.md
@@ -4,10 +4,6 @@ context:
   title: Tabs | Components
 ---
 
-# Tabs
-
-<hr>
-
 Tabs organise and allow navigation between groups of content that are related and at the same level of hierarchy.
 
 To select the active tab add the attribute `aria-selected="true"` and that list item will have the correct styling.

--- a/templates/docs/patterns/tooltips/accessibility.md
+++ b/templates/docs/patterns/tooltips/accessibility.md
@@ -4,13 +4,11 @@ context:
   title: Tooltips | Components
 ---
 
-## Accessibility
-
-### How it works
+## How it works
 
 A tooltip is text that appears in a small overlay on demand, usually when hovering over the thing it describes. It is hidden by default, and becomes available on hover or focus of the control it describes. It should provide information that isn’t self explanatory or well known.
 
-### Considerations
+## Considerations
 
 This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
 
@@ -19,7 +17,7 @@ This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3
 - Avoid using tooltips to provide instructions or guidance, or any rich information.
 - They shouldn’t be used on disabled elements. It should be clear to the user why the button is disabled without the tooltip.
 
-### Resources
+## Resources
 
 - Inclusive Components by Heydon Pickering
 - Guidelines

--- a/templates/docs/patterns/tooltips/index.md
+++ b/templates/docs/patterns/tooltips/index.md
@@ -4,10 +4,6 @@ context:
   title: Tooltips | Components
 ---
 
-# Tooltips
-
-<hr>
-
 Tooltips are text labels that appear when the user hovers over, focuses on, or touches an element on the screen.
 
 They can be used to provide information about concepts/terms/actions that are not self-explanatory or well known.

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -147,9 +147,12 @@ def global_template_context():
     version_parts = VANILLA_VERSION.split(".")
     version_minor = f"{version_parts[0]}.{version_parts[1]}"
 
-    docs_slug = flask.request.path.replace("/docs/", "")
-    docs_slug = docs_slug.replace("/design/", "")
-    docs_slug = docs_slug.replace("/accessibility", "")
+    docs_slug = (
+        flask.request.path.replace("/docs/", "")
+        .replace("/design/", "")
+        .replace("/accessibility", "")
+    )
+
     docs_slug = "" if docs_slug == "/docs" else docs_slug
 
     # Read navigation.yaml


### PR DESCRIPTION
## Done

Add tabs to all other patterns that had accessibility sections:
- patterns/breadcrumbs
- patterns/buttons
- patterns/card
- patterns/contextual-menu
- patterns/grid
- patterns/heading-icon
- patterns/icon
- patterns/links
- patterns/lists
- patterns/logo-section
- patterns/modal
- patterns/navigation
- patterns/notification
- patterns/pagination
- patterns/search-box
- patterns/status-labels
- patterns/strip
- patterns/switch
- patterns/tabs
- patterns/tooltips

## QA

- Check all other patterns with accessibility pages, they should have the menu and work just as well as accordion did on the previous PR.
