### PR TITLE
Update "What's new" table

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -90,7 +90,7 @@
               {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
               {{ side_nav_item("/docs/patterns/segmented-control", "Segmented control", 'new', 'positive') }}
               {{ side_nav_item("/docs/patterns/slider", "Slider") }}
-              {{ side_nav_item("/docs/patterns/status-labels", "Status labels", 'new', 'positive') }}
+              {{ side_nav_item("/docs/patterns/status-labels", "Status labels") }}
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}
               {{ side_nav_item("/docs/patterns/switch", "Switch") }}
               {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -22,7 +22,7 @@ When we add, make significant updates, or deprecate a component we update their 
   <tbody>
   <!-- 3.3.0 -->
     <tr>
-      <th><a href="/docs/patterns/navigation">Side navigation</a></th>
+      <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
         <span class="p-status-label--information">Updated</span>
       </td>
@@ -30,7 +30,7 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>We've made some changes to the side navigation, improving accessibility and renaming some classes.</td>
     </tr>
     <tr>
-      <th><a href="/docs/patterns/navigation">Side navigation</a></th>
+      <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
         <span class="p-status-label--negative">Deprecated</span>
       </td>

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -20,23 +20,46 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-    <!-- 3.3.1 -->
+  <!-- 3.3.0 -->
+    <tr>
+      <th><a href="/docs/patterns/navigation">Side navigation</a></th>
+      <td>
+        <span class="p-status-label--information">Updated</span>
+      </td>
+      <td>3.3.0</td>
+      <td>We've made some changes to the side navigation, improving accessibility and renaming some classes.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/navigation">Side navigation</a></th>
+      <td>
+        <span class="p-status-label--negative">Deprecated</span>
+      </td>
+      <td>3.3.0</td>
+      <td>We've updated the class names in the side navigation. <code>.is-expanded</code> and <code>.is-collapsed</code> are deprecated and replaced by <code>.is-drawer-expanded</code> and <code>.is-drawer-expanded</code>.</td>
+    </tr>
     <tr>
       <th><a href="/docs/patterns/accordion">Accordion</a></th>
       <td>
         <span class="p-status-label--information">Updated</span>
       </td>
-      <td>3.2.1</td>
-      <td>We changed the icon of the accordion tab.</td>
+      <td>3.3.0</td>
+      <td>We updated the Accordion icon to a chevron which animates on open and close.</td>
     </tr>
-    <!-- 3.3.0 -->
     <tr>
       <th><a href="/docs/patterns/segmented-control">Segmented control</a></th>
       <td>
-        <span class="p-status-label--information">New</span>
+        <span class="p-status-label--positive">New</span>
       </td>
       <td>3.3.0</td>
-      <td>The Tab buttons component has been renamed to Segmented control</td>
+      <td>The Tab buttons component has been renamed to Segmented control.</td>
+    </tr>
+        <tr>
+      <th><a href="/docs/patterns/segmented-control">Tab buttons</a></th>
+      <td>
+        <span class="p-status-label--negative">Deprecated</span>
+      </td>
+      <td>3.3.0</td>
+      <td><code>p-tab-buttons</code> has been renamed to <code>p-segmented-control</code>.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Done

Fix inconsistencies in what's new table

Fixes [list issues/bugs if needed]

## QA

- Open [demo](https://vanilla-framework-4441.demos.haus/)
- Check what's new table and side nav are consistent with correct labels

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
