### PR TITLE
Fix page jumping after codepen loads

### DIFF
--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -270,6 +270,15 @@
     return scripts;
   }
 
+  function fixScroll() {
+    const titleId = window.location.hash;
+    const title = document.querySelector(`${titleId}`);
+    var rect = title.getBoundingClientRect();
+    if (title) {
+      window.scrollTo(0, rect.top);
+    }
+  }
+
   /**
     Attaches change event listener to a given select.
     @param {HTMLElement} dropdown Select element belonging to a code snippet.
@@ -293,4 +302,5 @@
       }
     });
   }
+  fixScroll();
 })();

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -166,6 +166,7 @@
           var style = iframe.contentWindow.getComputedStyle(iframe.contentDocument.body);
           iframe.height = frameHeight + 32 + 'px'; // accommodate for body margin
           clearInterval(resizeInterval);
+          fixScroll();
         }
       }, 100);
 
@@ -272,10 +273,9 @@
 
   function fixScroll() {
     const titleId = window.location.hash;
-    const title = document.querySelector(`${titleId}`);
-    var rect = title.getBoundingClientRect();
-    if (title) {
-      window.scrollTo(0, rect.top);
+    if (titleId) {
+      const title = document.querySelector(titleId);
+      title.scrollIntoView();
     }
   }
 
@@ -302,5 +302,4 @@
       }
     });
   }
-  fixScroll();
 })();


### PR DESCRIPTION
## Done

- Add a fix scroll function to ensure the codepen loading doesn't move the title out of view

Fixes #3017 

## QA

- Open [demo](https://vanilla-framework-4432.demos.haus/docs/patterns/navigation#side-navigation)
- Check that the "Side navigation" title is in view. 
- Compare to [main](https://vanillaframework.io/docs/patterns/navigation#side-navigation)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
