### PR TITLE
Add heading styles for side navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.4.0",
+  "version": "3.5.0",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -41,6 +41,12 @@
         .p-side-navigation__toggle--in-drawer:
             Side navigation toggle button in drawer (to close navigation on small screens).
 
+    Items list heading:
+        .p-side-navigation__heading:
+            Heading for side navigation items group (text only).
+        .p-side-navigation__heading--linked:
+            Heading for side navigation items group that contains a link (`.p-side-navigation__link`).
+
     Items list:
         .p-side-navigation__list:
             Group of side navigation items (usually a `<ul>` element).
@@ -276,6 +282,18 @@
     padding-top: $spv--x-small;
   }
 
+  %side-navigation__heading {
+    @extend %side-navigation__text;
+
+    // reset heading styles
+    @extend %common-default-text-properties;
+    @extend %bold;
+
+    display: block;
+    font-size: map-get($base-font-sizes, base);
+    margin: 0;
+  }
+
   %side-navigation__link {
     @include vf-focus;
 
@@ -300,6 +318,7 @@
     @extend %side-navigation__link;
   }
 
+  .p-side-navigation__heading,
   .p-side-navigation__text,
   .p-side-navigation__link {
     @extend %side-navigation__text;
@@ -345,6 +364,15 @@
     padding-left: $spv--small;
   }
 
+  .p-side-navigation__heading,
+  .p-side-navigation__heading--linked {
+    @extend %side-navigation__heading;
+  }
+
+  .p-side-navigation__heading--linked {
+    padding: 0; // padding will come from the link in heading
+  }
+
   // Styles for markup in raw HTML docs variant
   .p-side-navigation--raw-html {
     // stylelint-disable selector-max-type -- we support raw HTML markup for discourse-generated side nav
@@ -353,14 +381,7 @@
     h4,
     h5,
     h6 {
-      @extend %side-navigation__text;
-
-      // reset heading styles
-      @extend %common-default-text-properties;
-      @extend %bold;
-
-      font-size: map-get($base-font-sizes, base);
-      margin: 0;
+      @extend %side-navigation__heading;
     }
 
     ul {
@@ -558,6 +579,8 @@
     }
   }
 
+  .p-side-navigation__heading,
+  .p-side-navigation__heading--linked .p-side-navigation__link,
   .p-side-navigation__item--title,
   .p-side-navigation__item--title .p-side-navigation__link {
     color: $color-sidenav-text-active;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -82,9 +82,9 @@
               {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
               {{ side_nav_item("/docs/patterns/modal", "Modal") }}
               {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
-              {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
+              {{ side_nav_item("/docs/patterns/navigation", "Navigation", "updated", "information") }}
               {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
-              {{ side_nav_item("/docs/patterns/pagination", "Pagination", 'updated', 'information') }}
+              {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
               {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
               {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
               {{ side_nav_item("/docs/patterns/search-box", "Search box") }}

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -13,10 +13,8 @@
       </a>
     </div>
 
+    <h3 class="p-side-navigation__heading">Group heading</h3>
     <ul class="p-side-navigation__list">
-      <li class="p-side-navigation__item--title">
-        <a class="p-side-navigation__link" href="#">Title that is a link</a>
-      </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link</a>
       </li>
@@ -53,6 +51,9 @@
           </li>
         </ul>
       </li>
+      <li class="p-side-navigation__item--title">
+        <a class="p-side-navigation__link" href="#">List title that is a link</a>
+      </li>
       <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level item that is not a link</span>
       </li>
@@ -72,10 +73,9 @@
         </div></a>
       </li>
     </ul>
+
+    <h3 class="p-side-navigation__heading--linked"><a class="p-side-navigation__link" href="#">Group heading linked</a></h3>
     <ul class="p-side-navigation__list">
-      <li class="p-side-navigation__item--title">
-        <span class="p-side-navigation__text">Title that is not a link</span>
-      </li>
       <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level text</span>
       </li>
@@ -106,6 +106,9 @@
             </ul>
           </li>
         </ul>
+      </li>
+      <li class="p-side-navigation__item--title">
+        <span class="p-side-navigation__text">List title that is not a link</span>
       </li>
       <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level item that is not a link</span>

--- a/templates/docs/examples/patterns/side-navigation/_docs.html
+++ b/templates/docs/examples/patterns/side-navigation/_docs.html
@@ -12,10 +12,8 @@
       </a>
     </div>
 
+    <h3 class="p-side-navigation__heading">Introduction</h3>
     <ul class="p-side-navigation__list">
-      <li class="p-side-navigation__item--title">
-        <a class="p-side-navigation__link" href="#">Introduction</a>
-      </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">About MAAS</a>
       </li>
@@ -28,10 +26,8 @@
         </span></a>
       </li>
     </ul>
+    <h3 class="p-side-navigation__heading">Machines</h3>
     <ul class="p-side-navigation__list">
-      <li class="p-side-navigation__item--title">
-        <a class="p-side-navigation__link" href="#">Machines</a>
-      </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Commission machines</a>
       </li>
@@ -58,10 +54,8 @@
         <a class="p-side-navigation__link">Concepts & terms</a>
       </li>
     </ul>
+    <h3 class="p-side-navigation__heading--linked"><a class="p-side-navigation__link">Troubleshoot</a></h3>
     <ul class="p-side-navigation__list">
-      <li class="p-side-navigation__item--title">
-        <a class="p-side-navigation__link">Troubleshoot</a>
-      </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">Getting help</a>
       </li>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -16,10 +16,8 @@
       </a>
     </div>
 
+    <h3 class="p-side-navigation__heading">Group heading</h3>
     <ul class="p-side-navigation__list">
-      <li class="p-side-navigation__item--title">
-        <a class="p-side-navigation__link" href="#">Title that is a link</a>
-      </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#"><i class="p-icon--information {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link</a>
       </li>
@@ -56,6 +54,9 @@
           </li>
         </ul>
       </li>
+      <li class="p-side-navigation__item--title">
+        <a class="p-side-navigation__link" href="#">Title that is a link</a>
+      </li>
       <li class="p-side-navigation__item">
         <span class="p-side-navigation__text"><i class="p-icon--collapse {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level item that is not a link</span>
       </li>
@@ -75,10 +76,9 @@
         </div></a>
       </li>
     </ul>
+
+    <h3 class="p-side-navigation__heading--linked"><a class="p-side-navigation__link" href="#">Group heading linked</a></h3>
     <ul class="p-side-navigation__list">
-      <li class="p-side-navigation__item--title">
-        <span class="p-side-navigation__text">Title that is not a link</span>
-      </li>
       <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level text</span>
       </li>
@@ -109,6 +109,9 @@
             </ul>
           </li>
         </ul>
+      </li>
+      <li class="p-side-navigation__item--title">
+        <span class="p-side-navigation__text">Title that is not a link</span>
       </li>
       <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level item that is not a link</span>

--- a/templates/docs/patterns/navigation/index.md
+++ b/templates/docs/patterns/navigation/index.md
@@ -73,7 +73,7 @@ Current page in the side navigation should be highlighted by adding `aria-curren
 
 Use `p-side-navigation__status` inside `p-side-navigation__link` elements to add status labels or icons on right side of navigation items.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/docs" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/docs" class="js-example" data-height="600">
 View example of the side navigation pattern
 </a></div>
 
@@ -88,7 +88,7 @@ To add icons on the left side of the items in side navigation use the `.p-side-n
   </p>
 </div>
 
-<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/icons" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/icons" class="js-example" data-height="600">
 View example of the side navigation pattern with icons
 </a></div>
 
@@ -102,7 +102,7 @@ On pages with content significantly longer than the side navigation contents you
     <span class="p-notification__message">Side navigation used to be sticky by default, but since Vanilla 2.21.0 <code>.is-sticky</code> class is needed to add this functionality.</p></span>
 </div>
 
-<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/sticky" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/sticky" class="js-example" data-height="600">
 View example of the sticky side navigation pattern
 </a></div>
 
@@ -141,7 +141,7 @@ Because of the limitations of raw HTML markup without class names, it's not poss
   </div>
 </div>
 
-<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/raw-html" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/side-navigation/raw-html" class="js-example" data-height="600">
 View example of the side navigation pattern for raw HTML
 </a></div>
 

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -20,22 +20,14 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
- <!-- 3.4.0 -->
-     <tr>
-      <th><a href="/docs/patterns/pagination">Pagination</a></th>
-      <td>
-        <span class="p-status-label--negative">Deprecated</span>
-      </td>
-      <td>3.4.0</td>
-      <td>We've deprecated the use of the <code>p-navigation</code> class on lists, the class should now be used on the wrapping nav only.</td>
-    </tr>
+    <!-- 3.5.0 -->
     <tr>
-      <th><a href="/docs/patterns/pagination">Pagination</a></th>
+      <th><a href="/docs/patterns/navigation#side-navigation">Side navigation - Headings</a></th>
       <td>
         <span class="p-status-label--information">Updated</span>
       </td>
-      <td>3.4.0</td>
-      <td>We've added a new <code>p-pagination__items</code> class name to the list and moved the <code>p-pagination</code> class to the nav element.</td>
+      <td>3.5.0</td>
+      <td>We've added a new <code>p-side-navigation__heading</code> and <code>p-side-navigation__heading--linked</code> classes to allow adding headings for side navigation item groups.</td>
     </tr>
   </tbody>
 </table>
@@ -52,6 +44,23 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 3.4.0 -->
+     <tr>
+      <th><a href="/docs/patterns/pagination">Pagination</a></th>
+      <td>
+        <span class="p-status-label--negative">Deprecated</span>
+      </td>
+      <td>3.4.0</td>
+      <td>We've deprecated the use of the <code>p-navigation</code> class on lists, the class should now be used on the wrapping nav only.</td>
+    </tr>
+    <tr>
+      <th><a href="/docs/patterns/pagination">Pagination</a></th>
+      <td>
+        <span class="p-status-label--information">Updated</span>
+      </td>
+      <td>3.4.0</td>
+      <td>We've added a new <code>p-pagination__items</code> class name to the list and moved the <code>p-pagination</code> class to the nav element.</td>
+    </tr>
     <!-- 3.3.0 -->
     <tr>
       <th><a href="/docs/patterns/navigation#side-navigation">Side navigation</a></th>


### PR DESCRIPTION
## Done

Adds new `p-side-navigation__heading` class (with a `--linked` variant) to be used in docs to provide headings for side navigation item groups.

Drive by: Fixes an issue with too small embedded examples for side nav components

Fixes #4485 

## QA

- Open [demo](https://vanilla-framework-4487.demos.haus/docs/examples/patterns/side-navigation/docs)
- Check if side navigation headings look as expected
- Review updated documentation:
  - Make sure it works in all variants:
  - https://vanilla-framework-4487.demos.haus/docs/examples/patterns/side-navigation/default
  - https://vanilla-framework-4487.demos.haus/docs/examples/patterns/side-navigation/dark
  

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="464" alt="image" src="https://user-images.githubusercontent.com/83575/172619914-ac1fe8b7-4d26-4141-b525-4c57783993ef.png">
