### PR TITLE
Docker: Make pip install slightly faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@
 FROM ubuntu:focal AS python-dependencies
 RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools
 ADD requirements.txt /tmp/requirements.txt
+RUN pip3 config set global.disable-pip-version-check true
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
 
 


### PR DESCRIPTION
On startup, pip checks if you’re running the latest version or not, and print a warning if you’re not.

This saves about 0.2-0.3s, not a very significant improvement; the actual improvement probably depends on your network speed and other factors. 