### PR TITLE
Add contextual menu accessibility docs

### DIFF
--- a/component_tabs.yaml
+++ b/component_tabs.yaml
@@ -8,6 +8,8 @@ patterns/buttons:
   accessibility: True
 patterns/card:
   accessibility: True
+patterns/contextual-menu:
+  accessibility: True
 patterns/grid:
   accessibility: True
 patterns/heading-icon:

--- a/templates/docs/patterns/contextual-menu/accessibility.md
+++ b/templates/docs/patterns/contextual-menu/accessibility.md
@@ -1,0 +1,33 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Contextual menu | Components
+---
+
+## How it works
+
+The contextual menu is a secondary menu which can be applied to any button. The button contains a few aria-attributes:
+
+- An `aria-controls` attribute matching the `id` of the span containing the menu.
+- An `aria-expanded` attribute, the value always being the opposite of the `aria-hidden` value on the span containing the menu.
+- An `aria-haspopup` with the value of true.
+- Keyboard interaction:
+  - The Enter and space keys opens the menu
+  - The Escape closes the menu
+  - When the menu is open, the Tab key will move through the menu items and once it leaves the final item, the menu closes. AT will then announce the pop up has collapsed.
+
+## Considerations
+
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+
+- The control element should have the `role=”button”`, in our example we use the native button element.
+- JavaScript will be needed to show/hide the content of the menu. The script should find the toggle element `.p-contextual-menu__toggle`, and what it controls via `aria-controls`.
+- The target element is shown/hidden by changing `aria-hidden` to true or false accordingly. The `aria-expanded` attribute on the control element should change accordingly.
+- When using the `p-contextual-menu__toggle` class on a `button` element, please ensure that the button label contains a trailing ellipsis `...`, e.g. "Take action...". This is a convention used to indicate that the button launches a dialog.
+- In cases where a contextual menu is shown on click, focus should be set within the menu element, using JavaScript.
+
+## Resources
+
+- [WAI-ARIA practices - Menu button](https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton)
+- [WCAG 2.1 - 2.4.7: Understanding focus visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible)
+- [WAI-ARIA - Menu role](https://www.w3.org/TR/wai-aria-1.2/#menu)

--- a/templates/docs/patterns/contextual-menu/index.md
+++ b/templates/docs/patterns/contextual-menu/index.md
@@ -5,10 +5,6 @@ context:
   title: Contextual menu | Components
 ---
 
-# Contextual menu
-
-<hr>
-
 A contextual menu can be applied to any button, link or navigation item that requires a secondary menu. To interact with the menu it will require some javascript to hide/show each pattern. This is achieved by finding the toggle element `p-contextual-menu__toggle` and what it controls `aria-controls`.
 
 The target element will be hidden or shown with `aria-hidden="true"` or `false`. The control element will change to `aria-expanded` so screen readers will know it's active.
@@ -49,12 +45,6 @@ View example of the contextual menu pattern
 ## Functionality
 
 Please ensure the `aria-control` attribute matches an ID of an element. If `aria-expanded` is true, then the contextual menu will be open by default. When clicking on the `p-contextual-menu__toggle`, you must toggle the `aria-expanded` attribute on the toggle and the `aria-hidden` attribute on the drop-down.
-
-## Accessibility
-
-When using the `p-contextual-menu__toggle` class on a `button` element, please ensure that the button label contains a trailing ellipsis `…`, e.g. "Take action&hellip;". This is a convention used to indicate that the button launches a dialog.
-
-In cases where a contextual menu is shown on click, focus should be set within the menu element, using JavaScript.
 
 ## Theming
 


### PR DESCRIPTION
## Done

- Add [accessibility doc](https://docs.google.com/document/d/1uRHo5Jp034T31E18IuTSdgpzLaF77lOFGHzn7U49hqk/edit?pli=1) for contextual menu component

Fixes #4042 

## QA

- Open [demo](https://vanilla-framework-4450.demos.haus/docs)
- Go to contextual menu component
- Review updated documentation:
  - Contextual menu

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

