### PR TITLE
Updated middot list style

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.6.0",
+  "version": "3.6.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.6.1",
+  "version": "3.6.0",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @import 'settings';
 $list-status-icon-height: 0.875rem; // 14px value from svg as rem so it can be used in calculations
 $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that positions the icon correctly
@@ -179,7 +178,7 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
         content: '\2022';
         line-height: map-get($line-heights, default-text);
         position: relative;
-        right: -(math.div($sp-unit, 2));
+        right: -0.25rem;
       }
 
       &:last-of-type,

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import 'settings';
 $list-status-icon-height: 0.875rem; // 14px value from svg as rem so it can be used in calculations
 $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that positions the icon correctly
@@ -171,14 +172,14 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 
     .p-inline-list__item {
       @include vf-inline-list-item;
-
+      margin-right: $sph--small;
       position: relative;
 
       &::after {
         content: '\2022';
         line-height: map-get($line-heights, default-text);
-        position: absolute;
-        right: -$sp-unit;
+        position: relative;
+        right: -(math.div($sp-unit, 2));
       }
 
       &:last-of-type,


### PR DESCRIPTION
## Done

- Changed middot's position to relative
- Updated the right margin of the middot list item

Fixes #4429 

## QA

- Open [demo](insert-demo-url)
- Reduce browser width to ~280px
- Verify dots are displayed correctly

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots
![image](https://user-images.githubusercontent.com/24393395/175519198-bbd59958-1fbd-41ab-95bc-dba07795519c.png)
