### PR TITLE
Fix the logo title to a specific font size

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.5.0",
+  "version": "3.5.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -245,7 +245,7 @@ $spv-navigation-logo: 0.3125rem;
 
     .p-navigation__logo-title {
       @extend %vf-heading-4;
-
+      font-size: #{map-get($font-sizes, h4)}rem;
       line-height: map-get($line-heights, x-small);
     }
 


### PR DESCRIPTION


## Done

Fix the font size to the one of a H4 on large screens

Fixes #4460

## QA

- Open [demo](insert-demo-url)
- resize the window
- the font size should remain the same

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![Peek 2022-06-24 09-58](https://user-images.githubusercontent.com/11927929/175491115-b63704ab-c5e6-4c92-8774-8b3dadbd4cf1.gif)

