### PR TITLE
Fix nesting and font weight when parent is a title

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.6.0",
+  "version": "3.6.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -250,8 +250,6 @@
     @extend %vf-list;
     @extend %vf-pseudo-border--bottom;
 
-    font-weight: $font-weight-regular-text; // reset the font weight as this may be a child of a bolded title
-
     &::after {
       @include vf-side-navigation-spacing-left($prop: left);
 
@@ -271,10 +269,6 @@
     @extend %side-navigation__list;
   }
 
-  .p-side-navigation__item--title {
-    font-weight: $font-weight-bold;
-  }
-
   %side-navigation__text {
     @include vf-side-navigation-spacing-left;
 
@@ -282,6 +276,10 @@
     padding-bottom: $spv--x-small;
     padding-right: $sph--large;
     padding-top: $spv--x-small;
+
+    .p-side-navigation__item--title > & {
+      font-weight: $font-weight-bold;
+    }
   }
 
   %side-navigation__heading {

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -250,6 +250,8 @@
     @extend %vf-list;
     @extend %vf-pseudo-border--bottom;
 
+    font-weight: $font-weight-regular-text; // reset the font weight as this may be a child of a bolded title
+
     &::after {
       @include vf-side-navigation-spacing-left($prop: left);
 
@@ -330,6 +332,7 @@
     }
 
     // nested 2nd level of navigation
+    .p-side-navigation__item--title .p-side-navigation__item &,
     .p-side-navigation__item .p-side-navigation__item & {
       @include vf-side-navigation-spacing-left($multiplier: 2);
 
@@ -340,6 +343,7 @@
     }
 
     // nested 3rd level of navigation
+    .p-side-navigation__item--title .p-side-navigation__item .p-side-navigation__item &,
     .p-side-navigation__item .p-side-navigation__item .p-side-navigation__item & {
       @include vf-side-navigation-spacing-left($multiplier: 3);
 

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -54,6 +54,14 @@
       <li class="p-side-navigation__item--title">
         <a class="p-side-navigation__link" href="#">List title that is a link</a>
       </li>
+      <li class="p-side-navigation__item--title">
+        <a class="p-side-navigation__link" href="#">Title with children</a>
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item">
+            <a class="p-side-navigation__link" href="#">Second level link</a>
+          </li>
+        </ul>
+      </li>
       <li class="p-side-navigation__item">
         <span class="p-side-navigation__text">First level item that is not a link</span>
       </li>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -57,6 +57,14 @@
       <li class="p-side-navigation__item--title">
         <a class="p-side-navigation__link" href="#">Title that is a link</a>
       </li>
+      <li class="p-side-navigation__item--title">
+        <a class="p-side-navigation__link" href="#">Title with children</a>
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item">
+            <a class="p-side-navigation__link" href="#">Second level link</a>
+          </li>
+        </ul>
+      </li>
       <li class="p-side-navigation__item">
         <span class="p-side-navigation__text"><i class="p-icon--collapse {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level item that is not a link</span>
       </li>


### PR DESCRIPTION
## Done

Fixes font weight and indent of the items nested under the title items.

Fixes #4490 

## QA

- Open [demo](https://vanilla-framework-4501.demos.haus/docs/examples/patterns/side-navigation/default)
- Make sure that when parent element is a bolded title, its children are not bolded and are properly indented

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)



## Screenshots
<img width="370" alt="image" src="https://user-images.githubusercontent.com/83575/176188743-98bb46d2-5385-485f-ab5e-e41fcbe5fc5d.png">
