### PR TITLE
Update brand name in navigation example logos

### DIFF
--- a/templates/docs/examples/patterns/navigation/default-dark.html
+++ b/templates/docs/examples/patterns/navigation/default-dark.html
@@ -12,7 +12,7 @@
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
           </div>
-          <span class="p-navigation__logo-title">Canonical</span>
+          <span class="p-navigation__logo-title">Ubuntu</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/default.html
+++ b/templates/docs/examples/patterns/navigation/default.html
@@ -12,7 +12,7 @@
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
           </div>
-          <span class="p-navigation__logo-title">Canonical</span>
+          <span class="p-navigation__logo-title">Ubuntu</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/dropdown-dark.html
+++ b/templates/docs/examples/patterns/navigation/dropdown-dark.html
@@ -12,7 +12,7 @@
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="" >
           </div>
-          <span class="p-navigation__logo-title">LXD</span>
+          <span class="p-navigation__logo-title">Ubuntu</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/dropdown.html
+++ b/templates/docs/examples/patterns/navigation/dropdown.html
@@ -12,7 +12,7 @@
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
           </div>
-          <span class="p-navigation__logo-title">LXD</span>
+          <span class="p-navigation__logo-title">Ubuntu</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/full-width.html
+++ b/templates/docs/examples/patterns/navigation/full-width.html
@@ -12,7 +12,7 @@
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
           </div>
-          <span class="p-navigation__logo-title">Canonical</span>
+          <span class="p-navigation__logo-title">Ubuntu</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/docs/examples/patterns/navigation/search-dark.html
+++ b/templates/docs/examples/patterns/navigation/search-dark.html
@@ -14,7 +14,7 @@
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
           </div>
-          <span class="p-navigation__logo-title">Canonical</span>
+          <span class="p-navigation__logo-title">Ubuntu</span>
         </a>
       </div>
       <ul class="p-navigation__items">

--- a/templates/docs/examples/patterns/navigation/search-light.html
+++ b/templates/docs/examples/patterns/navigation/search-light.html
@@ -14,7 +14,7 @@
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
           </div>
-          <span class="p-navigation__logo-title">Canonical</span>
+          <span class="p-navigation__logo-title">Ubuntu</span>
         </a>
       </div>
       <ul class="p-navigation__items">


### PR DESCRIPTION
## Done

Replaces "Canonical" brand name in new logo examples to Ubuntu, as this is the only one officially published.

## QA

- Open [demo](https://vanilla-framework-4468.demos.haus/docs/patterns/navigation)
- Make sure navigation examples show "Ubuntu" name in logo

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.




<img width="918" alt="Screenshot 2022-05-20 at 08 25 25" src="https://user-images.githubusercontent.com/83575/169466255-2a16354d-1e15-4ccf-9241-404412f5a624.png">
