### PR TITLE
Add accessibility doc for quotes

### DIFF
--- a/component_tabs.yaml
+++ b/component_tabs.yaml
@@ -28,6 +28,8 @@ patterns/notification:
   accessibility: True
 patterns/pagination:
   accessibility: True
+patterns/pull-quote:
+  accessibility: True
 patterns/search-box:
   accessibility: True
 patterns/status-labels:

--- a/templates/docs/patterns/pull-quote/accessibility.md
+++ b/templates/docs/patterns/pull-quote/accessibility.md
@@ -1,0 +1,19 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Pull quote | Components
+---
+
+## How it works
+
+The pull quote component uses semantic HTML to represent a section that is quoted from another source. Containing quotes in a blockquote element means users are able to jump between quotes.
+
+## Considerations
+
+- If a cite element is used, it should quote the title or name of someone’s work, but not their name.
+- Quotes and block quotes must only be used to highlight quotes - they should not be used to format text in italic, for example, or obtain an indented paragraph.
+
+## Resources
+
+- [W3C - Blockquotes](https://www.w3.org/html/wg/wiki/Guide/e/blockquote)
+- [W3C WAI-ARIA - Quotes](https://www.w3.org/WAI/tutorials/page-structure/content/#quotes)

--- a/templates/docs/patterns/pull-quote/index.md
+++ b/templates/docs/patterns/pull-quote/index.md
@@ -4,10 +4,6 @@ context:
   title: Pull quote | Components
 ---
 
-# Pull quote
-
-<hr>
-
 Use the pull quote pattern to highlight content from different sources in a
 visually prominent way.
 


### PR DESCRIPTION
## Done

- Add accessibility notes to quotes
- Update content to include tabs

Fixes [#1352](https://github.com/canonical-web-and-design/vanilla-squad/issues/1352)

## QA

- Open [demo](https://vanilla-framework-4443.demos.haus/docs/patterns/pull-quote)
- Check the tabs work as expected
- The accessibility text has already been reviewed so this is only a QA of them on the site

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

