### PR TITLE
Update search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.0.5
 canonicalwebteam.discourse==4.0.9
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.search==1.1.0
+canonicalwebteam.search==1.2.0
 canonicalwebteam.image-template==1.3.1
 mistune==0.8.4
 pyyaml==5.4.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -245,7 +245,6 @@ app.add_url_rule(
         session=session,
         site="vanillaframework.io/docs",
         template_path="docs/search.html",
-        search_engine_id="adb2397a224a1fe55",  # https://cse.google.co.uk/cse/setup/basic?cx=adb2397a224a1fe55
     ),
 )
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)


### PR DESCRIPTION
## Done

Fixes and unblocks future renovate updates

## QA

- Open [demo](https://vanilla-framework-4482.demos.haus/)
- Search any keywords that are contained in the docs e.g. "cards", "patterns"
- Make sure you see results

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.
