### PR TITLE
Close side nav drawer when anchors are clicked

### DIFF
--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -106,10 +106,10 @@
   }
 
   setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
-})();
 
-// Add table of contents to side navigation on documentation pages
-(function () {
+  // Add table of contents to side navigation on documentation pages
+  const sideNav = document.querySelector('.p-side-navigation, [class*="p-side-navigation--"]');
+
   // Generate id from H2s content when it does not exist
   document.querySelectorAll('main h2:not([id])').forEach(function (heading) {
     var id = heading.textContent
@@ -135,6 +135,9 @@
     var thisAnchor = anchor.cloneNode();
     thisAnchor.setAttribute('href', '#' + heading.id);
     thisAnchor.textContent = heading.textContent;
+    thisAnchor.addEventListener('click', () => {
+      toggleDrawer(sideNav, false);
+    });
     thisItem.appendChild(thisAnchor);
     list.appendChild(thisItem);
   });


### PR DESCRIPTION
## Done

Closes side navigation when in-page anchors are clicked

Fixes #4484 

## QA

- Open [demo](https://vanilla-framework-4489.demos.haus/docs)
- Visit any Vanilla docs page on small screen
- Open the side navigation
- Click on any anchor link to a heading on the current page
- Side nav should close and page should be scrolled to correct position

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


