### PR TITLE
Add u.c blog card example and necessary styles

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -1,6 +1,7 @@
 @import 'settings';
 
 @mixin vf-p-card {
+  @include vf-p-card-article-preview;
   @include vf-p-card-default;
   @include vf-p-card-highlighted;
   @include vf-p-card-overlay;
@@ -15,6 +16,36 @@
     @extend %vf-has-round-corners;
 
     padding: calc(#{$spv--large} - 1px);
+  }
+}
+@mixin vf-p-card-article-preview {
+  .p-card--article-preview {
+    @extend %vf-bg--x-light;
+    @extend %vf-has-round-corners;
+    @extend %vf-has-box-shadow;
+
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas: 
+      'header'
+      'main'
+      'footer';
+
+      & > .p-card__header--muted {
+        grid-area: header;
+      }
+
+      & > .p-card__inner {
+        grid-area: main;
+      }
+
+      & > .p-card__footer {
+        grid-area: footer;
+      }
+
+    margin-bottom: $spv--x-large;
+    overflow: auto; // prevent overflow of child margins
   }
 }
 
@@ -72,6 +103,16 @@
     }
   }
 
+  .p-card__header--muted {
+    @extend %vf-pseudo-border--bottom;
+    @include vf-highlight-bar($color-information, top, true);
+  }
+
+  .p-card__footer {
+    @extend %vf-pseudo-border--top;
+    @extend %vf-card-padding;
+  }
+
   .p-card__inner {
     @extend %vf-card-padding;
   }
@@ -87,7 +128,7 @@
   [class*='p-card'] {
     // FIXME: this is overly complex
     // stylelint-disable selector-max-type
-    > p:not([class*='p-heading--']),
+    > p:not([class*='p-heading--']):not([class='p-muted-heading']),
     > h5,
     > h6 {
       &:last-child {

--- a/templates/docs/examples/patterns/card/article-preview.html
+++ b/templates/docs/examples/patterns/card/article-preview.html
@@ -1,0 +1,23 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Card / Content Bleed{% endblock %}
+
+{% block standalone_css %}patterns_card{% endblock %}
+
+{% block content %}
+<div class="p-card--article-preview">
+    <header class="p-card__header--muted">
+        <div class="p-card__inner">
+            <span class="p-muted-heading">Charms</span>
+         </div>
+    </header>
+    <div class="p-card__inner">
+        <img class="p-card__image" src="https://assets.ubuntu.com/v1/0f33d832-The-State-of-Robotics.jpg">
+        <h3>The State of Robotics - August 2021</h3>
+        <p>From robots learning to encourage social participation to detect serious environmental problems, it was a
+            learning month.</p>
+    </div>
+    <div class="p-card__footer">
+        by <a href="#">Bartek Szopka</a> on 21st August 2021
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Done
Add a card flavour similar to the u.c blog article cards: (for reference - this is in response to this [issue](https://github.com/canonical-web-and-design/vanilla-framework/pull/4496))
![image](https://user-images.githubusercontent.com/2741678/174677623-8528e55b-6185-4a37-9abc-8ef2a277f921.png)
- header, main, footer parts, with the footer sticking to the bottom in case it is used in an equal heights scenario (which is the case on u.c)
## QA

- Open [demo](https://vanilla-framework-4496.demos.haus/docs/examples/patterns/card/article-preview)
- review the article-preview example `/docs/examples/patterns/card/article-preview`
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
