### PR TITLE
Update classnames in Pagination component

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.3.0",
+  "version": "3.4.0",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -13,7 +13,9 @@
     }
   }
 
-  .p-pagination,
+  // .p-pagination on the <ol> element is deprecated. It should be used on the wrapping <nav> element instead, and .p-pagination__items on the <ol> or <ul> element.
+  ul.p-pagination,
+  ol.p-pagination,
   .p-pagination__items {
     display: flex;
     flex-direction: row;

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -13,7 +13,8 @@
     }
   }
 
-  .p-pagination {
+  .p-pagination,
+  .p-pagination__items {
     display: flex;
     flex-direction: row;
     list-style: none;

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -14,8 +14,9 @@
   }
 
   // .p-pagination on the <ol> element is deprecated. It should be used on the wrapping <nav> element instead, and .p-pagination__items on the <ol> or <ul> element.
-  ul.p-pagination,
-  ol.p-pagination,
+
+  // stylelint-disable selector-max-type
+  .p-pagination:not(nav),
   .p-pagination__items {
     display: flex;
     flex-direction: row;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -62,7 +62,7 @@
 
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
-              {{ side_nav_item("/docs/patterns/accordion", "Accordion", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
               {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
               {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
               {{ side_nav_item("/docs/patterns/card", "Cards") }}
@@ -82,13 +82,13 @@
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}
               {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
-              {{ side_nav_item("/docs/patterns/navigation", "Navigation", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
               {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
-              {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
+              {{ side_nav_item("/docs/patterns/pagination", "Pagination", 'updated', 'information') }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
               {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
-              {{ side_nav_item("/docs/patterns/segmented-control", "Segmented control", 'new', 'positive') }}
+              {{ side_nav_item("/docs/patterns/segmented-control", "Segmented control") }}
               {{ side_nav_item("/docs/patterns/slider", "Slider") }}
               {{ side_nav_item("/docs/patterns/status-labels", "Status labels") }}
               {{ side_nav_item("/docs/patterns/strip", "Strip") }}

--- a/templates/docs/examples/patterns/pagination/pagination-deprecated.html
+++ b/templates/docs/examples/patterns/pagination/pagination-deprecated.html
@@ -1,0 +1,32 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Pagination / Deprecated{% endblock %}
+
+{% block standalone_css %}patterns_pagination{% endblock %}
+
+{% block content %}
+<nav aria-label="Pagination">
+  <ol class="p-pagination">
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#1" aria-label="Page 1">1</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#2" aria-label="Page 2">2</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link is-active" aria-current="page" href="#3" aria-label="Page 3">3</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#4" aria-label="Page 4">4</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link" href="#5" aria-label="Page 5">5</a>
+    </li>
+    <li class="p-pagination__item">
+      <a class="p-pagination__link--next" href="#next" title="Next page"><i class="p-icon--chevron-down">Next page</i></a>
+    </li>
+  </ol>
+</nav>
+{% endblock %}

--- a/templates/docs/examples/patterns/pagination/pagination-disabled.html
+++ b/templates/docs/examples/patterns/pagination/pagination-disabled.html
@@ -4,8 +4,8 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<nav aria-label="Pagination">
-  <ol class="p-pagination">
+<nav class="p-pagination" aria-label="Pagination">
+  <ol class="p-pagination__items">
     <li class="p-pagination__item">
       <span class="p-pagination__link--previous is-disabled" aria-disabled="true"><i class="p-icon--chevron-down">Previous page</i></span>
     </li>

--- a/templates/docs/examples/patterns/pagination/pagination-truncated.html
+++ b/templates/docs/examples/patterns/pagination/pagination-truncated.html
@@ -4,8 +4,8 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<nav aria-label="Pagination">
-  <ol class="p-pagination">
+<nav class="p-pagination" aria-label="Pagination">
+  <ol class="p-pagination__items">
     <li class="p-pagination__item">
       <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
     </li>

--- a/templates/docs/examples/patterns/pagination/pagination-verbose.html
+++ b/templates/docs/examples/patterns/pagination/pagination-verbose.html
@@ -4,8 +4,8 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<nav aria-label="Pagination">
-  <ol class="p-pagination">
+<nav class="p-pagination" aria-label="Pagination">
+  <ol class="p-pagination__items">
     <li class="p-pagination__item">
       <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down"></i><span>Previous page</span></a>
     </li>

--- a/templates/docs/examples/patterns/pagination/pagination.html
+++ b/templates/docs/examples/patterns/pagination/pagination.html
@@ -4,8 +4,8 @@
 {% block standalone_css %}patterns_pagination{% endblock %}
 
 {% block content %}
-<nav aria-label="Pagination">
-  <ol class="p-pagination">
+<nav class="p-pagination" aria-label="Pagination">
+  <ol class="p-pagination__items">
     <li class="p-pagination__item">
       <a class="p-pagination__link--previous" href="#previous" title="Previous page"><i class="p-icon--chevron-down">Previous page</i></a>
     </li>

--- a/templates/docs/patterns/pagination/index.md
+++ b/templates/docs/patterns/pagination/index.md
@@ -10,6 +10,12 @@ Use the pagination component to paginate large sets of data:
 View example of the pagination pattern
 </a></div>
 
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <p class="p-notification__message">The <code>.p-pagination</code> class has been moved to the wrapping <code>nav</code> element, it's use is deprecated on the <code>ol</code> element. The new <code>.p-pagination__items</code> class should now be used on the <code>ol</code>.</p>
+  </div>
+</div>
+
 ## Truncated
 
 Use the truncated version when the number of pages is too large to comfortably display a button for each page:

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -21,13 +21,21 @@ When we add, make significant updates, or deprecate a component we update their 
   </thead>
   <tbody>
  <!-- 3.4.0 -->
+     <tr>
+      <th><a href="/docs/patterns/pagination">Pagination</a></th>
+      <td>
+        <span class="p-status-label--negative">Deprecated</span>
+      </td>
+      <td>3.4.0</td>
+      <td>We've deprecated the use of the <code>p-navigation</code> class on lists, the class should now be used on the wrapping nav only.</td>
+    </tr>
     <tr>
       <th><a href="/docs/patterns/pagination">Pagination</a></th>
       <td>
         <span class="p-status-label--information">Updated</span>
       </td>
       <td>3.4.0</td>
-      <td>We've added a new <code>p-navigation__items</code> class name to the list and moved the <code>p-navigation</code> to the nav element</td>
+      <td>We've added a new <code>p-pagination__items</code> class name to the list and moved the <code>p-pagination</code> class to the nav element.</td>
     </tr>
   </tbody>
 </table>

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -20,7 +20,31 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-  <!-- 3.3.0 -->
+ <!-- 3.4.0 -->
+    <tr>
+      <th><a href="/docs/patterns/pagination">Pagination</a></th>
+      <td>
+        <span class="p-status-label--information">Updated</span>
+      </td>
+      <td>3.4.0</td>
+      <td>We've added a new <code>p-navigation__items</code> class name to the list and moved the <code>p-navigation</code> to the nav element</td>
+    </tr>
+  </tbody>
+</table>
+
+## Previously in Vanilla v3
+
+<table aria-label="Previously in Vanilla v3">
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- 3.3.0 -->
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>
       <td>
@@ -61,21 +85,6 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>3.3.0</td>
       <td><code>p-tab-buttons</code> has been renamed to <code>p-segmented-control</code>.</td>
     </tr>
-  </tbody>
-</table>
-
-## Previously in Vanilla v3
-
-<table aria-label="Previously in Vanilla v3">
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
     <!-- 3.2.0 -->
     <tr>
       <th><a href="/docs/patterns/navigation#expanding-search-box">Navigation - Search</a></th>


### PR DESCRIPTION
## Done

- Move `p-pagination` classname to the `<nav>` element
- Add new `p-pagination__items` class name to the `<ol>` element. 

It seems the styles can be applied to both class names and nothing breaks on old and new structure... 

Fixes #4257 

## QA

- Open [demo](https://vanilla-framework-4451.demos.haus)
- Check all examples of Pagination component. Update the HTML in the browser to the older structure to check it's backwards compatible
- Review updated documentation:
  - What's new table
  - Side nav in docs should be updated

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

