### PR TITLE
Add functionality to keep tooltip open on click

### DIFF
--- a/templates/docs/examples/patterns/tooltips/_tooltips_script.js
+++ b/templates/docs/examples/patterns/tooltips/_tooltips_script.js
@@ -16,11 +16,15 @@ function setTooltipPosition(trigger, container) {
 function handleTooltipEvents(target, tooltipContainers) {
   var trigger = document.querySelector("[aria-describedby='" + target.getAttribute('id') + "']");
   var timeout;
-  var showEvents = ['mouseenter', 'focus'];
+  var showEvents = ['click', 'mouseenter', 'focus'];
   var hideEvents = ['click', 'mouseout', 'blur'];
+  var tooltipClickedOpen = false;
 
   showEvents.forEach(function (event) {
     trigger.addEventListener(event, function () {
+      if (event === 'click') {
+        tooltipClickedOpen = !tooltipClickedOpen;
+      }
       // wait 200ms before showing the tooltip,
       // so we know there is intent
       timeout = setTimeout(function () {
@@ -28,7 +32,6 @@ function handleTooltipEvents(target, tooltipContainers) {
         tooltipContainers.forEach(function (container) {
           container.classList.add('u-hide');
         });
-
         target.classList.remove('u-hide');
         setTooltipPosition(trigger, target);
       }, 200);
@@ -38,8 +41,25 @@ function handleTooltipEvents(target, tooltipContainers) {
   hideEvents.forEach(function (event) {
     trigger.addEventListener(event, function (e) {
       if (e.target.parentNode !== trigger) {
-        clearTimeout(timeout);
-        target.classList.add('u-hide');
+        if (tooltipClickedOpen) {
+          return;
+        } else {
+          clearTimeout(timeout);
+          target.classList.add('u-hide');
+        }
+      }
+    });
+  });
+
+  // Hide the tooltip when the user clicks outside the trigger or presses escape
+  ['keyup', 'click'].forEach(function (event) {
+    document.addEventListener(event, function (e) {
+      if (tooltipClickedOpen) {
+        if (e.target !== trigger || e.key === 'Escape') {
+          clearTimeout(timeout);
+          target.classList.add('u-hide');
+          tooltipClickedOpen = false;
+        }
       }
     });
   });


### PR DESCRIPTION
## Done

- Ensured the detached tooltip stays open on click of the trigger, and closes when escape is pressed or the user clicks outside or on the trigger

Fixes #4412 

## QA

- Open [demo](https://vanilla-framework-4454.demos.haus/docs/examples/patterns/tooltips/detached)
- Hover/focus over the detached tooltip and check the functionality is still the same
- Click on the tooltip and move the mouse away. The tooltip should remain open
- Now press escape and check the tooltip closes
- Do the same again but click outside instead of pressing escape - the tooltip should close. 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

